### PR TITLE
add non recursive recipes for AE cells

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/CustomItemList.java
+++ b/src/main/java/com/dreammaster/gthandler/CustomItemList.java
@@ -138,7 +138,8 @@ public enum CustomItemList implements IItemContainer
 	ArtificialLeather,
 	EctoplasmaChip, EctoplasmaFragment, ArcaneShardChip, ArcaneShardFragment,
 	RuneOfPowerFragment, RuneOfAgilityFragment, RuneOfVigorFragment, RuneOfDefenseFragment, RuneOfMagicFragment, RuneOfVoidFragment,
-	NandChipBoard,
+	NandChipBoard, LogicProcessorItemGoldCore, EngineeringProcessorItemDiamondCore, EngineeringProcessorItemEmeraldCore,
+	EngineeringProcessorItemAdvEmeraldCore,
 	Display;
 
 

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Items.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Items.java
@@ -4,6 +4,7 @@ import com.dreammaster.item.ItemList;
 import gregtech.api.enums.SubTag;
 import gregtech.common.items.GT_MetaGenerated_Item_01;
 import gregtech.api.items.GT_MetaGenerated_Item_X32;
+import net.minecraft.item.Item;
 
 public class GT_Loader_Items
 {
@@ -595,6 +596,10 @@ public class GT_Loader_Items
 		CustomItemList.RuneOfMagicFragment.set(ItemList.RuneOfMagicFragment.getIS());
 		CustomItemList.RuneOfVoidFragment.set(ItemList.RuneOfVoidFragment.getIS());
 		CustomItemList.NandChipBoard.set(GT.addItem(81, "NAND Chip Array", "Chips on Board", "circuitPrimitiveArray", SubTag.NO_UNIFICATION));
+		CustomItemList.LogicProcessorItemGoldCore.set(ItemList.LogicProcessorItemGoldCore.getIS());
+		CustomItemList.EngineeringProcessorItemDiamondCore.set(ItemList.EngineeringProcessorItemDiamondCore.getIS());
+		CustomItemList.EngineeringProcessorItemEmeraldCore.set(ItemList.EngineeringProcessorItemEmeraldCore.getIS());
+		CustomItemList.EngineeringProcessorItemAdvEmeraldCore.set(ItemList.EngineeringProcessorItemAdvEmeraldCore.getIS());
 		CustomItemList.Display.set(ItemList.Display.getIS());
 
 	}

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -430,6 +430,287 @@ public class GT_MachineRecipeLoader implements Runnable {
 
             GT_Values.RA.addMixerRecipe(CustomItemList.ChargedCertusQuartzDust.get(1L), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 1L), GT_Values.NI, GT_Values.NI, GT_Utility.getIntegratedCircuit(4), Materials.Water.getFluid(500L), GT_Values.NF, GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 2L, 8), 20, 16);
             GT_Values.RA.addMixerRecipe(CustomItemList.ChargedCertusQuartzDust.get(1L), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 1L), GT_Values.NI, GT_Values.NI, GT_Utility.getIntegratedCircuit(4), GT_ModHandler.getDistilledWater(500L), GT_Values.NF, GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 2L, 8), 20, 16);
