### PR TITLE
Reuse warding focus when crafting warded glass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ dependencies {
     }
 
     compile "com.enderio.core:EnderCore:${config.minecraft.version}-${config.endercore.version}:dev"
+    compile "thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev"
 
     compile fileTree(dir: 'libs', include: '*.jar')
 }

--- a/src/main/java/com/dreammaster/config/CoreModConfig.java
+++ b/src/main/java/com/dreammaster/config/CoreModConfig.java
@@ -31,6 +31,7 @@ public class CoreModConfig extends ConfigManager
 
   public boolean AvaritiaFixEnabled;
   public boolean MinetweakerFurnaceFixEnabled;
+  public boolean ReuseWardFocusFixEnabled;
   public String[] SkullFireSwordEntityTargets;
   public String[] BlacklistedTileEntiyClassNames;
 
@@ -52,6 +53,7 @@ public class CoreModConfig extends ConfigManager
 
     AvaritiaFixEnabled = false;
     MinetweakerFurnaceFixEnabled = true;
+    ReuseWardFocusFixEnabled = true;
     PotionTimer = 100;
 
     BlacklistedTileEntiyClassNames = new String[] { "com.rwtema.extrautils.tileentity.enderquarry.TileEntityEnderQuarry" };
@@ -75,6 +77,7 @@ public class CoreModConfig extends ConfigManager
 
     AvaritiaFixEnabled = _mainConfig.getBoolean( "AvaritiaFixEnabled", "ModFixes", AvaritiaFixEnabled, "Set to true to enable the modfix for Avaritia SkullFireSword" );
     MinetweakerFurnaceFixEnabled = _mainConfig.getBoolean( "MinetweakerFurnaceFixEnabled", "ModFixes", MinetweakerFurnaceFixEnabled, "Set to true to allow Minetweaker to override the vanilla furnace fuel handler, allowing the burn value of WOOD material items to be changed." );
+    ReuseWardFocusFixEnabled = _mainConfig.getBoolean( "ReuseWardFocusFixEnabled", "ModFixes", ReuseWardFocusFixEnabled, "Set to true to not consume the warding wand focus when crafting warded glass." );
     SkullFireSwordEntityTargets = _mainConfig.getStringList( "Avaritia_SkullFireSwordEntityTargets", "ModFixes.Avaritia", SkullFireSwordEntityTargets, "The Canonical Class-Name of the Entity" );
     BlacklistedTileEntiyClassNames = _mainConfig.getStringList( "BlacklistedTileEntiyClassNames", "Modules.Worldaccelerator", BlacklistedTileEntiyClassNames, "The Canonical Class-Names of TileEntities that should be ignored by the WorldAccelerator" );
     OilFixConfig = new OilGeneratorFix.OilConfig( _mainConfig );

--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -27,6 +27,7 @@ import com.dreammaster.modfixes.ModFixesMaster;
 import com.dreammaster.modfixes.avaritia.SkullFireSwordDropFix;
 import com.dreammaster.modfixes.minetweaker.MinetweakerFurnaceFix;
 import com.dreammaster.modfixes.oilgen.OilGeneratorFix;
+import com.dreammaster.modfixes.thaumcraft.ReuseWardFocusFix;
 import com.dreammaster.modhazardousitems.HazardousItemsHandler;
 import com.dreammaster.network.CoreModDispatcher;
 import com.dreammaster.oredict.OreDictHandler;
@@ -444,6 +445,9 @@ public class MainRegistry
         }
         if (CoreConfig.MinetweakerFurnaceFixEnabled) {
             ModFixesMaster.registerModFix(new MinetweakerFurnaceFix());
+        }
+        if (CoreConfig.ReuseWardFocusFixEnabled) {
+            ModFixesMaster.registerModFix(new ReuseWardFocusFix());
         }
 
     }

--- a/src/main/java/com/dreammaster/modfixes/thaumcraft/ReuseWardFocusFix.java
+++ b/src/main/java/com/dreammaster/modfixes/thaumcraft/ReuseWardFocusFix.java
@@ -1,0 +1,57 @@
+package com.dreammaster.modfixes.thaumcraft;
+
+import com.dreammaster.modfixes.ModFixBase;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import thaumcraft.common.tiles.TileArcaneWorkbench;
+
+public class ReuseWardFocusFix extends ModFixBase {
+    private ItemStack wardedGlass, focusWard;
+
+    public ReuseWardFocusFix() {
+        super("ReuseWardFocusFix");
+    }
+
+    @Override
+    public boolean needsForgeEventBus() {
+        return true;
+    }
+
+    @Override
+    public boolean needsFMLEventBus() {
+        return true;
+    }
+
+    @Override
+    public boolean getIsActive() {
+        return wardedGlass != null && focusWard != null;
+    }
+
+    @Override
+    public boolean init() {
+        Block wardedGlassBlock = GameRegistry.findBlock("Thaumcraft", "blockCosmeticOpaque");
+        if (wardedGlassBlock == null)
+            return false;
+        wardedGlass = new ItemStack(wardedGlassBlock, 1, 2);
+        return (focusWard = GameRegistry.findItemStack("Thaumcraft", "FocusWarding", 2)) != null;
+    }
+
+    @SubscribeEvent
+    public void onItemCrafted(PlayerEvent.ItemCraftedEvent e) {
+        if (getIsActive()) {
+            if (e.craftMatrix instanceof TileArcaneWorkbench && wardedGlass.isItemEqual(e.crafting)) {
+                for (int i = 0; i < 9; i++) {
+                    if (focusWard.isItemEqual(e.craftMatrix.getStackInSlot(i))) {
+                        // just a copy is enough. the max stack size is 1 and we got a stack with size 2
+                        // later TC code will decrease the stack size back to one
+                        // therefore setting it to this stack will be effectively the same as not consuming
+                        ((TileArcaneWorkbench) e.craftMatrix).setInventorySlotContentsSoftly(i, focusWard.copy());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/dreammaster/modfixes/thaumcraft/ReuseWardFocusFix.java
+++ b/src/main/java/com/dreammaster/modfixes/thaumcraft/ReuseWardFocusFix.java
@@ -17,7 +17,7 @@ public class ReuseWardFocusFix extends ModFixBase {
 
     @Override
     public boolean needsForgeEventBus() {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Support for GTNewHorizons/GT-New-Horizons-Modpack#6846

This is a fix targeting a specific recipe. It can be expanded to allows ingredient reusing in any arcane recipes, but for now let's keep it simple.