### PR TITLE
Add correct recycling recipes for railcraft boiler tanks, steam loco, etc

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -1187,11 +1187,25 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
                     bits4,
                     new Object[] { "SPS", "BdB", "SPS", 'S', OrePrefixes.screw.get(Materials.AnyIron), 'B',
                             new ItemStack(Blocks.iron_bars, 1, 0), 'P', OrePrefixes.pipeLarge.get(Materials.Bronze) });
+            // for recycling
+            GT_ModHandler.addCraftingRecipe(
+                    GT_ModHandler.getModItem(Railcraft.ID, aTextMachineBeta, 1L, 3),
+                    GT_ModHandler.RecipeBits.REVERSIBLE,
+                    new Object[] { "PPP", " h ", "PPP", 'P', OrePrefixes.itemCasing.get(Materials.Iron) });
+            GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(Railcraft.ID, aTextMachineBeta, 1L, 3));
+            // actual
             GT_ModHandler.addCraftingRecipe(
                     GT_ModHandler.getModItem(Railcraft.ID, aTextMachineBeta, 1L, 3),
                     bits4,
                     new Object[] { "PPP", "ShS", "PPP", 'P', OrePrefixes.itemCasing.get(Materials.Iron), 'S',
                             OrePrefixes.screw.get(Materials.AnyIron) });
+            // for recycling
+            GT_ModHandler.addCraftingRecipe(
+                    GT_ModHandler.getModItem(Railcraft.ID, aTextMachineBeta, 1L, 4),
+                    GT_ModHandler.RecipeBits.REVERSIBLE,
+                    new Object[] { "PPP", " h ", "PPP", 'P', OrePrefixes.itemCasing.get(Materials.Steel) });
+            GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getModItem(Railcraft.ID, aTextMachineBeta, 1L, 4));
+            // actual
             GT_ModHandler.addCraftingRecipe(
                     GT_ModHandler.getModItem(Railcraft.ID, aTextMachineBeta, 1L, 4),
                     bits4,


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11912 and https://discord.com/channels/181078474394566657/181078474394566657/1110363691628646460
adds the correct recycling for the iron and steam boiler tank. which also affects all machines that use these like the loco.

crucially it does not reintroduce any exploit. :)

![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/1d4cbcd4-011a-43e8-8f92-07c0402bd4a4)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/bd5a2dc8-f4b7-442e-8ced-91064d8f6999)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/d1b77c1e-3d7f-47bf-aef9-f84ff6fe1a79)
