### PR TITLE
AsGa fluid extraction fix

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/FluidExtractorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/FluidExtractorRecipes.java
@@ -29,9 +29,9 @@ public class FluidExtractorRecipes implements Runnable {
         GT_Values.RA.addFluidExtractionRecipe(
                 ItemList.GalliumArsenideCrystal.get(1L),
                 GT_Values.NI,
-                Materials.GalliumArsenide.getMolten(144L),
+                Materials.GalliumArsenide.getMolten(288L),
                 10000,
-                24,
+                48,
                 37);
 
         if (PamsHarvestCraft.isModLoaded()) {


### PR DESCRIPTION
Fixes a small oversight in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/381.
A GaAr crystal is now worth 2 dust or ingots. That has to be the case for fluid extraction too.