### PR TITLE
Override any vanilla burn times with Minetweaker

### DIFF
--- a/src/main/java/com/dreammaster/config/CoreModConfig.java
+++ b/src/main/java/com/dreammaster/config/CoreModConfig.java
@@ -27,6 +27,7 @@ public class CoreModConfig extends ConfigManager
   public int PotionTimer;
 
   public boolean AvaritiaFixEnabled;
+  public boolean MinetweakerFurnaceFixEnabled;
   public String[] SkullFireSwordEntityTargets;
   public String[] BlacklistedTileEntiyClassNames;
 
@@ -43,8 +44,9 @@ public class CoreModConfig extends ConfigManager
     ModAdminErrorLogs_Enabled = true;
     ModBabyChest_Enabled = true;
     OreDictItems_Enabled = true;
-    
+
     AvaritiaFixEnabled = false;
+    MinetweakerFurnaceFixEnabled = true;
     PotionTimer = 100;
 
     BlacklistedTileEntiyClassNames = new String[] { "com.rwtema.extrautils.tileentity.enderquarry.TileEntityEnderQuarry" };
@@ -65,6 +67,7 @@ public class CoreModConfig extends ConfigManager
     PotionTimer = _mainConfig.getInt( "PotionTimer", "Limits", PotionTimer, 100, 2048, "The time (in ticks) the potion effect will remain on the player when he drops the bucket. 20 = 1 second" );
 
     AvaritiaFixEnabled = _mainConfig.getBoolean( "AvaritiaFixEnabled", "ModFixes", AvaritiaFixEnabled, "Set to true to enable the modfix for Avaritia SkullFireSword" );
+    MinetweakerFurnaceFixEnabled = _mainConfig.getBoolean( "MinetweakerFurnaceFixEnabled", "ModFixes", MinetweakerFurnaceFixEnabled, "Set to true to allow Minetweaker to override the vanilla furnace fuel handler, allowing the burn value of WOOD material items to be changed." );
     SkullFireSwordEntityTargets = _mainConfig.getStringList( "Avaritia_SkullFireSwordEntityTargets", "ModFixes.Avaritia", SkullFireSwordEntityTargets, "The Canonical Class-Name of the Entity" );
     BlacklistedTileEntiyClassNames = _mainConfig.getStringList( "BlacklistedTileEntiyClassNames", "Modules.Worldaccelerator", BlacklistedTileEntiyClassNames, "The Canonical Class-Names of TileEntities that should be ignored by the WorldAccelerator" );
     OilFixConfig = new OilGeneratorFix.OilConfig( _mainConfig );

--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -21,6 +21,7 @@ import com.dreammaster.modcustomdrops.CustomDropsHandler;
 import com.dreammaster.modcustomfuels.CustomFuelsHandler;
 import com.dreammaster.modfixes.ModFixesMaster;
 import com.dreammaster.modfixes.avaritia.SkullFireSwordDropFix;
+import com.dreammaster.modfixes.minetweaker.MinetweakerFurnaceFix;
 import com.dreammaster.modfixes.oilgen.OilGeneratorFix;
 import com.dreammaster.modhazardousitems.HazardousItemsHandler;
 import com.dreammaster.network.CoreModDispatcher;
@@ -345,14 +346,17 @@ public class MainRegistry
     /**
      * Register your mod-fixes here
      */
-    private void registerModFixes()
-    {
-      if (CoreConfig.AvaritiaFixEnabled) {
-          ModFixesMaster.registerModFix(new SkullFireSwordDropFix());
-      }
-      if (CoreConfig.OilFixConfig.OilFixEnabled) {
-          ModFixesMaster.registerModFix(new OilGeneratorFix());
-      }
+    private void registerModFixes() {
+        if (CoreConfig.AvaritiaFixEnabled) {
+            ModFixesMaster.registerModFix(new SkullFireSwordDropFix());
+        }
+        if (CoreConfig.OilFixConfig.OilFixEnabled) {
+            ModFixesMaster.registerModFix(new OilGeneratorFix());
+        }
+        if (CoreConfig.MinetweakerFurnaceFixEnabled) {
+            ModFixesMaster.registerModFix(new MinetweakerFurnaceFix());
+        }
+
     }
 
     /**

--- a/src/main/java/com/dreammaster/modfixes/minetweaker/MinetweakerFurnaceFix.java
+++ b/src/main/java/com/dreammaster/modfixes/minetweaker/MinetweakerFurnaceFix.java
@@ -1,0 +1,59 @@
+package com.dreammaster.modfixes.minetweaker;
+
+import com.dreammaster.modfixes.ModFixBase;
+import cpw.mods.fml.common.eventhandler.Event;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraftforge.event.FuelBurnTimeEvent;
+
+/**
+ * Created by Rio on 4/8/2018.
+ */
+public class MinetweakerFurnaceFix extends ModFixBase {
+
+    public MinetweakerFurnaceFix() {
+        super("MinetweakerFurnaceFix");
+    }
+
+    @Override
+    public boolean needsForgeEventBus() {
+        return true;
+    }
+
+    @Override
+    public boolean needsFMLEventBus() {
+        return false;
+    }
+
+    @Override
+    public boolean getIsActive() {
+        return true;
+    }
+
+    @Override
+    public boolean init() {
+        return true;
+    }
+
+    @SubscribeEvent
+    public void onFuelBurnTime(FuelBurnTimeEvent event) {
+        /*
+            Minetweaker's feature to change fuel burn values is implemented through an `IFuelHandler` which is
+            forcibly registered with GameRegistry as the only fuel handler. However, the vanilla Furnace code
+            always checks a small hardcoded list of fuels (including a check for `material == WOOD`) before calling
+            the `IFuelHandler`.
+
+            Before checking the hardcoded list, the Furnace is patched by Forge to obey any result returned by a
+            `FuelBurnTimeEvent`, allowing the event handler to override the vanilla handling.
+
+            This event handler simply delegates the fuel value to Minetweaker's `IFuelHandler`, which will be the only
+            fuel handler registered, by simply calling `GameRegistry.getFuelValue`. In turn, this fuel handler will
+            delegate to this mod's `CustomFuelsHandler` if no MT script changes the fuel value for the item.
+         */
+        int burnTime = GameRegistry.getFuelValue(event.fuel);
+        if (burnTime > 0) {
+            event.burnTime = burnTime;
+            event.setResult(Event.Result.ALLOW);
+        }
+    }
+}


### PR DESCRIPTION
GTNewHorizons/NewHorizons#2805

Also allows this mod's `CustomFuels` XML files to override the vanilla burn times.

Mostly useful to override burn times for items where `material == WOOD`, since the material check normally takes precedence over Minetweaker and custom fuels.