### PR TITLE
Move Ztones from script to coremod

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -295,5 +295,12 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
             GT_ModHandler.addRollingMachineRecipe(GT_ModHandler.getModItem(aTextRailcraft, "post.metal.purple", 64L), new Object[]{aTextIron1, aTextIron2, aTextIron1, 'X', OrePrefixes.stick.get(Materials.Titanium).toString()});
             GT_ModHandler.addRollingMachineRecipe(GT_ModHandler.getModItem(aTextRailcraft, "post.metal.black", 64L), new Object[]{aTextIron1, aTextIron2, aTextIron1, 'X', OrePrefixes.stick.get(Materials.Tungsten).toString()});
         }
+        
+        if (Loader.isModLoaded("Ztones")) {
+        	GT_ModHandler.addCraftingRecipe(GT_ModHandler.getModItem("Ztones", "stoneTile", 8L, 0), bits, new Object[]{"SSS", "STS", "SSS", 'S', new ItemStack(Blocks.stone_slab, 1), 'T', new ItemStack(Blocks.stone, 1)});
+        	GT_ModHandler.addCraftingRecipe(GT_ModHandler.getModItem("Ztones", "auroraBlock", 8L, 0), bits, new Object[]{"GGG", "GDG", "GGG", 'G', new ItemStack(Blocks.glass, 1), 'D', new ItemStack(Items.dye, 1, GT_Values.W)});        	
+        	GT_ModHandler.addCraftingRecipe(GT_ModHandler.getModItem("Ztones", "minicharcoal", 7L, 0), bits, new Object[]{"T  ", "C  ", "   ", 'T', ToolDictNames.craftingToolSoftHammer, 'C', OrePrefixes.dust.get(Materials.Charcoal)});
+        	GT_ModHandler.addCraftingRecipe(GT_ModHandler.getModItem("Ztones", "minicoal", 7L, 0), bits, new Object[]{"T  ", "C  ", "   ", 'T', ToolDictNames.craftingToolSoftHammer, 'C', OrePrefixes.dust.get(Materials.Coal)});
+        }
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -2072,6 +2072,50 @@ public class GT_MachineRecipeLoader implements Runnable {
             GT_Values.RA.addPulveriserRecipe(GT_ModHandler.getModItem("GalaxySpace", "tcetieblocks", 1L, 2), new ItemStack[]{CustomItemList.TCetiEStoneDust.get(1L), GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Lapis, 1), GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Apatite, 1), GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Bedrockium, 1)}, new int[]{10000, 2500, 2000, 1500}, 400, 4096);
         }
 
