### PR TITLE
fix random values with bound of 1 being oob

### DIFF
--- a/src/main/java/com/dreammaster/modcustomdrops/CustomDropsHandler.java
+++ b/src/main/java/com/dreammaster/modcustomdrops/CustomDropsHandler.java
@@ -273,7 +273,7 @@ public class CustomDropsHandler
                 }
 
                 if (dr.getIsRandomAmount()) {
-                    tFinalAmount = 1 + MainRegistry.Rnd.nextInt(dr.getAmount() - 1);
+                    tFinalAmount = Math.max(1,MainRegistry.Rnd.nextInt(dr.getAmount() + 1));
                 }
 
                 ItemStack tDropStack = ItemDescriptor.fromString(dr.getItemName()).getItemStackwNBT(tFinalAmount, dr.mTag);


### PR DESCRIPTION
fix this warning:
<details>
<summary>log</summary>

```
[01:11:08 WARN]: java.lang.IllegalArgumentException: bound must be positive
[01:11:08 WARN]:        at java.util.Random.nextInt(Random.java:388)
[01:11:08 WARN]:        at com.dreammaster.modcustomdrops.CustomDropsHandler.HandleCustomDrops(CustomDropsHandler.java:276)
[01:11:08 WARN]:        at com.dreammaster.modcustomdrops.CustomDropsHandler.onMobDrops(CustomDropsHandler.java:208)
[01:11:08 WARN]:        at cpw.mods.fml.common.eventhandler.ASMEventHandler_890_CustomDropsHandler_onMobDrops_LivingDropsEvent.invoke(.dynamic)
[01:11:08 WARN]:        at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
[01:11:08 WARN]:        at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
[01:11:08 WARN]:        at net.minecraftforge.common.ForgeHooks.onLivingDrops(ForgeHooks.java:319)
[01:11:08 WARN]:        at net.minecraft.entity.EntityLivingBase.func_70645_a(EntityLivingBase.java:1062)
[01:11:08 WARN]:        at twilightforest.entity.EntityTFKobold.func_70645_a(EntityTFKobold.java:146)
[01:11:08 WARN]:        at net.minecraft.entity.EntityLivingBase.func_70097_a(EntityLivingBase.java:978)
[01:11:08 WARN]:        at net.minecraft.entity.monster.EntityMob.func_70097_a(EntityMob.java:71)
[01:11:08 WARN]:        at net.minecraft.entity.player.EntityPlayer.func_71059_n(Unknown Source)
[01:11:08 WARN]:        at net.minecraft.entity.player.EntityPlayerMP.localAttackTargetEntityWithCurrentItem(EntityPlayerMP.java)
[01:11:08 WARN]:        at api.player.server.ServerPlayerAPI.attackTargetEntityWithCurrentItem(Unknown Source)
[01:11:08 WARN]:        at net.minecraft.entity.player.EntityPlayerMP.func_71059_n(EntityPlayerMP.java)
[01:11:08 WARN]:        at net.minecraft.network.NetHandlerPlayServer.func_147340_a(NetHandlerPlayServer.java:1611)
[01:11:08 WARN]:        at net.minecraft.network.play.client.C02PacketUseEntity.func_148833_a(SourceFile:55)
[01:11:08 WARN]:        at net.minecraft.network.play.client.C02PacketUseEntity.func_148833_a(SourceFile:10)
[01:11:08 WARN]:        at net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:245)
[01:11:08 WARN]:        at net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:181)
[01:11:08 WARN]:        at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:1023)
[01:11:08 WARN]:        at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:432)
[01:11:08 WARN]:        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:841)
[01:11:08 WARN]:        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:693)
[01:11:08 WARN]:        at java.lang.Thread.run(Thread.java:748)
```
</details>

So it looks like the code was trying to generate an amount between 1 and the value set in the xml, so i rewrote it to be correct.