### PR TITLE
Jabba upgrades

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -16816,7 +16816,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                         new ItemStack[] {
                             GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                             GT_ModHandler.getModItem("bartworks", "gt.bwMetaGeneratedplate", 1L, 88),
-                            GT_ModHandler.getModItem("bartworks", "gt.bwMetaGeneratedstick>", 1L, 88),
+                            GT_ModHandler.getModItem("bartworks", "gt.bwMetaGeneratedstick", 1L, 88),
                             GT_Utility.getIntegratedCircuit(1)
                         },
                         GT_Values.NF,

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -16815,8 +16815,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                 GT_Values.RA.addAssemblerRecipe(
                         new ItemStack[] {
                             GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
-                            GT_ModHandler.getModItem("bartworks", "gt.bwMetaGeneratedplate", 1L, 88),
-                            GT_ModHandler.getModItem("bartworks", "gt.bwMetaGeneratedstick", 1L, 88),
+                            GT_ModHandler.getModItem("bartworks", "gt.bwMetaGeneratedplate", 2L, 88),
+                            GT_ModHandler.getModItem("bartworks", "gt.bwMetaGeneratedstick", 2L, 88),
                             GT_Utility.getIntegratedCircuit(1)
                         },
                         GT_Values.NF,

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -16716,7 +16716,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 0),
@@ -16726,7 +16727,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Copper, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Copper, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Copper, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 1),
@@ -16736,7 +16738,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Iron, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Iron, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 2),
@@ -16746,7 +16749,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Bronze, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Bronze, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Bronze, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 3),
@@ -16756,7 +16760,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Steel, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Steel, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 4),
@@ -16766,7 +16771,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Aluminium, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Aluminium, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 5),
@@ -16776,7 +16782,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.StainlessSteel, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.StainlessSteel, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 6),
@@ -16786,7 +16793,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Titanium, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Titanium, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 7),
@@ -16796,27 +16804,44 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.TungstenSteel, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.TungstenSteel, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 8),
                     200,
                     16);
-            GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] {
-                        GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Chrome, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Chrome, 2)
-                    },
-                    GT_Values.NF,
-                    GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 9),
-                    200,
-                    16);
+            if (Loader.isModLoaded("bartworks")) {
+                GT_Values.RA.addAssemblerRecipe(
+                        new ItemStack[] {
+                            GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
+                            GT_ModHandler.getModItem("bartworks", "gt.bwMetaGeneratedplate", 1L, 88),
+                            GT_ModHandler.getModItem("bartworks", "gt.bwMetaGeneratedstick>", 1L, 88),
+                            GT_Utility.getIntegratedCircuit(1)
+                        },
+                        GT_Values.NF,
+                        GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 9),
+                        200,
+                        16);
+            } else {
+                GT_Values.RA.addAssemblerRecipe(
+                        new ItemStack[] {
+                            GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Chrome, 2),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Chrome, 2),
+                            GT_Utility.getIntegratedCircuit(1)
+                        },
+                        GT_Values.NF,
+                        GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 9),
+                        200,
+                        16);
+            }
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iridium, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Iridium, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Iridium, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 10),
@@ -16826,7 +16851,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Osmium, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Osmium, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Osmium, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 11),
@@ -16836,7 +16862,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Neutronium, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Neutronium, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Neutronium, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 12),
@@ -16846,7 +16873,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                     new ItemStack[] {
                         GT_ModHandler.getModItem("JABBA", "barrel", 1L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.BlackPlutonium, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.BlackPlutonium, 2)
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.BlackPlutonium, 2),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     GT_Values.NF,
                     GT_ModHandler.getModItem("JABBA", "upgradeStructural", 1L, 13),

--- a/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
@@ -155,13 +155,50 @@ public class ScriptJABBA implements IScriptLoader {
                 new ItemStack[] {
                     getModItem("JABBA", "upgradeCore", 1),
                     ItemList.Electric_Piston_IV.get(1L),
-                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 16L),
                     GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 9),
                 3600,
                 7680);