+        if (Loader.isModLoaded("Ztones")) {
+        	GT_Values.RA.addAssemblerRecipe(new ItemStack[]{new ItemStack(Blocks.stone_slab, 4), new ItemStack(Blocks.stone, 1), GT_Utility.getIntegratedCircuit(1)}, GT_Values.NF, GT_ModHandler.getModItem("Ztones", "stoneTile", 8L, 0), 160, 4);
+        	GT_Values.RA.addAssemblerRecipe(new ItemStack[]{new ItemStack(Blocks.glass, 4), new ItemStack(Items.dye, 1, GT_Values.W), GT_Utility.getIntegratedCircuit(1)}, GT_Values.NF, GT_ModHandler.getModItem("Ztones", "auroraBlock", 8L, 0), 160, 4);
+        	GT_Values.RA.addAssemblerRecipe(new ItemStack[]{new ItemStack(Blocks.sand, 4, GT_Values.W), new ItemStack(Blocks.dirt, 4, GT_Values.W), GT_Utility.getIntegratedCircuit(1)}, Materials.SeedOil.getFluid(5L), GT_ModHandler.getModItem("Ztones", "cleanDirt", 8L, 0), 160, 4);
+        	GT_Values.RA.addAssemblerRecipe(new ItemStack[]{new ItemStack(Blocks.stone_pressure_plate, 0), GT_Utility.getIntegratedCircuit(1)}, Materials.Blaze.getFluid(8L), GT_ModHandler.getModItem("Ztones", "booster", 8L, 0), 100, 30);
+        	GT_Values.RA.addForgeHammerRecipe(new ItemStack(Items.coal, 1, 0), GT_ModHandler.getModItem("Ztones", "minicoal", 9L, 0), 50, 8);
+        	GT_Values.RA.addForgeHammerRecipe(new ItemStack(Items.coal, 1, 1), GT_ModHandler.getModItem("Ztones", "minicharcoal", 9L, 0), 50, 8);
+
+        	if (Loader.isModLoaded("ProjRed|Core")) {
+        		GT_Values.RA.addCutterRecipe(GT_ModHandler.getModItem("ProjRed|Illumination", "projectred.illumination.lamp", 1L, 16), Materials.Water.getFluid(100L), GT_ModHandler.getModItem("Ztones", "lampf", 4L, 0), GT_Values.NI, 200, 4);
+            	GT_Values.RA.addCutterRecipe(GT_ModHandler.getModItem("ProjRed|Illumination", "projectred.illumination.lamp", 1L, 16), GT_ModHandler.getDistilledWater(75L), GT_ModHandler.getModItem("Ztones", "lampf", 4L, 0), GT_Values.NI, 200, 4);
+            	GT_Values.RA.addCutterRecipe(GT_ModHandler.getModItem("ProjRed|Illumination", "projectred.illumination.lamp", 1L, 16), Materials.Lubricant.getFluid(25L), GT_ModHandler.getModItem("Ztones", "lampf", 4L, 0), GT_Values.NI, 100, 4);
+            	
+            	GT_Values.RA.addCutterRecipe(GT_ModHandler.getModItem("ProjRed|Illumination", "projectred.illumination.lamp", 1L, 24), Materials.Water.getFluid(100L), GT_ModHandler.getModItem("Ztones", "lampt", 4L, 0), GT_Values.NI, 200, 4);
+            	GT_Values.RA.addCutterRecipe(GT_ModHandler.getModItem("ProjRed|Illumination", "projectred.illumination.lamp", 1L, 24), GT_ModHandler.getDistilledWater(75L), GT_ModHandler.getModItem("Ztones", "lampt", 4L, 0), GT_Values.NI, 200, 4);
+            	GT_Values.RA.addCutterRecipe(GT_ModHandler.getModItem("ProjRed|Illumination", "projectred.illumination.lamp", 1L, 24), Materials.Lubricant.getFluid(25L), GT_ModHandler.getModItem("Ztones", "lampt", 4L, 0), GT_Values.NI, 100, 4);
+            	
+            	GT_Values.RA.addCutterRecipe(GT_ModHandler.getModItem("ProjRed|Illumination", "projectred.illumination.lamp", 1L, 23), Materials.Water.getFluid(100L), GT_ModHandler.getModItem("Ztones", "lampb", 4L, 0), GT_Values.NI, 200, 4);
+            	GT_Values.RA.addCutterRecipe(GT_ModHandler.getModItem("ProjRed|Illumination", "projectred.illumination.lamp", 1L, 23), GT_ModHandler.getDistilledWater(75L), GT_ModHandler.getModItem("Ztones", "lampb", 4L, 0), GT_Values.NI, 200, 4);
+            	GT_Values.RA.addCutterRecipe(GT_ModHandler.getModItem("ProjRed|Illumination", "projectred.illumination.lamp", 1L, 23), Materials.Lubricant.getFluid(25L), GT_ModHandler.getModItem("Ztones", "lampb", 4L, 0), GT_Values.NI, 100, 4);
+        	}
+        	
+        	//This replaces the type of block, and the item used to make it for the 0-15 meta, and the 21+12 different versions of ztones blocks (glaxx is separate)
+        	//Normal crafting recipes are not affected, so they might be crafted differently
+    		String[] blockName = {"agon", "azur", "bitt", "cray", "fort", "iszm", "jelt", "korp", "kryp", "lair", "lave", "mint", "myst", "reds", "reed", "roen", "sols", "sync", "tank", "vect", "vena"};
+        	String[] zblockName = {"zane", "zech", "zest", "zeta", "zion", "zkul", "zoea", "zome", "zone", "zorg", "ztyl", "zyth"};
+        	ItemStack[] item = {new ItemStack(Items.dye, 1, 7), new ItemStack(Items.dye, 1, 4), new ItemStack(Blocks.wool, 1, 0), new ItemStack(Blocks.hardened_clay, 1, 0), new ItemStack(Items.dye, 1, 3), new ItemStack(Items.dye, 1, 8), new ItemStack(Items.gold_ingot, 1, 0), new ItemStack(Blocks.obsidian, 1, 0), new ItemStack(Blocks.soul_sand, 1, 0),
+        			new ItemStack(Blocks.netherrack, 1, 0), new ItemStack(Blocks.ice, 1, 0), new ItemStack(Items.slime_ball, 1, 0), new ItemStack(Blocks.brown_mushroom, 1, 0), new ItemStack(Items.redstone, 1, 0), new ItemStack(Items.reeds, 1, 0), new ItemStack(Blocks.sandstone, 1, 0), new ItemStack(Items.blaze_powder, 1, 0), new ItemStack(Items.emerald, 1, 0),
+        			new ItemStack(Items.iron_ingot, 1, 0), new ItemStack(Items.ghast_tear, 1, 0), new ItemStack(Items.ender_pearl, 1, 0)};
+        	ItemStack[] zitem = {new ItemStack(Items.dye, 1, 0), new ItemStack(Items.dye, 1, 1), new ItemStack(Items.dye, 1, 2), new ItemStack(Items.dye, 1, 5), new ItemStack(Items.dye, 1, 6), new ItemStack(Items.dye, 1, 9), new ItemStack(Items.dye, 1, 10), new ItemStack(Items.dye, 1, 11), new ItemStack(Items.dye, 1, 12), 
+        			new ItemStack(Items.dye, 1, 13), new ItemStack(Items.dye, 1, 14), new ItemStack(Items.dye, 1, 15)};        	
+        	
+        	for (int j = 0; j < 21; j++)
+        		for (int i = 0; i < 16; i++)
+        			GT_Values.RA.addAssemblerRecipe(new ItemStack[]{GT_ModHandler.getModItem("Ztones", "stoneTile", 4L, 0), item[j], GT_Utility.getIntegratedCircuit(i)}, GT_Values.NF, GT_ModHandler.getModItem("Ztones", "tile." + blockName[j] + "Block", 8L, i), 200, 16);
+        	
+        	for (int j = 0; j < 12; j++)
+        		for (int i = 0; i < 16; i++)
+        			GT_Values.RA.addAssemblerRecipe(new ItemStack[]{GT_ModHandler.getModItem("Ztones", "auroraBlock", 4L, 0), zitem[j], GT_Utility.getIntegratedCircuit(i)}, GT_Values.NF, GT_ModHandler.getModItem("Ztones", "tile." + zblockName[j] + "Block", 8L, i), 200, 16);
+        	
+        	for (int i = 0; i < 16; i++)
+        		GT_Values.RA.addAssemblerRecipe(new ItemStack[]{GT_ModHandler.getModItem("Ztones", "auroraBlock", 4L, 0), new ItemStack(Blocks.glass, 1, 0), GT_Utility.getIntegratedCircuit(i)}, GT_Values.NF, GT_ModHandler.getModItem("Ztones", "tile.glaxx", 8L, i), 200, 16);
+    	}
+        
         GT_Values.RA.addPulveriserRecipe(GT_ModHandler.getModItem("IC2", "itemFuelPlantBall", 2L, 0), new ItemStack[]{CustomItemList.MaceratedPlantmass.get(1L), CustomItemList.MaceratedPlantmass.get(1L), CustomItemList.MaceratedPlantmass.get(1L), CustomItemList.MaceratedPlantmass.get(1L)}, new int[]{10000, 10000, 5000, 2500}, 200, 30);
         GT_Values.RA.addPulveriserRecipe(new ItemStack(Items.flint, 2, 0), new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Flint, 1L)}, null, 800, 2);
         GT_Values.RA.addPulveriserRecipe(CustomItemList.CokeOvenBrick.get(1L), new ItemStack[]{CustomItemList.CokeOvenBrickDust.get(1L), CustomItemList.CokeOvenBrickDust.get(1L), CustomItemList.CokeOvenBrickDust.get(1L), CustomItemList.CokeOvenBrickDust.get(1L)}, new int[]{10000, 2500, 750, 500}, 200, 30);

