### PR TITLE
Add recipes to the nei planet blocks

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -18969,6 +18969,7 @@ public class GT_MachineRecipeLoader implements Runnable {
 
         registerMixedMetalIngotRecipes();
         registerReinforcedIronAlloyPlates();
+        registerNEIPlanetRecipes();
 
         // Heat Exchangers
         GT_Values.RA.addAssemblerRecipe(
@@ -25895,5 +25896,453 @@ public class GT_MachineRecipeLoader implements Runnable {
                 CustomItemList.ReinforcedBedrockiumIronPlate.get(1),
                 100,
                 7864320);
+    }
+
+    private static final void registerNEIPlanetRecipes() {
+        // NEI Ore Plugin planets
+        if (Loader.isModLoaded("gtneioreplugin")) {
+            // T0 Planets
+            // Overworld
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("minecraft", "stone", 64L, 0),
+                        GT_ModHandler.getModItem("minecraft", "grass", 64L, 0),
+                        GT_ModHandler.getModItem("minecraft", "sapling", 1L, 0)
+                    },
+                    Materials.Water.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ow", 1L, 0),
+                    300,
+                    30);
+            // Twilight Forest
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("minecraft", "stone", 64L, 0),
+                        GT_ModHandler.getModItem("minecraft", "grass", 64L, 0),
+                        GT_ModHandler.getModItem("TwilightForest", "tile.TFSapling", 1L, 1)
+                    },
+                    Materials.Water.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_TF", 1L, 0),
+                    300,
+                    30);
+            // Nether
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("minecraft", "netherrack", 64L, 0),
+                        GT_ModHandler.getModItem("minecraft", "soul_sand", 64L, 0),
+                        GT_ModHandler.getModItem("BiomesOPlenty", "ash", 64L, 0)
+                    },
+                    Materials.Lava.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ne", 1L, 0),
+                    300,
+                    30);
+            // End
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("minecraft", "end_stone", 64L, 0),
+                        GT_ModHandler.getModItem("minecraft", "obsidian", 64L, 0),
+                        GT_ModHandler.getModItem("Natura", "Cloud", 64L, 1)
+                    },
+                    FluidRegistry.getFluidStack("ender", 10000),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_ED", 1L, 0),
+                    300,
+                    30);
+            // Far End Asteroids
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("HardcoreEnderExpansion", "end_stone_terrain", 64L, 0),
+                        GT_ModHandler.getModItem("HardcoreEnderExpansion", "end_stone_terrain", 64L, 1),
+                        GT_ModHandler.getModItem("HardcoreEnderExpansion", "end_stone_terrain", 64L, 2)
+                    },
+                    FluidRegistry.getFluidStack("endergoo", 10000),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_EA", 1L, 0),
+                    300,
+                    30);
+            // T1 Planets
+            // The Moon
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 3),
+                        GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 4),
+                        GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 14)
+                    },
+                    Materials.SaltWater.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Mo", 1L, 0),
+                    300,
+                    480);
+            // T2 Planets
+            // Deimos
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "deimosblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "deimosblocks", 64L, 1),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Uranium, 64L)
+                    },
+                    Materials.SulfuricAcid.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_De", 1L, 0),
+                    300,
+                    1920);
+            // Phobos
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "phobosblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "phobosblocks", 64L, 1),
+                        GT_ModHandler.getModItem("GalaxySpace", "phobosblocks", 64L, 2)
+                    },
+                    Materials.SulfuricAcid.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ph", 1L, 0),
+                    300,
+                    1920);
+            // Mars
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalacticraftMars", "tile.mars", 64L, 5),
+                        GT_ModHandler.getModItem("GalacticraftMars", "tile.mars", 64L, 6),
+                        GT_ModHandler.getModItem("GalacticraftMars", "tile.mars", 64L, 7)
+                    },
+                    Materials.Chlorobenzene.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ma", 1L, 0),
+                    300,
+                    1920);
+            // T3 Planets
+            // Ceres
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "ceresblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "ceresblocks", 64L, 1),
+                        GT_ModHandler.getModItem("GalaxySpace", "ceresblocks", 64L, 2)
+                    },
+                    Materials.Oxygen.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ce", 1L, 0),
+                    300,
+                    7680);
+            // Callisto
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "callistoblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "callistoblocks", 64L, 1),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.CallistoIce, 64L)
+                    },
+                    Materials.LiquidAir.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ca", 1L, 0),
+                    300,
+                    7680);
+            // Asteroids
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalacticraftMars", "tile.asteroidsBlock", 64L, 0),
+                        GT_ModHandler.getModItem("GalacticraftMars", "tile.asteroidsBlock", 64L, 1),
+                        GT_ModHandler.getModItem("GalacticraftMars", "tile.denseIce", 64L, 0)
+                    },
+                    FluidRegistry.getFluidStack("ice", 10000),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_As", 1L, 0),
+                    300,
+                    7680);
+            // Ganymede
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "ganymedeblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "ganymedeblocks", 64L, 1),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Platinum, 64L)
+                    },
+                    Materials.Oxygen.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ga", 1L, 0),
+                    300,
+                    7680);
+            // Europa
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "europagrunt", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "europagrunt", 64L, 1),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Manganese, 64L)
+                    },
+                    Materials.Water.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Eu", 1L, 0),
+                    300,
+                    7680);
+            // Ross 128b
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("minecraft", "dirt", 64L, 2),
+                        GT_ModHandler.getModItem("minecraft", "stone", 64L, 0),
+                        ItemList.Generator_Naquadah_Mark_I.get(1L)
+                    },
+                    Materials.Lava.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Rb", 1L, 0),
+                    300,
+                    7680);
+            // T4 Planets
+            // Io
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "ioblocks", 64L, 1),
+                        GT_ModHandler.getModItem("GalaxySpace", "ioblocks", 64L, 2),
+                        GT_ModHandler.getModItem("GalaxySpace", "ioblocks", 64L, 3)
+                    },
+                    Materials.Lead.getMolten(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Io", 1L, 0),
+                    300,
+                    30720);
+            // Mercury
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "mercuryblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "mercuryblocks", 64L, 1),
+                        GT_ModHandler.getModItem("GalaxySpace", "mercuryblocks", 64L, 2)
+                    },
+                    Materials.Iron.getMolten(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Me", 1L, 0),
+                    300,
+                    30720);
+            // Venus
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "venusblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "venusblocks", 64L, 1),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Quantium, 64L)
+                    },
+                    Materials.CarbonDioxide.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ve", 1L, 0),
+                    300,
+                    30720);
+            // T5 Planets
+            // Miranda
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "mirandablocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "mirandablocks", 64L, 1),
+                        GT_ModHandler.getModItem("GalaxySpace", "mirandablocks", 64L, 2)
+                    },
+                    Materials.HydricSulfide.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Mi", 1L, 0),
+                    300,
+                    122880);
+            // Oberon
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "oberonblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "oberonblocks", 64L, 1),
+                        GT_ModHandler.getModItem("GalaxySpace", "oberonblocks", 64L, 2)
+                    },
+                    Materials.CarbonMonoxide.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ob", 1L, 0),
+                    300,
+                    122880);
+            // Enceladus
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "enceladusblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "enceladusblocks", 64L, 1),
+                        GT_ModHandler.getModItem("GalaxySpace", "enceladusblocks", 64L, 2)
+                    },
+                    Materials.Oxygen.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_En", 1L, 0),
+                    300,
+                    122880);
+            // Titan
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "titanblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "titanblocks", 64L, 1),
+                        GT_ModHandler.getModItem("GalaxySpace", "titanblocks", 64L, 2)
+                    },
+                    Materials.Methane.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ti", 1L, 0),
+                    300,
+                    122880);
+            // Ross 128ba
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 3),
+                        GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 4),
+                        GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 5)
+                    },
+                    Materials.Helium_3.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ra", 1L, 0),
+                    300,
+                    122880);
+            // T6 Planets
+            // Triton
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "tritonblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "tritonblocks", 64L, 1),
+                        GT_ModHandler.getModItem("GalaxySpace", "tritonblocks", 64L, 2)
+                    },
+                    Materials.Ethylene.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Tr", 1L, 0),
+                    300,
+                    491520);
+            // Proteus
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "proteusblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "proteusblocks", 64L, 2),
+                        GT_ModHandler.getModItem("GalaxySpace", "proteusblocks", 64L, 3)
+                    },
+                    Materials.Deuterium.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Pr", 1L, 0),
+                    300,
+                    491520);
+            // T7 Planets
+            // Haumea
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "haumeablocks", 64L, 0),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.NetherStar, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Naquadah, 64L)
+                    },
+                    Materials.InfusedGold.getMolten(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ha", 1L, 0),
+                    300,
+                    1966080);
+            // Pluto
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "plutoblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "plutoblocks", 64L, 4),
+                        GT_ModHandler.getModItem("GalaxySpace", "plutoblocks", 64L, 6),
+                    },
+                    Materials.Fluorine.getGas(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Pl", 1L, 0),
+                    300,
+                    1966080);
+            // Makemake
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "makemakegrunt", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "makemakegrunt", 64L, 1),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Chrysotile, 64L)
+                    },
+                    Materials.HydrofluoricAcid.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_MM", 1L, 0),
+                    300,
+                    1966080);
+            // Kuiper Belt
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalacticraftMars", "tile.asteroidsBlock", 64L, 0),
+                        GT_ModHandler.getModItem("GalacticraftMars", "tile.denseIce", 64L, 0),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Neutronium, 64L)
+                    },
+                    FluidRegistry.getFluidStack("ice", 10000),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_KB", 1L, 0),
+                    300,
+                    1966080);
+            // T8 Planets
+            // Vega B
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "vegabgrunt", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "vegabsubgrunt", 64L, 0),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.InfinityCatalyst, 64L)
+                    },
+                    Materials.Neutronium.getMolten(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_VB", 1L, 0),
+                    300,
+                    7864320);
+            // Barnard C
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("minecraft", "stone", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "barnardaCgrass", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "barnardaCsapling", 1L, 0),
+                    },
+                    FluidRegistry.getFluidStack("unknowwater", 10000),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_BC", 1L, 0),
+                    300,
+                    7864320);
+            // Barnard E
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "barnardaEgrunt", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "barnardaEsubgrunt", 64L, 0),
+                        GT_OreDictUnificator.get(OrePrefixes.block, Materials.Unstable, 64L)
+                    },
+                    Materials.LiquidAir.getFluid(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_BE", 1L, 0),
+                    300,
+                    7864320);
+            // Barnard F
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "barnardaFgrunt", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "barnardaFsubgrunt", 64L, 0),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Bedrockium, 64L)
+                    },
+                    Materials.Tin.getMolten(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_BF", 1L, 0),
+                    300,
+                    7864320);
+            // T Ceti E
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "tcetieblocks", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "tcetieblocks", 64L, 2),
+                        GT_ModHandler.getModItem("GalaxySpace", "tcetiedandelions", 64L, 4)
+                    },
+                    GT_ModHandler.getDistilledWater(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_TE", 1L, 0),
+                    300,
+                    7864320);
+            // Alpha Centauri Bb
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "acentauribbgrunt", 64L, 0),
+                        GT_ModHandler.getModItem("GalaxySpace", "acentauribbsubgrunt", 64L, 0),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Samarium, 64L)
+                    },
+                    Materials.Copper.getMolten(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_CB", 1L, 0),
+                    300,
+                    7864320);
+            // Technically T9
+            // Deep Dark
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
+                        GT_ModHandler.getModItem("minecraft", "cobblestone", 64L, 0),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Dilithium, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Pumice, 64L)
+                    },
+                    Materials.SpaceTime.getMolten(10000L),
+                    GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_DD", 1L, 0),
+                    300,
+                    125829120);
+        }
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -19620,6 +19620,40 @@ public class GT_MachineRecipeLoader implements Runnable {
                     GT_ModHandler.getModItem("EnderIO", "itemBasicCapacitor", 1L, 5),
                     200,
                     30720);
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("bartworks", "gt.bwMetaGeneratedbolt", 4L, 10024),
+                        GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Manganese, 4),
+                        ItemList.Gravistar.get(1L),
+                        GT_ModHandler.getModItem("EnderIO", "itemFrankenSkull", 1L, 5),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StellarAlloy, 2),
+                        GT_Utility.getIntegratedCircuit(1)
+                    },
+                    Materials.Neutronium.getMolten(1440),
+                    GT_ModHandler.getModItem("EnderIO", "itemBasicCapacitor", 1L, 6),
+                    200,
+                    122880);
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("EnderIO", "itemBasicCapacitor", 1L, 5),
+                        ItemList.Gravistar.get(1L),
+                        GT_ModHandler.getModItem("EnderIO", "itemFrankenSkull", 1L, 5),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StellarAlloy, 2)
+                    },
+                    Materials.Neutronium.getMolten(1152),
+                    GT_ModHandler.getModItem("EnderIO", "itemBasicCapacitor", 1L, 6),
+                    200,
+                    122880);
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] {
+                        GT_ModHandler.getModItem("minecraft", "skull", 1L, 0),
+                        GT_ModHandler.getModItem("minecraft", "rotten_flesh", 2L, 0),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.SiliconSG, 1)
+                    },
+                    Materials.Soularium.getMolten(288),
+                    GT_ModHandler.getModItem("EnderIO", "itemFrankenSkull", 1L, 5),
+                    100,
+                    122880);
         }
 
         GT_Values.RA.addLaserEngraverRecipe(

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -18,6 +18,7 @@ import gregtech.common.items.GT_MetaGenerated_Tool_01;
 import gregtech.common.tileentities.machines.basic.GT_MetaTileEntity_Disassembler;
 import gtPlusPlus.core.material.ALLOY;
 import gtPlusPlus.core.material.ELEMENT;
+import gtPlusPlus.core.recipe.common.CI;
 import ic2.core.Ic2Items;
 import java.lang.reflect.Field;
 import java.util.List;
@@ -25908,7 +25909,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("minecraft", "stone", 64L, 0),
                         GT_ModHandler.getModItem("minecraft", "grass", 64L, 0),
-                        GT_ModHandler.getModItem("minecraft", "sapling", 1L, 0)
+                        GT_ModHandler.getModItem("minecraft", "sapling", 1L, 0),
+                        GT_Utility.getIntegratedCircuit(0)
                     },
                     Materials.Water.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ow", 1L, 0),
