### PR TITLE
Port of Holo-Inventory, SpiceOfLife, BiblioCraft and sleeping bags scripts into code.

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -1,5 +1,6 @@
 package com.dreammaster.gthandler;
 
+import com.dreammaster.main.MainRegistry;
 import com.dreammaster.scripts.*;
 import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 import cpw.mods.fml.common.Loader;
@@ -12,9 +13,6 @@ import ic2.core.Ic2Items;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-
-import java.util.HashMap;
-import java.util.Map;
 
 import static gregtech.api.enums.OrePrefixes.screw;
 import static gregtech.api.util.GT_ModHandler.RecipeBits.DELETE_ALL_OTHER_RECIPES;
@@ -313,7 +311,7 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
         	GT_ModHandler.addCraftingRecipe(GT_ModHandler.getModItem("Ztones", "minicoal", 7L, 0), bits, new Object[]{"T  ", "C  ", "   ", 'T', ToolDictNames.craftingToolSoftHammer, 'C', OrePrefixes.dust.get(Materials.Coal)});
         }
 
-        Map<String, Long> executionTimes = new HashMap<>();
+
         IScriptLoader[] scripts = new IScriptLoader[]{
                 new ScriptBiblioCraft(),
                 new ScriptBiblioWoodsNatura(),
@@ -323,8 +321,8 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
 
         for (IScriptLoader script: scripts){
             if (script.isScriptLoadable()){
-                script.loadRecipe();
-                executionTimes.put(script.getScriptName(), script.getExecutionTime());
+                script.loadRecipes();
+                MainRegistry.Logger.info(script.getScriptName()+" took "+script.getExecutionTime()+" ms.");
             }
         }
     }

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -317,7 +317,8 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
                 new ScriptBiblioWoodsNatura(),
                 new ScriptBiblioWoodsBoP(),
                 new ScriptBiblioWoodsForestry(),
-                new ScriptHoloInventory()
+                new ScriptHoloInventory(),
+                new ScriptSleepingBags()
         };
 
         for (IScriptLoader script: scripts){

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -318,7 +318,7 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
                 new ScriptBiblioWoodsBoP(),
                 new ScriptBiblioWoodsForestry(),
                 new ScriptHoloInventory(),
-                //new ScriptSleepingBags(),
+                new ScriptSleepingBags(),
                 new ScriptSpiceOfLife()
         };
 

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -1,5 +1,6 @@
 package com.dreammaster.gthandler;
 
+import com.dreammaster.scripts.*;
 import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 import cpw.mods.fml.common.Loader;
 import gregtech.api.enums.*;
@@ -11,6 +12,9 @@ import ic2.core.Ic2Items;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static gregtech.api.enums.OrePrefixes.screw;
 import static gregtech.api.util.GT_ModHandler.RecipeBits.DELETE_ALL_OTHER_RECIPES;
@@ -307,6 +311,21 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
         	GT_ModHandler.addCraftingRecipe(GT_ModHandler.getModItem("Ztones", "auroraBlock", 8L, 0), bits, new Object[]{"GGG", "GDG", "GGG", 'G', new ItemStack(Blocks.glass, 1), 'D', new ItemStack(Items.dye, 1, GT_Values.W)});        	
         	GT_ModHandler.addCraftingRecipe(GT_ModHandler.getModItem("Ztones", "minicharcoal", 7L, 0), bits, new Object[]{"T  ", "C  ", "   ", 'T', ToolDictNames.craftingToolSoftHammer, 'C', OrePrefixes.dust.get(Materials.Charcoal)});
         	GT_ModHandler.addCraftingRecipe(GT_ModHandler.getModItem("Ztones", "minicoal", 7L, 0), bits, new Object[]{"T  ", "C  ", "   ", 'T', ToolDictNames.craftingToolSoftHammer, 'C', OrePrefixes.dust.get(Materials.Coal)});
+        }
+
+        Map<String, Long> executionTimes = new HashMap<>();
+        IScriptLoader[] scripts = new IScriptLoader[]{
+                new ScriptBiblioCraft(),
+                new ScriptBiblioWoodsNatura(),
+                new ScriptBiblioWoodsBoP(),
+                new ScriptBiblioWoodsForestry()
+        };
+
+        for (IScriptLoader script: scripts){
+            if (script.isScriptLoadable()){
+                script.loadRecipe();
+                executionTimes.put(script.getScriptName(), script.getExecutionTime());
+            }
         }
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -318,13 +318,17 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
                 new ScriptBiblioWoodsBoP(),
                 new ScriptBiblioWoodsForestry(),
                 new ScriptHoloInventory(),
-                new ScriptSleepingBags()
+                //new ScriptSleepingBags(),
+                new ScriptSpiceOfLife()
         };
 
         for (IScriptLoader script: scripts){
             if (script.isScriptLoadable()){
                 script.loadRecipes();
                 MainRegistry.Logger.info(script.getScriptName()+" took "+script.getExecutionTime()+" ms.");
+            }
+            else {
+                MainRegistry.Logger.info("missing requirements for the script "+script.getScriptName()+". It won't be loaded");
             }
         }
     }

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -316,7 +316,8 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
                 new ScriptBiblioCraft(),
                 new ScriptBiblioWoodsNatura(),
                 new ScriptBiblioWoodsBoP(),
