### PR TITLE
Adds AsGa crystal fluid extraction

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -3544,6 +3544,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addForgeHammerRecipe(ItemList.GalliumArsenideCrystal.get(1L), ItemList.GalliumArsenideCrystalSmallPart.get(4L), 50, 4);
         GT_Values.RA.addPulveriserRecipe(ItemList.GalliumArsenideCrystal.get(1L), new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.dust, Materials.GalliumArsenide, 1)}, new int[]{10000},100, 4);
         GT_Values.RA.addPulveriserRecipe(ItemList.GalliumArsenideCrystalSmallPart.get(1L), new ItemStack[]{GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.GalliumArsenide, 1)}, new int[]{10000},25, 4);
+        GT_Values.RA.addFluidExtractionRecipe(ItemList.GalliumArsenideCrystal.get(1L), GT_Values.NI, Materials.GalliumArsenide.getMolten(144L), 10000, 24, 37);
 
         GT_Values.RA.addAutoclaveSpaceRecipe(GT_OreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 12), GT_Values.NI, Materials.UUMatter.getFluid(250L), ItemList.Tool_DataOrb.get(1L), 10000, 12000, 960, true);
         GT_Values.RA.addAutoclaveSpaceRecipe(GT_OreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Olivine, 12), GT_Values.NI, Materials.UUMatter.getFluid(250L), ItemList.Tool_DataOrb.get(1L), 10000, 12000, 960, true);


### PR DESCRIPTION
Adds a simple fluid extraction recipe for the Gallium Arsenide Crystal.

Explanation is here: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10331
TLDR: The fluid is used for QBITs and the current way to obtain it is convoluted for no reason.

Recipe time/tier/duration is just the same as the ingot.

![image](https://user-images.githubusercontent.com/40274384/180604020-8da98147-c902-4796-a2db-539d0b506359.png)