@@ -25920,7 +25922,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("minecraft", "stone", 64L, 0),
                         GT_ModHandler.getModItem("minecraft", "grass", 64L, 0),
-                        GT_ModHandler.getModItem("TwilightForest", "tile.TFSapling", 1L, 1)
+                        GT_ModHandler.getModItem("TwilightForest", "tile.TFSapling", 1L, 1),
+                        GT_Utility.getIntegratedCircuit(1)
                     },
                     Materials.Water.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_TF", 1L, 0),
@@ -25932,7 +25935,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("minecraft", "netherrack", 64L, 0),
                         GT_ModHandler.getModItem("minecraft", "soul_sand", 64L, 0),
-                        GT_ModHandler.getModItem("BiomesOPlenty", "ash", 64L, 0)
+                        GT_ModHandler.getModItem("BiomesOPlenty", "ash", 64L, 0),
+                        GT_Utility.getIntegratedCircuit(2)
                     },
                     Materials.Lava.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ne", 1L, 0),
@@ -25944,7 +25948,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("minecraft", "end_stone", 64L, 0),
                         GT_ModHandler.getModItem("minecraft", "obsidian", 64L, 0),
-                        GT_ModHandler.getModItem("Natura", "Cloud", 64L, 1)
+                        GT_ModHandler.getModItem("Natura", "Cloud", 64L, 1),
+                        GT_Utility.getIntegratedCircuit(3)
                     },
                     FluidRegistry.getFluidStack("ender", 10000),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_ED", 1L, 0),
