### PR TITLE
Add vanilla chest assembler recipes for GT++ wood logs

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -1354,6 +1354,138 @@ public class ScriptMinecraft implements IScriptLoader {
                 .duration(100).eut(30).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(Minecraft.ID, "planks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(BiomesOPlenty.ID, "planks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(ExtraTrees.ID, "planks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(Forestry.ID, "planks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(Forestry.ID, "planksFireproof", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(Natura.ID, "planks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
+                        getModItem(Witchery.ID, "witchwood", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(Minecraft.ID, "planks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(BiomesOPlenty.ID, "planks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(ExtraTrees.ID, "planks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(Forestry.ID, "planks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(Forestry.ID, "planksFireproof", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(Natura.ID, "planks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
+                        getModItem(Witchery.ID, "witchwood", 2, 32767, missing))
+                .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(100).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(Minecraft.ID, "stone_button", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "lever", 1, 0, missing)).noFluidInputs().noFluidOutputs()


### PR DESCRIPTION
Adds chest recipes for GT++ Rainforest Oak and Pine logs to the assembler.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13429

![2023-05-07_00 24 32](https://user-images.githubusercontent.com/1928113/236648791-e3dbf9a0-dabe-49cb-8b01-b0b2e3d576c5.png)