+
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                        getModItem("JABBA", "upgradeCore", 1),
+                        ItemList.Electric_Piston_IV.get(1L),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 32L),
+                        GT_Utility.getIntegratedCircuit(1)
+                },
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 11),
+                4200,
+                30720);
+
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                        getModItem("JABBA", "upgradeCore", 1),
+                        ItemList.Electric_Piston_IV.get(1L),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Ultimate, 64L),
+                        GT_Utility.getIntegratedCircuit(1)
+                },
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 12),
+                4800,
+                122880);
+
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                        getModItem("JABBA", "upgradeCore", 1),
+                        ItemList.Electric_Piston_IV.get(1L),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Infinity, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Infinity, 64L),
+                        GT_Utility.getIntegratedCircuit(1)
+                },
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 13),
+                5400,
+                500000);
 
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
@@ -203,6 +240,31 @@ public class ScriptJABBA implements IScriptLoader {
                 getModItem("JABBA", "upgradeCore", 1, 9),
                 150,
                 480);
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                        getModItem("JABBA", "upgradeCore", 3, 9), getModItem("gregtech", "gt.integrated_circuit", 0, 3)
+                },
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 11),
+                100,
+                960);
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                        getModItem("JABBA", "upgradeCore", 3, 11), getModItem("gregtech", "gt.integrated_circuit", 0, 3)
+                },
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 12),
+                50,
+                1920);
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                        getModItem("JABBA", "upgradeCore", 3, 12), getModItem("gregtech", "gt.integrated_circuit", 0, 3)
+                },
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 13),
+                25,
+                4096);
+
 
         addShapedRecipe(getModItem("JABBA", "barrel", 1), new Object[] {
             "logWood", "slabWood", "logWood",

--- a/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
@@ -88,10 +88,19 @@ public class ScriptJABBA implements IScriptLoader {
                 getModItem("JABBA", "upgradeCore", 1),
                 1200,
                 16);
-
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                     getModItem("JABBA", "barrel", 1),
+                    getModItem("gregtech", "gt.metaitem.01", 1, 32640),
+                    getModItem("gregtech", "gt.integrated_circuit", 0, 2)
+                },
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1),
+                1200,
+                16);
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                    getModItem("JABBA", "upgradeCore", 1),
                     getModItem("gregtech", "gt.metaitem.01", 1, 32640),
                     getModItem("gregtech", "gt.integrated_circuit", 0, 1)
                 }, // LV Piston
@@ -102,7 +111,7 @@ public class ScriptJABBA implements IScriptLoader {
 
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                    getModItem("JABBA", "barrel", 1),
+                    getModItem("JABBA", "upgradeCore", 1),
                     getModItem("gregtech", "gt.metaitem.01", 1, 32641),
                     getModItem("gregtech", "gt.integrated_circuit", 0, 1)
                 }, // MV Piston
@@ -113,7 +122,7 @@ public class ScriptJABBA implements IScriptLoader {
 
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                    getModItem("JABBA", "barrel", 1),
+                    getModItem("JABBA", "upgradeCore", 1),
                     getModItem("gregtech", "gt.metaitem.01", 1, 32642),
                     getModItem("gregtech", "gt.integrated_circuit", 0, 1)
                 }, // HV Piston
@@ -124,7 +133,7 @@ public class ScriptJABBA implements IScriptLoader {
 
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                    getModItem("JABBA", "barrel", 1),
+                    getModItem("JABBA", "upgradeCore", 1),
                     getModItem("gregtech", "gt.metaitem.01", 1, 32643),
                     getModItem("gregtech", "gt.integrated_circuit", 0, 1)
                 }, // EV Piston
@@ -135,7 +144,7 @@ public class ScriptJABBA implements IScriptLoader {
 
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                    getModItem("JABBA", "barrel", 1),
+                    getModItem("JABBA", "upgradeCore", 1),
                     getModItem("gregtech", "gt.metaitem.01", 1, 32644),
                     getModItem("gregtech", "gt.integrated_circuit", 0, 1)
                 }, // IV Piston
@@ -299,7 +308,7 @@ public class ScriptJABBA implements IScriptLoader {
                 "plateRhodium-PlatedPalladium", getModItem("JABBA", "barrel", 1), "plateRhodium-PlatedPalladium",
                 "stickRhodium-PlatedPalladium", "plateRhodium-PlatedPalladium", "stickRhodium-PlatedPalladium"
             });