@@ -25956,7 +25961,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("HardcoreEnderExpansion", "end_stone_terrain", 64L, 0),
                         GT_ModHandler.getModItem("HardcoreEnderExpansion", "end_stone_terrain", 64L, 1),
-                        GT_ModHandler.getModItem("HardcoreEnderExpansion", "end_stone_terrain", 64L, 2)
+                        GT_ModHandler.getModItem("HardcoreEnderExpansion", "end_stone_terrain", 64L, 2),
+                        GT_Utility.getIntegratedCircuit(4)
                     },
                     FluidRegistry.getFluidStack("endergoo", 10000),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_EA", 1L, 0),
@@ -25969,7 +25975,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 3),
                         GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 4),
-                        GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 14)
+                        GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 14),
+                        GT_Utility.getIntegratedCircuit(5)
                     },
                     Materials.SaltWater.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Mo", 1L, 0),
@@ -25982,7 +25989,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "deimosblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "deimosblocks", 64L, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Uranium, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Uranium, 64L),
+                        GT_Utility.getIntegratedCircuit(6)
                     },
                     Materials.SulfuricAcid.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_De", 1L, 0),
@@ -25994,7 +26002,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "phobosblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "phobosblocks", 64L, 1),
-                        GT_ModHandler.getModItem("GalaxySpace", "phobosblocks", 64L, 2)
+                        GT_ModHandler.getModItem("GalaxySpace", "phobosblocks", 64L, 2),
+                        GT_Utility.getIntegratedCircuit(7)
                     },
                     Materials.SulfuricAcid.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ph", 1L, 0),
