### PR TITLE
Replace 4x and 16x co-processor recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_Recipe_Remover.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Recipe_Remover.java
@@ -7,6 +7,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
 public class GT_Recipe_Remover implements Runnable {
+    private static final String modNameAE = "appliedenergistics2";
 	private static final String modNameBG2 = "battlegear2";
 	private static final String modNameFor = "Forestry";
 	private static final String modNameIC2 = "IC2";
@@ -19,6 +20,9 @@ public class GT_Recipe_Remover implements Runnable {
 	public void run() {
 		//Vanilla
         GT_ModHandler.removeRecipeByOutputDelayed(new ItemStack(Blocks.iron_bars, 1, 32767), true, false, true);
+        //AE
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameAE, "tile.BlockCraftingUnit", 1, 2), true, false, true);
+        GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem(modNameAE, "tile.BlockCraftingUnit", 1, 3), true, false, true);
 		//ASP
         GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("AdvancedSolarPanel", "BlockAdvSolarPanel", 1L, 0), true, false, true);
         GT_ModHandler.removeRecipeByOutputDelayed(GT_ModHandler.getModItem("AdvancedSolarPanel", "BlockAdvSolarPanel", 1L, 1), true, false, true);

--- a/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
@@ -1,0 +1,60 @@
+package com.dreammaster.scripts;
+import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.gthandler.GT_CustomLoader;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
+import net.minecraft.item.ItemStack;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraftforge.oredict.ShapedOreRecipe;
+
+import static gregtech.api.util.GT_ModHandler.getModItem;
+
+public class ScriptAppliedEnergistics2 implements IScriptLoader {
+
+    public ScriptAppliedEnergistics2(){
+
+    }
+
+    @Override
+    public void initScriptData(){
+        scriptName.setLength(0);
+        scriptName.append("AppliedEnergistics2");
+        dependencies.clear();
+        dependencies.addAll(java.util.Arrays.asList("appliedenergistics2"));
+    }
+
+    @Override
+    public void loadRecipes() {
+        final ItemStack CraftingUnit = getModItem("appliedenergistics2", "tile.BlockCraftingUnit", 1);
+        final ItemStack CoCraftingUnit4x = getModItem("appliedenergistics2", "tile.BlockCraftingUnit", 1, 2);
+        final ItemStack CoCraftingUnit16x = getModItem("appliedenergistics2", "tile.BlockCraftingUnit", 1, 3);
+
+        GT_Values.RA.addAssemblerRecipe(
+                CraftingUnit,
+                OrePrefixes.circuit.get(Materials.Elite),
+                2,
+                GT_Values.NF,
+                CoCraftingUnit4x,
+                100,
+                480
+        );
+
+        GT_Values.RA.addAssemblerRecipe(
+                CraftingUnit,
+                OrePrefixes.circuit.get(Materials.Superconductor),
+                2,
+                GT_Values.NF,
+                CoCraftingUnit16x,
+                100,
+                30720
+        );
+    }
+
+}

--- a/src/main/java/com/dreammaster/scripts/ScriptLoader.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptLoader.java
@@ -8,6 +8,7 @@ public class ScriptLoader {
                 new ScriptAE2FC(),
                 new ScriptAFSU(),
                 new ScriptAlveary(),
+                new ScriptAppliedEnergistics2(),
                 new ScriptArchitectureCraft(),
                 new ScriptAvaritiaAddons(),
                 new ScriptBetterQuesting(),


### PR DESCRIPTION
Recipes are simple following example of normal co-processor

4x takes IV circuits
![image](https://user-images.githubusercontent.com/73182109/185635817-f2444977-f5da-441d-8bf7-7b0cc6e708fd.png)

16x takes UV circuits
![image](https://user-images.githubusercontent.com/73182109/185636041-74473ee3-ca74-4f8a-a786-4baba68bf292.png)
