### PR TITLE
Make MV cooling lossless on coolant

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -7549,7 +7549,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                 GT_Values.NI,
                 GT_Values.NI,
                 null,
-                600,
+                800,
                 120);
 
         // Mysterious crystal upgrading

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -7511,45 +7511,45 @@ public class GT_MachineRecipeLoader implements Runnable {
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.ingotHot, Materials.Kanthal, 1L),
                 new FluidStack(FluidRegistry.getFluid("ic2coolant"), 1000),
-                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 250),
+                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 750),
                 GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Kanthal, 1L),
                 GT_Values.NI,
                 GT_Values.NI,
                 null,
-                1200,
+                400,
                 120);
         // Cooling Hot Tantalum MV
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.ingotHot, Materials.Tantalum, 1L),
                 new FluidStack(FluidRegistry.getFluid("ic2coolant"), 1000),
-                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 250),
+                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 750),
                 GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Tantalum, 1L),
                 GT_Values.NI,
                 GT_Values.NI,
                 null,
-                1800,
+                400,
                 120);
         // Cooling Hot Silicon MV
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.ingotHot, Materials.Silicon, 1L),
                 new FluidStack(FluidRegistry.getFluid("ic2coolant"), 1000),
-                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 250),
+                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 750),
                 GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Silicon, 1L),
                 GT_Values.NI,
                 GT_Values.NI,
                 null,
-                600,
+                400,
                 120);
         // Cooling Hot SiliconSG MV
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.ingotHot, Materials.SiliconSG, 1L),
                 new FluidStack(FluidRegistry.getFluid("ic2coolant"), 1000),
-                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 250),
+                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 750),
                 GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.SiliconSG, 1L),
                 GT_Values.NI,
                 GT_Values.NI,
                 null,
-                800,
+                400,
                 120);
 
         // Mysterious crystal upgrading

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -7510,46 +7510,46 @@ public class GT_MachineRecipeLoader implements Runnable {
         // Cooling Hot Khantal MV
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.ingotHot, Materials.Kanthal, 1L),
-                new FluidStack(FluidRegistry.getFluid("ic2coolant"), 1000),
-                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 750),
+                new FluidStack(FluidRegistry.getFluid("ic2coolant"), 250),
+                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 250),
                 GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Kanthal, 1L),
                 GT_Values.NI,
                 GT_Values.NI,
                 null,
-                400,
+                1200,
                 120);
         // Cooling Hot Tantalum MV
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.ingotHot, Materials.Tantalum, 1L),
-                new FluidStack(FluidRegistry.getFluid("ic2coolant"), 1000),
-                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 750),
+                new FluidStack(FluidRegistry.getFluid("ic2coolant"), 250),
+                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 250),
                 GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Tantalum, 1L),
                 GT_Values.NI,
                 GT_Values.NI,
                 null,
-                400,
+                1800,
                 120);
         // Cooling Hot Silicon MV
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.ingotHot, Materials.Silicon, 1L),
-                new FluidStack(FluidRegistry.getFluid("ic2coolant"), 1000),
-                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 750),
+                new FluidStack(FluidRegistry.getFluid("ic2coolant"), 250),
+                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 250),
                 GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Silicon, 1L),
                 GT_Values.NI,
                 GT_Values.NI,
                 null,
-                400,
+                600,
                 120);
         // Cooling Hot SiliconSG MV
         GT_Values.RA.addChemicalBathRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.ingotHot, Materials.SiliconSG, 1L),
-                new FluidStack(FluidRegistry.getFluid("ic2coolant"), 1000),
-                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 750),
+                new FluidStack(FluidRegistry.getFluid("ic2coolant"), 250),
+                new FluidStack(FluidRegistry.getFluid("ic2hotcoolant"), 250),
                 GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.SiliconSG, 1L),
                 GT_Values.NI,
                 GT_Values.NI,
                 null,
-                400,
+                600,
                 120);
 
         // Mysterious crystal upgrading


### PR DESCRIPTION
Problems:
1. MV cooling is a pretty bad mandatory time sink. I think the bit of complexity is very nice (ic2 coolant, potentially cooling the hot coolant back down). And some difficulty here makes the progression to the vac freezer feel good. But currently the time sink is over the top imo. It literally takes 2 hours of cooling (with one machine) to upgrade one EBF to kanthal. Then ofc there is Silicon and potentially Tantalum cooling. Kanthal cooling being annoying and over the top is the most common feedback from all players that have recently played MV.

2. The 75% loss of coolant is pretty extreme compared to other lossy processes. If you lose so much there is no incentive to try to invest in the recovery process.

3. its unclear why the cooling times for the 4 ingots should be so different. (but this is not that important)


Solution:
This PR reduces and unifies all the cooling times to 20 seconds and the loss to just 25%. This makes the times more appropriate to the tier and the 'hot coolant' cooling more interesting.