### PR TITLE
Remove broken duplicate recipes with forestry slabs and other duplicate slab recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/LatheRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/LatheRecipes.java
@@ -77,23 +77,8 @@ public class LatheRecipes implements Runnable {
                 .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sLatheRecipes);
 
         if (Forestry.isModLoaded()) {
-            // todo: investigate why getModItem is null here
-            for (int i = 0; i < 8; i++) {
-                GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(Forestry.ID, "slabs1", 1, i))
-                        .itemOutputs(
-                                new ItemStack(Items.bowl, 1),
-                                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
-                        .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8)
-                        .addTo(sLatheRecipes);
-
-                GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(Forestry.ID, "slabs2", 1, i))
-                        .itemOutputs(
-                                new ItemStack(Items.bowl, 1),
-                                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
-                        .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8)
-                        .addTo(sLatheRecipes);
-
-                GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(Forestry.ID, "slabs3", 1, i))
+            for (int i = 0; i < 29; i++) {
+                GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(Forestry.ID, "slabs", 1, i))
                         .itemOutputs(
                                 new ItemStack(Items.bowl, 1),
                                 GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))

--- a/src/main/java/com/dreammaster/gthandler/recipes/LatheRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/LatheRecipes.java
@@ -1,6 +1,5 @@
 package com.dreammaster.gthandler.recipes;
 
-import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLatheRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
@@ -75,16 +74,5 @@ public class LatheRecipes implements Runnable {
                         new ItemStack(Items.bowl, 1),
                         GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
                 .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sLatheRecipes);
-
-        if (Forestry.isModLoaded()) {
-            for (int i = 0; i < 29; i++) {
-                GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(Forestry.ID, "slabs", 1, i))
-                        .itemOutputs(
-                                new ItemStack(Items.bowl, 1),
-                                GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
-                        .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8)
-                        .addTo(sLatheRecipes);
-            }
-        }
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/LatheRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/LatheRecipes.java
@@ -4,11 +4,6 @@ import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLatheRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
-import static gregtech.api.util.GT_RecipeBuilder.TICKS;
-
-import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
-import net.minecraft.item.ItemStack;
 
 import com.dreammaster.gthandler.CustomItemList;
 import com.dreammaster.gthandler.GT_CoreModSupport;
@@ -38,41 +33,5 @@ public class LatheRecipes implements Runnable {
                         CustomItemList.ReinforcedGlassLense.get(1L),
                         GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Glass, 1L))
                 .noFluidInputs().noFluidOutputs().duration(20 * SECONDS).eut(16).addTo(sLatheRecipes);
-
-        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.wooden_slab, 1, 0))
-                .itemOutputs(
-                        new ItemStack(Items.bowl, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
-                .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sLatheRecipes);
-
-        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.wooden_slab, 1, 1))
-                .itemOutputs(
-                        new ItemStack(Items.bowl, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
-                .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sLatheRecipes);
-
-        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.wooden_slab, 1, 2))
-                .itemOutputs(
-                        new ItemStack(Items.bowl, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
-                .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sLatheRecipes);
-
-        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.wooden_slab, 1, 3))
-                .itemOutputs(
-                        new ItemStack(Items.bowl, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
-                .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sLatheRecipes);
-
-        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.wooden_slab, 1, 4))
-                .itemOutputs(
-                        new ItemStack(Items.bowl, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
-                .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sLatheRecipes);
-
-        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.wooden_slab, 1, 5))
-                .itemOutputs(
-                        new ItemStack(Items.bowl, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Wood, 1))
-                .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sLatheRecipes);
     }
 }


### PR DESCRIPTION
They were just giving null inputs in game and throwing errors in the normal log.

First I fixed them but then I realized they are already generated in GT itself in a much smarter and robust way (oredicts!). So they can just be deleted here.

Also removed some more duplicate recipes that are all covered in a smarter way by GT.
