### PR TITLE
Add helper to create pyrolyse oven recipes for logWood

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft.version=1.7.10
 forge.version=10.13.4.1614
-coremod.version=1.7.10-1.8.01
+coremod.version=1.7.10-1.8.02
 
 
 yamcore.version=0.5.78

--- a/src/main/java/com/dreammaster/bartworksHandler/PyrolyseOvenLoader.java
+++ b/src/main/java/com/dreammaster/bartworksHandler/PyrolyseOvenLoader.java
@@ -1,0 +1,24 @@
+package com.dreammaster.bartworksHandler;
+
+import gregtech.loaders.oreprocessing.ProcessingLog;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+/**
+ * Helper class to create pyrolyse oven recipes for all woods.
+ * <p>
+ * This needs to be run post-GT initialization, so that all woods have had a
+ * chance to get registered in the ore dictionary.
+ *
+ * @see <a href="https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8047">
+ *     Discussion on GitHub</a>
+ */
+public class PyrolyseOvenLoader {
+    private PyrolyseOvenLoader() {}
+
+    public static void registerRecipes() {
+        for (ItemStack log : OreDictionary.getOres("logWood")) {
+            ProcessingLog.addPyrolyeOvenRecipes(log);
+        }
+    }
+}

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -1964,20 +1964,6 @@ public class GT_MachineRecipeLoader implements Runnable{
         GT_Values.RA.addVacuumFreezerRecipe(GT_OreDictUnificator.get(OrePrefixes.ingotHot, Materials.Titanium, 1L), GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Titanium, 1L), 144, 480);
         GT_Values.RA.addVacuumFreezerRecipe(CustomItemList.HotNetherrackBrick.get(1L), CustomItemList.InfernalBrick.get(1L), 200, 120);
 
-        if (Loader.isModLoaded("ExtraTrees")) {
-        	GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), GT_Values.NF,                    1,  Materials.Charcoal.getGems(20), Materials.Creosote.getFluid(4000),         640, 64);
-            GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), Materials.Nitrogen.getGas(1000), 2,  Materials.Charcoal.getGems(20), Materials.Creosote.getFluid(4000),         320, 96);
-            GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), GT_Values.NF,                    3,  Materials.Ash.getDust(4),       Materials.OilHeavy.getFluid(200),          320, 192);
-            GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), GT_Values.NF,                    3,  Materials.Charcoal.getGems(20), Materials.CharcoalByproducts.getGas(4000), 640, 64);
-            GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), Materials.Nitrogen.getGas(1000), 4,  Materials.Charcoal.getGems(20), Materials.CharcoalByproducts.getGas(4000), 320, 96);
-            GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), GT_Values.NF,                    5,  Materials.Charcoal.getGems(20), Materials.WoodGas.getGas(1500),            640, 64);
-            GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), Materials.Nitrogen.getGas(1000), 6,  Materials.Charcoal.getGems(20), Materials.WoodGas.getGas(1500),            320, 96);
-            GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), GT_Values.NF,                    7,  Materials.Charcoal.getGems(20), Materials.WoodVinegar.getFluid(3000),      640, 64);
-            GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), Materials.Nitrogen.getGas(1000), 8,  Materials.Charcoal.getGems(20), Materials.WoodVinegar.getFluid(3000),      320, 96);
-            GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), GT_Values.NF,                    9,  Materials.Charcoal.getGems(20), Materials.WoodTar.getFluid(1500),          640, 64);
-            GT_Values.RA.addPyrolyseRecipe(GT_ModHandler.getModItem("ExtraTrees", "log", 16L, GT_Values.W), Materials.Nitrogen.getGas(1000), 10, Materials.Charcoal.getGems(20), Materials.WoodTar.getFluid(1500),          320, 96);
-        }
-
         GT_Values.RA.addLatheRecipe(new ItemStack(Blocks.wooden_slab, 1, 0), new ItemStack(Items.bowl, 1), GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1), 50, 8);
         GT_Values.RA.addLatheRecipe(new ItemStack(Blocks.wooden_slab, 1, 1), new ItemStack(Items.bowl, 1), GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1), 50, 8);
         GT_Values.RA.addLatheRecipe(new ItemStack(Blocks.wooden_slab, 1, 2), new ItemStack(Items.bowl, 1), GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1), 50, 8);

--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -56,6 +56,7 @@ import gregtech.GT_Mod;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.Materials;
 import gregtech.api.util.GT_LanguageManager;
+import com.dreammaster.bartworksHandler.PyrolyseOvenLoader;
 import com.dreammaster.bartworksHandler.VoidMinerLoader;
 import gregtech.common.items.GT_MetaGenerated_Item_01;
 import net.minecraft.block.Block;
@@ -317,6 +318,11 @@ public class MainRegistry
         // Register additional OreDictionary Names
         if(CoreConfig.OreDictItems_Enabled)
         OreDictHandler.register_all();
+
+        GregTech_API.sAfterGTPostload.add(() -> {
+            Logger.debug("Add Runnable to GT to create pyrolyse oven logWood recipes");
+            PyrolyseOvenLoader.registerRecipes();
+        });
 
         // Register Dimensions in GalacticGregGT5
         if (Loader.isModLoaded("galacticgreg"))


### PR DESCRIPTION
Add helper class to create pyrolyse oven recipes for `logWood`. Where this class is currently registered to run (GT post-load) works; I know that GT++ postinit will also work. Earlier than that, some woods may not have been registered in the ore dictionary yet. Let me know if there is a better place to put this code.

I've tested that with this change, all `logWood` woods work in the pyrolyse oven. This will allow us to delete the BW and GT dynamic pyrolyse recipe generation code which is causing lag.

I deleted the `ExtraTrees` pyrolyse recipes in `GT_MachineRecipeLoader` because they are just a copy of the method the new code is calling:
https://github.com/GTNewHorizons/GT5-Unofficial/blob/experimental/src/main/java/gregtech/loaders/oreprocessing/ProcessingLog.java#L97-L107
so that code is now redundant.
 * BW code removed in https://github.com/GTNewHorizons/bartworks/pull/19
 * GT code removed in https://github.com/GTNewHorizons/GT5-Unofficial/pull/608
 * See: GTNewHorizons/GT-New-Horizons-Modpack#8047