### PR TITLE
Charged certus quartz fixes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
@@ -1,5 +1,6 @@
 package com.dreammaster.gthandler;
 
+import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.BloodArsenal;
 import static gregtech.api.enums.Mods.Computronics;
@@ -22,6 +23,7 @@ import static gregtech.api.enums.Mods.StevesCarts2;
 import static gregtech.api.enums.Mods.TaintedMagic;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.ThaumicTinkerer;
+import static gregtech.api.util.GT_ModHandler.getModItem;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -151,14 +153,25 @@ public class GT_Loader_OreDictionary extends gregtech.loaders.preload.GT_Loader_
         GT_OreDictUnificator
                 .registerOre("dustQuartzSand", GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.SandDust", 1L, 0));
         GT_OreDictUnificator.registerOre(
-                "dustChargedCertusQuartz",
+                OrePrefixes.dust,
+                Materials.CertusQuartzCharged,
                 GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzDust", 1L, 0));
         GT_OreDictUnificator.registerOre(
-                "plateChargedCertusQuartz",
+                OrePrefixes.plate,
+                Materials.CertusQuartzCharged,
                 GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzPlate", 1L, 0));
         GT_OreDictUnificator.registerOre(
-                "stickChargedCertusQuartz",
+                OrePrefixes.stick,
+                Materials.CertusQuartzCharged,
                 GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzRod", 1L, 0));
+        GT_OreDictUnificator.registerOre(
+                OrePrefixes.crystal,
+                Materials.CertusQuartzCharged,
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1));
+        GT_OreDictUnificator.registerOre(
+                OrePrefixes.gem,
+                Materials.CertusQuartzCharged,
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1));
         GT_OreDictUnificator.registerOre(
                 "dustCokeOvenBrick",
                 GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CokeOvenBrickDust", 1L, 0));

--- a/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
@@ -1479,7 +1479,7 @@ public class MixerRecipes implements Runnable {
 
         if (AppliedEnergistics2.isModLoaded()) {
             GT_Values.RA.addMixerRecipe(
-                    CustomItemList.ChargedCertusQuartzDust.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartzCharged, 1),
                     GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L),
                     GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 1L),
                     GT_Values.NI,
@@ -1491,7 +1491,7 @@ public class MixerRecipes implements Runnable {
                     20,
                     16);
             GT_Values.RA.addMixerRecipe(
-                    CustomItemList.ChargedCertusQuartzDust.get(1L),
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartzCharged, 1),
                     GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Redstone, 1L),
                     GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 1L),
                     GT_Values.NI,

--- a/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
@@ -15,7 +15,6 @@ import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAutoclaveRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBlastRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes;
@@ -1717,13 +1716,13 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
         addShapedRecipe(
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 35, missing),
                 "circuitPrimitive",
-                getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzDust", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartzCharged, 1),
                 "circuitPrimitive",
-                getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzDust", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartzCharged, 1),
                 getModItem(NewHorizonsCoreMod.ID, "item.LogicProcessorItemGoldCore", 1, 0, missing),
-                getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzDust", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartzCharged, 1),
                 "circuitPrimitive",
-                getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzDust", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartzCharged, 1),
                 "circuitPrimitive");
         addShapedRecipe(
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 36, missing),
@@ -2110,21 +2109,6 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
                         getModItem(AppliedEnergistics2.ID, "tile.BlockEnergyCell", 1, 0, missing))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ToolPortableCell", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzDust", 1, 0, missing))
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1, missing))
-                .outputChances(7000).fluidInputs(FluidRegistry.getFluidStack("water", 200)).noFluidOutputs()
-                .duration(2000).eut(24).addTo(sAutoclaveRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzDust", 1, 0, missing))
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1, missing))
-                .outputChances(9000).fluidInputs(FluidRegistry.getFluidStack("ic2distilledwater", 100)).noFluidOutputs()
-                .duration(1500).eut(24).addTo(sAutoclaveRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzDust", 1, 0, missing))
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1, missing))
-                .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("molten.void", 72)).noFluidOutputs()
-                .duration(1000).eut(24).addTo(sAutoclaveRecipes);
         // Quartz Glass
         GT_Values.RA.stdBuilder()
                 .itemInputs(


### PR DESCRIPTION
- add gem and crystal oredict to charged certus quartz item to generate sifting and autoclaving recipe.
- use the material in the oredict definitions to ensure its correct
- remove the manual autoclaving recipes from the script
- use the oredicts in the recipes

images combined with https://github.com/GTNewHorizons/GT5-Unofficial/pull/2013:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/e9b05b52-4ae3-40c3-8276-f0c8a565c845)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/bbd7086b-29d7-4bbe-b307-6ff50e514e01)
