### PR TITLE
Oredicts diodes and inductors for 2A-16A diodes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -682,80 +682,41 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
                     GT_ModHandler.addCraftingRecipe(
                             ItemRegistry.diode12A[i],
                             BITSD,
-                            new Object[] { "WDW", "DCD", "PDP", 'D',
-                                    ItemList.Circuit_Parts_Diode.get(1L, ItemList.Circuit_Parts_DiodeSMD.get(1L)), 'W',
-                                    GT_OreDictUnificator
-                                            .get(i < 13 ? OrePrefixes.cableGt12 : OrePrefixes.wireGt12, cable, 1L),
-                                    'P', hull, 'C', machinehull });
-                    GT_ModHandler.addCraftingRecipe(
-                            ItemRegistry.diode12A[i],
-                            BITSD,
-                            new Object[] { "WDW", "DCD", "PDP", 'D',
-                                    ItemList.Circuit_Parts_DiodeSMD.get(1L, ItemList.Circuit_Parts_Diode.get(1L)), 'W',
+                            new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode),
+                                    'W',
                                     GT_OreDictUnificator
                                             .get(i < 13 ? OrePrefixes.cableGt12 : OrePrefixes.wireGt12, cable, 1L),
                                     'P', hull, 'C', machinehull });
                     GT_ModHandler.addCraftingRecipe(
                             ItemRegistry.diode8A[i],
                             BITSD,
-                            new Object[] { "WDW", "DCD", "PDP", 'D',
-                                    ItemList.Circuit_Parts_Diode.get(1L, ItemList.Circuit_Parts_DiodeSMD.get(1L)), 'W',
-                                    GT_OreDictUnificator
-                                            .get(i < 13 ? OrePrefixes.cableGt08 : OrePrefixes.wireGt08, cable, 1L),
-                                    'P', hull, 'C', machinehull });
-                    GT_ModHandler.addCraftingRecipe(
-                            ItemRegistry.diode8A[i],
-                            BITSD,
-                            new Object[] { "WDW", "DCD", "PDP", 'D',
-                                    ItemList.Circuit_Parts_DiodeSMD.get(1L, ItemList.Circuit_Parts_Diode.get(1L)), 'W',
+                            new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode),
+                                    'W',
                                     GT_OreDictUnificator
                                             .get(i < 13 ? OrePrefixes.cableGt08 : OrePrefixes.wireGt08, cable, 1L),
                                     'P', hull, 'C', machinehull });
                     GT_ModHandler.addCraftingRecipe(
                             ItemRegistry.diode4A[i],
                             BITSD,
-                            new Object[] { "WDW", "DCD", "PDP", 'D',
-                                    ItemList.Circuit_Parts_Diode.get(1L, ItemList.Circuit_Parts_DiodeSMD.get(1L)), 'W',
-                                    GT_OreDictUnificator
-                                            .get(i < 13 ? OrePrefixes.cableGt04 : OrePrefixes.wireGt04, cable, 1L),
-                                    'P', hull, 'C', machinehull });
-                    GT_ModHandler.addCraftingRecipe(
-                            ItemRegistry.diode4A[i],
-                            BITSD,
-                            new Object[] { "WDW", "DCD", "PDP", 'D',
-                                    ItemList.Circuit_Parts_DiodeSMD.get(1L, ItemList.Circuit_Parts_Diode.get(1L)), 'W',
+                            new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode),
+                                    'W',
                                     GT_OreDictUnificator
                                             .get(i < 13 ? OrePrefixes.cableGt04 : OrePrefixes.wireGt04, cable, 1L),
                                     'P', hull, 'C', machinehull });
                     GT_ModHandler.addCraftingRecipe(
                             ItemRegistry.diode2A[i],
                             BITSD,
-                            new Object[] { "WDW", "DCD", "PDP", 'D',
-                                    ItemList.Circuit_Parts_Diode.get(1L, ItemList.Circuit_Parts_DiodeSMD.get(1L)), 'W',
-                                    GT_OreDictUnificator
-                                            .get(i < 13 ? OrePrefixes.cableGt02 : OrePrefixes.wireGt02, cable, 1L),
-                                    'P', hull, 'C', machinehull });
-                    GT_ModHandler.addCraftingRecipe(
-                            ItemRegistry.diode2A[i],
-                            BITSD,
-                            new Object[] { "WDW", "DCD", "PDP", 'D',
-                                    ItemList.Circuit_Parts_DiodeSMD.get(1L, ItemList.Circuit_Parts_Diode.get(1L)), 'W',
+                            new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode),
+                                    'W',
                                     GT_OreDictUnificator
                                             .get(i < 13 ? OrePrefixes.cableGt02 : OrePrefixes.wireGt02, cable, 1L),
                                     'P', hull, 'C', machinehull });
                     GT_ModHandler.addCraftingRecipe(
                             ItemRegistry.diode16A[i],
                             BITSD,
-                            new Object[] { "WHW", "DCD", "PDP", 'H', ItemList.Circuit_Parts_Coil.get(1L), 'D',
-                                    ItemList.Circuit_Parts_Diode.get(1L, ItemList.Circuit_Parts_DiodeSMD.get(1L)), 'W',
-                                    GT_OreDictUnificator
-                                            .get(i < 13 ? OrePrefixes.cableGt16 : OrePrefixes.wireGt16, cable, 1L),
-                                    'P', hull, 'C', machinehull });
-                    GT_ModHandler.addCraftingRecipe(
-                            ItemRegistry.diode16A[i],
-                            BITSD,
-                            new Object[] { "WHW", "DCD", "PDP", 'H', ItemList.Circuit_Parts_Coil.get(1L), 'D',
-                                    ItemList.Circuit_Parts_DiodeSMD.get(1L, ItemList.Circuit_Parts_Diode.get(1L)), 'W',
+                            new Object[] { "WHW", "DCD", "PDP", 'H',
+                                    OrePrefixes.componentCircuit.get(Materials.Inductor), 'D',
+                                    OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                     GT_OreDictUnificator
                                             .get(i < 13 ? OrePrefixes.cableGt16 : OrePrefixes.wireGt16, cable, 1L),
                                     'P', hull, 'C', machinehull });


### PR DESCRIPTION
- this allows smd inductors in 16A diodes which adresses https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13250 on the coremod side. (needs bartworks fix for the lower tiers)
- instead of 2 separate recipes there is now only one with cycling ingredients as it should be. (also needs to be done in bartworks for lower tiers)