### PR TITLE
Replace Assline Solder in CoreMod Recipes

### DIFF
--- a/src/main/java/com/dreammaster/bartworksHandler/BW_Recipe_Loader.java
+++ b/src/main/java/com/dreammaster/bartworksHandler/BW_Recipe_Loader.java
@@ -5,6 +5,7 @@ import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
 import gregtech.api.util.GT_ModHandler;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import static com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader.*;
@@ -25,7 +26,7 @@ public class BW_Recipe_Loader implements Runnable {
                         Ruridit.get(bolt, 4)
                 },
                 new FluidStack[]{
-                        Materials.SolderingAlloy.getMolten(36)
+                        FluidRegistry.getFluidStack("molten.indalloy140", 36)
                 },
                 CustomItemList.HeavyDutyAlloyIngotT4.get(1L), 300, 30720
         );

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -342,7 +342,7 @@ public class GT_MachineRecipeLoader implements Runnable {
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier5.get(1L), CustomItemList.LeadOriharukonPlate.get(10L),  Materials.Tritanium.getMolten(576L), CustomItemList.HeavyDutyAlloyIngotT6.get(1L), 300, 500000);
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier6.get(1L), CustomItemList.MysteriousCrystalCompressedPlate.get(12L), Materials.Neutronium.getMolten(1152L), CustomItemList.HeavyDutyAlloyIngotT7.get(1L), 300, 2000000);
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier7.get(1L), CustomItemList.BlackPlutoniumCompressedPlate.get(14L), Materials.Neutronium.getMolten(4608L), CustomItemList.HeavyDutyAlloyIngotT8.get(1L), 1200, 2000000);
-        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null ? FluidRegistry.getFluid("molten.indalloy140") : FluidRegistry.getFluid("solderingalloy");
+        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null ? FluidRegistry.getFluid("molten.indalloy140") : FluidRegistry.getFluid("molten.solderingalloy");
 
         if (!Loader.isModLoaded("bartworks"))
             GT_Values.RA.addAssemblylineRecipe(
@@ -4037,7 +4037,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack(FluidRegistry.getFluid("ic2coolant"), 2000)
         }, ItemList.Circuit_Chip_BioCPU.get(1L), 600, 600000);
 
-        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null ? FluidRegistry.getFluid("molten.indalloy140") : FluidRegistry.getFluid("solderingalloy");
+        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null ? FluidRegistry.getFluid("molten.indalloy140") : FluidRegistry.getFluid("molten.solderingalloy");
 
         GT_Values.RA.addAssemblylineRecipe(ItemList.Energy_LapotronicOrb.get(1L), 288000, new Object[]{
                 ItemList.Circuit_Board_Multifiberglass.get(1L),

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -342,7 +342,7 @@ public class GT_MachineRecipeLoader implements Runnable {
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier5.get(1L), CustomItemList.LeadOriharukonPlate.get(10L),  Materials.Tritanium.getMolten(576L), CustomItemList.HeavyDutyAlloyIngotT6.get(1L), 300, 500000);
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier6.get(1L), CustomItemList.MysteriousCrystalCompressedPlate.get(12L), Materials.Neutronium.getMolten(1152L), CustomItemList.HeavyDutyAlloyIngotT7.get(1L), 300, 2000000);
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier7.get(1L), CustomItemList.BlackPlutoniumCompressedPlate.get(14L), Materials.Neutronium.getMolten(4608L), CustomItemList.HeavyDutyAlloyIngotT8.get(1L), 1200, 2000000);
-        Fluid solderIndalloy = FluidRegistry.isFluidRegistered("molten.indalloy140") != false ? FluidRegistry.getFluid("molten.indalloy140") : Materials.SolderingAlloy.mFluid;
+        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null ? FluidRegistry.getFluid("molten.indalloy140") : Materials.SolderingAlloy.mFluid;
 
         if (!Loader.isModLoaded("bartworks"))
             GT_Values.RA.addAssemblylineRecipe(
@@ -4037,7 +4037,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack(FluidRegistry.getFluid("ic2coolant"), 2000)
         }, ItemList.Circuit_Chip_BioCPU.get(1L), 600, 600000);
 
