### PR TITLE
Recipe and unification fixes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
@@ -222,7 +222,7 @@ public class GT_Loader_OreDictionary extends gregtech.loaders.preload.GT_Loader_
         GT_OreDictUnificator.registerOre(
                 OrePrefixes.ingot,
                 Materials.HeeEndium,
-                GT_ModHandler.getModItem(HardcoreEnderExpansion.ID, "tile.endium_ingot", 1L, 0));
+                GT_ModHandler.getModItem(HardcoreEnderExpansion.ID, "endium_ingot", 1L, 0));
         GT_OreDictUnificator.registerOre(
                 OrePrefixes.block,
                 Materials.HeeEndium,

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
@@ -367,7 +367,7 @@ public class GT_Loader_OreDictionary extends gregtech.loaders.preload.GT_Loader_
         GT_OreDictUnificator.registerOre(
                 OrePrefixes.block,
                 Materials.Amber,
-                GT_ModHandler.getModItem(Thaumcraft.ID, "item.blockCosmeticOpaque", 1L, 0));
+                GT_ModHandler.getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1L, 0));
 
         GT_OreDictUnificator.registerOre(
                 OrePrefixes.ingot,

--- a/src/main/java/com/dreammaster/gthandler/GT_Recipe_Remover.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Recipe_Remover.java
@@ -1189,7 +1189,8 @@ public class GT_Recipe_Remover implements Runnable {
                 .removeRecipeByOutputDelayed(getModItem(GalacticraftMars.ID, "tile.mars", 1L, 8), true, false, true);
 
         // --- Desh Ingot
-        GT_ModHandler.removeRecipeByOutputDelayed(getModItem("ore", "ingotDesh", 1L, 0), true, false, true);
+        GT_ModHandler
+                .removeRecipeByOutputDelayed(getModItem(GalacticraftMars.ID, "item.null", 1L, 2), true, false, true);
 
         // --- Desh Stick
         GT_ModHandler

--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
@@ -5,7 +5,6 @@ import static gregtech.api.enums.Mods.DraconicEvolution;
 import static gregtech.api.enums.Mods.Gendustry;
 import static gregtech.api.enums.Mods.Genetics;
 import static gregtech.api.enums.Mods.HardcoreEnderExpansion;
-import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.IndustrialCraft2Classic;
 import static gregtech.api.enums.Mods.Natura;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
@@ -399,7 +398,7 @@ public class ChemicalReactorRecipes implements Runnable {
                     true);
         }
 
-        if (Gendustry.isModLoaded() && IndustrialCraft2.isModLoaded()) {
+        if (Gendustry.isModLoaded() && IndustrialCraft2Classic.isModLoaded()) {
             GT_Values.RA.addChemicalRecipe(
                     CustomItemList.TheBigEgg.get(1L),
                     GT_ModHandler.getModItem(IndustrialCraft2Classic.ID, "itemUran238", 64L, 0),

--- a/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
@@ -515,7 +515,7 @@ public class FluidSolidifierRecipes implements Runnable {
                     200,
                     120);
             GT_Values.RA.addFluidSolidifierRecipe(
-                    GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.ShapeBotte", 1, 0),
+                    GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.ShapeBottle", 1, 0),
                     Materials.Steel.getMolten(576L),
                     ItemList.Shape_Extruder_Bottle.get(1L),
                     200,
@@ -554,12 +554,6 @@ public class FluidSolidifierRecipes implements Runnable {
                     GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.ShapeIngot", 1, 0),
                     Materials.Steel.getMolten(576L),
                     ItemList.Shape_Extruder_Ingot.get(1L),
-                    200,
-                    120);
-            GT_Values.RA.addFluidSolidifierRecipe(
-                    GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.ShapeBottle", 1, 0),
-                    Materials.Steel.getMolten(576L),
-                    ItemList.Shape_Extruder_Bottle.get(1L),
                     200,
                     120);
             GT_Values.RA.addFluidSolidifierRecipe(

--- a/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
@@ -36,7 +36,7 @@ public class LaserEngraverRecipes implements Runnable {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Tesseract.get(1),
-                        GT_Utility.copyAmount(0, GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01:>", 1, 32105)))
+                        GT_Utility.copyAmount(0, GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1, 32105)))
                 .itemOutputs(ItemList.EnergisedTesseract.get(1)).noFluidInputs()
                 .fluidOutputs(MaterialsUEVplus.ExcitedDTEC.getFluid(100)).requiresCleanRoom().duration(30 * SECONDS)
                 .eut(32_000_000).noOptimize().addTo(sLaserEngraverRecipes);


### PR DESCRIPTION
- fix desh ingot in recipe removals
- fix incorrect modloaded check for ic2classic item
- fix typo for bottle shape recipe and remove the duplicate recipe that was added after the one with the typo didnt work
- fix energized tesseract recipe
- fix endium unification
- fix amberblock unification

after my previous efforts to clean up the gt log, spotting these is now very easy :P