-                new ScriptBiblioWoodsForestry()
+                new ScriptBiblioWoodsForestry(),
+                new ScriptHoloInventory()
         };
 
         for (IScriptLoader script: scripts){

--- a/src/main/java/com/dreammaster/scripts/IScriptLoader.java
+++ b/src/main/java/com/dreammaster/scripts/IScriptLoader.java
@@ -1,5 +1,6 @@
 package com.dreammaster.scripts;
 
+import com.dreammaster.main.MainRegistry;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
 import gregtech.api.objects.ItemData;
@@ -10,6 +11,7 @@ import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
+import org.apache.logging.log4j.Level;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,11 +19,13 @@ import java.util.Collections;
 import java.util.List;
 
 public interface IScriptLoader {
+    //todo: cache the lookups for the itemstacks
+    //todo: make an error for the itemstack lookup if it returns null
 
     /**
      * Should be called externally to load the recipes in the ported script
      */
-    public void loadRecipe();
+    public void loadRecipes();
 
 
     /**
@@ -35,68 +39,69 @@ public interface IScriptLoader {
         Object[] slots = new Object[9];
         String fullString = "";
         String slotMappings = "abcdefghi";
-        for (int i=0; i<9; i++) {
-            Object o = inputs[i];
-            if (o instanceof ItemStack) {
-                final ItemStack itemStack = ((ItemStack) o).copy();
-                itemStack.stackSize = 1;
-                slots[i] = itemStack.copy();
-                fullString += slotMappings.charAt(i);
-            }
-            else if (o instanceof Item) {
-                final ItemStack itemStack = new ItemStack((Item) o, 1);
-                slots[i] = itemStack.copy();
-                fullString += slotMappings.charAt(i);
-            }
-            else if (o instanceof Block) {
-                final ItemStack itemStack = new ItemStack((Block) o, 1);
-                slots[i] = itemStack.copy();
-                fullString += slotMappings.charAt(i);
-            }
-            else if (o instanceof String) {
-                slots[i] = o;
-                fullString += slotMappings.charAt(i);
-            }
-            else if (o instanceof ItemData) {
-                ItemData data = (ItemData) o;
-                ItemStack itemStack = GT_OreDictUnificator.get(data.mPrefix, data.mMaterial.mMaterial, 1);
-                if (itemStack == null) {
-                    throw new NullPointerException("bad item passed in the recipe");
-                } else {
-                    slots[i] = itemStack;
+        try {
+            for (int i = 0; i < 9; i++) {
+                Object o = inputs[i];
+                if (o instanceof ItemStack) {
+                    final ItemStack itemStack = ((ItemStack) o).copy();
+                    itemStack.stackSize = 1;
+                    slots[i] = itemStack.copy();
                     fullString += slotMappings.charAt(i);
-                }
+                } else if (o instanceof Item) {
+                    final ItemStack itemStack = new ItemStack((Item) o, 1);
+                    slots[i] = itemStack.copy();
+                    fullString += slotMappings.charAt(i);
+                } else if (o instanceof Block) {
+                    final ItemStack itemStack = new ItemStack((Block) o, 1);
+                    slots[i] = itemStack.copy();
+                    fullString += slotMappings.charAt(i);
+                } else if (o instanceof String) {
+                    slots[i] = o;
+                    fullString += slotMappings.charAt(i);
+                } else if (o instanceof ItemData) {
+                    ItemData data = (ItemData) o;
+                    ItemStack itemStack = GT_OreDictUnificator.get(data.mPrefix, data.mMaterial.mMaterial, 1);
+                    if (itemStack == null) {
+                        throw new NullPointerException("bad item passed in the recipe");
+                    } else {
+                        slots[i] = itemStack;
+                        fullString += slotMappings.charAt(i);
+                    }
 
+                } else if (o == null) {
+                    slots[i] = null;
+                    fullString += " ";
+                } else {
+                    slots[i] = null;
+                    throw new NullPointerException("bad recipe generated");
+                }
             }
-            else if (o == null) {
-                slots[i] = null;
-                fullString += " ";
+            String aRow1 = fullString.substring(0, 3);
+            String aRow2 = fullString.substring(3, 6);
+            String aRow3 = fullString.substring(6, 9);
+            String[] recipeRows = new String[]{aRow1, aRow2, aRow3};
+            Object[] recipeInputs = new Object[19];
+            recipeInputs[0] = recipeRows;
+            int aIndex = 0;
+            for (int u = 1; u < 20; u += 2) {
+                if (aIndex == 9) {
+                    break;
+                }
+                if (fullString.charAt(aIndex) != (' ')) {
+                    recipeInputs[u] = fullString.charAt(aIndex);
+                    recipeInputs[u + 1] = slots[aIndex];
+                }
+                aIndex++;
             }
-            else {
-                slots[i] = null;
-                throw new NullPointerException("bad recipe generated");
-            }
+            recipeInputs = removeNulls(recipeInputs);
+            ShapedOreRecipe aRecipe = new ShapedOreRecipe(aOutputStack, recipeInputs);
+            GameRegistry.addRecipe(aRecipe);
         }
-        String aRow1 = fullString.substring(0, 3);
-        String aRow2 = fullString.substring(3, 6);
-        String aRow3 = fullString.substring(6, 9);
-        String[] recipeRows = new String[] {aRow1, aRow2, aRow3};
-        Object[] recipeInputs = new Object[19];
-        recipeInputs[0] = recipeRows;
-        int aIndex = 0;
-        for (int u=1;u<20;u+=2) {
-            if (aIndex == 9) {
-                break;
-            }
-            if (fullString.charAt(aIndex) != (' ')) {
-                recipeInputs[u] = fullString.charAt(aIndex);
-                recipeInputs[u+1] = slots[aIndex];
-            }
-            aIndex++;
+        catch(Exception e) {
+            MainRegistry.Logger.error("a recipe went wrong:");
+            e.printStackTrace();
+            return false;
         }
-        recipeInputs = removeNulls(recipeInputs);
-        ShapedOreRecipe aRecipe = new ShapedOreRecipe(aOutputStack, recipeInputs);
-        GameRegistry.addRecipe(aRecipe);
         return true;
     }
 

--- a/src/main/java/com/dreammaster/scripts/IScriptLoader.java
+++ b/src/main/java/com/dreammaster/scripts/IScriptLoader.java
@@ -1,0 +1,164 @@
+package com.dreammaster.scripts;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.registry.GameRegistry;
+import gregtech.api.objects.ItemData;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.common.items.GT_MetaGenerated_Item_01;
+import gregtech.common.items.GT_MetaGenerated_Item_02;
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.ShapedOreRecipe;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public interface IScriptLoader {
+
+    /**
+     * Should be called externally to load the recipes in the ported script
+     */
+    public void loadRecipe();
+
+
+    /**
+     * Code strongly inspired from what did alkalus in GT++.
+     * @param inputs Object array that should contain only the 9 object representing the items in the crafting grid.
+     *               Acceptable types are Item, Block, ItemStack, ItemData and null (for empty slots).
+     * @param aOutputStack The result of the crafting recipe
+     * @return a boolean
+     */
+    default boolean addShapedRecipe(ItemStack aOutputStack, Object[] inputs) {
+        Object[] slots = new Object[9];
+        String fullString = "";
+        String slotMappings = "abcdefghi";
+        for (int i=0; i<9; i++) {
+            Object o = inputs[i];
+            if (o instanceof ItemStack) {
+                final ItemStack itemStack = ((ItemStack) o).copy();
+                itemStack.stackSize = 1;
+                slots[i] = itemStack.copy();
+                fullString += slotMappings.charAt(i);
+            }
+            else if (o instanceof Item) {
+                final ItemStack itemStack = new ItemStack((Item) o, 1);
+                slots[i] = itemStack.copy();
+                fullString += slotMappings.charAt(i);
+            }
+            else if (o instanceof Block) {
+                final ItemStack itemStack = new ItemStack((Block) o, 1);
+                slots[i] = itemStack.copy();
+                fullString += slotMappings.charAt(i);
+            }
+            else if (o instanceof String) {
+                slots[i] = o;
+                fullString += slotMappings.charAt(i);
+            }
+            else if (o instanceof ItemData) {
+                ItemData data = (ItemData) o;
+                ItemStack itemStack = GT_OreDictUnificator.get(data.mPrefix, data.mMaterial.mMaterial, 1);
+                if (itemStack == null) {
+                    throw new NullPointerException("bad item passed in the recipe");
+                } else {
+                    slots[i] = itemStack;
+                    fullString += slotMappings.charAt(i);
+                }
+
+            }
+            else if (o == null) {
+                slots[i] = null;
+                fullString += " ";
+            }
+            else {
+                slots[i] = null;
+                throw new NullPointerException("bad recipe generated");
+            }
+        }
+        String aRow1 = fullString.substring(0, 3);
+        String aRow2 = fullString.substring(3, 6);
+        String aRow3 = fullString.substring(6, 9);
+        String[] recipeRows = new String[] {aRow1, aRow2, aRow3};
+        Object[] recipeInputs = new Object[19];
+        recipeInputs[0] = recipeRows;
+        int aIndex = 0;
+        for (int u=1;u<20;u+=2) {
+            if (aIndex == 9) {
+                break;
+            }
+            if (fullString.charAt(aIndex) != (' ')) {
+                recipeInputs[u] = fullString.charAt(aIndex);
+                recipeInputs[u+1] = slots[aIndex];
+            }
+            aIndex++;
+        }
+        recipeInputs = removeNulls(recipeInputs);
+        ShapedOreRecipe aRecipe = new ShapedOreRecipe(aOutputStack, recipeInputs);
+        GameRegistry.addRecipe(aRecipe);
+        return true;
+    }
+
+    /**
+     * Utility fonction copied from GT++ to strip nulls from the array.
+     * @param v The object array to process.
+     * @return An object array with null elements removed
+     */
+    public static Object[] removeNulls(final Object[] v) {
+        List<Object> list = new ArrayList<Object>(Arrays.asList(v));
+        list.removeAll(Collections.singleton((Object)null));
+        return list.toArray(new Object[list.size()]);
+    }
+
+    /**
+     * Helper function to get the GT_MetaGenerated_Item_02 item based on its meta.
+     * @param meta the meta id of the item to look at.
+     * @return an itemstack with a stacksize of 1 corresponding to the item looked for.
+     */
+    default ItemStack getMeta02(int meta){
+        return new ItemStack(GT_MetaGenerated_Item_02.INSTANCE, 1, meta);
+    }
+
+    /**
+     * Helper function to get the GT_MetaGenerated_Item_02 item based on its meta.
+     * @param meta the meta id of the item to look at.
+     * @return an itemstack with a stacksize of 1 corresponding to the item looked for.
+     */
+    default ItemStack getMeta01(int meta){
+        return new ItemStack(GT_MetaGenerated_Item_01.INSTANCE, 1, meta);
+    }
+
+    /**
+     * function to get the time of execution for the script in milliseconds.
+     * @return a long object holding the time of execution.
+     */
+    public long getExecutionTime();
+
+    /**
+     * Function to get the list of all the dependencies needed to load the script. Avoid manual checks with
+     * Loader.isModLoaded.
+     * @return a list of string containing the dependencies.
+     */
+    public List<String> getDependencies();
+
+    /**
+     * Function to get the name of the script.
+     * @return the name of the script.
+     */
+    public String getScriptName();
+
+    /**
+     * Function to know if a script is loadable: if at least one of its dependencies is missing then it won't be
+     * considered as loadable.
+     * @return a boolean representing if the script is loadable.
+     */
+    public default boolean isScriptLoadable(){
+        for (String dep: getDependencies()){
+            if (!Loader.isModLoaded(dep)){
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/dreammaster/scripts/ScriptBiblioCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiblioCraft.java
@@ -1,0 +1,315 @@
+package com.dreammaster.scripts;
+
+import cpw.mods.fml.common.Loader;
+import net.minecraft.item.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static gregtech.api.util.GT_ModHandler.getModItem;
+
+public class ScriptBiblioCraft implements IScriptLoader {
+    private long startTime;
+    private long endTime;
+    private static final String scriptName = "BiblioCraft";
+    private static final List<String> dependencies = Arrays.asList("BiblioCraft", "harvestcraft", "FloodLights");
+    public ScriptBiblioCraft(){
+
+    }
+
+    @Override
+    public void loadRecipe() {
+            startTime = System.currentTimeMillis();
+            ItemStack[] TypeWriterB = new ItemStack[16];
+            ItemStack[] Pedestals = new ItemStack[16];
+            ItemStack[] cwool16 = new ItemStack[16];
+            ItemStack[] FPT1 = new ItemStack[7]; //FPT1
+            ItemStack[] FPT2 = new ItemStack[7]; //FPT2
+            ItemStack[] FPT3 = new ItemStack[7]; //FPT3
+            ItemStack[] FPT4 = new ItemStack[7]; //FPT4
+            ItemStack[] LableB = new ItemStack[7];
+            ItemStack[] FrameB = new ItemStack[7];
+            ItemStack[] PaintingB = new ItemStack[7];
+            ItemStack[] FClockB = new ItemStack[7];
+            ItemStack[] Swood = new ItemStack[]{
+                    getModItem("minecraft", "wooden_slab", 1, 0),
+                    getModItem("minecraft", "wooden_slab", 1, 1),
+                    getModItem("minecraft", "wooden_slab", 1, 2),
+                    getModItem("minecraft", "wooden_slab", 1, 3),
+                    getModItem("minecraft", "wooden_slab", 1, 4),
+                    getModItem("minecraft", "wooden_slab", 1, 5),
+                    getModItem("BiblioCraft", "item.FramingSheet", 1, 0)
+            };
+
+            ItemStack[] color16 = new ItemStack[]{
+                getMeta02(32429), //white
+                getMeta02(32421), //light grey
+                getMeta02(32422), //grey
+                getMeta02(32414), //black
+                getMeta02(32415), //red
+                getMeta02(32428), //orange
+                getMeta02(32425), //yellow
+                getMeta02(32424), //lime
+                getMeta02(32416), //green
+                getMeta02(32420), //cyan
+                getMeta02(32426), //light blue
+                getMeta02(32418), //blue
+                getMeta02(32419), //purple
+                getMeta02(32427), //magenta
+                getMeta02(32423), //pink
+                getMeta02(32417)  //brown
+            };
+
+            for (int i = 0; i < 16; i++) {
+                TypeWriterB[i] = getModItem("BiblioCraft", "BiblioTypewriter", 1, i);
+                Pedestals[i] = getModItem("BiblioCraft", "BiblioSwordPedestal", 1, i);
+                cwool16[i] = getModItem("minecraft", "wool", 1, i);
+
+                if (i < 7) {
+                    FPT1[i] = getModItem("BiblioCraft", "BiblioFlatPainting", 1, i);
+                    FPT2[i] = getModItem("BiblioCraft", "BiblioSimplePainting", 1, i);
+                    FPT3[i] = getModItem("BiblioCraft", "BiblioMiddlePainting", 1, i);
+                    FPT4[i] = getModItem("BiblioCraft", "BiblioFancyPainting", 1, i);
+                    LableB[i] = getModItem("BiblioCraft", "BiblioLabel", 1, i);
+                    FrameB[i] = getModItem("BiblioCraft", "BiblioMapFrames", 1, i);
+                    PaintingB[i] = getModItem("BiblioCraft", "BiblioBorderlessPainting", 1, i);
+                    FClockB[i] = getModItem("BiblioCraft", "BiblioClock", 1, i);
+                }
+            }
+
+            addShapedRecipe(getModItem("BiblioCraft", "Printing Press", 1), new Object[]{
+                    "plateThaumium", "stickBlaze", "plateThaumium",
+                    "plateAluminium", getMeta01(32601), "plateAluminium",
+                    "blockSteel", "blockSteel", "blockSteel"
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.BiblioChase", 1), new Object[]{
+                    "stickWoodSealed", "stickWoodSealed", "stickWoodSealed",
+                    "stickWoodSealed", null, "stickWoodSealed",
+                    "stickWoodSealed", "stickWoodSealed", "stickWoodSealed"
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "Typesetting Machine", 1), new Object[]{
+                    "plateAluminium", getModItem("BiblioCraft", "item.BiblioChase", 1), "plateAluminium",
+                    "plateWoodSealed", "frameGtWoodSealed", "plateWoodSealed",
+                    "plateWoodSealed", "plateWoodSealed", "plateWoodSealed"
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "tile.BiblioFramedChest", 1), new Object[]{
+                    getModItem("BiblioCraft", "item.FramingSheet", 1), getModItem("BiblioCraft", "item.FramingSheet", 1), getModItem("BiblioCraft", "item.FramingSheet", 1),
+                    "screwIron", getModItem("BiblioCraft", "BiblioLabel", 1, 6), "screwIron",
+                    getModItem("BiblioCraft", "item.FramingSheet", 1), getModItem("BiblioCraft", "item.FramingSheet", 1), getModItem("BiblioCraft", "item.FramingSheet", 1)
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioPaneler", 1), new Object[]{
+                    "plateIron", "craftingToolSaw", "plateIron",
+                    getModItem("minecraft", "wooden_slab", 1), getMeta02(32470), getModItem("minecraft", "wooden_slab", 1),
+                    getModItem("minecraft", "planks", 1), getModItem("minecraft", "planks", 1), getModItem("minecraft", "planks", 1)
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioPaneler", 1, 1), new Object[]{
+                    "plateIron", "craftingToolSaw", "plateIron",
+                    getModItem("minecraft", "wooden_slab", 1, 1), getMeta02(32471), getModItem("minecraft", "wooden_slab", 1, 1),
+                    getModItem("minecraft", "planks", 1, 1), getModItem("minecraft", "planks", 1, 1), getModItem("minecraft", "planks", 1, 1)
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioPaneler", 1, 2), new Object[]{
+                    "plateIron", "craftingToolSaw", "plateIron",
+                    getModItem("minecraft", "wooden_slab", 1, 2), getMeta02(32472), getModItem("minecraft", "wooden_slab", 1, 2),
+                    getModItem("minecraft", "planks", 1, 2), getModItem("minecraft", "planks", 1, 2), getModItem("minecraft", "planks", 1, 2)
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioPaneler", 1, 3), new Object[]{
+                    "plateIron", "craftingToolSaw", "plateIron",
+                    getModItem("minecraft", "wooden_slab", 1, 3), getMeta02(32473), getModItem("minecraft", "wooden_slab", 1, 3),
+                    getModItem("minecraft", "planks", 1, 3), getModItem("minecraft", "planks", 1, 3), getModItem("minecraft", "planks", 1, 3)
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioPaneler", 1, 4), new Object[]{
+                    "plateIron", "craftingToolSaw", "plateIron",
+                    getModItem("minecraft", "wooden_slab", 1, 4), getMeta02(32474), getModItem("minecraft", "wooden_slab", 1, 4),
+                    getModItem("minecraft", "planks", 1, 4), getModItem("minecraft", "planks", 1, 4), getModItem("minecraft", "planks", 1, 4)
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioPaneler", 1, 5), new Object[]{
+                    "plateIron", "craftingToolSaw", "plateIron",
+                    getModItem("minecraft", "wooden_slab", 1, 5), getMeta02(32475), getModItem("minecraft", "wooden_slab", 1, 5),
+                    getModItem("minecraft", "planks", 1, 5), getModItem("minecraft", "planks", 1, 5), getModItem("minecraft", "planks", 1, 5)
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioPaneler", 1, 6), new Object[]{
+                    "plateIron", "craftingToolSaw", "plateIron",
+                    getModItem("BiblioCraft", "item.FramingBoard", 1), getModItem("BiblioCraft", "item.FramingSheet", 1), getModItem("BiblioCraft", "item.FramingBoard", 1),
+                    getModItem("BiblioCraft", "item.FramingSheet", 1), getModItem("BiblioCraft", "item.FramingSheet", 1), getModItem("BiblioCraft", "item.FramingSheet", 1)
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.AtlasBook", 1), new Object[]{
+                    "platePaper", getModItem("BiblioCraft","item.BiblioMapTool", 1), "platePaper",
+                    "platePaper", "craftingBook", "platePaper",
+                    "platePaper", "paperMap", "platePaper"
+            });
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioPaintPress", 1), new Object[]{
+                    "plateIron", "plateIron", "boltIron",
+                    "ringIron", null, null,
+                    "blockIron", "blockIron", "blockIron"});
+
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioLantern", 1), new Object[]{
+                    "plateGold", "dustGlowstone", "plateGold",
+                    "paneGlassColorless", getModItem("harvestcraft", "pamcandleDeco1", 1), "paneGlassColorless",
+                    "plateGold", "plateGold", "plateGold"});
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioIronLantern", 1), new Object[]{
+                    "plateIron", "dustGlowstone", "plateIron",
+                    "paneGlassColorless", getModItem("harvestcraft", "pamcandleDeco1", 1), "paneGlassColorless",
+                    "plateIron", "plateIron", "plateIron"});
+
+
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioLamp", 1), new Object[]{
+                    "plateGold", getModItem("FloodLights", "electricIncandescentLightBulb", 1), "plateGold",
+                    null, "stickGold", null,
+                    "plateGold", "plateGold", "plateGold"});
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioIronLamp", 1), new Object[]{
+                    "plateIron", getModItem("FloodLights", "electricIncandescentLightBulb", 1), "plateIron",
+                    null, "stickGold", null,
+                    "plateIron", "plateIron", "plateIron"});
+
+
+            addShapedRecipe(getModItem("BiblioCraft", "ArmorStand", 1), new Object[]{
+                    "boltIron", "stickIron", "boltIron",
+                    "craftingToolHardHammer", "stickIron", "craftingToolSaw",
+                    "plateIron", getModItem("minecraft", "stone_pressure_plate", 1), "plateIron"});
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioBell", 1), new Object[]{
+                    null, getModItem("minecraft", "stone_button", 1), null,
+                    null, "plateIron", null,
+                    "plateIron", null, "plateIron"});
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioStuffs", 1), new Object[]{
+                    null, "plateAnyRubber", null,
+                    getModItem("minecraft", "glass_pane", 1), null, getModItem("minecraft", "glass_pane", 1),
+                    getModItem("minecraft", "glass_pane", 1), getModItem("minecraft", "glass_pane", 1), getModItem("minecraft", "glass_pane", 1)});
+
+            addShapedRecipe(getModItem("BiblioCraft", "BiblioStuffs", 1, 2), new Object[]{
+                    null, null, null,
+                    "plateNetherQuartz", null, "plateNetherQuartz",
+                    null, "plateNetherQuartz", null});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.FramingSheet", 2), new Object[]{
+                    getMeta02(32470), "craftingToolSaw", null,
+                    null, null, null,
+                    null, null, null});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.FramingBoard", 2), new Object[]{
+                    getModItem("BiblioCraft", "item.FramingSheet", 1), "craftingToolSaw", null,
+                    null, null, null,
+                    null, null, null});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.BiblioMapTool", 1), new Object[]{
+                    "stickIron", "screwIron", "stickIron",
+                    "stickIron", "stickIron", "craftingToolFile",
+                    "stickIron", "screwIron", "craftingToolScrewdriver"});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.BiblioMapTool", 1), new Object[]{
+                    "stickIron", "screwIron", "stickIron",
+                    "stickIron", "stickIron", "craftingToolFile",
+                    "stickIron", "screwIron", "craftingToolScrewdriver"});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.BiblioGlasses", 1, 2), new Object[]{
+                    "ringGold", "wireFineGold", "wireFineGold",
+                    "lensGlass", "craftingToolSoftHammer", "wireFineGold",
+                    null, "wireFineGold", null});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.PlumbLine", 1), new Object[]{
+                    "wireFineSteel", "wireFineSteel", "wireFineSteel",
+                    "plateLead", "craftingToolSoftHammer", "wireFineSteel",
+                    "roundLead", null, "wireFineSteel"});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.BiblioGlasses", 1), new Object[]{
+                    "stickIron", "screwIron", "stickIron",
+                    "ringIron", "boltIron", "ringIron",
+                    "lensGlass", "craftingToolScrewdriver", "lensGlass"});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.BiblioDrill", 1), new Object[]{
+                    "screwIron", "boltIron", "craftingToolScrewdriver",
+                    "gearGtSmallIron", getModItem("IC2", "itemRecipePart", 1, 3), "gearGtSmallIron",
+                    "plateIron", getModItem("IC2", "itemBatREDischarged", 1), "plateIron"});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.tape", 1), new Object[]{
+                    "wireFineIron", "wireFineIron", "wireFineIron",
+                    "wireFineIron", "dyeYellow", "wireFineIron",
+                    "wireFineIron", "wireFineIron", "wireFineIron"});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.tapeMeasure", 1), new Object[]{
+                    getModItem("BiblioCraft", "item.tape", 1), getModItem("BiblioCraft", "item.tape", 1), getModItem("BiblioCraft", "item.tape", 1),
+                    "stickIron", "stickIron", "stickIron",
+                    null, null, null});
+
+            addShapedRecipe(getModItem("BiblioCraft", "item.BiblioClipboard", 1), new Object[]{
+                    "screwIron", "springSmallIron", "screwIron",
+                    "craftingToolScrewdriver", getMeta01(17809), "craftingToolSaw",
+                    getModItem("minecraft", "paper", 1), getModItem("minecraft", "paper", 1), getModItem("minecraft", "paper", 1)});
+
+            for (int i =0; i <16; i++){
+                addShapedRecipe(TypeWriterB[i], new Object[]{
+                        "plateRubber", getModItem("OpenComputers", "item", 1, 20), "plateRubber",
+                        "ringIron", color16[i], "ringIron",
+                        "plateIron", "blockIron", "plateIron"
+                });
+                if (i < 7) {
+                    addShapedRecipe(FClockB[i], new Object[]{
+                            Swood[i], getModItem("minecraft", "clock", 1), Swood[i],
+                            Swood[i], "stickWood", Swood[i],
+                            Swood[i], "plateGold", Swood[i]});
+                    addShapedRecipe(PaintingB[i], new Object[]{
+                            Swood[i], Swood[i], Swood[i],
+                            Swood[i], getModItem("BiblioCraft", "item.PaintingCanvas", 1), Swood[i],
+                            Swood[i], Swood[i], Swood[i]});
+                    addShapedRecipe(FPT1[i], new Object[]{
+                            "stickWood", "stickWood", "stickWood",
+                            "stickWood", PaintingB[i], "stickWood",
+                            "stickWood", "stickWood", "stickWood"});
+                    addShapedRecipe(FPT2[i], new Object[]{
+                            "stickWood", "stickWood", "stickWood",
+                            "stickWood", FPT1[i], "stickWood",
+                            "stickWood", "stickWood", "stickWood"});
+                    addShapedRecipe(FPT3[i], new Object[]{
+                            "stickWood", "stickWood", "stickWood",
+                            "stickWood", FPT2[i], "stickWood",
+                            "stickWood", "stickWood", "stickWood"});
+                    addShapedRecipe(FPT4[i], new Object[]{
+                            "stickWood", "stickWood", "stickWood",
+                            "stickWood", FPT3[i], "stickWood",
+                            "stickWood", "stickWood", "stickWood"});
+                    addShapedRecipe(Pedestals[i], new Object[]{
+                            null, null, null,
+                            "plateIron", "ringIron", "plateIron",
+                            "slabStone", cwool16[i], "slabStone"});
+                    addShapedRecipe(LableB[i], new Object[]{
+                            "stickWood", "stickWood", "stickWood",
+                            "stickWood", FrameB[i], "stickWood",
+                            "stickWood", "stickWood", "stickWood"});
+
+                }
+            }
+        endTime = System.currentTimeMillis();
+    }
+    @Override
+    public long getExecutionTime(){
+        return endTime-startTime;
+    }
+
+    @Override
+    public List<String> getDependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public String getScriptName() {
+        return scriptName;
+    }
+}
+

