### PR TITLE
Fix for Tungstensteel Ingots Needing TPV Coils

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BlastFurnaceRecipes.java
@@ -1445,7 +1445,7 @@ public class BlastFurnaceRecipes implements Runnable {
                 GT_Values.NI,
                 3000,
                 1920,
-                3000);
+                4000);
         GT_Values.RA.addBlastRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.TungstenSteel, 1L),
                 GT_Utility.getIntegratedCircuit(11),
@@ -1455,7 +1455,7 @@ public class BlastFurnaceRecipes implements Runnable {
                 GT_Values.NI,
                 2500,
                 1920,
-                3000);
+                4000);
 
         GT_Values.RA.addBlastRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.TungstenCarbide, 1L),


### PR DESCRIPTION
- Corrected the appropriate recipes in order to set EBF temperature to 4000K, as intended by the last change.

See https://github.com/GTNewHorizons/GT5-Unofficial/pull/1628 for the PR that was originally meant to change this.