--- a/src/main/java/com/dreammaster/gthandler/GT_Recipe_Remover.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Recipe_Remover.java
@@ -7,179 +7,191 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
 public class GT_Recipe_Remover implements Runnable {
-	private static final String aTextRailcraft = "Railcraft";
-    private static final String aTextMachineBeta = "machine.beta";
+	private static final String modNameBG2 = "battlegear2";
+	private static final String modNameFor = "Forestry";
+	private static final String modNameIC2 = "IC2";
+	private static final String modNameOS = "opensecurity";
+	private static final String modNameRC = "Railcraft";
+	private static final String modNameZt = "Ztones";
+	private static final String aTextMachineBeta = "machine.beta";
     private static final String aTextMachineAlpha = "machine.alpha";
-    private static final String aTextIron1 = "X X";
-    private static final String aTextIron2 = "XXX";
-    private static final String aTextForestry = "Forestry";
 	
 	public void run() {
-
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("AdvancedSolarPanel", "BlockAdvSolarPanel", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("AdvancedSolarPanel", "BlockAdvSolarPanel", 1L, 1), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("AdvancedSolarPanel", "BlockAdvSolarPanel", 1L, 2), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("AdvancedSolarPanel", "BlockAdvSolarPanel", 1L, 3), true, false, true);
-
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "quiver", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "shield.wood", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "shield.hide", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "shield.iron", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "shield.gold", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "shield.diamond", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "dagger.wood", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "dagger.stone", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "dagger.iron", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "dagger.gold", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "dagger.diamond", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "spear.wood", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "spear.stone", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "spear.iron", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "spear.gold", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "spear.diamond", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "waraxe.wood", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "waraxe.stone", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "waraxe.iron", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "waraxe.gold", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "waraxe.diamond", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "mace.wood", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "mace.stone", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "mace.iron", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "mace.gold", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "mace.diamond", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("battlegear2", "chain", 1L, 0), true, false, true);
-        //railcraft
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 1), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 2), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 3), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 4), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 5), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 6), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 7), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 8), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 9), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 10), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 11), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 12), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 13), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 14), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineBeta, 1L, 15), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 1), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 2), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 3), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 5), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 6), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 8), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 9), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 10), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 11), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 12), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 13), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 14), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, aTextMachineAlpha, 1L, 15), true, false, true);
-
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "tool.crowbar", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "tool.crowbar.reinforced", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "tool.whistle.tuner", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "part.turbine.blade", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "part.turbine.disk", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "part.turbine.rotor", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "borehead.iron", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "borehead.steel", 1L, 0),true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "borehead.diamond", 1L, 0),true, false, true);
-
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "cart.loco.steam.solid", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "cart.loco.electric", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "cart.bore", 1L, 0), true, false, true);
-
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "part.circuit", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "part.circuit", 1L, 1), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(aTextRailcraft, "part.circuit", 1L, 2), true, false, true);
-        //forestry
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "stamps", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "stamps", 1L, 1), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "stamps", 1L, 2), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "stamps", 1L, 3), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "stamps", 1L, 4), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "stamps", 1L, 5), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "stamps", 1L, 6), true, false, true);
-
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "engine", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "engine", 1L, 1), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "engine", 1L, 2), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Forestry", "engine", 1L, 4), true, false, true);
-        //Steve Carts
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("StevesCarts", "ModuleComponents", 1L, 9), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("StevesCarts", "ModuleComponents", 1L, 16), true, false, true);
-        //Vanilla
-        GT_ModHandler.removeRecipeByOutput(new ItemStack(Blocks.iron_bars, 1, 32767), true, false, true);
-        //Natural Compass
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("naturescompass", "NaturesCompass", 1L, 0), true, false, true);
-        //IC2
-        GT_ModHandler.removeRecipeByOutput(ItemList.IC2_Energium_Dust.get(1L));
-        GT_ModHandler.removeRecipeByOutput(ItemList.IC2_LapotronCrystal.get(1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorNanoBoots", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorNanoChestplate", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorNanoHelmet", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorNanoLegs", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorQuantumBoots", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorQuantumChestplate", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorQuantumHelmet", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorQuantumLegs", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorBatpack", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorAdvBatpack", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorEnergypack", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemAdvBat", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemNightvisionGoggles", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorJetpackElectric", 1L));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemArmorJetpack", 1L, GT_Values.W));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemBatChargeRE", 1L, GT_Values.W));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemBatChargeAdv", 1L, GT_Values.W));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemBatChargeCrystal", 1L, GT_Values.W));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemBatChargeLamaCrystal", 1L, GT_Values.W));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemTreetapElectric",1,GT_Values.W));
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("IC2","itemToolHoe",1,GT_Values.W));
-        //Open Printers
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("openprinter", "openprinter.printer", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("openprinter", "openprinter.shredder", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("openprinter", "openprinter.printerInkBlack", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("openprinter", "openprinter.printerInkColor", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("openprinter", "openprinter.folder", 1L, 0), true, false, true);
-        //Open Security
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "magreader", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "rfidreader", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "rfidwriter", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "alarm", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "entitydetector", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "doorcontroller", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.DataBlock", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.SwitchableHub", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.BlockKVM", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "energyTurretBlock", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "keypadLock", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "biometricScanner", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.magCard", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.rfidCard", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.rfidReaderCard", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.secureNetworkCard", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.securityDoor", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.securityDoorPrivate", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.damageUpgrade", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.cooldownUpgrade", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.energyUpgrade", 1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("opensecurity", "opensecurity.movementUpgrade", 1L, 0), true, false, true);
-        //Steve Carts
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("StevesCarts","ModuleComponents",1L, 18),true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("StevesCarts","ModuleComponents",1L, 19),true, false, true);
-        //Translocator
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("Translocator","diamondNugget",2L, 0), true, false, true);
+		//Vanilla
+        GT_ModHandler.removeRecipeByOutputDelayed(new ItemStack(Blocks.iron_bars, 1, 32767), true, false, true);
+		//ASP
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("AdvancedSolarPanel", "BlockAdvSolarPanel", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("AdvancedSolarPanel", "BlockAdvSolarPanel", 1L, 1), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("AdvancedSolarPanel", "BlockAdvSolarPanel", 1L, 2), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("AdvancedSolarPanel", "BlockAdvSolarPanel", 1L, 3), true, false, true);
+        //BG2
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "quiver", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "shield.wood", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "shield.hide", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "shield.iron", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "shield.gold", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "shield.diamond", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "dagger.wood", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "dagger.stone", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "dagger.iron", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "dagger.gold", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "dagger.diamond", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "spear.wood", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "spear.stone", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "spear.iron", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "spear.gold", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "spear.diamond", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "waraxe.wood", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "waraxe.stone", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "waraxe.iron", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "waraxe.gold", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "waraxe.diamond", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "mace.wood", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "mace.stone", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "mace.iron", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "mace.gold", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "mace.diamond", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameBG2, "chain", 1L, 0), true, false, true);
         //Draconic Evolution
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("DraconicEvolution","chaosShard",1L, 0), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("DraconicEvolution","chaosFragment",1L, 2), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("DraconicEvolution","chaosFragment",1L, 1), true, false, true);
-        GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem("DraconicEvolution","chaosFragment",1L, 0), true, false, true);
-    }
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("DraconicEvolution","chaosShard", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("DraconicEvolution","chaosFragment", 1L, 2), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("DraconicEvolution","chaosFragment", 1L, 1), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("DraconicEvolution","chaosFragment", 1L, 0), true, false, true);
+        //Forestry
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "stamps", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "stamps", 1L, 1), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "stamps", 1L, 2), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "stamps", 1L, 3), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "stamps", 1L, 4), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "stamps", 1L, 5), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "stamps", 1L, 6), true, false, true);
 
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "engine", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "engine", 1L, 1), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "engine", 1L, 2), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameFor, "engine", 1L, 4), true, false, true); 
+        //IC2
+        GT_ModHandler.removeRecipeByOutputDelayed(ItemList.IC2_Energium_Dust.get(1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(ItemList.IC2_LapotronCrystal.get(1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorNanoBoots", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorNanoChestplate", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorNanoHelmet", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorNanoLegs", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorQuantumBoots", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorQuantumChestplate", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorQuantumHelmet", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorQuantumLegs", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorBatpack", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorAdvBatpack", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorEnergypack", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemAdvBat", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemNightvisionGoggles", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorJetpackElectric", 1L));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemArmorJetpack", 1L, GT_Values.W));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemBatChargeRE", 1L, GT_Values.W));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemBatChargeAdv", 1L, GT_Values.W));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemBatChargeCrystal", 1L, GT_Values.W));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemBatChargeLamaCrystal", 1L, GT_Values.W));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemTreetapElectric",1,GT_Values.W));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameIC2,"itemToolHoe",1,GT_Values.W));
+        //Natural Compass
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("naturescompass", "NaturesCompass", 1L, 0), true, false, true);  
+        //Open Printers
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("openprinter", "openprinter.printer", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("openprinter", "openprinter.shredder", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("openprinter", "openprinter.printerInkBlack", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("openprinter", "openprinter.printerInkColor", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("openprinter", "openprinter.folder", 1L, 0), true, false, true);
+        //Open Security
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "magreader", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "rfidreader", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "rfidwriter", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "alarm", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "entitydetector", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "doorcontroller", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.DataBlock", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.SwitchableHub", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.BlockKVM", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "energyTurretBlock", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "keypadLock", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "biometricScanner", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.magCard", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.rfidCard", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.rfidReaderCard", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.secureNetworkCard", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.securityDoor", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.securityDoorPrivate", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.damageUpgrade", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.cooldownUpgrade", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.energyUpgrade", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameOS, "opensecurity.movementUpgrade", 1L, 0), true, false, true);
+        //Railcraft
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 1), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 2), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 3), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 4), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 5), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 6), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 7), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 8), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 9), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 10), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 11), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 12), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 13), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 14), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineBeta, 1L, 15), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 1), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 2), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 3), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 5), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 6), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 8), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 9), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 10), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 11), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 12), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 13), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 14), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, aTextMachineAlpha, 1L, 15), true, false, true);
+
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "tool.crowbar", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "tool.crowbar.reinforced", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "tool.whistle.tuner", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "part.turbine.blade", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "part.turbine.disk", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "part.turbine.rotor", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "borehead.iron", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "borehead.steel", 1L, 0),true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "borehead.diamond", 1L, 0),true, false, true);
+
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "cart.loco.steam.solid", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "cart.loco.electric", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "cart.bore", 1L, 0), true, false, true);
+
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "part.circuit", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "part.circuit", 1L, 1), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameRC, "part.circuit", 1L, 2), true, false, true);
+        //Steve Carts
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("StevesCarts", "ModuleComponents", 1L, 9), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("StevesCarts", "ModuleComponents", 1L, 16), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("StevesCarts","ModuleComponents", 1L, 18),true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("StevesCarts","ModuleComponents", 1L, 19),true, false, true);
+        //Translocator
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("Translocator","diamondNugget", 2L, 0), true, false, true);
+        //Ztones
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameZt, "ofanix", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeDelayed(GT_ModHandler.getModItem(modNameZt,"ofanix", 1L, 0));
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameZt, "stoneTile", 1L, 0), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameZt, "auroraBlock", 1L, 0), true, false, true);
+    	GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameZt, "minicharcoal", 1L, 0), true, false, true);
+    	GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameZt, "minicoal", 1L, 0), true, false, true);
+    	GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameZt, "cleanDirt", 1L, 0), true, false, true);
+    	GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameZt, "booster", 1L, 0), true, false, true);
+    	GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameZt, "lampf", 1L, 0), true, false, true);
+    	GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameZt, "lampt", 1L, 0), true, false, true);
+    	GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameZt, "lampb", 1L, 0), true, false, true);  
+    }
 }


### PR DESCRIPTION
Also add assembler recipes for the blocks
Also resort the RR file alphabetically and use vars for repeated strings
Also changed to delayed version for the removed recipes. All the recipes in the crafting file are buffered, so it should be ok?

This should fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7736
The ztones script file needs to be removed after merging.