--- a/src/main/java/com/dreammaster/scripts/ScriptBiblioCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiblioCraft.java
@@ -1,11 +1,17 @@
 package com.dreammaster.scripts;
 
 import cpw.mods.fml.common.Loader;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
 import net.minecraft.item.ItemStack;
 
 import java.util.Arrays;
 import java.util.List;
 
+import static gregtech.api.util.GT_ModHandler.addShapelessCraftingRecipe;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 
 public class ScriptBiblioCraft implements IScriptLoader {
@@ -18,7 +24,7 @@ public class ScriptBiblioCraft implements IScriptLoader {
     }
 
     @Override
-    public void loadRecipe() {
+    public void loadRecipes() {
             startTime = System.currentTimeMillis();
             ItemStack[] TypeWriterB = new ItemStack[16];
             ItemStack[] Pedestals = new ItemStack[16];
@@ -178,7 +184,7 @@ public class ScriptBiblioCraft implements IScriptLoader {
                     "plateIron", "plateIron", "plateIron"});
 
 
-            addShapedRecipe(getModItem("BiblioCraft", "ArmorStand", 1), new Object[]{
+            addShapedRecipe(getModItem("BiblioCraft", "Armor Stand", 1), new Object[]{
                     "boltIron", "stickIron", "boltIron",
                     "craftingToolHardHammer", "stickIron", "craftingToolSaw",
                     "plateIron", getModItem("minecraft", "stone_pressure_plate", 1), "plateIron"});
@@ -295,8 +301,29 @@ public class ScriptBiblioCraft implements IScriptLoader {
 
                 }
             }
+        loadCuttingRecipes();
+        loadShapelessRecipes();
         endTime = System.currentTimeMillis();
     }
+
+     public void loadCuttingRecipes(){
+        // --- Frame Sheet
+        GT_Values.RA.addCutterRecipe(getMeta02(32470),Materials.Water.getFluid(4),GT_ModHandler.getModItem("BiblioCraft","item.FramingSheet", 4), GT_Values.NI, 50, 4);
+        GT_Values.RA.addCutterRecipe(getMeta02(32470),GT_ModHandler.getDistilledWater(2),GT_ModHandler.getModItem("BiblioCraft","item.FramingSheet", 4), GT_Values.NI, 50, 4);
+        GT_Values.RA.addCutterRecipe(getMeta02(32470),Materials.Lubricant.getFluid(1),GT_ModHandler.getModItem("BiblioCraft","item.FramingSheet", 4), GT_Values.NI, 25, 4);
+        // --- Frame Board
+        GT_Values.RA.addCutterRecipe(getModItem("BiblioCraft","item.FramingSheet",1),Materials.Water.getFluid(4),GT_ModHandler.getModItem("BiblioCraft","item.FramingBoard", 4), GT_Values.NI, 50, 4);
+        GT_Values.RA.addCutterRecipe(getModItem("BiblioCraft","item.FramingSheet",1),GT_ModHandler.getDistilledWater(2),GT_ModHandler.getModItem("BiblioCraft","item.FramingBoard", 4), GT_Values.NI, 50, 4);
+        GT_Values.RA.addCutterRecipe(getModItem("BiblioCraft","item.FramingSheet",1),Materials.Lubricant.getFluid(1),GT_ModHandler.getModItem("BiblioCraft","item.FramingBoard", 4), GT_Values.NI, 25, 4);
+    }
+
+    public void loadShapelessRecipes(){
+        addShapelessCraftingRecipe(getModItem("BiblioCraft","item.BiblioClipboard", 1), new Object[]{
+                "platePaper",
+                getModItem("BiblioCraft","item.BiblioClipboard", 1, 32767)
+        });
+    }
+
     @Override
     public long getExecutionTime(){
         return endTime-startTime;

--- a/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsBoP.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsBoP.java
@@ -1,0 +1,214 @@
+package com.dreammaster.scripts;
+
+import net.minecraft.item.ItemStack;
+
+
+import java.util.Arrays;
+import java.util.List;
+
+import static gregtech.api.util.GT_ModHandler.getModItem;
+
+public class ScriptBiblioWoodsBoP implements IScriptLoader{
+
+    private long startTime;
+    private long endTime;
+    private static final String scriptName = "BiblioWoodsBoP";
+    private static final List<String> dependencies = Arrays.asList("BiomesOPlenty", "BiblioWoodsBoP", "BiblioCraft");
+
+    @Override
+    public void loadRecipe(){
+        startTime = System.currentTimeMillis();
+        ItemStack[] BOBwood= new ItemStack[]{
+                getModItem("BiomesOPlenty", "woodenSingleSlab1", 1),
+                getModItem("BiomesOPlenty", "woodenSingleSlab1", 1, 1),
+                getModItem("BiomesOPlenty", "woodenSingleSlab1", 1, 2),
+                getModItem("BiomesOPlenty", "woodenSingleSlab1", 1, 3),
+                getModItem("BiomesOPlenty", "woodenSingleSlab2", 1, 3),
+                getModItem("BiomesOPlenty", "woodenSingleSlab1", 1, 4),
+                getModItem("BiomesOPlenty", "woodenSingleSlab2", 1, 4),
+                getModItem("BiomesOPlenty", "woodenSingleSlab1", 1, 5),
+                getModItem("BiomesOPlenty", "woodenSingleSlab1", 1, 6),
+                getModItem("BiomesOPlenty", "woodenSingleSlab1", 1, 7),
+                getModItem("BiomesOPlenty", "woodenSingleSlab2", 1, 2),
+                getModItem("BiomesOPlenty", "woodenSingleSlab2", 1),
+                getModItem("BiomesOPlenty", "woodenSingleSlab2", 1, 1),
+                getModItem("BiomesOPlenty", "woodenSingleSlab2", 1, 5)};
+
+        ItemStack[] FClockBOP= new ItemStack[]{
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 2),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 3),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 4),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 5),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 6),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 7),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 8),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 9),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 10),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 11),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 12),
+                getModItem("BiblioWoodsBoP", "BiblioWoodClock", 1, 13)};
+
+        ItemStack[] PaintingBOP= new ItemStack[]{
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 2),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 3),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 4),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 5),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 6),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 7),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 8),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 9),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 10),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 11),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 12),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT0", 1, 13)};
+
+        ItemStack[] BOBPT1= new ItemStack[]{
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 2),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 3),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 4),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 5),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 6),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 7),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 8),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 9),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 10),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 11),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 12),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT1", 1, 13)};
+
+        ItemStack[] BOBPT2= new ItemStack[]{
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 2),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 3),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 4),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 5),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 6),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 7),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 8),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 9),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 10),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 11),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 12),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT2", 1, 13)};
+
+        ItemStack[] BOBPT3= new ItemStack[]{
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 2),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 3),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 4),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 5),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 6),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 7),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 8),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 9),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 10),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 11),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 12),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT3", 1, 13)};
+
+        ItemStack[] BOBPT4= new ItemStack[]{
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 2),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 3),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 4),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 5),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 6),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 7),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 8),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 9),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 10),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 11),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 12),
+                getModItem("BiblioWoodsBoP", "BiblioWoodPaintingT4", 1, 13)};
+
+        ItemStack[] FrameBOP= new ItemStack[]{
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 2),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 3),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 4),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 5),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 6),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 7),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 8),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 9),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 10),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 11),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 12),
+                getModItem("BiblioWoodsBoP", "BiblioWoodMapFrame", 1, 13)};
+
+        ItemStack[] LableBOP= new ItemStack[]{
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 1),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 2),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 3),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 4),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 5),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 6),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 7),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 8),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 9),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 10),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 11),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 12),
+                getModItem("BiblioWoodsBoP", "BiblioWoodlabel", 1, 13)};
+
+        for (int i=0;i<14;i++){
+            addShapedRecipe(FClockBOP[i], new Object[]{
+                    BOBwood[i], getModItem("minecraft", "clock", 1), BOBwood[i],
+                    BOBwood[i], "stickWood", BOBwood[i],
+                    BOBwood[i], "plateGold", BOBwood[i]});
+            addShapedRecipe(PaintingBOP[i], new Object[]{
+                    BOBwood[i], BOBwood[i], BOBwood[i],
+                    BOBwood[i], getModItem("BiblioCraft", "item.PaintingCanvas", 1), BOBwood[i],
+                    BOBwood[i], BOBwood[i], BOBwood[i]});
+            addShapedRecipe(BOBPT1[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", PaintingBOP[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(BOBPT2[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", BOBPT1[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(BOBPT3[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", BOBPT2[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(BOBPT4[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", BOBPT3[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(LableBOP[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", FrameBOP[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+        }
+        endTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public long getExecutionTime(){
+        return endTime-startTime;
+    }
+
+    @Override
+    public List<String> getDependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public String getScriptName() {
+        return scriptName;
+    }
+}
+
+

--- a/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsBoP.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsBoP.java
@@ -16,7 +16,7 @@ public class ScriptBiblioWoodsBoP implements IScriptLoader{
     private static final List<String> dependencies = Arrays.asList("BiomesOPlenty", "BiblioWoodsBoP", "BiblioCraft");
 
     @Override
-    public void loadRecipe(){
+    public void loadRecipes(){
         startTime = System.currentTimeMillis();
         ItemStack[] BOBwood= new ItemStack[]{
                 getModItem("BiomesOPlenty", "woodenSingleSlab1", 1),

--- a/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsForestry.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsForestry.java
@@ -1,5 +1,6 @@
 package com.dreammaster.scripts;
 
+import gregtech.api.util.GT_OreDictUnificator;
 import net.minecraft.item.ItemStack;
 
 import java.util.Arrays;
@@ -14,7 +15,7 @@ public class ScriptBiblioWoodsForestry implements IScriptLoader {
     private static final List<String> dependencies = Arrays.asList("BiblioCraft", "Forestry","BiblioWoodsForestry");
 
     @Override
-    public void loadRecipe() {
+    public void loadRecipes() {
         startTime = System.currentTimeMillis();
         ItemStack[] F1wood= new ItemStack[]{
                 getModItem("Forestry", "slabs", 1, 2),
@@ -311,6 +312,1908 @@ public class ScriptBiblioWoodsForestry implements IScriptLoader {
                         F2wood[i], F2wood[i], F2wood[i]});
             }
         }
+        // the 2.4k lines that i auto generated
+        //oredicts
+        GT_OreDictUnificator.registerOre("PlumPlanks",getModItem("Forestry", "planks", 1, 21));
+        GT_OreDictUnificator.registerOre("PlumPlanks",getModItem("Forestry", "planksFireproof", 1, 21));
+        GT_OreDictUnificator.registerOre("PlumSlab",getModItem("Forestry", "slabs", 1, 21));
+        GT_OreDictUnificator.registerOre("PlumSlab",getModItem("Forestry", "slabsFireproof", 1, 21));
+        GT_OreDictUnificator.registerOre("PinePlanks",getModItem("Forestry", "planks", 1, 20));
+        GT_OreDictUnificator.registerOre("PinePlanks",getModItem("Forestry", "planksFireproof", 1, 20));
+        GT_OreDictUnificator.registerOre("PineSlab",getModItem("Forestry", "slabs", 1, 20));
+        GT_OreDictUnificator.registerOre("PineSlab",getModItem("Forestry", "slabsFireproof", 1, 20));
+        GT_OreDictUnificator.registerOre("PoplarPlanks",getModItem("Forestry", "planks", 1, 22));
+        GT_OreDictUnificator.registerOre("PoplarPlanks",getModItem("Forestry", "planksFireproof", 1, 22));
+        GT_OreDictUnificator.registerOre("PoplarSlab",getModItem("Forestry", "slabs", 1, 22));
+        GT_OreDictUnificator.registerOre("PoplarSlab",getModItem("Forestry", "slabsFireproof", 1, 22));
+        GT_OreDictUnificator.registerOre("SequoiaPlanks",getModItem("Forestry", "planks", 1, 7));
+        GT_OreDictUnificator.registerOre("SequoiaPlanks",getModItem("Forestry", "planksFireproof", 1, 7));
+        GT_OreDictUnificator.registerOre("SequoiaSlab",getModItem("Forestry", "slabs", 1, 7));
+        GT_OreDictUnificator.registerOre("SequoiaSlab",getModItem("Forestry", "slabsFireproof", 1, 7));
+        GT_OreDictUnificator.registerOre("TeakPlanks",getModItem("Forestry", "planks", 1, 1));
+        GT_OreDictUnificator.registerOre("TeakPlanks",getModItem("Forestry", "planksFireproof", 1, 1));
+        GT_OreDictUnificator.registerOre("TeakSlab",getModItem("Forestry", "slabs", 1, 1));
+        GT_OreDictUnificator.registerOre("TeakSlab",getModItem("Forestry", "slabsFireproof", 1, 1));
+        GT_OreDictUnificator.registerOre("WalnutPlanks",getModItem("Forestry", "planks", 1, 13));
+        GT_OreDictUnificator.registerOre("WalnutPlanks",getModItem("Forestry", "planksFireproof", 1, 13));
+        GT_OreDictUnificator.registerOre("WalnutSlab",getModItem("Forestry", "slabs", 1, 13));
+        GT_OreDictUnificator.registerOre("WalnutSlab",getModItem("Forestry", "slabsFireproof", 1, 13));
+        GT_OreDictUnificator.registerOre("WengePlanks",getModItem("Forestry", "planks", 1, 5));
+        GT_OreDictUnificator.registerOre("WengePlanks",getModItem("Forestry", "planksFireproof", 1, 5));
+        GT_OreDictUnificator.registerOre("WengeSlab",getModItem("Forestry", "slabs", 1, 5));
+        GT_OreDictUnificator.registerOre("WengeSlab",getModItem("Forestry", "slabsFireproof", 1, 5));
+        GT_OreDictUnificator.registerOre("WillowPlanks",getModItem("Forestry", "planks", 1, 12));
+        GT_OreDictUnificator.registerOre("WillowPlanks",getModItem("Forestry", "planksFireproof", 1, 12));
+        GT_OreDictUnificator.registerOre("WillowSlab",getModItem("Forestry", "slabs", 1, 12));
+        GT_OreDictUnificator.registerOre("WillowSlab",getModItem("Forestry", "slabsFireproof", 1, 12));
+        GT_OreDictUnificator.registerOre("AcaciaPlanks",getModItem("Forestry", "planks", 1, 2));
+        GT_OreDictUnificator.registerOre("AcaciaPlanks",getModItem("Forestry", "planksFireproof", 1, 2));
+        GT_OreDictUnificator.registerOre("AcaciaSlab",getModItem("Forestry", "slabs", 1, 2));
+        GT_OreDictUnificator.registerOre("AcaciaSlab",getModItem("Forestry", "slabsFireproof", 1, 2));
+        GT_OreDictUnificator.registerOre("BalsaPlanks",getModItem("Forestry", "planks", 1, 11));
+        GT_OreDictUnificator.registerOre("BalsaPlanks",getModItem("Forestry", "planksFireproof", 1, 11));
+        GT_OreDictUnificator.registerOre("BalsaSlab",getModItem("Forestry", "slabs", 1, 11));
+        GT_OreDictUnificator.registerOre("BalsaSlab",getModItem("Forestry", "slabsFireproof", 1, 11));
+        GT_OreDictUnificator.registerOre("BaobabPlanks",getModItem("Forestry", "planks", 1, 6));
+        GT_OreDictUnificator.registerOre("BaobabPlanks",getModItem("Forestry", "planksFireproof", 1, 6));
+        GT_OreDictUnificator.registerOre("BaobabSlab",getModItem("Forestry", "slabs", 1, 6));
+        GT_OreDictUnificator.registerOre("BaobabSlab",getModItem("Forestry", "slabsFireproof", 1, 6));
+        GT_OreDictUnificator.registerOre("CherryPlanks",getModItem("Forestry", "planks", 1, 15));
+        GT_OreDictUnificator.registerOre("CherryPlanks",getModItem("Forestry", "planksFireproof", 1, 15));
+        GT_OreDictUnificator.registerOre("CherrySlab",getModItem("Forestry", "slabs", 1, 15));
+        GT_OreDictUnificator.registerOre("CherrySlab",getModItem("Forestry", "slabsFireproof", 1, 15));
+        GT_OreDictUnificator.registerOre("ChestnutPlanks",getModItem("Forestry", "planks", 1, 4));
+        GT_OreDictUnificator.registerOre("ChestnutPlanks",getModItem("Forestry", "planksFireproof", 1, 4));
+        GT_OreDictUnificator.registerOre("ChestnutSlab",getModItem("Forestry", "slabs", 1, 4));
+        GT_OreDictUnificator.registerOre("ChestnutSlab",getModItem("Forestry", "slabsFireproof", 1, 4));
+        GT_OreDictUnificator.registerOre("CitrusPlanks",getModItem("Forestry", "planks", 1, 23));
+        GT_OreDictUnificator.registerOre("CitrusPlanks",getModItem("Forestry", "planksFireproof", 1, 23));
+        GT_OreDictUnificator.registerOre("CitrusSlab",getModItem("Forestry", "slabs", 1, 23));
+        GT_OreDictUnificator.registerOre("CitrusSlab",getModItem("Forestry", "slabsFireproof", 1, 23));
+        GT_OreDictUnificator.registerOre("EbonyPlanks",getModItem("Forestry", "planks", 1, 9));
+        GT_OreDictUnificator.registerOre("EbonyPlanks",getModItem("Forestry", "planksFireproof", 1, 9));
+        GT_OreDictUnificator.registerOre("EbonySlab",getModItem("Forestry", "slabs", 1, 9));
+        GT_OreDictUnificator.registerOre("EbonySlab",getModItem("Forestry", "slabsFireproof", 1, 9));
+        GT_OreDictUnificator.registerOre("GreenheartPlanks",getModItem("Forestry", "planks", 1, 14));
+        GT_OreDictUnificator.registerOre("GreenheartPlanks",getModItem("Forestry", "planksFireproof", 1, 14));
+        GT_OreDictUnificator.registerOre("GreenheartSlabs",getModItem("Forestry", "slabs", 1, 14));
+        GT_OreDictUnificator.registerOre("GreenheartSlabs",getModItem("Forestry", "slabsFireproof", 1, 14));
+        GT_OreDictUnificator.registerOre("KapokPlanks",getModItem("Forestry", "planks", 1, 8));
+        GT_OreDictUnificator.registerOre("KapokPlanks",getModItem("Forestry", "planksFireproof", 1, 8));
+        GT_OreDictUnificator.registerOre("KapokSlabs",getModItem("Forestry", "slabs", 1, 8));
+        GT_OreDictUnificator.registerOre("KapokSlabs",getModItem("Forestry", "slabsFireproof", 1, 8));
+        GT_OreDictUnificator.registerOre("LarchPlanks",getModItem("Forestry", "planks", 1, 0));
+        GT_OreDictUnificator.registerOre("LarchPlanks",getModItem("Forestry", "planksFireproof", 1, 0));
+        GT_OreDictUnificator.registerOre("LarchSlabs",getModItem("Forestry", "slabs", 1, 0));
+        GT_OreDictUnificator.registerOre("LarchSlabs",getModItem("Forestry", "slabsFireproof", 1, 0));
+        GT_OreDictUnificator.registerOre("LimePlanks",getModItem("Forestry", "planks", 1, 3));
+        GT_OreDictUnificator.registerOre("LimePlanks",getModItem("Forestry", "planksFireproof", 1, 3));
+        GT_OreDictUnificator.registerOre("LimeSlabs",getModItem("Forestry", "slabs", 1, 3));
+        GT_OreDictUnificator.registerOre("LimeSlabs",getModItem("Forestry", "slabsFireproof", 1, 3));
+        GT_OreDictUnificator.registerOre("MahoePlanks",getModItem("Forestry", "planks", 1, 16));
+        GT_OreDictUnificator.registerOre("MahoePlanks",getModItem("Forestry", "planksFireproof", 1, 16));
+        GT_OreDictUnificator.registerOre("MahoeSlabs",getModItem("Forestry", "slabs", 1, 16));
+        GT_OreDictUnificator.registerOre("MahoeSlabs",getModItem("Forestry", "slabsFireproof", 1, 16));
+        GT_OreDictUnificator.registerOre("MahoganyPlanks",getModItem("Forestry", "planks", 1, 10));
+        GT_OreDictUnificator.registerOre("MahoganyPlanks",getModItem("Forestry", "planksFireproof", 1, 10));
+        GT_OreDictUnificator.registerOre("MahoganySlabs",getModItem("Forestry", "slabs", 1, 10));
+        GT_OreDictUnificator.registerOre("MahoganySlabs",getModItem("Forestry", "slabsFireproof", 1, 10));
+        GT_OreDictUnificator.registerOre("MapplePlanks",getModItem("Forestry", "planks", 1, 22));
+        GT_OreDictUnificator.registerOre("MapplePlanks",getModItem("Forestry", "planksFireproof", 1, 22));
+        GT_OreDictUnificator.registerOre("MappleSlabs",getModItem("Forestry", "slabs", 1, 22));
+        GT_OreDictUnificator.registerOre("MappleSlabs",getModItem("Forestry", "slabsFireproof", 1, 22));
+        GT_OreDictUnificator.registerOre("PalmPlanks",getModItem("Forestry", "planks", 1, 18));
+        GT_OreDictUnificator.registerOre("PalmPlanks",getModItem("Forestry", "planksFireproof", 1, 18));
+        GT_OreDictUnificator.registerOre("PalmSlabs",getModItem("Forestry", "slabs", 1, 18));
+        GT_OreDictUnificator.registerOre("PalmSlabs",getModItem("Forestry", "slabsFireproof", 1, 18));
+        GT_OreDictUnificator.registerOre("PapayaPlanks",getModItem("Forestry", "planks", 1, 19));
+        GT_OreDictUnificator.registerOre("PapayaPlanks",getModItem("Forestry", "planksFireproof", 1, 19));
+        GT_OreDictUnificator.registerOre("PapayaSlabs",getModItem("Forestry", "slabs", 1, 19));
+        GT_OreDictUnificator.registerOre("PapayaSlabs",getModItem("Forestry", "slabsFireproof", 1, 19));
+
+
+        //recipes
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 1), new Object[]{
+                "PlumPlanks", "PlumSlab", "PlumPlanks",
+                "PlumPlanks", "PlumSlab", "PlumPlanks",
+                "PlumPlanks", "PlumSlab", "PlumPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf2", 1, 1), new Object[]{
+                "PlumSlab", "PlumSlab", "PlumSlab",
+                "PlumPlanks", "bottleEmpty", "PlumPlanks",
+                "PlumSlab", "PlumSlab", "PlumSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf2", 1, 1), new Object[]{
+                "PlumSlab", "PlumSlab", "PlumSlab",
+                null, "PlumPlanks", null,
+                "PlumSlab", "PlumSlab", "PlumSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack2", 1, 1), new Object[]{
+                "PlumSlab", "PlumSlab", "PlumSlab",
+                "PlumSlab", "ingotIron", "PlumSlab",
+                "PlumSlab", "PlumSlab", "PlumSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase1", 1, 1), new Object[]{
+                "PlumSlab", "glass", "PlumSlab",
+                "PlumSlab", "blockWool", "PlumSlab",
+                "PlumSlab", "PlumSlab", "PlumSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk2", 1, 1), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "PlumSlab", "PlumSlab", "PlumSlab",
+                "PlumPlanks", null, "PlumPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat2", 1, 1), new Object[]{
+                null, "slabCloth", null,
+                null, "PlumSlab", null,
+                "stickWood", "PlumSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable2", 1, 1), new Object[]{
+                "PlumSlab", "PlumSlab", "PlumSlab",
+                null, "PlumPlanks", null,
+                null, "PlumPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 1), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "PlumSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench2", 1, 1), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "PlumSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 1), "PlumSlab",
+                "PlumSlab", "PlumSlab", "PlumSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 17), new Object[]{
+                null, "blockWool", null,
+                null, "PlumSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 17), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "PlumSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 17), new Object[]{
+                "PlumSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 17), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 17), new Object[]{
+                null, "blockWool", null,
+                null, "PlumSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 17), new Object[]{
+                "PlumSlab", "PlumSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 17), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 0), new Object[]{
+                "PinePlanks", "PineSlab", "PinePlanks",
+                "PinePlanks", "PineSlab", "PinePlanks",
+                "PinePlanks", "PineSlab", "PinePlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf2", 1, 0), new Object[]{
+                "PineSlab", "PineSlab", "PineSlab",
+                "PinePlanks", "bottleEmpty", "PinePlanks",
+                "PineSlab", "PineSlab", "PineSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf2", 1, 0), new Object[]{
+                "PineSlab", "PineSlab", "PineSlab",
+                null, "PinePlanks", null,
+                "PineSlab", "PineSlab", "PineSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack2", 1, 0), new Object[]{
+                "PineSlab", "PineSlab", "PineSlab",
+                "PineSlab", "ingotIron", "PineSlab",
+                "PineSlab", "PineSlab", "PineSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase1", 1, 0), new Object[]{
+                "PineSlab", "glass", "PineSlab",
+                "PineSlab", "blockWool", "PineSlab",
+                "PineSlab", "PineSlab", "PineSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk2", 1, 0), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "PineSlab", "PineSlab", "PineSlab",
+                "PinePlanks", null, "PinePlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat2", 1, 0), new Object[]{
+                null, "slabCloth", null,
+                null, "PineSlab", null,
+                "stickWood", "PineSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable2", 1, 0), new Object[]{
+                "PineSlab", "PineSlab", "PineSlab",
+                null, "PinePlanks", null,
+                null, "PinePlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 0), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "PineSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench2", 1, 0), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "PineSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 0), "PineSlab",
+                "PineSlab", "PineSlab", "PineSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 16), new Object[]{
+                null, "blockWool", null,
+                null, "PineSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 16), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "PineSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 16), new Object[]{
+                "PineSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 16), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 16), new Object[]{
+                null, "blockWool", null,
+                null, "PineSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 16), new Object[]{
+                "PineSlab", "PineSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 16), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 2), new Object[]{
+                "PoplarPlanks", "PoplarSlab", "PoplarPlanks",
+                "PoplarPlanks", "PoplarSlab", "PoplarPlanks",
+                "PoplarPlanks", "PoplarSlab", "PoplarPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf2", 1, 2), new Object[]{
+                "PoplarSlab", "PoplarSlab", "PoplarSlab",
+                "PoplarPlanks", "bottleEmpty", "PoplarPlanks",
+                "PoplarSlab", "PoplarSlab", "PoplarSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf2", 1, 2), new Object[]{
+                "PoplarSlab", "PoplarSlab", "PoplarSlab",
+                null, "PoplarPlanks", null,
+                "PoplarSlab", "PoplarSlab", "PoplarSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack2", 1, 2), new Object[]{
+                "PoplarSlab", "PoplarSlab", "PoplarSlab",
+                "PoplarSlab", "ingotIron", "PoplarSlab",
+                "PoplarSlab", "PoplarSlab", "PoplarSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase1", 1, 2), new Object[]{
+                "PoplarSlab", "glass", "PoplarSlab",
+                "PoplarSlab", "blockWool", "PoplarSlab",
+                "PoplarSlab", "PoplarSlab", "PoplarSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk2", 1, 2), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "PoplarSlab", "PoplarSlab", "PoplarSlab",
+                "PoplarPlanks", null, "PoplarPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat2", 1, 2), new Object[]{
+                null, "slabCloth", null,
+                null, "PoplarSlab", null,
+                "stickWood", "PoplarSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable2", 1, 2), new Object[]{
+                "PoplarSlab", "PoplarSlab", "PoplarSlab",
+                null, "PoplarPlanks", null,
+                null, "PoplarPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 2), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "PoplarSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench2", 1, 2), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "PoplarSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 2), "PoplarSlab",
+                "PoplarSlab", "PoplarSlab", "PoplarSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 18), new Object[]{
+                null, "blockWool", null,
+                null, "PoplarSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 18), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "PoplarSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 18), new Object[]{
+                "PoplarSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 18), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 18), new Object[]{
+                null, "blockWool", null,
+                null, "PoplarSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 18), new Object[]{
+                "PoplarSlab", "PoplarSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 18), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 3), new Object[]{
+                "SequoiaPlanks", "SequoiaSlab", "SequoiaPlanks",
+                "SequoiaPlanks", "SequoiaSlab", "SequoiaPlanks",
+                "SequoiaPlanks", "SequoiaSlab", "SequoiaPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf2", 1, 3), new Object[]{
+                "SequoiaSlab", "SequoiaSlab", "SequoiaSlab",
+                "SequoiaPlanks", "bottleEmpty", "SequoiaPlanks",
+                "SequoiaSlab", "SequoiaSlab", "SequoiaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf2", 1, 3), new Object[]{
+                "SequoiaSlab", "SequoiaSlab", "SequoiaSlab",
+                null, "SequoiaPlanks", null,
+                "SequoiaSlab", "SequoiaSlab", "SequoiaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack2", 1, 3), new Object[]{
+                "SequoiaSlab", "SequoiaSlab", "SequoiaSlab",
+                "SequoiaSlab", "ingotIron", "SequoiaSlab",
+                "SequoiaSlab", "SequoiaSlab", "SequoiaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase1", 1, 3), new Object[]{
+                "SequoiaSlab", "glass", "SequoiaSlab",
+                "SequoiaSlab", "blockWool", "SequoiaSlab",
+                "SequoiaSlab", "SequoiaSlab", "SequoiaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk2", 1, 3), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "SequoiaSlab", "SequoiaSlab", "SequoiaSlab",
+                "SequoiaPlanks", null, "SequoiaPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat2", 1, 3), new Object[]{
+                null, "slabCloth", null,
+                null, "SequoiaSlab", null,
+                "stickWood", "SequoiaSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable2", 1, 3), new Object[]{
+                "SequoiaSlab", "SequoiaSlab", "SequoiaSlab",
+                null, "SequoiaPlanks", null,
+                null, "SequoiaPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 3), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "SequoiaSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench2", 1, 3), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "SequoiaSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 3), "SequoiaSlab",
+                "SequoiaSlab", "SequoiaSlab", "SequoiaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 19), new Object[]{
+                null, "blockWool", null,
+                null, "SequoiaSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 19), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "SequoiaSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 19), new Object[]{
+                "SequoiaSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 19), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 19), new Object[]{
+                null, "blockWool", null,
+                null, "SequoiaSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 19), new Object[]{
+                "SequoiaSlab", "SequoiaSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 19), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 4), new Object[]{
+                "TeakPlanks", "TeakSlab", "TeakPlanks",
+                "TeakPlanks", "TeakSlab", "TeakPlanks",
+                "TeakPlanks", "TeakSlab", "TeakPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf2", 1, 4), new Object[]{
+                "TeakSlab", "TeakSlab", "TeakSlab",
+                "TeakPlanks", "bottleEmpty", "TeakPlanks",
+                "TeakSlab", "TeakSlab", "TeakSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf2", 1, 4), new Object[]{
+                "TeakSlab", "TeakSlab", "TeakSlab",
+                null, "TeakPlanks", null,
+                "TeakSlab", "TeakSlab", "TeakSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack2", 1, 4), new Object[]{
+                "TeakSlab", "TeakSlab", "TeakSlab",
+                "TeakSlab", "ingotIron", "TeakSlab",
+                "TeakSlab", "TeakSlab", "TeakSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase1", 1, 4), new Object[]{
+                "TeakSlab", "glass", "TeakSlab",
+                "TeakSlab", "blockWool", "TeakSlab",
+                "TeakSlab", "TeakSlab", "TeakSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk2", 1, 4), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "TeakSlab", "TeakSlab", "TeakSlab",
+                "TeakPlanks", null, "TeakPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat2", 1, 4), new Object[]{
+                null, "slabCloth", null,
+                null, "TeakSlab", null,
+                "stickWood", "TeakSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable2", 1, 4), new Object[]{
+                "TeakSlab", "TeakSlab", "TeakSlab",
+                null, "TeakPlanks", null,
+                null, "TeakPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 4), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "TeakSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench2", 1, 4), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "TeakSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 4), "TeakSlab",
+                "TeakSlab", "TeakSlab", "TeakSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 20), new Object[]{
+                null, "blockWool", null,
+                null, "TeakSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 20), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "TeakSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 20), new Object[]{
+                "TeakSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 20), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 20), new Object[]{
+                null, "blockWool", null,
+                null, "TeakSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 20), new Object[]{
+                "TeakSlab", "TeakSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 20), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 5), new Object[]{
+                "WalnutPlanks", "WalnutSlab", "WalnutPlanks",
+                "WalnutPlanks", "WalnutSlab", "WalnutPlanks",
+                "WalnutPlanks", "WalnutSlab", "WalnutPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf2", 1, 5), new Object[]{
+                "WalnutSlab", "WalnutSlab", "WalnutSlab",
+                "WalnutPlanks", "bottleEmpty", "WalnutPlanks",
+                "WalnutSlab", "WalnutSlab", "WalnutSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf2", 1, 5), new Object[]{
+                "WalnutSlab", "WalnutSlab", "WalnutSlab",
+                null, "WalnutPlanks", null,
+                "WalnutSlab", "WalnutSlab", "WalnutSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack2", 1, 5), new Object[]{
+                "WalnutSlab", "WalnutSlab", "WalnutSlab",
+                "WalnutSlab", "ingotIron", "WalnutSlab",
+                "WalnutSlab", "WalnutSlab", "WalnutSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase1", 1, 5), new Object[]{
+                "WalnutSlab", "glass", "WalnutSlab",
+                "WalnutSlab", "blockWool", "WalnutSlab",
+                "WalnutSlab", "WalnutSlab", "WalnutSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk2", 1, 5), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "WalnutSlab", "WalnutSlab", "WalnutSlab",
+                "WalnutPlanks", null, "WalnutPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat2", 1, 5), new Object[]{
+                null, "slabCloth", null,
+                null, "WalnutSlab", null,
+                "stickWood", "WalnutSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable2", 1, 5), new Object[]{
+                "WalnutSlab", "WalnutSlab", "WalnutSlab",
+                null, "WalnutPlanks", null,
+                null, "WalnutPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 5), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "WalnutSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench2", 1, 5), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "WalnutSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 5), "WalnutSlab",
+                "WalnutSlab", "WalnutSlab", "WalnutSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 21), new Object[]{
+                null, "blockWool", null,
+                null, "WalnutSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 21), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "WalnutSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 21), new Object[]{
+                "WalnutSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 21), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 21), new Object[]{
+                null, "blockWool", null,
+                null, "WalnutSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 21), new Object[]{
+                "WalnutSlab", "WalnutSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 21), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 6), new Object[]{
+                "WengePlanks", "WengeSlab", "WengePlanks",
+                "WengePlanks", "WengeSlab", "WengePlanks",
+                "WengePlanks", "WengeSlab", "WengePlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf2", 1, 6), new Object[]{
+                "WengeSlab", "WengeSlab", "WengeSlab",
+                "WengePlanks", "bottleEmpty", "WengePlanks",
+                "WengeSlab", "WengeSlab", "WengeSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf2", 1, 6), new Object[]{
+                "WengeSlab", "WengeSlab", "WengeSlab",
+                null, "WengePlanks", null,
+                "WengeSlab", "WengeSlab", "WengeSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack2", 1, 6), new Object[]{
+                "WengeSlab", "WengeSlab", "WengeSlab",
+                "WengeSlab", "ingotIron", "WengeSlab",
+                "WengeSlab", "WengeSlab", "WengeSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase1", 1, 6), new Object[]{
+                "WengeSlab", "glass", "WengeSlab",
+                "WengeSlab", "blockWool", "WengeSlab",
+                "WengeSlab", "WengeSlab", "WengeSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk2", 1, 6), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "WengeSlab", "WengeSlab", "WengeSlab",
+                "WengePlanks", null, "WengePlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat2", 1, 6), new Object[]{
+                null, "slabCloth", null,
+                null, "WengeSlab", null,
+                "stickWood", "WengeSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable2", 1, 6), new Object[]{
+                "WengeSlab", "WengeSlab", "WengeSlab",
+                null, "WengePlanks", null,
+                null, "WengePlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 6), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "WengeSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench2", 1, 6), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "WengeSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 6), "WengeSlab",
+                "WengeSlab", "WengeSlab", "WengeSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 22), new Object[]{
+                null, "blockWool", null,
+                null, "WengeSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 22), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "WengeSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 22), new Object[]{
+                "WengeSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 22), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 22), new Object[]{
+                null, "blockWool", null,
+                null, "WengeSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 22), new Object[]{
+                "WengeSlab", "WengeSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 22), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 7), new Object[]{
+                "WillowPlanks", "WillowSlab", "WillowPlanks",
+                "WillowPlanks", "WillowSlab", "WillowPlanks",
+                "WillowPlanks", "WillowSlab", "WillowPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf2", 1, 7), new Object[]{
+                "WillowSlab", "WillowSlab", "WillowSlab",
+                "WillowPlanks", "bottleEmpty", "WillowPlanks",
+                "WillowSlab", "WillowSlab", "WillowSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf2", 1, 7), new Object[]{
+                "WillowSlab", "WillowSlab", "WillowSlab",
+                null, "WillowPlanks", null,
+                "WillowSlab", "WillowSlab", "WillowSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack2", 1, 7), new Object[]{
+                "WillowSlab", "WillowSlab", "WillowSlab",
+                "WillowSlab", "ingotIron", "WillowSlab",
+                "WillowSlab", "WillowSlab", "WillowSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase1", 1, 7), new Object[]{
+                "WillowSlab", "glass", "WillowSlab",
+                "WillowSlab", "blockWool", "WillowSlab",
+                "WillowSlab", "WillowSlab", "WillowSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk2", 1, 7), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "WillowSlab", "WillowSlab", "WillowSlab",
+                "WillowPlanks", null, "WillowPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat2", 1, 7), new Object[]{
+                null, "slabCloth", null,
+                null, "WillowSlab", null,
+                "stickWood", "WillowSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable2", 1, 7), new Object[]{
+                "WillowSlab", "WillowSlab", "WillowSlab",
+                null, "WillowPlanks", null,
+                null, "WillowPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 7), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "WillowSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench2", 1, 7), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "WillowSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase2", 1, 7), "WillowSlab",
+                "WillowSlab", "WillowSlab", "WillowSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 23), new Object[]{
+                null, "blockWool", null,
+                null, "WillowSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 23), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "WillowSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 23), new Object[]{
+                "WillowSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 23), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 23), new Object[]{
+                null, "blockWool", null,
+                null, "WillowSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 23), new Object[]{
+                "WillowSlab", "WillowSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 23), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 0), new Object[]{
+                "AcaciaPlanks", "AcaciaSlab", "AcaciaPlanks",
+                "AcaciaPlanks", "AcaciaSlab", "AcaciaPlanks",
+                "AcaciaPlanks", "AcaciaSlab", "AcaciaPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 0), new Object[]{
+                "AcaciaSlab", "AcaciaSlab", "AcaciaSlab",
+                "AcaciaPlanks", "bottleEmpty", "AcaciaPlanks",
+                "AcaciaSlab", "AcaciaSlab", "AcaciaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 0), new Object[]{
+                "AcaciaSlab", "AcaciaSlab", "AcaciaSlab",
+                null, "AcaciaPlanks", null,
+                "AcaciaSlab", "AcaciaSlab", "AcaciaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 0), new Object[]{
+                "AcaciaSlab", "AcaciaSlab", "AcaciaSlab",
+                "AcaciaSlab", "ingotIron", "AcaciaSlab",
+                "AcaciaSlab", "AcaciaSlab", "AcaciaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 0), new Object[]{
+                "AcaciaSlab", "glass", "AcaciaSlab",
+                "AcaciaSlab", "blockWool", "AcaciaSlab",
+                "AcaciaSlab", "AcaciaSlab", "AcaciaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 0), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "AcaciaSlab", "AcaciaSlab", "AcaciaSlab",
+                "AcaciaPlanks", null, "AcaciaPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 0), new Object[]{
+                null, "slabCloth", null,
+                null, "AcaciaSlab", null,
+                "stickWood", "AcaciaSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 0), new Object[]{
+                "AcaciaSlab", "AcaciaSlab", "AcaciaSlab",
+                null, "AcaciaPlanks", null,
+                null, "AcaciaPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 0), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "AcaciaSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 0), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "AcaciaSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 0), "AcaciaSlab",
+                "AcaciaSlab", "AcaciaSlab", "AcaciaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 0), new Object[]{
+                null, "blockWool", null,
+                null, "AcaciaSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 0), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "AcaciaSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 0), new Object[]{
+                "AcaciaSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 0), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 0), new Object[]{
+                null, "blockWool", null,
+                null, "AcaciaSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 0), new Object[]{
+                "AcaciaSlab", "AcaciaSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 0), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 1), new Object[]{
+                "BalsaPlanks", "BalsaSlab", "BalsaPlanks",
+                "BalsaPlanks", "BalsaSlab", "BalsaPlanks",
+                "BalsaPlanks", "BalsaSlab", "BalsaPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 1), new Object[]{
+                "BalsaSlab", "BalsaSlab", "BalsaSlab",
+                "BalsaPlanks", "bottleEmpty", "BalsaPlanks",
+                "BalsaSlab", "BalsaSlab", "BalsaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 1), new Object[]{
+                "BalsaSlab", "BalsaSlab", "BalsaSlab",
+                null, "BalsaPlanks", null,
+                "BalsaSlab", "BalsaSlab", "BalsaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 1), new Object[]{
+                "BalsaSlab", "BalsaSlab", "BalsaSlab",
+                "BalsaSlab", "ingotIron", "BalsaSlab",
+                "BalsaSlab", "BalsaSlab", "BalsaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 1), new Object[]{
+                "BalsaSlab", "glass", "BalsaSlab",
+                "BalsaSlab", "blockWool", "BalsaSlab",
+                "BalsaSlab", "BalsaSlab", "BalsaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 1), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "BalsaSlab", "BalsaSlab", "BalsaSlab",
+                "BalsaPlanks", null, "BalsaPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 1), new Object[]{
+                null, "slabCloth", null,
+                null, "BalsaSlab", null,
+                "stickWood", "BalsaSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 1), new Object[]{
+                "BalsaSlab", "BalsaSlab", "BalsaSlab",
+                null, "BalsaPlanks", null,
+                null, "BalsaPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 1), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "BalsaSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 1), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "BalsaSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 1), "BalsaSlab",
+                "BalsaSlab", "BalsaSlab", "BalsaSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 1), new Object[]{
+                null, "blockWool", null,
+                null, "BalsaSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 1), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "BalsaSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 1), new Object[]{
+                "BalsaSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 1), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 1), new Object[]{
+                null, "blockWool", null,
+                null, "BalsaSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 1), new Object[]{
+                "BalsaSlab", "BalsaSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 1), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 2), new Object[]{
+                "BaobabPlanks", "BaobabSlab", "BaobabPlanks",
+                "BaobabPlanks", "BaobabSlab", "BaobabPlanks",
+                "BaobabPlanks", "BaobabSlab", "BaobabPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 2), new Object[]{
+                "BaobabSlab", "BaobabSlab", "BaobabSlab",
+                "BaobabPlanks", "bottleEmpty", "BaobabPlanks",
+                "BaobabSlab", "BaobabSlab", "BaobabSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 2), new Object[]{
+                "BaobabSlab", "BaobabSlab", "BaobabSlab",
+                null, "BaobabPlanks", null,
+                "BaobabSlab", "BaobabSlab", "BaobabSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 2), new Object[]{
+                "BaobabSlab", "BaobabSlab", "BaobabSlab",
+                "BaobabSlab", "ingotIron", "BaobabSlab",
+                "BaobabSlab", "BaobabSlab", "BaobabSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 2), new Object[]{
+                "BaobabSlab", "glass", "BaobabSlab",
+                "BaobabSlab", "blockWool", "BaobabSlab",
+                "BaobabSlab", "BaobabSlab", "BaobabSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 2), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "BaobabSlab", "BaobabSlab", "BaobabSlab",
+                "BaobabPlanks", null, "BaobabPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 2), new Object[]{
+                null, "slabCloth", null,
+                null, "BaobabSlab", null,
+                "stickWood", "BaobabSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 2), new Object[]{
+                "BaobabSlab", "BaobabSlab", "BaobabSlab",
+                null, "BaobabPlanks", null,
+                null, "BaobabPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 2), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "BaobabSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 2), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "BaobabSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 2), "BaobabSlab",
+                "BaobabSlab", "BaobabSlab", "BaobabSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 2), new Object[]{
+                null, "blockWool", null,
+                null, "BaobabSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 2), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "BaobabSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 2), new Object[]{
+                "BaobabSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 2), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 2), new Object[]{
+                null, "blockWool", null,
+                null, "BaobabSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 2), new Object[]{
+                "BaobabSlab", "BaobabSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 2), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 3), new Object[]{
+                "CherryPlanks", "CherrySlab", "CherryPlanks",
+                "CherryPlanks", "CherrySlab", "CherryPlanks",
+                "CherryPlanks", "CherrySlab", "CherryPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 3), new Object[]{
+                "CherrySlab", "CherrySlab", "CherrySlab",
+                "CherryPlanks", "bottleEmpty", "CherryPlanks",
+                "CherrySlab", "CherrySlab", "CherrySlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 3), new Object[]{
+                "CherrySlab", "CherrySlab", "CherrySlab",
+                null, "CherryPlanks", null,
+                "CherrySlab", "CherrySlab", "CherrySlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 3), new Object[]{
+                "CherrySlab", "CherrySlab", "CherrySlab",
+                "CherrySlab", "ingotIron", "CherrySlab",
+                "CherrySlab", "CherrySlab", "CherrySlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 3), new Object[]{
+                "CherrySlab", "glass", "CherrySlab",
+                "CherrySlab", "blockWool", "CherrySlab",
+                "CherrySlab", "CherrySlab", "CherrySlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 3), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "CherrySlab", "CherrySlab", "CherrySlab",
+                "CherryPlanks", null, "CherryPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 3), new Object[]{
+                null, "slabCloth", null,
+                null, "CherrySlab", null,
+                "stickWood", "CherrySlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 3), new Object[]{
+                "CherrySlab", "CherrySlab", "CherrySlab",
+                null, "CherryPlanks", null,
+                null, "CherryPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 3), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "CherrySlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 3), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "CherrySlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 3), "CherrySlab",
+                "CherrySlab", "CherrySlab", "CherrySlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 3), new Object[]{
+                null, "blockWool", null,
+                null, "CherrySlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 3), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "CherrySlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 3), new Object[]{
+                "CherrySlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 3), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 3), new Object[]{
+                null, "blockWool", null,
+                null, "CherrySlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 3), new Object[]{
+                "CherrySlab", "CherrySlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 3), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 4), new Object[]{
+                "ChestnutPlanks", "ChestnutSlab", "ChestnutPlanks",
+                "ChestnutPlanks", "ChestnutSlab", "ChestnutPlanks",
+                "ChestnutPlanks", "ChestnutSlab", "ChestnutPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 4), new Object[]{
+                "ChestnutSlab", "ChestnutSlab", "ChestnutSlab",
+                "ChestnutPlanks", "bottleEmpty", "ChestnutPlanks",
+                "ChestnutSlab", "ChestnutSlab", "ChestnutSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 4), new Object[]{
+                "ChestnutSlab", "ChestnutSlab", "ChestnutSlab",
+                null, "ChestnutPlanks", null,
+                "ChestnutSlab", "ChestnutSlab", "ChestnutSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 4), new Object[]{
+                "ChestnutSlab", "ChestnutSlab", "ChestnutSlab",
+                "ChestnutSlab", "ingotIron", "ChestnutSlab",
+                "ChestnutSlab", "ChestnutSlab", "ChestnutSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 4), new Object[]{
+                "ChestnutSlab", "glass", "ChestnutSlab",
+                "ChestnutSlab", "blockWool", "ChestnutSlab",
+                "ChestnutSlab", "ChestnutSlab", "ChestnutSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 4), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "ChestnutSlab", "ChestnutSlab", "ChestnutSlab",
+                "ChestnutPlanks", null, "ChestnutPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 4), new Object[]{
+                null, "slabCloth", null,
+                null, "ChestnutSlab", null,
+                "stickWood", "ChestnutSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 4), new Object[]{
+                "ChestnutSlab", "ChestnutSlab", "ChestnutSlab",
+                null, "ChestnutPlanks", null,
+                null, "ChestnutPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 4), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "ChestnutSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 4), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "ChestnutSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 4), "ChestnutSlab",
+                "ChestnutSlab", "ChestnutSlab", "ChestnutSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 4), new Object[]{
+                null, "blockWool", null,
+                null, "ChestnutSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 4), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "ChestnutSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 4), new Object[]{
+                "ChestnutSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 4), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 4), new Object[]{
+                null, "blockWool", null,
+                null, "ChestnutSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 4), new Object[]{
+                "ChestnutSlab", "ChestnutSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 4), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 5), new Object[]{
+                "CitrusPlanks", "CitrusSlab", "CitrusPlanks",
+                "CitrusPlanks", "CitrusSlab", "CitrusPlanks",
+                "CitrusPlanks", "CitrusSlab", "CitrusPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 5), new Object[]{
+                "CitrusSlab", "CitrusSlab", "CitrusSlab",
+                "CitrusPlanks", "bottleEmpty", "CitrusPlanks",
+                "CitrusSlab", "CitrusSlab", "CitrusSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 5), new Object[]{
+                "CitrusSlab", "CitrusSlab", "CitrusSlab",
+                null, "CitrusPlanks", null,
+                "CitrusSlab", "CitrusSlab", "CitrusSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 5), new Object[]{
+                "CitrusSlab", "CitrusSlab", "CitrusSlab",
+                "CitrusSlab", "ingotIron", "CitrusSlab",
+                "CitrusSlab", "CitrusSlab", "CitrusSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 5), new Object[]{
+                "CitrusSlab", "glass", "CitrusSlab",
+                "CitrusSlab", "blockWool", "CitrusSlab",
+                "CitrusSlab", "CitrusSlab", "CitrusSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 5), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "CitrusSlab", "CitrusSlab", "CitrusSlab",
+                "CitrusPlanks", null, "CitrusPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 5), new Object[]{
+                null, "slabCloth", null,
+                null, "CitrusSlab", null,
+                "stickWood", "CitrusSlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 5), new Object[]{
+                "CitrusSlab", "CitrusSlab", "CitrusSlab",
+                null, "CitrusPlanks", null,
+                null, "CitrusPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 5), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "CitrusSlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 5), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "CitrusSlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 5), "CitrusSlab",
+                "CitrusSlab", "CitrusSlab", "CitrusSlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 5), new Object[]{
+                null, "blockWool", null,
+                null, "CitrusSlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 5), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "CitrusSlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 5), new Object[]{
+                "CitrusSlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 5), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 5), new Object[]{
+                null, "blockWool", null,
+                null, "CitrusSlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 5), new Object[]{
+                "CitrusSlab", "CitrusSlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 5), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 6), new Object[]{
+                "EbonyPlanks", "EbonySlab", "EbonyPlanks",
+                "EbonyPlanks", "EbonySlab", "EbonyPlanks",
+                "EbonyPlanks", "EbonySlab", "EbonyPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 6), new Object[]{
+                "EbonySlab", "EbonySlab", "EbonySlab",
+                "EbonyPlanks", "bottleEmpty", "EbonyPlanks",
+                "EbonySlab", "EbonySlab", "EbonySlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 6), new Object[]{
+                "EbonySlab", "EbonySlab", "EbonySlab",
+                null, "EbonyPlanks", null,
+                "EbonySlab", "EbonySlab", "EbonySlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 6), new Object[]{
+                "EbonySlab", "EbonySlab", "EbonySlab",
+                "EbonySlab", "ingotIron", "EbonySlab",
+                "EbonySlab", "EbonySlab", "EbonySlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 6), new Object[]{
+                "EbonySlab", "glass", "EbonySlab",
+                "EbonySlab", "blockWool", "EbonySlab",
+                "EbonySlab", "EbonySlab", "EbonySlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 6), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "EbonySlab", "EbonySlab", "EbonySlab",
+                "EbonyPlanks", null, "EbonyPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 6), new Object[]{
+                null, "slabCloth", null,
+                null, "EbonySlab", null,
+                "stickWood", "EbonySlab", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 6), new Object[]{
+                "EbonySlab", "EbonySlab", "EbonySlab",
+                null, "EbonyPlanks", null,
+                null, "EbonyPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 6), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "EbonySlab", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 6), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "EbonySlab", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 6), "EbonySlab",
+                "EbonySlab", "EbonySlab", "EbonySlab"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 6), new Object[]{
+                null, "blockWool", null,
+                null, "EbonySlab", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 6), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "EbonySlab", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 6), new Object[]{
+                "EbonySlab", getModItem("BiblioWoodsForestry", "seatBack2", 1, 6), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 6), new Object[]{
+                null, "blockWool", null,
+                null, "EbonySlab", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 6), new Object[]{
+                "EbonySlab", "EbonySlab", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 6), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 7), new Object[]{
+                "GreenheartPlanks", "GreenheartSlabs", "GreenheartPlanks",
+                "GreenheartPlanks", "GreenheartSlabs", "GreenheartPlanks",
+                "GreenheartPlanks", "GreenheartSlabs", "GreenheartPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 7), new Object[]{
+                "GreenheartSlabs", "GreenheartSlabs", "GreenheartSlabs",
+                "GreenheartPlanks", "bottleEmpty", "GreenheartPlanks",
+                "GreenheartSlabs", "GreenheartSlabs", "GreenheartSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 7), new Object[]{
+                "GreenheartSlabs", "GreenheartSlabs", "GreenheartSlabs",
+                null, "GreenheartPlanks", null,
+                "GreenheartSlabs", "GreenheartSlabs", "GreenheartSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 7), new Object[]{
+                "GreenheartSlabs", "GreenheartSlabs", "GreenheartSlabs",
+                "GreenheartSlabs", "ingotIron", "GreenheartSlabs",
+                "GreenheartSlabs", "GreenheartSlabs", "GreenheartSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 7), new Object[]{
+                "GreenheartSlabs", "glass", "GreenheartSlabs",
+                "GreenheartSlabs", "blockWool", "GreenheartSlabs",
+                "GreenheartSlabs", "GreenheartSlabs", "GreenheartSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 7), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "GreenheartSlabs", "GreenheartSlabs", "GreenheartSlabs",
+                "GreenheartPlanks", null, "GreenheartPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 7), new Object[]{
+                null, "slabCloth", null,
+                null, "GreenheartSlabs", null,
+                "stickWood", "GreenheartSlabs", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 7), new Object[]{
+                "GreenheartSlabs", "GreenheartSlabs", "GreenheartSlabs",
+                null, "GreenheartPlanks", null,
+                null, "GreenheartPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 7), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "GreenheartSlabs", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 7), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "GreenheartSlabs", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 7), "GreenheartSlabs",
+                "GreenheartSlabs", "GreenheartSlabs", "GreenheartSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 7), new Object[]{
+                null, "blockWool", null,
+                null, "GreenheartSlabs", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 7), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "GreenheartSlabs", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 7), new Object[]{
+                "GreenheartSlabs", getModItem("BiblioWoodsForestry", "seatBack2", 1, 7), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 7), new Object[]{
+                null, "blockWool", null,
+                null, "GreenheartSlabs", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 7), new Object[]{
+                "GreenheartSlabs", "GreenheartSlabs", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 7), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 8), new Object[]{
+                "KapokPlanks", "KapokSlabs", "KapokPlanks",
+                "KapokPlanks", "KapokSlabs", "KapokPlanks",
+                "KapokPlanks", "KapokSlabs", "KapokPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 8), new Object[]{
+                "KapokSlabs", "KapokSlabs", "KapokSlabs",
+                "KapokPlanks", "bottleEmpty", "KapokPlanks",
+                "KapokSlabs", "KapokSlabs", "KapokSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 8), new Object[]{
+                "KapokSlabs", "KapokSlabs", "KapokSlabs",
+                null, "KapokPlanks", null,
+                "KapokSlabs", "KapokSlabs", "KapokSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 8), new Object[]{
+                "KapokSlabs", "KapokSlabs", "KapokSlabs",
+                "KapokSlabs", "ingotIron", "KapokSlabs",
+                "KapokSlabs", "KapokSlabs", "KapokSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 8), new Object[]{
+                "KapokSlabs", "glass", "KapokSlabs",
+                "KapokSlabs", "blockWool", "KapokSlabs",
+                "KapokSlabs", "KapokSlabs", "KapokSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 8), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "KapokSlabs", "KapokSlabs", "KapokSlabs",
+                "KapokPlanks", null, "KapokPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 8), new Object[]{
+                null, "slabCloth", null,
+                null, "KapokSlabs", null,
+                "stickWood", "KapokSlabs", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 8), new Object[]{
+                "KapokSlabs", "KapokSlabs", "KapokSlabs",
+                null, "KapokPlanks", null,
+                null, "KapokPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 8), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "KapokSlabs", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 8), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "KapokSlabs", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 8), "KapokSlabs",
+                "KapokSlabs", "KapokSlabs", "KapokSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 8), new Object[]{
+                null, "blockWool", null,
+                null, "KapokSlabs", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 8), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "KapokSlabs", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 8), new Object[]{
+                "KapokSlabs", getModItem("BiblioWoodsForestry", "seatBack2", 1, 8), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 8), new Object[]{
+                null, "blockWool", null,
+                null, "KapokSlabs", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 8), new Object[]{
+                "KapokSlabs", "KapokSlabs", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 8), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 9), new Object[]{
+                "LarchPlanks", "LarchSlabs", "LarchPlanks",
+                "LarchPlanks", "LarchSlabs", "LarchPlanks",
+                "LarchPlanks", "LarchSlabs", "LarchPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 9), new Object[]{
+                "LarchSlabs", "LarchSlabs", "LarchSlabs",
+                "LarchPlanks", "bottleEmpty", "LarchPlanks",
+                "LarchSlabs", "LarchSlabs", "LarchSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 9), new Object[]{
+                "LarchSlabs", "LarchSlabs", "LarchSlabs",
+                null, "LarchPlanks", null,
+                "LarchSlabs", "LarchSlabs", "LarchSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 9), new Object[]{
+                "LarchSlabs", "LarchSlabs", "LarchSlabs",
+                "LarchSlabs", "ingotIron", "LarchSlabs",
+                "LarchSlabs", "LarchSlabs", "LarchSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 9), new Object[]{
+                "LarchSlabs", "glass", "LarchSlabs",
+                "LarchSlabs", "blockWool", "LarchSlabs",
+                "LarchSlabs", "LarchSlabs", "LarchSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 9), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "LarchSlabs", "LarchSlabs", "LarchSlabs",
+                "LarchPlanks", null, "LarchPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 9), new Object[]{
+                null, "slabCloth", null,
+                null, "LarchSlabs", null,
+                "stickWood", "LarchSlabs", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 9), new Object[]{
+                "LarchSlabs", "LarchSlabs", "LarchSlabs",
+                null, "LarchPlanks", null,
+                null, "LarchPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 9), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "LarchSlabs", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 9), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "LarchSlabs", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 9), "LarchSlabs",
+                "LarchSlabs", "LarchSlabs", "LarchSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 9), new Object[]{
+                null, "blockWool", null,
+                null, "LarchSlabs", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 9), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "LarchSlabs", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 9), new Object[]{
+                "LarchSlabs", getModItem("BiblioWoodsForestry", "seatBack2", 1, 9), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 9), new Object[]{
+                null, "blockWool", null,
+                null, "LarchSlabs", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 9), new Object[]{
+                "LarchSlabs", "LarchSlabs", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 9), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 10), new Object[]{
+                "LimePlanks", "LimeSlabs", "LimePlanks",
+                "LimePlanks", "LimeSlabs", "LimePlanks",
+                "LimePlanks", "LimeSlabs", "LimePlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 10), new Object[]{
+                "LimeSlabs", "LimeSlabs", "LimeSlabs",
+                "LimePlanks", "bottleEmpty", "LimePlanks",
+                "LimeSlabs", "LimeSlabs", "LimeSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 10), new Object[]{
+                "LimeSlabs", "LimeSlabs", "LimeSlabs",
+                null, "LimePlanks", null,
+                "LimeSlabs", "LimeSlabs", "LimeSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 10), new Object[]{
+                "LimeSlabs", "LimeSlabs", "LimeSlabs",
+                "LimeSlabs", "ingotIron", "LimeSlabs",
+                "LimeSlabs", "LimeSlabs", "LimeSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 10), new Object[]{
+                "LimeSlabs", "glass", "LimeSlabs",
+                "LimeSlabs", "blockWool", "LimeSlabs",
+                "LimeSlabs", "LimeSlabs", "LimeSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 10), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "LimeSlabs", "LimeSlabs", "LimeSlabs",
+                "LimePlanks", null, "LimePlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 10), new Object[]{
+                null, "slabCloth", null,
+                null, "LimeSlabs", null,
+                "stickWood", "LimeSlabs", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 10), new Object[]{
+                "LimeSlabs", "LimeSlabs", "LimeSlabs",
+                null, "LimePlanks", null,
+                null, "LimePlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 10), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "LimeSlabs", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 10), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "LimeSlabs", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 10), "LimeSlabs",
+                "LimeSlabs", "LimeSlabs", "LimeSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 10), new Object[]{
+                null, "blockWool", null,
+                null, "LimeSlabs", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 10), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "LimeSlabs", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 10), new Object[]{
+                "LimeSlabs", getModItem("BiblioWoodsForestry", "seatBack2", 1, 10), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 10), new Object[]{
+                null, "blockWool", null,
+                null, "LimeSlabs", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 10), new Object[]{
+                "LimeSlabs", "LimeSlabs", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 10), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 11), new Object[]{
+                "MahoePlanks", "MahoeSlabs", "MahoePlanks",
+                "MahoePlanks", "MahoeSlabs", "MahoePlanks",
+                "MahoePlanks", "MahoeSlabs", "MahoePlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 11), new Object[]{
+                "MahoeSlabs", "MahoeSlabs", "MahoeSlabs",
+                "MahoePlanks", "bottleEmpty", "MahoePlanks",
+                "MahoeSlabs", "MahoeSlabs", "MahoeSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 11), new Object[]{
+                "MahoeSlabs", "MahoeSlabs", "MahoeSlabs",
+                null, "MahoePlanks", null,
+                "MahoeSlabs", "MahoeSlabs", "MahoeSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 11), new Object[]{
+                "MahoeSlabs", "MahoeSlabs", "MahoeSlabs",
+                "MahoeSlabs", "ingotIron", "MahoeSlabs",
+                "MahoeSlabs", "MahoeSlabs", "MahoeSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 11), new Object[]{
+                "MahoeSlabs", "glass", "MahoeSlabs",
+                "MahoeSlabs", "blockWool", "MahoeSlabs",
+                "MahoeSlabs", "MahoeSlabs", "MahoeSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 11), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "MahoeSlabs", "MahoeSlabs", "MahoeSlabs",
+                "MahoePlanks", null, "MahoePlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 11), new Object[]{
+                null, "slabCloth", null,
+                null, "MahoeSlabs", null,
+                "stickWood", "MahoeSlabs", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 11), new Object[]{
+                "MahoeSlabs", "MahoeSlabs", "MahoeSlabs",
+                null, "MahoePlanks", null,
+                null, "MahoePlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 11), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "MahoeSlabs", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 11), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "MahoeSlabs", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 11), "MahoeSlabs",
+                "MahoeSlabs", "MahoeSlabs", "MahoeSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 11), new Object[]{
+                null, "blockWool", null,
+                null, "MahoeSlabs", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 11), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "MahoeSlabs", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 11), new Object[]{
+                "MahoeSlabs", getModItem("BiblioWoodsForestry", "seatBack2", 1, 11), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 11), new Object[]{
+                null, "blockWool", null,
+                null, "MahoeSlabs", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 11), new Object[]{
+                "MahoeSlabs", "MahoeSlabs", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 11), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 12), new Object[]{
+                "MahoganyPlanks", "MahoganySlabs", "MahoganyPlanks",
+                "MahoganyPlanks", "MahoganySlabs", "MahoganyPlanks",
+                "MahoganyPlanks", "MahoganySlabs", "MahoganyPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 12), new Object[]{
+                "MahoganySlabs", "MahoganySlabs", "MahoganySlabs",
+                "MahoganyPlanks", "bottleEmpty", "MahoganyPlanks",
+                "MahoganySlabs", "MahoganySlabs", "MahoganySlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 12), new Object[]{
+                "MahoganySlabs", "MahoganySlabs", "MahoganySlabs",
+                null, "MahoganyPlanks", null,
+                "MahoganySlabs", "MahoganySlabs", "MahoganySlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 12), new Object[]{
+                "MahoganySlabs", "MahoganySlabs", "MahoganySlabs",
+                "MahoganySlabs", "ingotIron", "MahoganySlabs",
+                "MahoganySlabs", "MahoganySlabs", "MahoganySlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 12), new Object[]{
+                "MahoganySlabs", "glass", "MahoganySlabs",
+                "MahoganySlabs", "blockWool", "MahoganySlabs",
+                "MahoganySlabs", "MahoganySlabs", "MahoganySlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 12), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "MahoganySlabs", "MahoganySlabs", "MahoganySlabs",
+                "MahoganyPlanks", null, "MahoganyPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 12), new Object[]{
+                null, "slabCloth", null,
+                null, "MahoganySlabs", null,
+                "stickWood", "MahoganySlabs", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 12), new Object[]{
+                "MahoganySlabs", "MahoganySlabs", "MahoganySlabs",
+                null, "MahoganyPlanks", null,
+                null, "MahoganyPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 12), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "MahoganySlabs", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 12), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "MahoganySlabs", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 12), "MahoganySlabs",
+                "MahoganySlabs", "MahoganySlabs", "MahoganySlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 12), new Object[]{
+                null, "blockWool", null,
+                null, "MahoganySlabs", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 12), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "MahoganySlabs", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 12), new Object[]{
+                "MahoganySlabs", getModItem("BiblioWoodsForestry", "seatBack2", 1, 12), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 12), new Object[]{
+                null, "blockWool", null,
+                null, "MahoganySlabs", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 12), new Object[]{
+                "MahoganySlabs", "MahoganySlabs", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 12), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 13), new Object[]{
+                "MapplePlanks", "MappleSlabs", "MapplePlanks",
+                "MapplePlanks", "MappleSlabs", "MapplePlanks",
+                "MapplePlanks", "MappleSlabs", "MapplePlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 13), new Object[]{
+                "MappleSlabs", "MappleSlabs", "MappleSlabs",
+                "MapplePlanks", "bottleEmpty", "MapplePlanks",
+                "MappleSlabs", "MappleSlabs", "MappleSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 13), new Object[]{
+                "MappleSlabs", "MappleSlabs", "MappleSlabs",
+                null, "MapplePlanks", null,
+                "MappleSlabs", "MappleSlabs", "MappleSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 13), new Object[]{
+                "MappleSlabs", "MappleSlabs", "MappleSlabs",
+                "MappleSlabs", "ingotIron", "MappleSlabs",
+                "MappleSlabs", "MappleSlabs", "MappleSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 13), new Object[]{
+                "MappleSlabs", "glass", "MappleSlabs",
+                "MappleSlabs", "blockWool", "MappleSlabs",
+                "MappleSlabs", "MappleSlabs", "MappleSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 13), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "MappleSlabs", "MappleSlabs", "MappleSlabs",
+                "MapplePlanks", null, "MapplePlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 13), new Object[]{
+                null, "slabCloth", null,
+                null, "MappleSlabs", null,
+                "stickWood", "MappleSlabs", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 13), new Object[]{
+                "MappleSlabs", "MappleSlabs", "MappleSlabs",
+                null, "MapplePlanks", null,
+                null, "MapplePlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 13), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "MappleSlabs", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 13), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "MappleSlabs", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 13), "MappleSlabs",
+                "MappleSlabs", "MappleSlabs", "MappleSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 13), new Object[]{
+                null, "blockWool", null,
+                null, "MappleSlabs", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 13), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "MappleSlabs", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 13), new Object[]{
+                "MappleSlabs", getModItem("BiblioWoodsForestry", "seatBack2", 1, 13), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 13), new Object[]{
+                null, "blockWool", null,
+                null, "MappleSlabs", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 13), new Object[]{
+                "MappleSlabs", "MappleSlabs", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 13), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 14), new Object[]{
+                "PalmPlanks", "PalmSlabs", "PalmPlanks",
+                "PalmPlanks", "PalmSlabs", "PalmPlanks",
+                "PalmPlanks", "PalmSlabs", "PalmPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 14), new Object[]{
+                "PalmSlabs", "PalmSlabs", "PalmSlabs",
+                "PalmPlanks", "bottleEmpty", "PalmPlanks",
+                "PalmSlabs", "PalmSlabs", "PalmSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 14), new Object[]{
+                "PalmSlabs", "PalmSlabs", "PalmSlabs",
+                null, "PalmPlanks", null,
+                "PalmSlabs", "PalmSlabs", "PalmSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 14), new Object[]{
+                "PalmSlabs", "PalmSlabs", "PalmSlabs",
+                "PalmSlabs", "ingotIron", "PalmSlabs",
+                "PalmSlabs", "PalmSlabs", "PalmSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 14), new Object[]{
+                "PalmSlabs", "glass", "PalmSlabs",
+                "PalmSlabs", "blockWool", "PalmSlabs",
+                "PalmSlabs", "PalmSlabs", "PalmSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 14), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "PalmSlabs", "PalmSlabs", "PalmSlabs",
+                "PalmPlanks", null, "PalmPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 14), new Object[]{
+                null, "slabCloth", null,
+                null, "PalmSlabs", null,
+                "stickWood", "PalmSlabs", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 14), new Object[]{
+                "PalmSlabs", "PalmSlabs", "PalmSlabs",
+                null, "PalmPlanks", null,
+                null, "PalmPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 14), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "PalmSlabs", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 14), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "PalmSlabs", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 14), "PalmSlabs",
+                "PalmSlabs", "PalmSlabs", "PalmSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 14), new Object[]{
+                null, "blockWool", null,
+                null, "PalmSlabs", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 14), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "PalmSlabs", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 14), new Object[]{
+                "PalmSlabs", getModItem("BiblioWoodsForestry", "seatBack2", 1, 14), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 14), new Object[]{
+                null, "blockWool", null,
+                null, "PalmSlabs", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 14), new Object[]{
+                "PalmSlabs", "PalmSlabs", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 14), null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 15), new Object[]{
+                "PapayaPlanks", "PapayaSlabs", "PapayaPlanks",
+                "PapayaPlanks", "PapayaSlabs", "PapayaPlanks",
+                "PapayaPlanks", "PapayaSlabs", "PapayaPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstpotshelf", 1, 15), new Object[]{
+                "PapayaSlabs", "PapayaSlabs", "PapayaSlabs",
+                "PapayaPlanks", "bottleEmpty", "PapayaPlanks",
+                "PapayaSlabs", "PapayaSlabs", "PapayaSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstshelf", 1, 15), new Object[]{
+                "PapayaSlabs", "PapayaSlabs", "PapayaSlabs",
+                null, "PapayaPlanks", null,
+                "PapayaSlabs", "PapayaSlabs", "PapayaSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstrack", 1, 15), new Object[]{
+                "PapayaSlabs", "PapayaSlabs", "PapayaSlabs",
+                "PapayaSlabs", "ingotIron", "PapayaSlabs",
+                "PapayaSlabs", "PapayaSlabs", "PapayaSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstcase0", 1, 15), new Object[]{
+                "PapayaSlabs", "glass", "PapayaSlabs",
+                "PapayaSlabs", "blockWool", "PapayaSlabs",
+                "PapayaSlabs", "PapayaSlabs", "PapayaSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFstdesk", 1, 15), new Object[]{
+                "blockTorch", null, "craftingFeather",
+                "PapayaSlabs", "PapayaSlabs", "PapayaSlabs",
+                "PapayaPlanks", null, "PapayaPlanks"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodSeat", 1, 15), new Object[]{
+                null, "slabCloth", null,
+                null, "PapayaSlabs", null,
+                "stickWood", "PapayaSlabs", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFsttable", 1, 15), new Object[]{
+                "PapayaSlabs", "PapayaSlabs", "PapayaSlabs",
+                null, "PapayaPlanks", null,
+                null, "PapayaPlanks", null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 15), new Object[]{
+                "stickWood", "stickWood", "stickWood",
+                "stickWood", "PapayaSlabs", "stickWood",
+                "stickWood", "stickWood", "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "BiblioWoodFancyWorkbench", 1, 15), new Object[]{
+                "dyeBlack", getModItem("minecraft", "crafting_table", 1), "craftingFeather",
+                "PapayaSlabs", getModItem("BiblioWoodsForestry", "BiblioWoodFstBookcase", 1, 15), "PapayaSlabs",
+                "PapayaSlabs", "PapayaSlabs", "PapayaSlabs"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack1", 1, 15), new Object[]{
+                null, "blockWool", null,
+                null, "PapayaSlabs", null,
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack2", 1, 15), new Object[]{
+                "stickWood", "blockWool", "stickWood",
+                "stickWood", "PapayaSlabs", "stickWood",
+                "stickWood", null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack3", 1, 15), new Object[]{
+                "PapayaSlabs", getModItem("BiblioWoodsForestry", "seatBack2", 1, 15), null,
+                null, null, null,
+                null, null, null});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack4", 1, 15), new Object[]{
+                null, "blockWool", null,
+                null, "PapayaSlabs", null,
+                null, null, "stickWood"});
+
+        addShapedRecipe(getModItem("BiblioWoodsForestry", "seatBack5", 1, 15), new Object[]{
+                "PapayaSlabs", "PapayaSlabs", null,
+                getModItem("BiblioWoodsForestry", "seatBack2", 1, 15), null, null,
+                null, null, null});
+
+
         endTime = System.currentTimeMillis();
     }
 