-        Fluid solderIndalloy = FluidRegistry.isFluidRegistered("molten.indalloy140") != false ? FluidRegistry.getFluid("molten.indalloy140") : Materials.SolderingAlloy.mFluid;
+        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null ? FluidRegistry.getFluid("molten.indalloy140") : Materials.SolderingAlloy.mFluid;
 
         GT_Values.RA.addAssemblylineRecipe(ItemList.Energy_LapotronicOrb.get(1L), 288000, new Object[]{
                 ItemList.Circuit_Board_Multifiberglass.get(1L),

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -342,7 +342,7 @@ public class GT_MachineRecipeLoader implements Runnable {
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier5.get(1L), CustomItemList.LeadOriharukonPlate.get(10L),  Materials.Tritanium.getMolten(576L), CustomItemList.HeavyDutyAlloyIngotT6.get(1L), 300, 500000);
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier6.get(1L), CustomItemList.MysteriousCrystalCompressedPlate.get(12L), Materials.Neutronium.getMolten(1152L), CustomItemList.HeavyDutyAlloyIngotT7.get(1L), 300, 2000000);
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier7.get(1L), CustomItemList.BlackPlutoniumCompressedPlate.get(14L), Materials.Neutronium.getMolten(4608L), CustomItemList.HeavyDutyAlloyIngotT8.get(1L), 1200, 2000000);
-        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null ? FluidRegistry.getFluid("molten.indalloy140") : Materials.SolderingAlloy.mFluid;
+        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null ? FluidRegistry.getFluid("molten.indalloy140") : FluidRegistry.getFluid("solderingalloy");
 
         if (!Loader.isModLoaded("bartworks"))
             GT_Values.RA.addAssemblylineRecipe(
@@ -4037,7 +4037,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack(FluidRegistry.getFluid("ic2coolant"), 2000)
         }, ItemList.Circuit_Chip_BioCPU.get(1L), 600, 600000);
 
-        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null ? FluidRegistry.getFluid("molten.indalloy140") : Materials.SolderingAlloy.mFluid;
+        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140") != null ? FluidRegistry.getFluid("molten.indalloy140") : FluidRegistry.getFluid("solderingalloy");
 
         GT_Values.RA.addAssemblylineRecipe(ItemList.Energy_LapotronicOrb.get(1L), 288000, new Object[]{
                 ItemList.Circuit_Board_Multifiberglass.get(1L),

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -342,7 +342,7 @@ public class GT_MachineRecipeLoader implements Runnable {
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier5.get(1L), CustomItemList.LeadOriharukonPlate.get(10L),  Materials.Tritanium.getMolten(576L), CustomItemList.HeavyDutyAlloyIngotT6.get(1L), 300, 500000);
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier6.get(1L), CustomItemList.MysteriousCrystalCompressedPlate.get(12L), Materials.Neutronium.getMolten(1152L), CustomItemList.HeavyDutyAlloyIngotT7.get(1L), 300, 2000000);
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier7.get(1L), CustomItemList.BlackPlutoniumCompressedPlate.get(14L), Materials.Neutronium.getMolten(4608L), CustomItemList.HeavyDutyAlloyIngotT8.get(1L), 1200, 2000000);
-        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140");
+        Fluid solderIndalloy = FluidRegistry.isFluidRegistered("molten.indalloy140") != false ? FluidRegistry.getFluid("molten.indalloy140") : Materials.SolderingAlloy.mFluid;
 
         if (!Loader.isModLoaded("bartworks"))
             GT_Values.RA.addAssemblylineRecipe(
@@ -4037,7 +4037,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack(FluidRegistry.getFluid("ic2coolant"), 2000)
         }, ItemList.Circuit_Chip_BioCPU.get(1L), 600, 600000);
 
