### PR TITLE
Fix sifter crash + add chance outputs

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.259-pre:dev")
+    compile("com.github.GTNewHorizons:GT5-Unofficial:5.09.41.263-pre:dev")
     compile("com.github.GTNewHorizons:Yamcl:0.5.84:dev")
     compile("com.github.GTNewHorizons:Baubles:1.0.1.14:dev")
     compile("com.github.GTNewHorizons:StructureLib:1.2.0-beta.2:dev")

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -26581,8 +26581,15 @@ public class GT_MachineRecipeLoader implements Runnable {
             GT_Values.RA.addSifterRecipe(
                     new ItemStack[] {NI},
                     new FluidStack[] {Materials.Water.getFluid(1000L)},
-                    new ItemStack[] {NI},
+                    new ItemStack[] {
+                        Materials.Stone.getDust(1),
+                        Materials.Clay.getDust(1),
+                        Materials.Calcite.getDust(1),
+                        Materials.Salt.getDust(1),
+                        Materials.PolyvinylChloride.getNuggets(1)
+                    },
                     new FluidStack[] {Materials.Grade1PurifiedWater.getFluid(900L)},
+                    new int[] {5000, 2000, 1000, 1000, 100},
                     500 * 10,
                     30_720,
                     true);


### PR DESCRIPTION
fixes the sifter method crash and adds contaminants to the grade 1 water recipe as chance outputs
![image](https://user-images.githubusercontent.com/93287602/215506976-2c80e662-68e3-45c0-a842-f16c7400b282.png)