### PR TITLE
Fix world world accelerator power consumption

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/accelerator/GT_MetaTileEntity_WorldAccelerator.java
+++ b/src/main/java/com/dreammaster/gthandler/accelerator/GT_MetaTileEntity_WorldAccelerator.java
@@ -184,7 +184,7 @@ public class GT_MetaTileEntity_WorldAccelerator extends GT_MetaTileEntity_Tiered
 
     // Include range setting into power calculation
     float multiplier = 100.0F / (float)mTier * (float)pRangeTier / 100.0F;
-    long demand = V[pSpeedTier] * 6;
+    long demand = V[pSpeedTier] * 3;
 
     float tDemand = demand * multiplier;
 

--- a/src/main/java/com/dreammaster/gthandler/accelerator/GT_MetaTileEntity_WorldAccelerator.java
+++ b/src/main/java/com/dreammaster/gthandler/accelerator/GT_MetaTileEntity_WorldAccelerator.java
@@ -178,9 +178,13 @@ public class GT_MetaTileEntity_WorldAccelerator extends GT_MetaTileEntity_Tiered
 
   public long getEnergyDemand( int pSpeedTier, int pRangeTier, boolean pIsAcceleratingTEs )
   {
+    // TE mode does not need to consider range setting
+    if (pIsAcceleratingTEs)
+      return V[pSpeedTier] * 6;
+
     // Include range setting into power calculation
     float multiplier = 100.0F / (float)mTier * (float)pRangeTier / 100.0F;
-    long demand = V[pSpeedTier] * ( pIsAcceleratingTEs ? 6 : 3 );
+    long demand = V[pSpeedTier] * 6;
 
     float tDemand = demand * multiplier;
 


### PR DESCRIPTION
If you configure the range to 1 in block mode, then switch to TE mode, HV WA consumes 1024EU/t. If you use the default, i.e. range max, it will consume 3072EU/t. The reduction in energy cost goes even higher for EV+ WA (max 85% reduction for ZPM WA, see screenshot below). The behavior persists after server restart. 

![85% off!](https://user-images.githubusercontent.com/4586901/78176782-a70cca00-748f-11ea-992d-9eb68870cf72.png)