-            
+
         } else {
 
             addShapedRecipe(getModItem("JABBA", "upgradeStructural", 1, 9), new Object[] {

--- a/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
@@ -2,6 +2,7 @@ package com.dreammaster.scripts;
 
 import static gregtech.api.util.GT_ModHandler.getModItem;
 
+import cpw.mods.fml.common.Loader;
 import gregtech.api.enums.GT_Values;
 import java.util.Arrays;
 import net.minecraft.item.ItemStack;
@@ -292,11 +293,21 @@ public class ScriptJABBA implements IScriptLoader {
             "stickTungstenSteel", "plateTungstenSteel", "stickTungstenSteel"
         });
 
-        addShapedRecipe(getModItem("JABBA", "upgradeStructural", 1, 9), new Object[] {
-            "stickChrome", "plateChrome", "stickChrome",
-            "plateChrome", getModItem("JABBA", "barrel", 1), "plateChrome",
-            "stickChrome", "plateChrome", "stickChrome"
-        });
+        if (Loader.isModLoaded("bartworks")) {
+            addShapedRecipe(getModItem("JABBA", "upgradeStructural", 1, 9), new Object[] {
+                "stickRhodium-PlatedPalladium", "plateRhodium-PlatedPalladium", "stickRhodium-PlatedPalladium",
+                "plateRhodium-PlatedPalladium", getModItem("JABBA", "barrel", 1), "plateRhodium-PlatedPalladium",
+                "stickRhodium-PlatedPalladium", "plateRhodium-PlatedPalladium", "stickRhodium-PlatedPalladium"
+            });
+            
+        } else {
+
+            addShapedRecipe(getModItem("JABBA", "upgradeStructural", 1, 9), new Object[] {
+                "stickChrome", "plateChrome", "stickChrome",
+                "plateChrome", getModItem("JABBA", "barrel", 1), "plateChrome",
+                "stickChrome", "plateChrome", "stickChrome"
+            });
+        }
 
         addShapedRecipe(getModItem("JABBA", "upgradeStructural", 1, 10), new Object[] {
             "stickIridium", "plateIridium", "stickIridium",

--- a/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
@@ -191,8 +191,8 @@ public class ScriptJABBA implements IScriptLoader {
                 new ItemStack[] {
                     getModItem("JABBA", "upgradeCore", 1),
                     ItemList.Electric_Piston_UV.get(1L),
-                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Infinite, 64L),
-                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Infinite, 64L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 64L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Superconductor, 64L),
                     GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,

--- a/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
@@ -4,6 +4,11 @@ import static gregtech.api.util.GT_ModHandler.getModItem;
 
 import cpw.mods.fml.common.Loader;
 import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
 import java.util.Arrays;
 import net.minecraft.item.ItemStack;
 
@@ -72,7 +77,7 @@ public class ScriptJABBA implements IScriptLoader {
                 new ItemStack[] {
                     getModItem("JABBA", "barrel", 1),
                     getModItem("minecraft", "piston", 1),
-                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                    GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1),
@@ -82,7 +87,7 @@ public class ScriptJABBA implements IScriptLoader {
                 new ItemStack[] {
                     getModItem("JABBA", "barrel", 1),
                     getModItem("minecraft", "sticky_piston", 1),
-                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                    GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1),
@@ -91,8 +96,8 @@ public class ScriptJABBA implements IScriptLoader {
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                     getModItem("JABBA", "barrel", 1),
-                    getModItem("gregtech", "gt.metaitem.01", 1, 32640),
-                    getModItem("gregtech", "gt.integrated_circuit", 0, 2)
+                    ItemList.Electric_Piston_LV.get(1L),
+                    GT_Utility.getIntegratedCircuit(2)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 3),
@@ -101,8 +106,9 @@ public class ScriptJABBA implements IScriptLoader {
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                     getModItem("JABBA", "upgradeCore", 1),
-                    getModItem("gregtech", "gt.metaitem.01", 1, 32640),
-                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                    ItemList.Electric_Piston_LV.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 1L),
+                    GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 4),
@@ -112,8 +118,9 @@ public class ScriptJABBA implements IScriptLoader {
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                     getModItem("JABBA", "upgradeCore", 1),
-                    getModItem("gregtech", "gt.metaitem.01", 1, 32641),
-                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                    ItemList.Electric_Piston_MV.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 2L),
+                    GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 5),
@@ -123,8 +130,9 @@ public class ScriptJABBA implements IScriptLoader {
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                     getModItem("JABBA", "upgradeCore", 1),
-                    getModItem("gregtech", "gt.metaitem.01", 1, 32642),
-                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                    ItemList.Electric_Piston_HV.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 4L),
+                    GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 6),
@@ -134,8 +142,9 @@ public class ScriptJABBA implements IScriptLoader {
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                     getModItem("JABBA", "upgradeCore", 1),
-                    getModItem("gregtech", "gt.metaitem.01", 1, 32643),
-                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                    ItemList.Electric_Piston_EV.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 8L),
+                    GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 8),
@@ -145,8 +154,9 @@ public class ScriptJABBA implements IScriptLoader {
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                     getModItem("JABBA", "upgradeCore", 1),
-                    getModItem("gregtech", "gt.metaitem.01", 1, 32644),
-                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                    ItemList.Electric_Piston_IV.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 16L),
+                    GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 9),

--- a/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
@@ -95,7 +95,7 @@ public class ScriptJABBA implements IScriptLoader {
                     getModItem("gregtech", "gt.integrated_circuit", 0, 2)
                 },
                 GT_Values.NF,
-                getModItem("JABBA", "upgradeCore", 1),
+                getModItem("JABBA", "upgradeCore", 3),
                 1200,
                 16);
         GT_Values.RA.addAssemblerRecipe(
@@ -103,7 +103,7 @@ public class ScriptJABBA implements IScriptLoader {
                     getModItem("JABBA", "upgradeCore", 1),
                     getModItem("gregtech", "gt.metaitem.01", 1, 32640),
                     getModItem("gregtech", "gt.integrated_circuit", 0, 1)
-                }, // LV Piston
+                },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 4),
                 1200,
