### PR TITLE
Fix compressed chest conflict

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptAvaritiaAddons.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAvaritiaAddons.java
@@ -56,7 +56,7 @@ public class ScriptAvaritiaAddons implements IScriptLoader {
                     getModItem("IronChest", "BlockIronChest", 1, 2),
                     ItemList.Electric_Piston_HV.get(1),
                     GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Obsidian, 2),
-                    GT_Utility.getIntegratedCircuit(2),
+                    GT_Utility.getIntegratedCircuit(3),
                 },
                 GT_Values.NF,
                 getModItem("avaritiaddons", "CompressedChest", 1),

--- a/src/main/java/com/dreammaster/scripts/ScriptAvaritiaAddons.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAvaritiaAddons.java
@@ -55,7 +55,7 @@ public class ScriptAvaritiaAddons implements IScriptLoader {
                     getModItem("IronChest", "BlockIronChest", 1, 6),
                     getModItem("IronChest", "BlockIronChest", 1, 2),
                     ItemList.Electric_Piston_HV.get(1),
-                    GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Obsidian, 2),
+                    GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Obsidian, 1),
                     GT_Utility.getIntegratedCircuit(3),
                 },
                 GT_Values.NF,


### PR DESCRIPTION
Fix one of the recipe conflicts in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12300 between compressed chest and obsidian chest.

also reduced the dense obsidian to be in line with the other recipes. Prompted by
![image](https://user-images.githubusercontent.com/40274384/212777896-416c5b4d-fc40-4c93-892e-bc3bacccbdc3.png)

new recipe:
![image](https://user-images.githubusercontent.com/40274384/212778651-8f1f201d-2321-4b1f-8398-d5f2ad6d440a.png)


