### PR TITLE
Add some more outputs to water line

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/DistillationRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DistillationRecipes.java
@@ -40,14 +40,18 @@ public class DistillationRecipes implements Runnable {
         if (Loader.isModLoaded("bartworks")) {
             GT_Values.RA.addDistillationTowerRecipe(
                     Materials.Grade2PurifiedWater.getFluid(1000L),
-                    new FluidStack[] { Materials.Grade3PurifiedWater.getFluid(900L), },
-                    null,
+                    new FluidStack[] { Materials.Grade3PurifiedWater.getFluid(900L),
+                            Materials.Grade2PurifiedWater.getFluid(50L), Materials.Grade1PurifiedWater.getFluid(100L),
+                            Materials.Oil.getFluid(50L), Materials.Ammonia.getFluid(100L) },
+                    Materials.Calcite.getDust(1),
                     500 * 10,
                     122_880);
 
             GT_Values.RA.addDistillationTowerRecipe(
                     Materials.Grade6PurifiedWater.getFluid(1000L),
-                    new FluidStack[] { Materials.Grade7PurifiedWater.getFluid(900L), },
+                    new FluidStack[] { Materials.Grade7PurifiedWater.getFluid(900L),
+                            Materials.Grade6PurifiedWater.getFluid(50L), Materials.Grade5PurifiedWater.getFluid(100L),
+                            Materials.Ethanol.getFluid(50L) },
                     null,
                     500 * 10,
                     1_966_080);

--- a/src/main/java/com/dreammaster/gthandler/recipes/DistillationRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DistillationRecipes.java
@@ -42,7 +42,7 @@ public class DistillationRecipes implements Runnable {
                     Materials.Grade2PurifiedWater.getFluid(1000L),
                     new FluidStack[] { Materials.Grade3PurifiedWater.getFluid(900L),
                             Materials.Grade2PurifiedWater.getFluid(50L), Materials.Grade1PurifiedWater.getFluid(100L),
-                            Materials.Oil.getFluid(50L), Materials.Ammonia.getFluid(100L) },
+                            Materials.Oil.getFluid(50L), Materials.Ammonia.getGas(100L) },
                     Materials.Calcite.getDust(1),
                     500 * 10,
                     122_880);

--- a/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
@@ -190,7 +190,8 @@ public class LaserEngraverRecipes implements Runnable {
                     new ItemStack[] { WerkstoffLoader.Hedenbergit.get(OrePrefixes.lens, 0) }, // Hedenbergite Lens
                     new FluidStack[] { Materials.Grade3PurifiedWater.getFluid(1000L) },
                     new ItemStack[] { NI },
-                    new FluidStack[] { Materials.Grade4PurifiedWater.getFluid(900L) },
+                    new FluidStack[] { Materials.Grade4PurifiedWater.getFluid(900L),
+                            FluidRegistry.getFluidStack("bacterialsludge", 50) },
                     500 * 10,
                     245_760,
                     true);
@@ -199,7 +200,7 @@ public class LaserEngraverRecipes implements Runnable {
                     new ItemStack[] { WerkstoffLoader.BArTiMaEuSNeK.get(OrePrefixes.lens, 0) }, // Bart Lens
                     new FluidStack[] { Materials.Grade5PurifiedWater.getFluid(1000L) },
                     new ItemStack[] { NI },
-                    new FluidStack[] { Materials.Grade6PurifiedWater.getFluid(900L) },
+                    new FluidStack[] { Materials.Grade6PurifiedWater.getFluid(900L), Materials.Water.getGas(8000L) },
                     500 * 10,
                     983_040,
                     true);

--- a/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
@@ -627,7 +627,8 @@ public class ScriptAE2FC implements IScriptLoader {
         // Wireless Fluid Pattern Terminal
         GT_Values.RA.addAssemblerRecipe(AE2_ITEM_WIRELESS, AE2FC_TERMINAL, null, AE2FC_PATTERN_WIRELESS, 600, 120);
         // Wireless Interface Terminal
-        GT_Values.RA.addAssemblerRecipe(AE2_ITEM_WIRELESS, AE2_INTERFACE_TERM, null, AE2FC_INTERFACE_WIRELESS, 600, 120);
+        GT_Values.RA
+                .addAssemblerRecipe(AE2_ITEM_WIRELESS, AE2_INTERFACE_TERM, null, AE2FC_INTERFACE_WIRELESS, 600, 120);
         // Interface from Small to Block and opposite
         GameRegistry.addShapelessRecipe(AE2FC_INTERFACE_SMALL, AE2FC_INTERFACE);
         GameRegistry.addShapelessRecipe(AE2FC_INTERFACE, AE2FC_INTERFACE_SMALL);


### PR DESCRIPTION
Adds small amounts of pollutant & misc outputs to the water line recipes to make them feel less empty.

Example(grade 7 water):
![image](https://user-images.githubusercontent.com/93287602/218170037-8cd166fa-d468-4f32-9ca6-2f7f8e33dc1e.png)