@@ -114,7 +114,7 @@ public class ScriptJABBA implements IScriptLoader {
                     getModItem("JABBA", "upgradeCore", 1),
                     getModItem("gregtech", "gt.metaitem.01", 1, 32641),
                     getModItem("gregtech", "gt.integrated_circuit", 0, 1)
-                }, // MV Piston
+                },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 5),
                 1200,
@@ -125,7 +125,7 @@ public class ScriptJABBA implements IScriptLoader {
                     getModItem("JABBA", "upgradeCore", 1),
                     getModItem("gregtech", "gt.metaitem.01", 1, 32642),
                     getModItem("gregtech", "gt.integrated_circuit", 0, 1)
-                }, // HV Piston
+                },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 6),
                 1200,
@@ -136,7 +136,7 @@ public class ScriptJABBA implements IScriptLoader {
                     getModItem("JABBA", "upgradeCore", 1),
                     getModItem("gregtech", "gt.metaitem.01", 1, 32643),
                     getModItem("gregtech", "gt.integrated_circuit", 0, 1)
-                }, // EV Piston
+                },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 8),
                 1200,
@@ -147,7 +147,7 @@ public class ScriptJABBA implements IScriptLoader {
                     getModItem("JABBA", "upgradeCore", 1),
                     getModItem("gregtech", "gt.metaitem.01", 1, 32644),
                     getModItem("gregtech", "gt.integrated_circuit", 0, 1)
-                }, // IV Piston
+                },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 9),
                 1200,

--- a/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
@@ -68,17 +68,81 @@ public class ScriptJABBA implements IScriptLoader {
                 200,
                 16);
         GT_Values.RA.addAssemblerRecipe(
-                new ItemStack[] {getModItem("JABBA", "barrel", 1), getModItem("minecraft", "piston", 1)},
+                new ItemStack[] {
+                    getModItem("JABBA", "barrel", 1),
+                    getModItem("minecraft", "piston", 1),
+                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1),
                 1200,
                 16);
         GT_Values.RA.addAssemblerRecipe(
-                new ItemStack[] {getModItem("JABBA", "barrel", 1), getModItem("minecraft", "sticky_piston", 1)},
+                new ItemStack[] {
+                    getModItem("JABBA", "barrel", 1),
+                    getModItem("minecraft", "sticky_piston", 1),
+                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1),
                 1200,
                 16);
+
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                    getModItem("JABBA", "barrel", 1),
+                    getModItem("gregtech", "gt.metaitem.01", 1, 32640),
+                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                }, // LV Piston
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 4),
+                1200,
+                30);
+
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                    getModItem("JABBA", "barrel", 1),
+                    getModItem("gregtech", "gt.metaitem.01", 1, 32641),
+                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                }, // MV Piston
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 5),
+                1200,
+                120);
+
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                    getModItem("JABBA", "barrel", 1),
+                    getModItem("gregtech", "gt.metaitem.01", 1, 32642),
+                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                }, // HV Piston
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 6),
+                1200,
+                480);
+
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                    getModItem("JABBA", "barrel", 1),
+                    getModItem("gregtech", "gt.metaitem.01", 1, 32643),
+                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                }, // EV Piston
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 8),
+                1200,
+                1920);
+
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] {
+                    getModItem("JABBA", "barrel", 1),
+                    getModItem("gregtech", "gt.metaitem.01", 1, 32644),
+                    getModItem("gregtech", "gt.integrated_circuit", 0, 1)
+                }, // IV Piston
+                GT_Values.NF,
+                getModItem("JABBA", "upgradeCore", 1, 9),
+                1200,
+                7680);
+
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
                     getModItem("JABBA", "upgradeCore", 3), getModItem("gregtech", "gt.integrated_circuit", 0, 3)