+
+            // 4k ME Storage Component
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Primitive, 16),
+                            CustomItemList.LogicProcessorItemGoldCore.get(1),
+                            ItemList.Circuit_Board_Coated_Basic.get(1)
+                    },
+                    Materials.Lead.getMolten(288),
+                    GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 36),
+                    200,
+                    30
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Primitive, 16),
+                            CustomItemList.LogicProcessorItemGoldCore.get(1),
+                            ItemList.Circuit_Board_Coated_Basic.get(1)
+                    },
+                    Materials.Tin.getMolten(144),
+                    GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 36),
+                    200,
+                    30
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Primitive, 16),
+                            CustomItemList.LogicProcessorItemGoldCore.get(1),
+                            ItemList.Circuit_Board_Coated_Basic.get(1)
+                    },
+                    Materials.SolderingAlloy.getMolten(72),
+                    GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 36),
+                    200,
+                    30
+            );
+
+            // 16k ME Storage Component
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 16),
+                            CustomItemList.LogicProcessorItemGoldCore.get(1),
+                            ItemList.Circuit_Board_Phenolic_Good.get(1)
+                    },
+                    Materials.Lead.getMolten(288),
+                    GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 37),
+                    200,
+                    120
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 16),
+                            CustomItemList.LogicProcessorItemGoldCore.get(1),
+                            ItemList.Circuit_Board_Phenolic_Good.get(1)
+                    },
+                    Materials.Tin.getMolten(144),
+                    GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 37),
+                    200,
+                    120
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 16),
+                            CustomItemList.LogicProcessorItemGoldCore.get(1),
+                            ItemList.Circuit_Board_Phenolic_Good.get(1)
+                    },
+                    Materials.SolderingAlloy.getMolten(72),
+                    GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 37),
+                    200,
+                    120
+            );
+
+            // 64k ME Storage Component
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 16),
+                            CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
+                            ItemList.Circuit_Board_Epoxy_Advanced.get(1)
+                    },
+                    Materials.Lead.getMolten(288),
+                    GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 38),
+                    200,
+                    480
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 16),
+                            CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
+                            ItemList.Circuit_Board_Epoxy_Advanced.get(1)
+                    },
+                    Materials.Tin.getMolten(144),
+                    GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 38),
+                    200,
+                    480
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 16),
+                            CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
+                            ItemList.Circuit_Board_Epoxy_Advanced.get(1)
+                    },
+                    Materials.SolderingAlloy.getMolten(72),
+                    GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 38),
+                    200,
+                    480
+            );
+        }
+        if (Loader.isModLoaded("extracells")){
+            // 256k ME Storage Component
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 16),
+                            CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
+                            ItemList.Circuit_Board_Fiberglass_Advanced.get(1)
+                    },
+                    Materials.Lead.getMolten(288),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 0),
+                    200,
+                    1920
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 16),
+                            CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
+                            ItemList.Circuit_Board_Fiberglass_Advanced.get(1)
+                    },
+                    Materials.Tin.getMolten(144),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 0),
+                    200,
+                    1920
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 16),
+                            CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
+                            ItemList.Circuit_Board_Fiberglass_Advanced.get(1)
+                    },
+                    Materials.SolderingAlloy.getMolten(72),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 0),
+                    200,
+                    1920
+            );
+
+            // 1024k ME Storage Component
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 16),
+                            CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
+                            ItemList.Circuit_Board_Multifiberglass_Elite.get(1)
+                    },
+                    Materials.Lead.getMolten(288),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 1),
+                    200,
+                    7680
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 16),
+                            CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
+                            ItemList.Circuit_Board_Multifiberglass_Elite.get(1)
+                    },
+                    Materials.Tin.getMolten(144),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 1),
+                    200,
+                    7680
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 16),
+                            CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
+                            ItemList.Circuit_Board_Multifiberglass_Elite.get(1)
+                    },
+                    Materials.SolderingAlloy.getMolten(72),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 1),
+                    200,
+                    7680
+            );
+
+            // 4096k ME Storage Component
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 16),
+                            CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
+                            ItemList.Circuit_Board_Wetware_Extreme.get(1)
+                    },
+                    Materials.Lead.getMolten(288),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 2),
+                    200,
+                    30720
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 16),
+                            CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
+                            ItemList.Circuit_Board_Wetware_Extreme.get(1)
+                    },
+                    Materials.Tin.getMolten(144),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 2),
+                    200,
+                    30720
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 16),
+                            CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
+                            ItemList.Circuit_Board_Wetware_Extreme.get(1)
+                    },
+                    Materials.SolderingAlloy.getMolten(72),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 2),
+                    200,
+                    30720
+            );
+
+            // 16384k ME Storage Component
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16),
+                            CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
+                            ItemList.Circuit_Board_Bio_Ultra.get(1)
+                    },
+                    Materials.Lead.getMolten(288),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
+                    200,
+                    491520
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16),
+                            CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
+                            ItemList.Circuit_Board_Bio_Ultra.get(1)
+                    },
+                    Materials.Tin.getMolten(144),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
+                    200,
+                    491520
+            );
+
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[]{
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16),
+                            CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
+                            ItemList.Circuit_Board_Bio_Ultra.get(1)
+                    },
+                    Materials.SolderingAlloy.getMolten(72),
+                    GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
+                    200,
+                    491520
+            );
         }
 
         GT_Values.RA.addAutoclaveRecipe(CustomItemList.LapotronDust.get(30L), Materials.EnergeticAlloy.getMolten(576L), CustomItemList.RawLapotronCrystal.get(1L), 10000, 2400, 480);

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -437,7 +437,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Primitive, 16),
                             CustomItemList.LogicProcessorItemGoldCore.get(1),
-                            ItemList.Circuit_Board_Coated_Basic.get(1)
+                            ItemList.Circuit_Board_Coated_Basic.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 36),
@@ -450,7 +451,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Primitive, 16),
                             CustomItemList.LogicProcessorItemGoldCore.get(1),
-                            ItemList.Circuit_Board_Coated_Basic.get(1)
+                            ItemList.Circuit_Board_Coated_Basic.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 36),
@@ -463,7 +465,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Primitive, 16),
                             CustomItemList.LogicProcessorItemGoldCore.get(1),
-                            ItemList.Circuit_Board_Coated_Basic.get(1)
+                            ItemList.Circuit_Board_Coated_Basic.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 36),
@@ -477,7 +480,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 16),
                             CustomItemList.LogicProcessorItemGoldCore.get(1),
