### PR TITLE
Add deploader functionality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,6 +224,9 @@ idea {
 task devJar(type: Jar) {
     from sourceSets.main.output
     classifier = 'dev'
+    manifest {
+        attributes 'FMLCorePlugin': 'com.dreammaster.coremod.DepLoader','FMLCorePluginContainsFMLMod': 'true'
+    }
 }
 
 task sourceJar(type: Jar) {
@@ -248,5 +251,11 @@ task signJar(dependsOn: 'reobf'){
             tsaurl: findProperty('signTSAurl') ?: '',
             verbose: true
             )
+    }
+}
+
+jar {
+    manifest {
+        attributes 'FMLCorePlugin': 'com.dreammaster.coremod.DreamCoreMod','FMLCorePluginContainsFMLMod': 'true'
     }
 }

--- a/src/main/java/com/dreammaster/coremod/DepLoader.java
+++ b/src/main/java/com/dreammaster/coremod/DepLoader.java
@@ -1,0 +1,198 @@
+package com.dreammaster.coremod;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import cpw.mods.fml.relauncher.IFMLCallHook;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.swing.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class DepLoader implements IFMLCallHook {
+    private File mcLocation;
+    private static final Logger LOGGER = LogManager.getLogger(DepLoader.class);
+    private DownloadProgressDialog dialog = null;
+
+    public static class Dependency {
+        private String url;
+        private String path;
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+    }
+
+    private class Downloader implements Runnable {
+        boolean downloaded = false;
+        List<Dependency> deps;
+        Exception e = null;
+
+        Downloader(List<Dependency> deps) {
+            this.deps = deps;
+        }
+
+        @Override
+        public void run() {
+            try {
+                if (deps.size() > 0) {
+                    for (Dependency dep : deps) {
+                        download(dep);
+                    }
+                }
+            } catch (Exception ex) {
+                e = ex;
+            }
+        }
+    }
+
+    @Override
+    public void injectData(Map<String, Object> data) {
+        mcLocation = (File) data.get("mcLocation");
+    }
+
+    @Override
+    public Void call() throws Exception {
+        // get dep info
+        Gson g = new GsonBuilder().disableHtmlEscaping().create();
+        List<Dependency> deps;
+        final File config = new File(mcLocation, "config" + File.separator + "dependencies.json");
+        if (!config.exists()) {
+            LOGGER.info("No dependencies found.");
+            return null;
+        }
+        try (FileReader fr = new FileReader(config)) {
+            deps = g.fromJson(fr, new TypeToken<List<Dependency>>() {
+            }.getType());
+        }
+        if (deps.size() == 0) {
+            LOGGER.info("No dependencies found.");
+            return null;
+        }
+        LOGGER.info("Found {} dependencies.", deps.size());
+
+        // check deps
+        boolean downloaded = false;
+        Thread netThread = null;
+        try {
+            dialog = new DownloadProgressDialog();
+            Thread mainThread = Thread.currentThread();
+            dialog.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    mainThread.interrupt();
+                }
+            });
+            precheck(deps);
+            if (deps.size() > 0) {
+                LOGGER.info("{} dependencies to download.", deps.size());
+                downloaded = true;
+                dialog.setJobCount(deps.size());
+                SwingUtilities.invokeLater(() ->dialog.setVisible(true));
+
+                final Downloader downloader = new Downloader(deps);
+
+                netThread = new Thread(downloader);
+                netThread.setDaemon(true);
+                netThread.start();
+                netThread.join();
+
+                if (downloader.e != null) {
+                    throw new Exception("Download error", downloader.e);
+                }
+            }
+        } catch (InterruptedException e) {
+            try {
+                Files.delete(new File(mcLocation, ".__gtnh_download_temp__").toPath());
+            } catch (IOException e2) {
+                // ignore
+            }
+            if (dialog != null) {
+                dialog.dispose();
+            }
+            netThread.interrupt();
+            // wait for up to 0.5 seconds
+            netThread.join(500);
+            throw new RuntimeException("Launch cancelled by user");
+        } catch (Exception e) {
+            if (dialog != null) {
+                dialog.dispose();
+            }
+            JOptionPane.showMessageDialog(null, "Download of additional files failed. Please refer to log for more info.", DownloadProgressDialog.WINDOW_TITLE, JOptionPane.ERROR_MESSAGE);
+            throw new RuntimeException("Download of additional files failed. Please refer to log for more info.", e);
+        }
+        dialog.dispose();
+        if (downloaded) {
+            // prompt for reload
+            JOptionPane.showMessageDialog(null, "Download complete! Please close this dialog now and launch the game from your launcher again to enjoy the pack.", DownloadProgressDialog.WINDOW_TITLE, JOptionPane.INFORMATION_MESSAGE);
+            throw new RuntimeException("Restart the game please.");
+        }
+        return null;
+    }
+
+    private void precheck(List<Dependency> deps) {
+        for (Iterator<Dependency> iter = deps.iterator(); iter.hasNext(); ) {
+            Dependency dep = iter.next();
+            File location = new File(mcLocation, dep.path);
+            if (location.exists()) {
+                if (location.isDirectory()) {
+                    // stupid user
+                    LOGGER.warn("Directory {} will be removed as it should be a mod jar!", dep.path);
+                    try {
+                        Files.delete(location.toPath());
+                    } catch (IOException e) {
+                        JOptionPane.showMessageDialog(null, String.format("Path %s is expected to be a mod jar, but it is a directory! Please check what's inside manually and move it. This pack cannot continue without that directory removed!", location.toString()));
+                        throw new RuntimeException(e);
+                    }
+                } else {
+                    // TODO implement checksum if a big crowd starts to complain about partially downloaded mod jars
+                    LOGGER.debug("Dependency {} found locally", dep.path);
+                    iter.remove();
+                }
+            }
+        }
+    }
+
+    private void download(Dependency dep) throws IOException {
+        final Path downloadTemp = new File(mcLocation, ".__gtnh_download_temp__").toPath();
+        LOGGER.info("Downloading {} to {}", dep.url, dep.path);
+        try (FileChannel fc = FileChannel.open(downloadTemp, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+             ReadableByteChannel net = Channels.newChannel(new URL(dep.url).openStream())) {
+            fc.transferFrom(net, 0, Long.MAX_VALUE);
+        }
+        final Path target = new File(mcLocation, dep.path).toPath();
+        final Path dir = target.getParent();
+        if (!Files.exists(dir)) {
+            Files.createDirectories(dir);
+        }
+        Files.move(downloadTemp, target);
+        dialog.progress();
+    }
+}

