### PR TITLE
Add Assembler recipes for Chisel blocks

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -5816,8 +5816,7 @@ public class AssemblerRecipes implements Runnable {
                     24);
             // Futura
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
-                            new ItemStack(Items.redstone, 1),
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4), new ItemStack(Items.redstone, 1),
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "futura", 8L, 0),
@@ -5825,8 +5824,7 @@ public class AssemblerRecipes implements Runnable {
                     24);
             // Fantasy Block
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
-                            new ItemStack(Items.gold_nugget, 1),
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4), new ItemStack(Items.gold_nugget, 1),
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "fantasyblock", 8L, 0),
@@ -5834,8 +5832,7 @@ public class AssemblerRecipes implements Runnable {
                     24);
             // Grimstone
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
-                            new ItemStack(Items.coal, 1),
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4), new ItemStack(Items.coal, 1),
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "grimstone", 8L, 0),
@@ -5843,8 +5840,7 @@ public class AssemblerRecipes implements Runnable {
                     24);
             // Hex Plating
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 2),
-                            new ItemStack(Items.coal, 4),
+                    new ItemStack[] { new ItemStack(Blocks.stone, 2), new ItemStack(Items.coal, 4),
                             GT_Utility.getIntegratedCircuit(11) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "hexPlating", 4L, 0),
@@ -5852,8 +5848,7 @@ public class AssemblerRecipes implements Runnable {
                     24);
             // Holystone
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
-                            new ItemStack(Items.feather, 1),
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4), new ItemStack(Items.feather, 1),
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "holystone", 8L, 0),
@@ -5861,8 +5856,7 @@ public class AssemblerRecipes implements Runnable {
                     24);
             // Laboratory Block
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
-                            new ItemStack(Items.quartz, 1),
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4), new ItemStack(Items.quartz, 1),
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "laboratoryblock", 8L, 0),
@@ -5870,8 +5864,7 @@ public class AssemblerRecipes implements Runnable {
                     24);
             // Lavastone
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
-                            GT_Utility.getIntegratedCircuit(24) },
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4), GT_Utility.getIntegratedCircuit(24) },
                     Materials.Lava.getFluid(1000L),
                     GT_ModHandler.getModItem(Chisel.ID, "lavastone", 8L, 0),
                     100,
@@ -5915,9 +5908,9 @@ public class AssemblerRecipes implements Runnable {
             // Mossy Temple Block
             if (BiomesOPlenty.isModLoaded()) {
                 GT_Values.RA.addAssemblerRecipe(
-                        new ItemStack[]{GT_ModHandler.getModItem(Chisel.ID, "templeblock", 8L, 0),
+                        new ItemStack[] { GT_ModHandler.getModItem(Chisel.ID, "templeblock", 8L, 0),
                                 GT_ModHandler.getModItem(BiomesOPlenty.ID, "moss", 8L, 0),
-                                GT_Utility.getIntegratedCircuit(24)},
+                                GT_Utility.getIntegratedCircuit(24) },
                         GT_Values.NF,
                         GT_ModHandler.getModItem(Chisel.ID, "mossy_templeblock", 4L, 0),
                         100,
@@ -5934,20 +5927,16 @@ public class AssemblerRecipes implements Runnable {
                     24);
             // Voidstone
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 2),
-                            new ItemStack(Blocks.obsidian, 2),
-                            new ItemStack(Items.ender_pearl, 1),
-                            GT_Utility.getIntegratedCircuit(24) },
+                    new ItemStack[] { new ItemStack(Blocks.stone, 2), new ItemStack(Blocks.obsidian, 2),
+                            new ItemStack(Items.ender_pearl, 1), GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "voidstone", 8L, 0),
                     100,
                     24);
             // Energised Voidstone
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 2),
-                            new ItemStack(Blocks.obsidian, 2),
-                            new ItemStack(Items.ender_pearl, 1),
-                            new ItemStack(Items.glowstone_dust, 1),
+                    new ItemStack[] { new ItemStack(Blocks.stone, 2), new ItemStack(Blocks.obsidian, 2),
+                            new ItemStack(Items.ender_pearl, 1), new ItemStack(Items.glowstone_dust, 1),
                             GT_Utility.getIntegratedCircuit(11) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "voidstone2", 8L, 0),
@@ -5955,8 +5944,7 @@ public class AssemblerRecipes implements Runnable {
                     24);
             // Warning Sign
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 2),
-                            new ItemStack(Items.sign, 1),
+                    new ItemStack[] { new ItemStack(Blocks.stone, 2), new ItemStack(Items.sign, 1),
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "warningSign", 4L, 0),
@@ -5964,8 +5952,7 @@ public class AssemblerRecipes implements Runnable {
                     24);
             // Waterstone
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
-                            GT_Utility.getIntegratedCircuit(24) },
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4), GT_Utility.getIntegratedCircuit(24) },
                     Materials.Water.getFluid(1000L),
                     GT_ModHandler.getModItem(Chisel.ID, "waterstone", 8L, 0),
                     100,

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -5897,7 +5897,7 @@ public class AssemblerRecipes implements Runnable {
             // Road Lines
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Items.redstone, 3),
-                            GT_OreDictUnificator.get(ItemList.Dye_Bonemeal.get(1L)),
+                            GT_OreDictUnificator.get(ItemList.Dye_Bonemeal.get(3L)),
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "road_line", 8L, 0),

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -52,6 +52,7 @@ import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.enums.Mods.ZTones;
+import static gregtech.api.enums.Mods.Chisel;
 
 import java.util.List;
 