-                            ItemList.Circuit_Board_Phenolic_Good.get(1)
+                            ItemList.Circuit_Board_Phenolic_Good.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 37),
@@ -490,7 +494,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 16),
                             CustomItemList.LogicProcessorItemGoldCore.get(1),
-                            ItemList.Circuit_Board_Phenolic_Good.get(1)
+                            ItemList.Circuit_Board_Phenolic_Good.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 37),
@@ -503,7 +508,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 16),
                             CustomItemList.LogicProcessorItemGoldCore.get(1),
-                            ItemList.Circuit_Board_Phenolic_Good.get(1)
+                            ItemList.Circuit_Board_Phenolic_Good.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 37),
@@ -517,7 +523,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 16),
                             CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
-                            ItemList.Circuit_Board_Epoxy_Advanced.get(1)
+                            ItemList.Circuit_Board_Epoxy_Advanced.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 38),
@@ -530,7 +537,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 16),
                             CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
-                            ItemList.Circuit_Board_Epoxy_Advanced.get(1)
+                            ItemList.Circuit_Board_Epoxy_Advanced.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 38),
@@ -543,7 +551,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 16),
                             CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
-                            ItemList.Circuit_Board_Epoxy_Advanced.get(1)
+                            ItemList.Circuit_Board_Epoxy_Advanced.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 38),
@@ -558,7 +567,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 16),
                             CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
-                            ItemList.Circuit_Board_Fiberglass_Advanced.get(1)
+                            ItemList.Circuit_Board_Fiberglass_Advanced.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 0),
@@ -571,7 +581,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 16),
                             CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
-                            ItemList.Circuit_Board_Fiberglass_Advanced.get(1)
+                            ItemList.Circuit_Board_Fiberglass_Advanced.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 0),
@@ -584,7 +595,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 16),
                             CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
-                            ItemList.Circuit_Board_Fiberglass_Advanced.get(1)
+                            ItemList.Circuit_Board_Fiberglass_Advanced.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 0),
@@ -598,7 +610,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 16),
                             CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
-                            ItemList.Circuit_Board_Multifiberglass_Elite.get(1)
+                            ItemList.Circuit_Board_Multifiberglass_Elite.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 1),
@@ -611,7 +624,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 16),
                             CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
-                            ItemList.Circuit_Board_Multifiberglass_Elite.get(1)
+                            ItemList.Circuit_Board_Multifiberglass_Elite.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 1),
@@ -624,7 +638,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 16),
                             CustomItemList.EngineeringProcessorItemDiamondCore.get(1),
-                            ItemList.Circuit_Board_Multifiberglass_Elite.get(1)
+                            ItemList.Circuit_Board_Multifiberglass_Elite.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 1),
@@ -638,7 +653,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 16),
                             CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
-                            ItemList.Circuit_Board_Wetware_Extreme.get(1)
+                            ItemList.Circuit_Board_Wetware_Extreme.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 2),
@@ -651,7 +667,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 16),
                             CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
-                            ItemList.Circuit_Board_Wetware_Extreme.get(1)
+                            ItemList.Circuit_Board_Wetware_Extreme.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 2),
@@ -664,7 +681,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 16),
                             CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
-                            ItemList.Circuit_Board_Wetware_Extreme.get(1)
+                            ItemList.Circuit_Board_Wetware_Extreme.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 2),
@@ -678,7 +696,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16),
                             CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
-                            ItemList.Circuit_Board_Bio_Ultra.get(1)
+                            ItemList.Circuit_Board_Bio_Ultra.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
@@ -691,7 +710,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16),
                             CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
-                            ItemList.Circuit_Board_Bio_Ultra.get(1)
+                            ItemList.Circuit_Board_Bio_Ultra.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
@@ -704,7 +724,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16),
                             CustomItemList.EngineeringProcessorItemAdvEmeraldCore.get(1),
-                            ItemList.Circuit_Board_Bio_Ultra.get(1)
+                            ItemList.Circuit_Board_Bio_Ultra.get(1),
+                            GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -720,7 +720,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
                     200,
-                    491520,
+                    500000,
                     true
             );
 
@@ -735,7 +735,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
                     200,
-                    491520,
+                    500000,
                     true
             );
 
@@ -750,7 +750,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
                     200,
