### PR TITLE
Move chisel assembler recipes to CoreMod

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -52,6 +52,7 @@ import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.enums.Mods.ZTones;
+import static gregtech.api.enums.Mods.Chisel;
 
 import java.util.List;
 
@@ -5748,6 +5749,42 @@ public class AssemblerRecipes implements Runnable {
                     GT_ModHandler.getModItem(IronTanks.ID, "titaniumTungstensteelUpgrade", 1L, 0),
                     1300,
                     480);
+        }
+
+        if (Chisel.isModLoaded()) {
+            // Chisel
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "chisel", 1L, 0),
+                    300,
+                    30);
+            // Obsidian Chisel
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.WroughtIron, 2L) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "obsidianChisel", 1L, 0),
+                    400,
+                    30);
+            // Diamond Chisel
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Steel, 2L) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "diamondChisel", 1L, 0),
+                    600,
+                    30);
+            // Nether Star Chisel
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Bedrockium, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.VanadiumSteel, 2L) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "netherStarChisel", 1L, 0),
+                    24000,
+                    480);
+
         }
     }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -13,6 +13,7 @@ import static gregtech.api.enums.Mods.Botania;
 import static gregtech.api.enums.Mods.BuildCraftCore;
 import static gregtech.api.enums.Mods.BuildCraftFactory;
 import static gregtech.api.enums.Mods.BuildCraftTransport;
+import static gregtech.api.enums.Mods.Chisel;
 import static gregtech.api.enums.Mods.Computronics;
 import static gregtech.api.enums.Mods.EnderIO;
 import static gregtech.api.enums.Mods.ExtraBees;
@@ -52,7 +53,6 @@ import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.enums.Mods.ZTones;
-import static gregtech.api.enums.Mods.Chisel;
 
 import java.util.List;
 


### PR DESCRIPTION
Adds the chisel assembler recipes via the CoreMod, no recipes/values were changed
Linked PR: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/13183