@@ -26006,7 +26015,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalacticraftMars", "tile.mars", 64L, 5),
                         GT_ModHandler.getModItem("GalacticraftMars", "tile.mars", 64L, 6),
-                        GT_ModHandler.getModItem("GalacticraftMars", "tile.mars", 64L, 7)
+                        GT_ModHandler.getModItem("GalacticraftMars", "tile.mars", 64L, 7),
+                        GT_Utility.getIntegratedCircuit(8)
                     },
                     Materials.Chlorobenzene.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ma", 1L, 0),
@@ -26019,7 +26029,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "ceresblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "ceresblocks", 64L, 1),
-                        GT_ModHandler.getModItem("GalaxySpace", "ceresblocks", 64L, 2)
+                        GT_ModHandler.getModItem("GalaxySpace", "ceresblocks", 64L, 2),
+                        GT_Utility.getIntegratedCircuit(9)
                     },
                     Materials.Oxygen.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ce", 1L, 0),
@@ -26031,7 +26042,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "callistoblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "callistoblocks", 64L, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.CallistoIce, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.CallistoIce, 64L),
+                        GT_Utility.getIntegratedCircuit(10)
                     },
                     Materials.LiquidAir.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ca", 1L, 0),
@@ -26043,7 +26055,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalacticraftMars", "tile.asteroidsBlock", 64L, 0),
                         GT_ModHandler.getModItem("GalacticraftMars", "tile.asteroidsBlock", 64L, 1),
