### PR TITLE
buff assembler recipes for 1EU and 8EU solars

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -3505,8 +3505,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     },
                     tMat.getMolten(72L * tMultiplier / 2L),
                     ItemList.Cover_SolarPanel.get(1L),
-                    600,
-                    64);
+                    200,
+                    120);
 
             //solar 8EU
             GT_Values.RA.addAssemblerRecipe(
@@ -3520,8 +3520,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     },
                     tMat.getMolten(72L * tMultiplier / 2L),
                     ItemList.Cover_SolarPanel_8V.get(1L),
-                    600,
-                    64);
+                    400,
+                    120);
             
             if (Loader.isModLoaded("OpenComputers")) {
                 make_lua_bios();


### PR DESCRIPTION
As discussed in DMs with @Dream-Master.

I don't remove the crafting recipes in this PR yet because i think this should be changed in the same PR as the rework of LV+ solars in the avaritia crafting table, to keep some consistency.

for reference, the recipes for 1EU and 8EU solars are located here: https://github.com/GTNewHorizons/NewHorizonsCoreMod/blob/97fb4cd5610f6bccdc077e04d17b98d2c4060e34/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java#L98-L100

