### PR TITLE
Recipe fixes for changed stone and glass

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CustomLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CustomLoader.java
@@ -156,8 +156,8 @@ public class GT_CustomLoader {
         MachineLoader.run();
         BatteryLoader.run();
         Remover.run();
+        OreDictionary.run();
         MachineRecipeLoader.run();
         CraftingRecipeLoader.run();
-        OreDictionary.run();
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptBuildCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBuildCraft.java
@@ -34,7 +34,10 @@ import java.util.List;
 import net.minecraftforge.fluids.FluidRegistry;
 
 import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GT_OreDictUnificator;
 
 public class ScriptBuildCraft implements IScriptLoader {
 
@@ -89,26 +92,26 @@ public class ScriptBuildCraft implements IScriptLoader {
                 "gearInvar");
         addShapedRecipe(
                 getModItem(BuildCraftTransport.ID, "item.buildcraftPipe.pipestructurecobblestone", 1, 0, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 23299, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Stone, 1),
                 getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 23299, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Stone, 1),
                 getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
                 getModItem(Minecraft.ID, "gravel", 1, 0, missing),
                 getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 23299, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Stone, 1),
                 getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 23299, missing));
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Stone, 1));
         addShapedRecipe(
                 getModItem(BuildCraftTransport.ID, "item.buildcraftPipe.pipepowercobblestone", 1, 0, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 23299, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Stone, 1),
                 getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 23299, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Stone, 1),
                 getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
                 "wireGt01Tin",
                 getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 23299, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Stone, 1),
                 getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 23299, missing));
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Stone, 1));
         addShapedRecipe(
                 getModItem(BuildCraftTransport.ID, "item.buildcraftPipe.pipepowerstone", 1, 0, missing),
                 getModItem(ForgeMicroblocks.ID, "stoneRod", 1, 0, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptCoreMod.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptCoreMod.java
@@ -48,7 +48,10 @@ import net.minecraftforge.fluids.FluidRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
 import forestry.api.recipes.RecipeManagers;
 import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
 import tconstruct.library.TConstructRegistry;
 import tconstruct.library.crafting.Smeltery;
 
@@ -92,7 +95,7 @@ public class ScriptCoreMod implements IScriptLoader {
                 "sandstone",
                 "craftingToolSaw");
         addShapedRecipe(
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 23299, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Stone, 1),
                 "craftingToolFile",
                 "cobblestone",
                 "craftingToolSaw");
@@ -1908,7 +1911,7 @@ public class ScriptCoreMod implements IScriptLoader {
                 .noFluidOutputs().duration(160).eut(16).addTo(sLatheRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "cobblestone", 1, 0, missing))
                 .itemOutputs(
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 23299, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Stone, 1),
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 1299, missing))
                 .noFluidInputs().noFluidOutputs().duration(160).eut(16).addTo(sLatheRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Forestry.ID, "mushroom", 1, wildcard, missing))

--- a/src/main/java/com/dreammaster/scripts/ScriptDraconicEvolution.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptDraconicEvolution.java
@@ -31,6 +31,9 @@ import net.minecraftforge.fluids.FluidRegistry;
 import fox.spiteful.avaritia.compat.ticon.Tonkers;
 import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
 import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GT_OreDictUnificator;
 import tconstruct.tools.TinkerTools;
 
 public class ScriptDraconicEvolution implements IScriptLoader {
@@ -1179,7 +1182,7 @@ public class ScriptDraconicEvolution implements IScriptLoader {
 
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(GregTech.ID, "gt.metaitem.01", 4, 17299, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Stone, 4),
                         getModItem(DraconicEvolution.ID, "draconiumDust", 1, 0, missing))
                 .itemOutputs(getModItem(DraconicEvolution.ID, "infoTablet", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(400).eut(480).addTo(sAssemblerRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptEMT.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEMT.java
@@ -30,6 +30,9 @@ import net.minecraftforge.fluids.FluidRegistry;
 import com.dreammaster.thaumcraft.TCHelper;
 
 import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GT_OreDictUnificator;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -2546,12 +2549,12 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("victus"), 16).add(Aspect.getAspect("vinculum"), 24)
                         .add(Aspect.getAspect("vitreus"), 16).add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
-                new ItemStack[] { getModItem(GregTech.ID, "gt.metaitem.01", 1, 17602, missing),
+                new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.ReinforceGlass, 1),
                         getModItem(GregTech.ID, "gt.blockreinforced", 1, 3, missing),
                         getModItem(IndustrialCraft2.ID, "itemPartAlloy", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17383, missing),
                         getModItem(GregTech.ID, "gt.blockreinforced", 1, 3, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17602, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.ReinforceGlass, 1),
                         getModItem(GregTech.ID, "gt.blockreinforced", 1, 3, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17383, missing),
                         getModItem(IndustrialCraft2.ID, "itemPartAlloy", 1, 0, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
@@ -29,6 +29,9 @@ import java.util.List;
 import net.minecraftforge.fluids.FluidRegistry;
 
 import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GT_OreDictUnificator;
 
 public class ScriptLogisticPipes implements IScriptLoader {
 
@@ -1057,15 +1060,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.02", 2, 22019, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 4, 17602, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.02", 16, 19086, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 64, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(100).eut(30).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(GregTech.ID, "gt.metaitem.02", 2, 22019, missing),
-                        getModItem(NewHorizonsCoreMod.ID, "item.ReinforcedGlassPlate", 4, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.ReinforceGlass, 4),
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19086, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 64, 0, missing))

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
@@ -27,7 +27,10 @@ import net.minecraftforge.fluids.FluidRegistry;
 import com.dreammaster.thaumcraft.TCHelper;
 
 import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -883,11 +886,11 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(GregTech.ID, "gt.blockmetal7", 1, 4, missing),
                 new ItemStack[] { getModItem(GregTech.ID, "gt.metaitem.01", 1, 17330, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17032, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17602, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.ReinforceGlass, 1),
                         getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
                         getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17500, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17602, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.ReinforceGlass, 1),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17086, missing), });
         TCHelper.setResearchAspects(
                 "REPAIRER",


### PR DESCRIPTION
- changes the load order in coremod. we need oredicts before the recipes. that fixes the PR circuit plate recipe.
- fixes thaumic restorer recipe (use oredict!)
- fixes BP pipe recipes (use oredict!)
- fixes shield focus recipes (use oredict!)
- fixes stone rod recipes (use oredict!)
- fixes draconic info tablet recipe (use oredict!)

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13506

(was caused by the script removal)