--- a/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsForestry.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsForestry.java
@@ -1,0 +1,331 @@
+package com.dreammaster.scripts;
+
+import net.minecraft.item.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static gregtech.api.util.GT_ModHandler.getModItem;
+
+public class ScriptBiblioWoodsForestry implements IScriptLoader {
+    private long startTime;
+    private long endTime;
+    private static final String scriptName = "BiblioWoodsForestry";
+    private static final List<String> dependencies = Arrays.asList("BiblioCraft", "Forestry","BiblioWoodsForestry");
+
+    @Override
+    public void loadRecipe() {
+        startTime = System.currentTimeMillis();
+        ItemStack[] F1wood= new ItemStack[]{
+                getModItem("Forestry", "slabs", 1, 2),
+                getModItem("Forestry", "slabs", 1, 11),
+                getModItem("Forestry", "slabs", 1, 6),
+                getModItem("Forestry", "slabs", 1, 15),
+                getModItem("Forestry", "slabs", 1, 4),
+                getModItem("Forestry", "slabs", 1, 23),
+                getModItem("Forestry", "slabs", 1, 9),
+                getModItem("Forestry", "slabs", 1, 14),
+                getModItem("Forestry", "slabs", 1, 8),
+                getModItem("Forestry", "slabs", 1),
+                getModItem("Forestry", "slabs", 1, 3),
+                getModItem("Forestry", "slabs", 1, 16),
+                getModItem("Forestry", "slabs", 1, 10),
+                getModItem("Forestry", "slabs", 1, 22),
+                getModItem("Forestry", "slabs", 1, 18),
+                getModItem("Forestry", "slabs", 1, 19)};
+        ItemStack[] F2wood= new ItemStack[]{
+                getModItem("Forestry", "slabs", 1, 20),
+                getModItem("Forestry", "slabs", 1, 21),
+                getModItem("Forestry", "slabs", 1, 17),
+                getModItem("Forestry", "slabs", 1, 7),
+                getModItem("Forestry", "slabs", 1, 1),
+                getModItem("Forestry", "slabs", 1, 13),
+                getModItem("Forestry", "slabs", 1, 5),
+                getModItem("Forestry", "slabs", 1, 12)};
+        ItemStack[] FClockF1= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 7),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 8),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 9),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 10),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 11),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 12),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 13),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 14),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock", 1, 15)};
+        ItemStack[] FClockF2= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock2", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock2", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock2", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock2", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock2", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock2", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock2", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodClock2", 1, 7)};
+        ItemStack[] PaintingF1= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 7),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 8),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 9),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 10),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 11),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 12),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 13),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 14),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0", 1, 15)};
+        ItemStack[] PaintingF2= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0b", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0b", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0b", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0b", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0b", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0b", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0b", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT0b", 1, 7)};
+        ItemStack[] FPT1a= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 7),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 8),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 9),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 10),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 11),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 12),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 13),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 14),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1", 1, 15)};
+        ItemStack[] FPT1b= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1b", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1b", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1b", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1b", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1b", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1b", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1b", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT1b", 1, 1)};
+        ItemStack[] FPT2a= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 7),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 8),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 9),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 10),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 11),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 12),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 13),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 14),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2", 1, 15)};
+        ItemStack[] FPT2b= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2b", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2b", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2b", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2b", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2b", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2b", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2b", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT2b", 1, 1)};
+        ItemStack[] FPT3a= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 7),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 8),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 9),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 10),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 11),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 12),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 13),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 14),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3", 1, 15)};
+        ItemStack[] FPT3b= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3b", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3b", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3b", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3b", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3b", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3b", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3b", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT3b", 1, 1)};
+        ItemStack[] FPT4a= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 7),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 8),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 9),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 10),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 11),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 12),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 13),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 14),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4", 1, 15)};
+        ItemStack[] FPT4b= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4b", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4b", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4b", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4b", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4b", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4b", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4b", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodPaintingT4b", 1, 1)};
+        ItemStack[] FrameF1= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 7),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 8),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 9),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 10),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 11),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 12),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 13),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 14),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame", 1, 15)};
+        ItemStack[] LableF1= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 7),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 8),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 9),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 10),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 11),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 12),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 13),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 14),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel", 1, 15)};
+        ItemStack[] FrameF2= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodMapFrame2", 1, 7)};
+        ItemStack[] LableF2= new ItemStack[]{
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel2", 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel2", 1, 1),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel2", 1, 2),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel2", 1, 3),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel2", 1, 4),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel2", 1, 5),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel2", 1, 6),
+                getModItem("BiblioWoodsForestry", "BiblioWoodFstlabel2", 1, 7)};
+
+        for (int i =0; i<16;i++){
+            addShapedRecipe(FClockF1[i], new Object[]{
+                    F1wood[i], getModItem("minecraft", "clock", 1), F1wood[i],
+                    F1wood[i], "stickWood", F1wood[i],
+                    F1wood[i], "plateGold", F1wood[i]});
+            addShapedRecipe(PaintingF1[i], new Object[]{
+                    F1wood[i], F1wood[i], F1wood[i],
+                    F1wood[i], getModItem("BiblioCraft", "item.PaintingCanvas", 1), F1wood[i],
+                    F1wood[i], F1wood[i], F1wood[i]});
+            addShapedRecipe(FPT1a[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", PaintingF1[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(FPT2a[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", FPT1a[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(FPT3a[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", FPT2a[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(FPT4a[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", FPT3a[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(LableF1[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", FrameF1[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            if (i<8){
+                addShapedRecipe(LableF2[i], new Object[]{
+                        "stickWood", "stickWood", "stickWood",
+                        "stickWood", FrameF2[i], "stickWood",
+                        "stickWood", "stickWood", "stickWood"});
+                addShapedRecipe(FPT4b[i], new Object[]{
+                        "stickWood", "stickWood", "stickWood",
+                        "stickWood", FPT3b[i], "stickWood",
+                        "stickWood", "stickWood", "stickWood"});
+                addShapedRecipe(FPT3b[i], new Object[]{
+                        "stickWood", "stickWood", "stickWood",
+                        "stickWood", FPT2b[i], "stickWood",
+                        "stickWood", "stickWood", "stickWood"});
+                addShapedRecipe(FPT2b[i], new Object[]{
+                        "stickWood", "stickWood", "stickWood",
+                        "stickWood", FPT1b[i], "stickWood",
+                        "stickWood", "stickWood", "stickWood"});
+                addShapedRecipe(FPT1b[i], new Object[]{
+                        "stickWood", "stickWood", "stickWood",
+                        "stickWood", PaintingF2[i], "stickWood",
+                        "stickWood", "stickWood", "stickWood"});
+                addShapedRecipe(FClockF2[i], new Object[]{
+                        F2wood[i], getModItem("minecraft", "clock", 1), F2wood[i],
+                        F2wood[i], "stickWood", F2wood[i],
+                        F2wood[i], "plateGold", F2wood[i]});
+                addShapedRecipe(PaintingF2[i], new Object[]{
+                        F2wood[i], F2wood[i], F2wood[i],
+                        F2wood[i], getModItem("BiblioCraft", "item.PaintingCanvas", 1), F2wood[i],
+                        F2wood[i], F2wood[i], F2wood[i]});
+            }
+        }
+        endTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public long getExecutionTime() {
+        return endTime - startTime;
+    }
+
+    @Override
+    public List<String> getDependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public String getScriptName() {
+        return scriptName;
+    }
+}

--- a/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsNatura.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsNatura.java
@@ -18,7 +18,7 @@ public class ScriptBiblioWoodsNatura implements IScriptLoader{
     }
 
     @Override
-    public void loadRecipe() {
+    public void loadRecipes() {
         startTime = System.currentTimeMillis();
         ItemStack[] FClockN= new ItemStack[]{
                 getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1),

--- a/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsNatura.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiblioWoodsNatura.java
@@ -1,0 +1,205 @@
+package com.dreammaster.scripts;
+
+import net.minecraft.item.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static gregtech.api.util.GT_ModHandler.getModItem;
+
+public class ScriptBiblioWoodsNatura implements IScriptLoader{
+    private long startTime;
+    private long endTime;
+    private static final String scriptName = "BiblioWoodsNatura";
+    private static final List<String> dependencies = Arrays.asList("BiomesOPlenty", "BiblioWoodsBoP", "BiblioCraft");
+
+    public ScriptBiblioWoodsNatura() {
+
+    }
+
+    @Override
+    public void loadRecipe() {
+        startTime = System.currentTimeMillis();
+        ItemStack[] FClockN= new ItemStack[]{
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 2),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 3),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 4),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 5),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 6),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 7),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 8),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 9),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 10),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 11),
+                getModItem("BiblioWoodsNatura", "BiblioWoodClock", 1, 12)};
+
+        ItemStack[] Nwood= new ItemStack[]{
+                getModItem("Natura", "plankSlab1", 1, 4),
+                getModItem("Natura", "plankSlab2", 1, 3),
+                getModItem("Natura", "plankSlab1", 1),
+                getModItem("Natura", "plankSlab2", 1, 4),
+                getModItem("Natura", "plankSlab1", 1, 2),
+                getModItem("Natura", "plankSlab1", 1, 5),
+                getModItem("Natura", "plankSlab1", 1, 6),
+                getModItem("Natura", "plankSlab2", 1),
+                getModItem("Natura", "plankSlab1", 1, 3),
+                getModItem("Natura", "plankSlab1", 1, 7),
+                getModItem("Natura", "plankSlab1", 1, 1),
+                getModItem("Natura", "plankSlab2", 1, 1),
+                getModItem("Natura", "plankSlab2", 1, 2)};
+
+        ItemStack[] PaintingN= new ItemStack[]{
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 2),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 3),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 4),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 5),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 6),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 7),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 8),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 9),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 10),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 11),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT0", 1, 12)};
+
+        ItemStack[] NPT1= new ItemStack[]{
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 2),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 3),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 4),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 5),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 6),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 7),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 8),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 9),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 10),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 11),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT1", 1, 12)};
+
+        ItemStack[] NPT2= new ItemStack[]{
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 2),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 3),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 4),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 5),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 6),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 7),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 8),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 9),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 10),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 11),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT2", 1, 12)};
+
+        ItemStack[] NPT3= new ItemStack[]{
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 2),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 3),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 4),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 5),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 6),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 7),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 8),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 9),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 10),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 11),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT3", 1, 12)};
+
+        ItemStack[] NPT4= new ItemStack[]{
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 2),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 3),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 4),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 5),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 6),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 7),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 8),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 9),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 10),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 11),
+                getModItem("BiblioWoodsNatura", "BiblioWoodPaintingT4", 1, 12)};
+
+        ItemStack[] FrameN= new ItemStack[]{
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 2),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 3),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 4),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 5),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 6),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 7),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 8),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 9),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 10),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 11),
+                getModItem("BiblioWoodsNatura", "BiblioWoodMapFrame", 1, 12)};
+
+        ItemStack[] LableN= new ItemStack[]{
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 1),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 2),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 3),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 4),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 5),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 6),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 7),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 8),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 9),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 10),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 11),
+                getModItem("BiblioWoodsNatura", "BiblioWoodlabel", 1, 12)};
+
+        for(int i=0; i < 13;i++){
+            addShapedRecipe(FClockN[i], new Object[]{
+                    Nwood[i], getModItem("minecraft", "clock", 1), Nwood[i],
+                    Nwood[i], "stickWood", Nwood[i],
+                    Nwood[i], "plateGold", Nwood[i]});
+            addShapedRecipe(PaintingN[i], new Object[]{
+                    Nwood[i], Nwood[i], Nwood[i],
+                    Nwood[i], getModItem("BiblioCraft", "item.PaintingCanvas", 1), Nwood[i],
+                    Nwood[i], Nwood[i], Nwood[i]});
+            addShapedRecipe(NPT1[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", PaintingN[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(NPT2[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", NPT1[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(NPT3[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", NPT2[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(NPT4[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", NPT3[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+            addShapedRecipe(LableN[i], new Object[]{
+                    "stickWood", "stickWood", "stickWood",
+                    "stickWood", FrameN[i], "stickWood",
+                    "stickWood", "stickWood", "stickWood"});
+        }
+        endTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public long getExecutionTime(){
+        return endTime-startTime;
+    }
+
+    @Override
+    public List<String> getDependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public String getScriptName() {
+        return scriptName;
+    }
+}

--- a/src/main/java/com/dreammaster/scripts/ScriptHoloInventory.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptHoloInventory.java
@@ -1,8 +1,5 @@
 package com.dreammaster.scripts;
 
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.event.entity.player.ItemTooltipEvent;
-
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/main/java/com/dreammaster/scripts/ScriptHoloInventory.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptHoloInventory.java
@@ -1,0 +1,44 @@
+package com.dreammaster.scripts;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static gregtech.api.util.GT_ModHandler.getModItem;
+
+public class ScriptHoloInventory implements IScriptLoader{
+    private long startTime;
+    private long endTime;
+    private static final String scriptName = "HoloInventory";
+    private static final List<String> dependencies = Arrays.asList("holoinventory");
+
+    public ScriptHoloInventory() {
+
+    }
+    @Override
+    public void loadRecipes() {
+        startTime = System.currentTimeMillis();
+        addShapedRecipe(getModItem("holoinventory", "Hologlasses", 1), new Object[]{
+                "stickSteel", "screwSteel", "stickSteel",
+                "ringSteel", "boltSteel", "ringSteel",
+                "lensInfusedEntropy", "craftingToolScrewdriver", "lensInfusedEntropy"});
+        endTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public long getExecutionTime(){
+        return endTime-startTime;
+    }
+
+    @Override
+    public List<String> getDependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public String getScriptName() {
+        return scriptName;
+    }
+}

--- a/src/main/java/com/dreammaster/scripts/ScriptSleepingBags.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptSleepingBags.java
@@ -1,0 +1,50 @@
+package com.dreammaster.scripts;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static gregtech.api.util.GT_ModHandler.addShapelessCraftingRecipe;
+import static gregtech.api.util.GT_ModHandler.getModItem;
+
+public class ScriptSleepingBags implements IScriptLoader{
+    private long startTime;
+    private long endTime;
+    private static final String scriptName = "SleepingBags";
+    private static final List<String> dependencies = Arrays.asList("sleepingbag", "adventurebackpack", "OpenBlocks");
+
+    public ScriptSleepingBags() {
+
+    }
+
+    @Override
+    public void loadRecipes() {
+        startTime = System.currentTimeMillis();
+        addShapedRecipe(getModItem("sleepingbag", "sleepingBag", 1), new Object[]{
+                getModItem("minecraft", "carpet", 1, 32767), getModItem("minecraft", "carpet", 1, 32767), getModItem("minecraft", "carpet", 1, 32767),
+                "blockWool", "blockWool", "blockWool",
+                getModItem("Backpack", "tannedLeather", 1), getModItem("Backpack", "tannedLeather", 1), getModItem("Backpack", "tannedLeather", 1)});
+
+        addShapelessCraftingRecipe(getModItem("sleepingbag", "sleepingBag", 1), new Object[]{
+                getModItem("adventurebackpack", "backpackComponent", 1, 1)});
+
+        addShapelessCraftingRecipe(getModItem("adventurebackpack", "backpackComponent", 1, 1), new Object[]{
+                getModItem("OpenBlocks", "sleepingBag", 1)});
+
+        endTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public long getExecutionTime(){
+        return endTime-startTime;
+    }
+
+    @Override
+    public List<String> getDependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public String getScriptName() {
+        return scriptName;
+    }
+}

--- a/src/main/java/com/dreammaster/scripts/ScriptSpiceOfLife.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptSpiceOfLife.java
@@ -1,0 +1,58 @@
+package com.dreammaster.scripts;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static gregtech.api.util.GT_ModHandler.addShapelessCraftingRecipe;
+import static gregtech.api.util.GT_ModHandler.getModItem;
+
+public class ScriptSpiceOfLife implements IScriptLoader{
+    private long startTime;
+    private long endTime;
+    private static final String scriptName = "SpiceOfLife";
+    private static final List<String> dependencies = Arrays.asList("IC2", "SpiceOfLife");
+
+    public ScriptSpiceOfLife() {
+
+    }
+
+    @Override
+    public void loadRecipes() {
+        startTime = System.currentTimeMillis();
+        addShapedRecipe(getModItem("SpiceOfLife", "lunchbag", 1), new Object[]{
+                getModItem("minecraft", "paper", 1), null, getModItem("minecraft", "paper", 1),
+                getModItem("IC2", "itemHarz", 1), getModItem("minecraft", "paper", 1), getModItem("IC2", "itemHarz", 1),
+                null, null, null});
+
+        addShapedRecipe(getModItem("SpiceOfLife", "lunchbox", 1), new Object[]{
+                "plateDoubleIron", "craftingToolScrewdriver", "plateDoubleIron",
+                "screwAnyIron", "plateDoubleIron", "screwAnyIron",
+                null, null, null});
+
+        addShapelessCraftingRecipe(getModItem("SpiceOfLife", "bookfoodjournal", 1), new Object[]{
+                new ItemStack(Items.wheat),
+                new ItemStack(Items.paper)
+        });
+
+        endTime = System.currentTimeMillis();
+    }
+
+    @Override
+    public long getExecutionTime(){
+        return endTime-startTime;
+    }
+
+    @Override
+    public List<String> getDependencies() {
+        return dependencies;
+    }
+
+    @Override
+    public String getScriptName() {
+        return scriptName;
+    }
+}


### PR DESCRIPTION
This requires:
- sleeping bag 1.1.2GTNH
- https://github.com/GTNewHorizons/HoloInventory/pull/15
- https://github.com/GTNewHorizons/SpiceOfLife/pull/18
- https://github.com/GTNewHorizons/Hodgepodge/pull/48 and https://github.com/GTNewHorizons/Hodgepodge/pull/45
- https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/9257 and https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/9263

For the biobliocraft/bibliowoods stuff, it needs extensive testing, as i translated the script into java via a python script, so idk if everything went well, but i didn't spot any error. But i remember that @Dream-Master told me that after the sledgehammer, some bibliocraft stuff is missing recipes.

Let me know which recipes and i'll add them back. I also didn't cached at all the lookups in the gameregistry for the item/blocks from other mods, so this definitely can be improved. But for now, i want to focus on the script port.