-                        GT_ModHandler.getModItem("GalacticraftMars", "tile.denseIce", 64L, 0)
+                        GT_ModHandler.getModItem("GalacticraftMars", "tile.denseIce", 64L, 0),
+                        GT_Utility.getIntegratedCircuit(11)
                     },
                     FluidRegistry.getFluidStack("ice", 10000),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_As", 1L, 0),
@@ -26055,7 +26068,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "ganymedeblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "ganymedeblocks", 64L, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Platinum, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Platinum, 64L),
+                        GT_Utility.getIntegratedCircuit(12)
                     },
                     Materials.Oxygen.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ga", 1L, 0),
@@ -26067,7 +26081,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "europagrunt", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "europagrunt", 64L, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Manganese, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Manganese, 64L),
+                        GT_Utility.getIntegratedCircuit(13)
                     },
                     Materials.Water.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Eu", 1L, 0),
@@ -26079,7 +26094,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("minecraft", "dirt", 64L, 2),
                         GT_ModHandler.getModItem("minecraft", "stone", 64L, 0),
-                        ItemList.Generator_Naquadah_Mark_I.get(1L)
+                        ItemList.Generator_Naquadah_Mark_I.get(1L),
+                        GT_Utility.getIntegratedCircuit(14)
                     },
                     Materials.Lava.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Rb", 1L, 0),
@@ -26092,7 +26108,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "ioblocks", 64L, 1),
                         GT_ModHandler.getModItem("GalaxySpace", "ioblocks", 64L, 2),
