### PR TITLE
Tiny Sunnarium Dust > Sunnarium Piece

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -1312,6 +1312,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addCompressorRecipe(GT_ModHandler.getModItem("IC2", "itemWeed", 16L), ItemList.IC2_Plantball.get(1L), 300, 2);
         GT_Values.RA.addCompressorRecipe(GT_ModHandler.getModItem("ExtraTrees", "food", 64L, 24), ItemList.IC2_Plantball.get(1L), 300, 2);
         GT_Values.RA.addCompressorRecipe(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sunnarium, 1L), GT_ModHandler.getModItem("AdvancedSolarPanel", "asp_crafting_items", 1L, 0), 300, 2);
+        GT_Values.RA.addCompressorRecipe(GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Sunnarium, 1L), GT_ModHandler.getModItem("AdvancedSolarPanel", "asp_crafting_items", 1L, 9), 300, 2);
         GT_Values.RA.addCompressorRecipe(GT_ModHandler.getModItem("AdvancedSolarPanel", "asp_crafting_items", 9L, 9), GT_ModHandler.getModItem("AdvancedSolarPanel", "asp_crafting_items", 1L, 0), 300, 2);
         GT_Values.RA.addCompressorRecipe(GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.WroughtIron, 9L), GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.WroughtIron, 1L), 300, 2);
         GT_Values.RA.addCompressorRecipe(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartz, 1L), GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 1L), 300, 2);


### PR DESCRIPTION
Allows the player to use their Sunnarium dust to divide into 9 and then get the Sunnarium Piece, which was unrealistically obtainable due to the recent MT changes
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/9913

Also provides backwards combability in any off chances of some Sunnarium changes/bugs/oversights.