@@ -5748,6 +5749,42 @@ public class AssemblerRecipes implements Runnable {
                     GT_ModHandler.getModItem(IronTanks.ID, "titaniumTungstensteelUpgrade", 1L, 0),
                     1300,
                     480);
+        }
+
+        if (Chisel.isModLoaded()) {
+            // Chisel
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "chisel", 1L, 0),
+                    300,
+                    30);
+            // Obsidian Chisel
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.WroughtIron, 2L) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "obsidianChisel", 1L, 0),
+                    400,
+                    30);
+            // Diamond Chisel
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Steel, 2L) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "diamondChisel", 1L, 0),
+                    600,
+                    30);
+            // Nether Star Chisel
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Bedrockium, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.VanadiumSteel, 2L) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "netherStarChisel", 1L, 0),
+                    24000,
+                    480);
+
         }
     }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -5794,8 +5794,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "factoryblock", 16L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Technical Block
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 5),
@@ -5803,8 +5803,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(11) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "technical", 16L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Tyrian
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 4),
@@ -5812,8 +5812,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(14) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "tyrian", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Futura
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 4),
@@ -5821,8 +5821,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "futura", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Fantasy Block
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 4),
@@ -5830,8 +5830,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "fantasyblock", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Grimstone
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 4),
@@ -5839,17 +5839,17 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "grimstone", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Hex Plating
             GT_Values.RA.addAssemblerRecipe(
-                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                    new ItemStack[] { new ItemStack(Blocks.stone, 2),
                             new ItemStack(Items.coal, 4),
                             GT_Utility.getIntegratedCircuit(11) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "hexPlating", 4L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Holystone
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 4),
@@ -5857,8 +5857,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "holystone", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Laboratory Block
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 4),
@@ -5866,16 +5866,16 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "laboratoryblock", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Lavastone
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 4),
                             GT_Utility.getIntegratedCircuit(24) },
                     Materials.Lava.getFluid(1000L),
                     GT_ModHandler.getModItem(Chisel.ID, "lavastone", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Paperwall
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Items.paper, 4),
@@ -5883,8 +5883,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "paperwall", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Paperwall Block
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Items.paper, 4),
@@ -5892,8 +5892,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(11) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "paperwall_block", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Road Lines
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Items.redstone, 3),
@@ -5901,8 +5901,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "road_line", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Temple Block
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 4),
@@ -5910,8 +5910,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "templeblock", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Mossy Temple Block
             if (BiomesOPlenty.isModLoaded()) {
                 GT_Values.RA.addAssemblerRecipe(
@@ -5920,8 +5920,8 @@ public class AssemblerRecipes implements Runnable {
                                 GT_Utility.getIntegratedCircuit(24)},
                         GT_Values.NF,
                         GT_ModHandler.getModItem(Chisel.ID, "mossy_templeblock", 4L, 0),
-                        200,
-                        16);
+                        100,
+                        24);
             }
             // Valentines Block
             GT_Values.RA.addAssemblerRecipe(
@@ -5930,8 +5930,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "valentines", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Voidstone
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 2),
@@ -5940,8 +5940,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "voidstone", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Energised Voidstone
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 2),
@@ -5951,8 +5951,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(11) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "voidstone2", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Warning Sign
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 2),
@@ -5960,16 +5960,16 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(24) },
                     GT_Values.NF,
                     GT_ModHandler.getModItem(Chisel.ID, "warningSign", 4L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
             // Waterstone
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { new ItemStack(Blocks.stone, 4),
                             GT_Utility.getIntegratedCircuit(24) },
                     Materials.Water.getFluid(1000L),
                     GT_ModHandler.getModItem(Chisel.ID, "waterstone", 8L, 0),
-                    200,
-                    16);
+                    100,
+                    24);
         }
     }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -13,6 +13,7 @@ import static gregtech.api.enums.Mods.Botania;
 import static gregtech.api.enums.Mods.BuildCraftCore;
 import static gregtech.api.enums.Mods.BuildCraftFactory;
 import static gregtech.api.enums.Mods.BuildCraftTransport;
+import static gregtech.api.enums.Mods.Chisel;
 import static gregtech.api.enums.Mods.Computronics;
 import static gregtech.api.enums.Mods.EnderIO;
 import static gregtech.api.enums.Mods.ExtraBees;
@@ -52,7 +53,6 @@ import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.enums.Mods.ZTones;
-import static gregtech.api.enums.Mods.Chisel;
 
 import java.util.List;
 