--- a/src/main/java/com/dreammaster/coremod/DownloadProgressDialog.java
+++ b/src/main/java/com/dreammaster/coremod/DownloadProgressDialog.java
@@ -1,0 +1,64 @@
+package com.dreammaster.coremod;
+
+import java.awt.*;
+import java.awt.event.WindowEvent;
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+
+class DownloadProgressDialog extends JDialog {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 6041491111144915139L;
+    public static final String WINDOW_TITLE = "GregTech: New Horizon";
+    private Thread netThread;
+    private JProgressBar progressBar;
+
+    public void setJobCount(int max) {
+        progressBar.setMaximum(max);
+    }
+
+    public void progress() {
+        progressBar.setValue(progressBar.getValue() + 1);
+    }
+
+    /**
+     * Create the dialog.
+     */
+    public DownloadProgressDialog() {
+        setTitle(WINDOW_TITLE);
+        setBounds(100, 100, 450, 172);
+        getContentPane().setLayout(new BorderLayout());
+        JPanel contentPanel = new JPanel();
+        contentPanel.setBorder(new EmptyBorder(15, 15, 15, 15));
+        getContentPane().add(contentPanel, BorderLayout.CENTER);
+        contentPanel.setLayout(new BorderLayout(0, 0));
+        {
+            JLabel lblNewLabel = new JLabel("Downloading additional files");
+            lblNewLabel.setFont(lblNewLabel.getFont().deriveFont(24.0f));
+            lblNewLabel.setHorizontalAlignment(SwingConstants.CENTER);
+            contentPanel.add(lblNewLabel, BorderLayout.NORTH);
+        }
+        {
+            JPanel buttonPane = new JPanel();
+            contentPanel.add(buttonPane, BorderLayout.SOUTH);
+            buttonPane.setLayout(new FlowLayout(FlowLayout.CENTER));
+            {
+                JButton cancelButton = new JButton("Cancel");
+                cancelButton.addActionListener(e -> DownloadProgressDialog.this.dispatchEvent(new WindowEvent(DownloadProgressDialog.this, WindowEvent.WINDOW_CLOSING)));
+                buttonPane.add(cancelButton);
+            }
+        }
+        {
+            JPanel panel = new JPanel();
+            contentPanel.add(panel, BorderLayout.CENTER);
+            panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+            {
+                progressBar = new JProgressBar();
+                progressBar.setStringPainted(true);
+                panel.add(progressBar);
+            }
+        }
+    }
+}

--- a/src/main/java/com/dreammaster/coremod/DreamCoreMod.java
+++ b/src/main/java/com/dreammaster/coremod/DreamCoreMod.java
@@ -1,0 +1,33 @@
+package com.dreammaster.coremod;
+
+import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
+
+import java.util.Map;
+
+@IFMLLoadingPlugin.TransformerExclusions("com.dreammaster.coremod")
+public class DreamCoreMod implements IFMLLoadingPlugin {
+    @Override
+    public String[] getASMTransformerClass() {
+        return new String[0];
+    }
+
+    @Override
+    public String getModContainerClass() {
+        return null;
+    }
+
+    @Override
+    public String getSetupClass() {
+        return "com.dreammaster.coremod.DepLoader";
+    }
+
+    @Override
+    public void injectData(Map<String, Object> data) {
+
+    }
+
+    @Override
+    public String getAccessTransformerClass() {
+        return null;
+    }
+}


### PR DESCRIPTION
1. Load stuff to download from config/dependencies.json. Format is as below.
```json
[
    {
        "path": "mods/AngerMod-1.7.10-0.6.jar",
        "url": "http://downloads.gtnewhorizons.com/Mods_for_Twitch/AngerMod-1.7.10-0.6.jar"
    },
    {
        "path": "mods/1.7.10/Baubles-1.7.10-1.0.1.12.jar",
        "url": "http://downloads.gtnewhorizons.com/Mods_for_Twitch/Baubles-1.7.10-1.0.1.12.jar"
    }
]
```
2. Do nothing if
    1. dependencies.json is not present
    2. dependencies.json is empty
    3. all dependencies specified are present

3. If a previous download fails half way, any files downloaded successfully will not be downloaded again, but the one that failed will have to restart from scratch.

4. Destination directories will be automatically created if it is not present

5. Destination directories are relative to .minecraft directory, e.g. to place stuff in mods folder, you put `mods/MyMod-1.0.jar` into `path`.

6. Make sure dependencies.json is a valid JSON file. Try an online JSON validator if you are not sure about that.
