### PR TITLE
Fix some ae recipes

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
@@ -420,35 +420,35 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
                 new ItemStack[] { getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 4, 536),
                         GT_Utility.getIntegratedCircuit(24) },
                 Materials.Silicone.getMolten(288L),
-                AE2_ME_Dense_Covered_Cable,
+                AE2_ME_Backbone_Covered_Cable,
                 250,
                 1920);
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] { getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 4, 536),
                         GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.PolyvinylChloride, 1) },
                 Materials.StyreneButadieneRubber.getMolten(144L),
-                AE2_ME_Dense_Covered_Cable,
+                AE2_ME_Backbone_Covered_Cable,
                 250,
                 1920);
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] { getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 4, 536),
                         GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.PolyvinylChloride, 1) },
                 Materials.Silicone.getMolten(144L),
-                AE2_ME_Dense_Covered_Cable,
+                AE2_ME_Backbone_Covered_Cable,
                 250,
                 1920);
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] { getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 4, 536),
                         GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Polydimethylsiloxane, 1) },
                 Materials.StyreneButadieneRubber.getMolten(144L),
-                AE2_ME_Dense_Covered_Cable,
+                AE2_ME_Backbone_Covered_Cable,
                 250,
                 1920);
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] { getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 4, 536),
                         GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Polydimethylsiloxane, 1) },
                 Materials.Silicone.getMolten(144L),
-                AE2_ME_Dense_Covered_Cable,
+                AE2_ME_Backbone_Covered_Cable,
                 250,
                 1920);
         GT_Values.RA.addAssemblerRecipe(


### PR DESCRIPTION
fixes a copy paste error in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/545 that resulted in recipes with no outputs, see https://discord.com/channels/181078474394566657/181078474394566657/1093927478021599372

fun fact: if you take 4 items to craft 1 of the same item, gt simplification nonsense subtracts the one and divides by 3.