@@ -5752,6 +5752,7 @@ public class AssemblerRecipes implements Runnable {
         }
 
         if (Chisel.isModLoaded()) {
+            // --- Items
             // Chisel
             GT_Values.RA.addAssemblerRecipe(
                     new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 2L),
@@ -5785,6 +5786,190 @@ public class AssemblerRecipes implements Runnable {
                     24000,
                     480);
 
+            // --- Blocks
+            // Factory Block
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 4L),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "factoryblock", 16L, 0),
+                    200,
+                    16);
+            // Technical Block
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 5),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 4L),
+                            GT_Utility.getIntegratedCircuit(11) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "technical", 16L, 0),
+                    200,
+                    16);
+            // Tyrian
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
+                            GT_Utility.getIntegratedCircuit(14) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "tyrian", 8L, 0),
+                    200,
+                    16);
+            // Futura
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            new ItemStack(Items.redstone, 1),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "futura", 8L, 0),
+                    200,
+                    16);
+            // Fantasy Block
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            new ItemStack(Items.gold_nugget, 1),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "fantasyblock", 8L, 0),
+                    200,
+                    16);
+            // Grimstone
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            new ItemStack(Items.coal, 1),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "grimstone", 8L, 0),
+                    200,
+                    16);
+            // Hex Plating
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            new ItemStack(Items.coal, 4),
+                            GT_Utility.getIntegratedCircuit(11) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "hexPlating", 4L, 0),
+                    200,
+                    16);
+            // Holystone
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            new ItemStack(Items.feather, 1),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "holystone", 8L, 0),
+                    200,
+                    16);
+            // Laboratory Block
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            new ItemStack(Items.quartz, 1),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "laboratoryblock", 8L, 0),
+                    200,
+                    16);
+            // Lavastone
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    Materials.Lava.getFluid(1000L),
+                    GT_ModHandler.getModItem(Chisel.ID, "lavastone", 8L, 0),
+                    200,
+                    16);
+            // Paperwall
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Items.paper, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "paperwall", 8L, 0),
+                    200,
+                    16);
+            // Paperwall Block
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Items.paper, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
+                            GT_Utility.getIntegratedCircuit(11) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "paperwall_block", 8L, 0),
+                    200,
+                    16);
+            // Road Lines
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Items.redstone, 3),
+                            GT_OreDictUnificator.get(ItemList.Dye_Bonemeal.get(1L)),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "road_line", 8L, 0),
+                    200,
+                    16);
+            // Temple Block
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            GT_OreDictUnificator.get(new ItemStack(Items.dye, 1, 4)),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "templeblock", 8L, 0),
+                    200,
+                    16);
+            // Mossy Temple Block
+            if (BiomesOPlenty.isModLoaded()) {
+                GT_Values.RA.addAssemblerRecipe(
+                        new ItemStack[]{GT_ModHandler.getModItem(Chisel.ID, "templeblock", 8L, 0),
+                                GT_ModHandler.getModItem(BiomesOPlenty.ID, "moss", 8L, 0),
+                                GT_Utility.getIntegratedCircuit(24)},
+                        GT_Values.NF,
+                        GT_ModHandler.getModItem(Chisel.ID, "mossy_templeblock", 4L, 0),
+                        200,
+                        16);
+            }
+            // Valentines Block
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            GT_OreDictUnificator.get(new ItemStack(Items.dye, 1, 9)),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "valentines", 8L, 0),
+                    200,
+                    16);
+            // Voidstone
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 2),
+                            new ItemStack(Blocks.obsidian, 2),
+                            new ItemStack(Items.ender_pearl, 1),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "voidstone", 8L, 0),
+                    200,
+                    16);
+            // Energised Voidstone
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 2),
+                            new ItemStack(Blocks.obsidian, 2),
+                            new ItemStack(Items.ender_pearl, 1),
+                            new ItemStack(Items.glowstone_dust, 1),
+                            GT_Utility.getIntegratedCircuit(11) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "voidstone2", 8L, 0),
+                    200,
+                    16);
+            // Warning Sign
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 2),
+                            new ItemStack(Items.sign, 1),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    GT_Values.NF,
+                    GT_ModHandler.getModItem(Chisel.ID, "warningSign", 4L, 0),
+                    200,
+                    16);
+            // Waterstone
+            GT_Values.RA.addAssemblerRecipe(
+                    new ItemStack[] { new ItemStack(Blocks.stone, 4),
+                            GT_Utility.getIntegratedCircuit(24) },
+                    Materials.Water.getFluid(1000L),
+                    GT_ModHandler.getModItem(Chisel.ID, "waterstone", 8L, 0),
+                    200,
+                    16);
         }
     }
 


### PR DESCRIPTION
Adds assembler recipes for new blocks added by Chisel. 
The recipes are LV tier and have a better efficiency, usually saving stone but sometimes other materials (e.g. factory block saves some iron)
Recipes are pretty much identical except iron ingots were replaced with iron plates
Also respects changes made to recipes in the modpack's zenscript like mossy temple block and energised voidstone

Depends on #559 