-                        GT_ModHandler.getModItem("GalaxySpace", "ioblocks", 64L, 3)
+                        GT_ModHandler.getModItem("GalaxySpace", "ioblocks", 64L, 3),
+                        GT_Utility.getIntegratedCircuit(15)
                     },
                     Materials.Lead.getMolten(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Io", 1L, 0),
@@ -26104,7 +26121,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "mercuryblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "mercuryblocks", 64L, 1),
-                        GT_ModHandler.getModItem("GalaxySpace", "mercuryblocks", 64L, 2)
+                        GT_ModHandler.getModItem("GalaxySpace", "mercuryblocks", 64L, 2),
+                        GT_Utility.getIntegratedCircuit(16)
                     },
                     Materials.Iron.getMolten(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Me", 1L, 0),
@@ -26116,7 +26134,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "venusblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "venusblocks", 64L, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Quantium, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Quantium, 64L),
+                        GT_Utility.getIntegratedCircuit(17)
                     },
                     Materials.CarbonDioxide.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ve", 1L, 0),
@@ -26129,7 +26148,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "mirandablocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "mirandablocks", 64L, 1),
-                        GT_ModHandler.getModItem("GalaxySpace", "mirandablocks", 64L, 2)
+                        GT_ModHandler.getModItem("GalaxySpace", "mirandablocks", 64L, 2),
+                        GT_Utility.getIntegratedCircuit(18)
                     },
                     Materials.HydricSulfide.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Mi", 1L, 0),
@@ -26141,7 +26161,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "oberonblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "oberonblocks", 64L, 1),
-                        GT_ModHandler.getModItem("GalaxySpace", "oberonblocks", 64L, 2)
+                        GT_ModHandler.getModItem("GalaxySpace", "oberonblocks", 64L, 2),
+                        GT_Utility.getIntegratedCircuit(19)
                     },
                     Materials.CarbonMonoxide.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ob", 1L, 0),
@@ -26153,7 +26174,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "enceladusblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "enceladusblocks", 64L, 1),
-                        GT_ModHandler.getModItem("GalaxySpace", "enceladusblocks", 64L, 2)
+                        GT_ModHandler.getModItem("GalaxySpace", "enceladusblocks", 64L, 2),
+                        GT_Utility.getIntegratedCircuit(20)
                     },
                     Materials.Oxygen.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_En", 1L, 0),
@@ -26165,7 +26187,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "titanblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "titanblocks", 64L, 1),
-                        GT_ModHandler.getModItem("GalaxySpace", "titanblocks", 64L, 2)
+                        GT_ModHandler.getModItem("GalaxySpace", "titanblocks", 64L, 2),
+                        GT_Utility.getIntegratedCircuit(21)
                     },
                     Materials.Methane.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ti", 1L, 0),
@@ -26177,7 +26200,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 3),
                         GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 4),
-                        GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 5)
+                        GT_ModHandler.getModItem("GalacticraftCore", "tile.moonBlock", 64L, 5),
+                        GT_Utility.getIntegratedCircuit(22)
                     },
                     Materials.Helium_3.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ra", 1L, 0),
@@ -26190,7 +26214,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "tritonblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "tritonblocks", 64L, 1),
-                        GT_ModHandler.getModItem("GalaxySpace", "tritonblocks", 64L, 2)
+                        GT_ModHandler.getModItem("GalaxySpace", "tritonblocks", 64L, 2),
+                        GT_Utility.getIntegratedCircuit(23)
                     },
                     Materials.Ethylene.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Tr", 1L, 0),
@@ -26202,7 +26227,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "proteusblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "proteusblocks", 64L, 2),
-                        GT_ModHandler.getModItem("GalaxySpace", "proteusblocks", 64L, 3)
+                        GT_ModHandler.getModItem("GalaxySpace", "proteusblocks", 64L, 3),
+                        GT_Utility.getIntegratedCircuit(24)
                     },
                     Materials.Deuterium.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Pr", 1L, 0),
