### PR TITLE
change 300s to 180s

### DIFF
--- a/src/main/java/com/dreammaster/bartworksHandler/BacteriaRegistry.java
+++ b/src/main/java/com/dreammaster/bartworksHandler/BacteriaRegistry.java
@@ -306,7 +306,7 @@ public class BacteriaRegistry {
                 CultureSet.get("CombinedBac"),
                 new FluidStack[] {Oil.getFluid(20)},
                 new FluidStack[] {Xenoxene.getFluid(20)},
-                6000,
+                3600,
                 BW_Util.getMachineVoltageFromTier(10),
                 Materials.NaquadahEnriched,
                 8,


### PR DESCRIPTION
Xenoxene as now is 300s at UEV, slowing the whole radox line to ground and it's honestly annoying to send that much energy into a culture that is already really dumb rng based to get slowed by it