### PR TITLE
Hid fake circuits from NEI

### DIFF
--- a/src/main/java/com/dreammaster/auxiliary/NEIGTNewHorizonsConfig.java
+++ b/src/main/java/com/dreammaster/auxiliary/NEIGTNewHorizonsConfig.java
@@ -13,7 +13,7 @@ import net.minecraft.item.ItemStack;
 public class NEIGTNewHorizonsConfig implements IConfigureNEI {
     @Override
     public void loadConfig() {
-    	hideFakeCircuits();
+        hideFakeCircuits();
         API.hideItem(new ItemStack(QuantumBread.Instance()));
         API.hideItem(GT_ModHandler.getModItem("Aroma1997Core", "wrenched", 1));
         API.hideItem(GT_ModHandler.getModItem("BiblioCraft", "BiblioClipboard", 1));
@@ -67,23 +67,23 @@ public class NEIGTNewHorizonsConfig implements IConfigureNEI {
         // Hide metaID 0, as this is the generic item for trash bags
         MainRegistry.Logger.info("Added NEI Config");
     }
-    
+
     private void hideFakeCircuits() {
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitULV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitLV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitMV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitHV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitEV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitIV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitLuV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitZPM", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUHV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUEV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUIV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUMV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUXV", 1));
-    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitMAX", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitULV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitLV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitMV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitHV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitEV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitIV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitLuV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitZPM", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUHV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUEV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUIV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUMV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUXV", 1));
+        API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitMAX", 1));
     }
 
     @Override

--- a/src/main/java/com/dreammaster/auxiliary/NEIGTNewHorizonsConfig.java
+++ b/src/main/java/com/dreammaster/auxiliary/NEIGTNewHorizonsConfig.java
@@ -1,5 +1,7 @@
 package com.dreammaster.auxiliary;
 
+import static gregtech.api.enums.GT_Values.MOD_ID_DC;
+
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
 import com.dreammaster.item.food.QuantumBread;
@@ -11,6 +13,7 @@ import net.minecraft.item.ItemStack;
 public class NEIGTNewHorizonsConfig implements IConfigureNEI {
     @Override
     public void loadConfig() {
+    	hideFakeCircuits();
         API.hideItem(new ItemStack(QuantumBread.Instance()));
         API.hideItem(GT_ModHandler.getModItem("Aroma1997Core", "wrenched", 1));
         API.hideItem(GT_ModHandler.getModItem("BiblioCraft", "BiblioClipboard", 1));
@@ -63,6 +66,24 @@ public class NEIGTNewHorizonsConfig implements IConfigureNEI {
         API.hideItem(GT_ModHandler.getModItem("sleepingbag", "sleepingBagBlock", 1));
         // Hide metaID 0, as this is the generic item for trash bags
         MainRegistry.Logger.info("Added NEI Config");
+    }
+    
+    private void hideFakeCircuits() {
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitULV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitLV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitMV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitHV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitEV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitIV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitLuV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitZPM", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUHV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUEV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUIV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUMV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitUXV", 1));
+    	API.hideItem(GT_ModHandler.getModItem(MOD_ID_DC, "item.CircuitMAX", 1));
     }
 
     @Override


### PR DESCRIPTION
So I made this PR a few days ago to try and "fix" the fake circuits and let them be used as OreDict wildcards: https://github.com/GTNewHorizons/GT5-Unofficial/pull/1350

But we don't really need to/care about supporting that, plus it'd apparently break the IC2 circuits, PLUS it wouldn't work anyway because AE2 just doesn't play nice on processing patterns for oreDicted circuits.

So we agreed that we should just hide these circuits from NEI. There's no reason for the player to see them anyway, they're really just an internal patch, and hiding them prevents players from *trying* to use them in that non-functional way.

@GlodBlock for your blessing since these are your circuits.