-                    491520,
+                    500000,
                     true
             );
         }

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -432,7 +432,7 @@ public class GT_MachineRecipeLoader implements Runnable {
             GT_Values.RA.addMixerRecipe(CustomItemList.ChargedCertusQuartzDust.get(1L), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 1L), GT_Values.NI, GT_Values.NI, GT_Utility.getIntegratedCircuit(4), GT_ModHandler.getDistilledWater(500L), GT_Values.NF, GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 2L, 8), 20, 16);
 
             // 4k ME Storage Component
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Primitive, 16),
@@ -445,7 +445,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     30
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Primitive, 16),
@@ -458,7 +458,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     30
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Primitive, 16),
@@ -472,7 +472,7 @@ public class GT_MachineRecipeLoader implements Runnable {
             );
 
             // 16k ME Storage Component
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 16),
@@ -485,7 +485,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     120
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 16),
@@ -498,7 +498,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     120
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 16),
@@ -512,7 +512,7 @@ public class GT_MachineRecipeLoader implements Runnable {
             );
 
             // 64k ME Storage Component
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 16),
@@ -525,7 +525,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     480
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 16),
@@ -538,7 +538,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     480
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 16),
@@ -553,7 +553,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         }
         if (Loader.isModLoaded("extracells")){
             // 256k ME Storage Component
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 16),
@@ -566,7 +566,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     1920
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 16),
@@ -579,7 +579,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     1920
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 16),
@@ -593,7 +593,7 @@ public class GT_MachineRecipeLoader implements Runnable {
             );
 
             // 1024k ME Storage Component
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 16),
@@ -606,7 +606,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     7680
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 16),
@@ -619,7 +619,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     7680
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 16),
@@ -633,7 +633,7 @@ public class GT_MachineRecipeLoader implements Runnable {
             );
 
             // 4096k ME Storage Component
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 16),
@@ -646,7 +646,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     30720
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 16),
@@ -659,7 +659,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     30720
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 16),
@@ -673,7 +673,7 @@ public class GT_MachineRecipeLoader implements Runnable {
             );
 
             // 16384k ME Storage Component
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16),
@@ -686,7 +686,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     491520
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16),
@@ -699,7 +699,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     491520
             );
 
-            GT_Values.RA.addAssemblerRecipe(
+            GT_Values.RA.addCircuitAssemblerRecipe(
                     new ItemStack[]{
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 4),
                             GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16),

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -443,7 +443,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 36),
                     200,
-                    30
+                    30,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -457,7 +458,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 36),
                     200,
-                    30
+                    30,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -471,7 +473,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 36),
                     200,
-                    30
+                    30,
+                    true
             );
 
             // 16k ME Storage Component
@@ -486,7 +489,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 37),
                     200,
-                    120
+                    120,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -500,7 +504,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 37),
                     200,
-                    120
+                    120,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -514,7 +519,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 37),
                     200,
-                    120
+                    120,
+                    true
             );
 
             // 64k ME Storage Component
@@ -529,7 +535,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 38),
                     200,
-                    480
+                    480,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -543,7 +550,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 38),
                     200,
-                    480
+                    480,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -557,7 +565,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("appliedenergistics2", "item.ItemMultiMaterial", 1L, 38),
                     200,
-                    480
+                    480,
+                    true
             );
         }
         if (Loader.isModLoaded("extracells")){
@@ -573,7 +582,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 0),
                     200,
-                    1920
+                    1920,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -587,7 +597,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 0),
                     200,
-                    1920
+                    1920,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -601,7 +612,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 0),
                     200,
-                    1920
+                    1920,
+                    true
             );
 
             // 1024k ME Storage Component
@@ -616,7 +628,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 1),
                     200,
-                    7680
+                    7680,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -630,7 +643,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 1),
                     200,
-                    7680
+                    7680,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -644,7 +658,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 1),
                     200,
-                    7680
+                    7680,
+                    true
             );
 
             // 4096k ME Storage Component
@@ -659,7 +674,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 2),
                     200,
-                    30720
+                    30720,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -673,7 +689,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 2),
                     200,
-                    30720
+                    30720,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -687,7 +704,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 2),
                     200,
-                    30720
+                    30720,
+                    true
             );
 
             // 16384k ME Storage Component
@@ -702,7 +720,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Lead.getMolten(288),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
                     200,
-                    491520
+                    491520,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -716,7 +735,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.Tin.getMolten(144),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
                     200,
-                    491520
+                    491520,
+                    true
             );
 
             GT_Values.RA.addCircuitAssemblerRecipe(
@@ -730,7 +750,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     Materials.SolderingAlloy.getMolten(72),
                     GT_ModHandler.getModItem("extracells", "storage.component", 1L, 3),
                     200,
-                    491520
+                    491520,
+                    true
             );
         }
 


### PR DESCRIPTION
Cut the recursion crap from current recipes for the AE2 cells:
![image](https://user-images.githubusercontent.com/12850933/145252409-7c88ff3b-557a-42c8-a3f6-70e6c36711ac.png)
![image](https://user-images.githubusercontent.com/12850933/145252442-18d93045-3c0b-4e8a-9766-c20f20d39077.png)

All the circuits are oredicted, and there is the usual declination for lead/tin/soldering alloy as fluid. Previous recursive recipes remain as is, and should only be considered when one wants to upgrade old cells into a bigger one.