@@ -26215,7 +26241,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "haumeablocks", 64L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.ore, Materials.NetherStar, 64L),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Naquadah, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Naquadah, 64L),
+                        CI.getNumberedAdvancedCircuit(0)
                     },
                     Materials.InfusedGold.getMolten(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Ha", 1L, 0),
@@ -26228,6 +26255,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("GalaxySpace", "plutoblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "plutoblocks", 64L, 4),
                         GT_ModHandler.getModItem("GalaxySpace", "plutoblocks", 64L, 6),
+                        CI.getNumberedAdvancedCircuit(1)
                     },
                     Materials.Fluorine.getGas(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_Pl", 1L, 0),
@@ -26239,7 +26267,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "makemakegrunt", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "makemakegrunt", 64L, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Chrysotile, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Chrysotile, 64L),
+                        CI.getNumberedAdvancedCircuit(2)
                     },
                     Materials.HydrofluoricAcid.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_MM", 1L, 0),
@@ -26251,7 +26280,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalacticraftMars", "tile.asteroidsBlock", 64L, 0),
                         GT_ModHandler.getModItem("GalacticraftMars", "tile.denseIce", 64L, 0),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Neutronium, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Neutronium, 64L),
+                        CI.getNumberedAdvancedCircuit(3)
                     },
                     FluidRegistry.getFluidStack("ice", 10000),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_KB", 1L, 0),
@@ -26264,7 +26294,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "vegabgrunt", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "vegabsubgrunt", 64L, 0),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.InfinityCatalyst, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.InfinityCatalyst, 64L),
+                        CI.getNumberedAdvancedCircuit(4)
                     },
                     Materials.Neutronium.getMolten(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_VB", 1L, 0),
@@ -26277,6 +26308,7 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("minecraft", "stone", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "barnardaCgrass", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "barnardaCsapling", 1L, 0),
+                        CI.getNumberedAdvancedCircuit(5)
                     },
                     FluidRegistry.getFluidStack("unknowwater", 10000),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_BC", 1L, 0),
@@ -26288,7 +26320,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "barnardaEgrunt", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "barnardaEsubgrunt", 64L, 0),
-                        GT_OreDictUnificator.get(OrePrefixes.block, Materials.Unstable, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.block, Materials.Unstable, 64L),
+                        CI.getNumberedAdvancedCircuit(6)
                     },
                     Materials.LiquidAir.getFluid(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_BE", 1L, 0),
@@ -26300,7 +26333,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "barnardaFgrunt", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "barnardaFsubgrunt", 64L, 0),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Bedrockium, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Bedrockium, 64L),
+                        CI.getNumberedAdvancedCircuit(7)
                     },
                     Materials.Tin.getMolten(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_BF", 1L, 0),
@@ -26312,7 +26346,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "tcetieblocks", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "tcetieblocks", 64L, 2),
-                        GT_ModHandler.getModItem("GalaxySpace", "tcetiedandelions", 64L, 4)
+                        GT_ModHandler.getModItem("GalaxySpace", "tcetiedandelions", 64L, 4),
+                        CI.getNumberedAdvancedCircuit(8)
                     },
                     GT_ModHandler.getDistilledWater(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_TE", 1L, 0),
@@ -26324,7 +26359,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "acentauribbgrunt", 64L, 0),
                         GT_ModHandler.getModItem("GalaxySpace", "acentauribbsubgrunt", 64L, 0),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Samarium, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Samarium, 64L),
+                        CI.getNumberedAdvancedCircuit(9)
                     },
                     Materials.Copper.getMolten(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_CB", 1L, 0),
@@ -26337,7 +26373,8 @@ public class GT_MachineRecipeLoader implements Runnable {
                         GT_ModHandler.getModItem("Botania", "tinyPlanetBlock", 1L, 0),
                         GT_ModHandler.getModItem("minecraft", "cobblestone", 64L, 0),
                         GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Dilithium, 64L),
-                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Pumice, 64L)
+                        GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Pumice, 64L),
+                        CI.getNumberedAdvancedCircuit(10)
                     },
                     Materials.SpaceTime.getMolten(10000L),
                     GT_ModHandler.getModItem("gtneioreplugin", "blockDimensionDisplay_DD", 1L, 0),


### PR DESCRIPTION
Adds recipes for the nei planet blocks as they are used in EOH recipe selection
They are tiered to fit their corresponding rocket tier and can be crafted after visiting their respective planets

Example:
![image](https://user-images.githubusercontent.com/93287602/212568456-97fde826-da1d-4fbe-bf75-2c04a2aad5b5.png)