-        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140");
+        Fluid solderIndalloy = FluidRegistry.isFluidRegistered("molten.indalloy140") != false ? FluidRegistry.getFluid("molten.indalloy140") : Materials.SolderingAlloy.mFluid;
 
         GT_Values.RA.addAssemblylineRecipe(ItemList.Energy_LapotronicOrb.get(1L), 288000, new Object[]{
                 ItemList.Circuit_Board_Multifiberglass.get(1L),

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -14,6 +14,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
@@ -341,6 +342,8 @@ public class GT_MachineRecipeLoader implements Runnable {
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier5.get(1L), CustomItemList.LeadOriharukonPlate.get(10L),  Materials.Tritanium.getMolten(576L), CustomItemList.HeavyDutyAlloyIngotT6.get(1L), 300, 500000);
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier6.get(1L), CustomItemList.MysteriousCrystalCompressedPlate.get(12L), Materials.Neutronium.getMolten(1152L), CustomItemList.HeavyDutyAlloyIngotT7.get(1L), 300, 2000000);
 //        GT_Values.RA.addAssemblerRecipe(CustomItemList.HeavyDutyPlateTier7.get(1L), CustomItemList.BlackPlutoniumCompressedPlate.get(14L), Materials.Neutronium.getMolten(4608L), CustomItemList.HeavyDutyAlloyIngotT8.get(1L), 1200, 2000000);
+        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140");
+
         if (!Loader.isModLoaded("bartworks"))
             GT_Values.RA.addAssemblylineRecipe(
                     GT_ModHandler.getModItem("GalacticraftMars", "item.itemBasicAsteroids", 1L, 0),
@@ -352,7 +355,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Osmiridium, 4)
                     },
                     new FluidStack[]{
-                            Materials.SolderingAlloy.getMolten(36)
+                            new FluidStack(solderIndalloy, 36)
                     },
                     CustomItemList.HeavyDutyAlloyIngotT4.get(1L), 300, 30720
             );
@@ -366,7 +369,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Europium, 8)
                 },
                 new FluidStack[]{
-                        Materials.SolderingAlloy.getMolten(72)
+                        new FluidStack(solderIndalloy, 72)
                 },
                 CustomItemList.HeavyDutyAlloyIngotT5.get(1L), 300, 122880
         );
@@ -380,7 +383,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Tritanium, 8)
                 },
                 new FluidStack[]{
-                        Materials.SolderingAlloy.getMolten(144)
+                        new FluidStack(solderIndalloy, 144)
                 },
                 CustomItemList.HeavyDutyAlloyIngotT6.get(1L), 300, 500000
         );
@@ -394,7 +397,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Neutronium, 10)
                 },
                 new FluidStack[]{
-                        Materials.SolderingAlloy.getMolten(288)
+                        new FluidStack(solderIndalloy, 288)
                 },
                 CustomItemList.HeavyDutyAlloyIngotT7.get(1L), 300, 2000000
         );
@@ -408,7 +411,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.BlackPlutonium, 12)
                 },
                 new FluidStack[]{
-                        Materials.SolderingAlloy.getMolten(576)
+                        new FluidStack(solderIndalloy, 576)
                 },
                 CustomItemList.HeavyDutyAlloyIngotT8.get(1L), 300, 8000000
         );
@@ -4034,6 +4037,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                 new FluidStack(FluidRegistry.getFluid("ic2coolant"), 2000)
         }, ItemList.Circuit_Chip_BioCPU.get(1L), 600, 600000);
 
+        Fluid solderIndalloy = FluidRegistry.getFluid("molten.indalloy140");
+
         GT_Values.RA.addAssemblylineRecipe(ItemList.Energy_LapotronicOrb.get(1L), 288000, new Object[]{
                 ItemList.Circuit_Board_Multifiberglass.get(1L),
                 GT_OreDictUnificator.get(OrePrefixes.foil, Materials.NaquadahAlloy, 64L),
@@ -4047,7 +4052,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 ItemList.Circuit_Parts_TransistorASMD.get(8L),
                 GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Platinum, 64),
         }, new FluidStack[]{
-                Materials.SolderingAlloy.getMolten(720L)
+                new FluidStack(solderIndalloy, 720)
         }, ItemList.Energy_LapotronicOrb2.get(1L), 1000, 80000);
 
         if (Loader.isModLoaded("GraviSuite")) {
@@ -4067,7 +4072,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                     ItemList.Electric_Motor_ZPM.get(2L),
                     GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Duranium, 4)
             }, new FluidStack[]{
-                    Materials.SolderingAlloy.getMolten(2304L),
+                    new FluidStack(solderIndalloy, 2304),
                     Materials.Tritanium.getMolten(1440L)
             }, GT_ModHandler.getModItem("GraviSuite", "graviChestPlate", 1, 26), 1500, 16388);
 


### PR DESCRIPTION
- Replaced the LV-tier Soldering Alloy in Assembly Line recipes with a higher tier, more complex solder that fits progression better.

Requires https://github.com/GTNewHorizons/GTplusplus/pull/193. See that PR for more information.