--- a/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
@@ -124,7 +124,7 @@ public class ScriptJABBA implements IScriptLoader {
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 5),
-                1200,
+                1800,
                 120);
 
         GT_Values.RA.addAssemblerRecipe(
@@ -136,7 +136,7 @@ public class ScriptJABBA implements IScriptLoader {
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 6),
-                1200,
+                2400,
                 480);
 
         GT_Values.RA.addAssemblerRecipe(
@@ -148,7 +148,7 @@ public class ScriptJABBA implements IScriptLoader {
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 8),
-                1200,
+                3000,
                 1920);
 
         GT_Values.RA.addAssemblerRecipe(
@@ -160,7 +160,7 @@ public class ScriptJABBA implements IScriptLoader {
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 9),
-                1200,
+                3600,
                 7680);
 
         GT_Values.RA.addAssemblerRecipe(

--- a/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptJABBA.java
@@ -165,10 +165,10 @@ public class ScriptJABBA implements IScriptLoader {
 
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                        getModItem("JABBA", "upgradeCore", 1),
-                        ItemList.Electric_Piston_IV.get(1L),
-                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 32L),
-                        GT_Utility.getIntegratedCircuit(1)
+                    getModItem("JABBA", "upgradeCore", 1),
+                    ItemList.Electric_Piston_LuV.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 32L),
+                    GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 11),
@@ -177,10 +177,10 @@ public class ScriptJABBA implements IScriptLoader {
 
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                        getModItem("JABBA", "upgradeCore", 1),
-                        ItemList.Electric_Piston_IV.get(1L),
-                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Ultimate, 64L),
-                        GT_Utility.getIntegratedCircuit(1)
+                    getModItem("JABBA", "upgradeCore", 1),
+                    ItemList.Electric_Piston_ZPM.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Ultimate, 64L),
+                    GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 12),
@@ -189,11 +189,11 @@ public class ScriptJABBA implements IScriptLoader {
 
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                        getModItem("JABBA", "upgradeCore", 1),
-                        ItemList.Electric_Piston_IV.get(1L),
-                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Infinity, 64L),
-                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Infinity, 64L),
-                        GT_Utility.getIntegratedCircuit(1)
+                    getModItem("JABBA", "upgradeCore", 1),
+                    ItemList.Electric_Piston_UV.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Infinite, 64L),
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Infinite, 64L),
+                    GT_Utility.getIntegratedCircuit(1)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 13),
@@ -242,7 +242,7 @@ public class ScriptJABBA implements IScriptLoader {
                 480);
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                        getModItem("JABBA", "upgradeCore", 3, 9), getModItem("gregtech", "gt.integrated_circuit", 0, 3)
+                    getModItem("JABBA", "upgradeCore", 3, 9), getModItem("gregtech", "gt.integrated_circuit", 0, 3)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 11),
@@ -250,7 +250,7 @@ public class ScriptJABBA implements IScriptLoader {
                 960);
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                        getModItem("JABBA", "upgradeCore", 3, 11), getModItem("gregtech", "gt.integrated_circuit", 0, 3)
+                    getModItem("JABBA", "upgradeCore", 3, 11), getModItem("gregtech", "gt.integrated_circuit", 0, 3)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 12),
@@ -258,13 +258,12 @@ public class ScriptJABBA implements IScriptLoader {
                 1920);
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] {
-                        getModItem("JABBA", "upgradeCore", 3, 12), getModItem("gregtech", "gt.integrated_circuit", 0, 3)
+                    getModItem("JABBA", "upgradeCore", 3, 12), getModItem("gregtech", "gt.integrated_circuit", 0, 3)
                 },
                 GT_Values.NF,
                 getModItem("JABBA", "upgradeCore", 1, 13),
                 25,
                 4096);
-
 
         addShapedRecipe(getModItem("JABBA", "barrel", 1), new Object[] {
             "logWood", "slabWood", "logWood",


### PR DESCRIPTION
No recursive Jabba upgrade crafting anymore
add control circuits to machine recipes
change Chrome to Rhodium-Plated Palladium if Bartworks is loaded