### PR TITLE
Iridium Neutron Reflector recipes skip

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -3462,7 +3462,36 @@ public class AssemblerRecipes implements Runnable {
                 900,
                 7680,
                 true);
-
+        GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateAlloy, Materials.Iridium, 2L),
+                        GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.TungstenCarbide, 36L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tin, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tin, 32L),
+                        GT_OreDictUnificator.get(OrePrefixes.plateAlloy, Materials.Carbon, 48L),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Graphite, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Graphite, 32L),
+                        GT_Utility.getIntegratedCircuit(2) },
+                GT_Values.NF,
+                ItemList.Neutron_Reflector.get(1L),
+                3150,
+                30720,
+                true);
+                GT_Values.RA.addAssemblerRecipe(
+                new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateAlloy, Materials.Iridium, 2L),
+                        GT_OreDictUnificator.get(OrePrefixes.plateDouble, Materials.Beryllium, 36L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tin, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tin, 32L),
+                        GT_OreDictUnificator.get(OrePrefixes.plateAlloy, Materials.Carbon, 48L),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Graphite, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Graphite, 64L),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Graphite, 64L),
+                        GT_Utility.getIntegratedCircuit(2) },
+                GT_Values.NF,
+                ItemList.Neutron_Reflector.get(1L),
+                3750,
+                30720,
+                true);
+        
         // Wood Plates
         GT_Recipe.GT_Recipe_Map.sAssemblerRecipes.addRecipe(
                 false,


### PR DESCRIPTION
Added high-tier 1 step recipe for Iridium Neutron Reflector.
This recipe changed to avoid unstackable items on recipes. With any bus except for stocking old recipes works very slow because of 1 recipe use ~4 slots. With super buses you cant use all parallel of your assembler for this craft.