### PR TITLE
Clean up the minecraft script

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -49,12 +49,14 @@ import java.util.List;
 
 import net.minecraftforge.fluids.FluidRegistry;
 
+import com.dreammaster.gthandler.CustomItemList;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
 
 public class ScriptMinecraft implements IScriptLoader {
 
@@ -135,50 +137,50 @@ public class ScriptMinecraft implements IScriptLoader {
                 .duration(5).eut(64).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "iron_ingot", 5, 0, missing),
-                        getModItem(NewHorizonsCoreMod.ID, "item.MoldHelmet", 0, 0, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Iron, 5L),
+                        CustomItemList.MoldHelmet.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_helmet", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "iron_ingot", 8, 0, missing),
-                        getModItem(NewHorizonsCoreMod.ID, "item.MoldChestplate", 0, 0, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Iron, 8L),
+                        CustomItemList.MoldChestplate.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_chestplate", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "iron_ingot", 7, 0, missing),
-                        getModItem(NewHorizonsCoreMod.ID, "item.MoldLeggings", 0, 0, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Iron, 7L),
+                        CustomItemList.MoldLeggings.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_leggings", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "iron_ingot", 4, 0, missing),
-                        getModItem(NewHorizonsCoreMod.ID, "item.MoldBoots", 0, 0, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Iron, 4L),
+                        CustomItemList.MoldBoots.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_boots", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "gold_ingot", 5, 0, missing),
-                        getModItem(NewHorizonsCoreMod.ID, "item.MoldHelmet", 0, 0, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Gold, 5L),
+                        CustomItemList.MoldHelmet.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "golden_helmet", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "gold_ingot", 8, 0, missing),
-                        getModItem(NewHorizonsCoreMod.ID, "item.MoldChestplate", 0, 0, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Gold, 8L),
+                        CustomItemList.MoldChestplate.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "golden_chestplate", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "gold_ingot", 7, 0, missing),
-                        getModItem(NewHorizonsCoreMod.ID, "item.MoldLeggings", 0, 0, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Gold, 7L),
+                        CustomItemList.MoldLeggings.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "golden_leggings", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "gold_ingot", 4, 0, missing),
-                        getModItem(NewHorizonsCoreMod.ID, "item.MoldBoots", 0, 0, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Gold, 4L),
+                        CustomItemList.MoldBoots.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "golden_boots", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "sand", 1, 1, missing))
@@ -192,7 +194,7 @@ public class ScriptMinecraft implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "barleyFood", 2, 3, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "string", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(10 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -211,7 +213,7 @@ public class ScriptMinecraft implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(MagicBees.ID, "miscResources", 6, 4, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
+                        GT_Utility.getIntegratedCircuit(6))
                 .itemOutputs(getModItem(Minecraft.ID, "skull", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.thaumium", 216)).noFluidOutputs()
                 .duration(10 * SECONDS).eut(96).addTo(sAssemblerRecipes);
@@ -1519,34 +1521,34 @@ public class ScriptMinecraft implements IScriptLoader {
                 .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27809, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
+                        GT_Utility.getIntegratedCircuit(6))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 2, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(8).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27032, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
+                        GT_Utility.getIntegratedCircuit(6))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 4, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(16).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27305, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
+                        GT_Utility.getIntegratedCircuit(6))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 8, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27019, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
+                        GT_Utility.getIntegratedCircuit(6))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 32, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "brick", 8, 0, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "brick_block", 2, 0, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("water", 500)).noFluidOutputs().duration(15 * SECONDS).eut(16)
                 .addTo(sAssemblerRecipes);
@@ -1831,7 +1833,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1839,7 +1841,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 0, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1847,7 +1849,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 1, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1855,7 +1857,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 2, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1863,7 +1865,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 3, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1871,7 +1873,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 4, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1879,7 +1881,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 5, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1887,7 +1889,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 6, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1895,7 +1897,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 7, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1903,7 +1905,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 8, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1911,7 +1913,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 9, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1919,7 +1921,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 10, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1927,7 +1929,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 11, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1935,7 +1937,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 12, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1943,7 +1945,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 13, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1951,7 +1953,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 14, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1959,7 +1961,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 15, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1967,7 +1969,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(GalacticraftAmunRa.ID, "tile.wood1", 2, 3, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1975,7 +1977,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(GalacticraftAmunRa.ID, "tile.wood1", 2, 2, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1983,7 +1985,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1991,7 +1993,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -1999,7 +2001,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2007,7 +2009,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2015,7 +2017,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2023,7 +2025,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2031,7 +2033,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 0, "{meta:0}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2039,7 +2041,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 1, "{meta:1}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2047,7 +2049,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 2, "{meta:2}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2055,7 +2057,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 3, "{meta:3}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2063,7 +2065,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 4, "{meta:4}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2071,7 +2073,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 5, "{meta:5}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2079,7 +2081,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 6, "{meta:6}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2087,7 +2089,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 7, "{meta:7}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2095,7 +2097,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 8, "{meta:8}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2103,7 +2105,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 9, "{meta:9}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2111,7 +2113,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 10, "{meta:10}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2119,7 +2121,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 11, "{meta:11}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2127,7 +2129,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 12, "{meta:12}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2135,7 +2137,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 13, "{meta:13}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2143,7 +2145,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 14, "{meta:14}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2151,7 +2153,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 15, "{meta:15}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2159,7 +2161,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 16, "{meta:16}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2167,7 +2169,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 17, "{meta:17}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2175,7 +2177,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 18, "{meta:18}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2183,7 +2185,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 19, "{meta:19}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2191,7 +2193,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 20, "{meta:20}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2199,7 +2201,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 21, "{meta:21}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2207,7 +2209,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 22, "{meta:22}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2215,7 +2217,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 23, "{meta:23}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2223,7 +2225,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 24, "{meta:24}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2231,7 +2233,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 25, "{meta:25}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2239,7 +2241,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 26, "{meta:26}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2247,7 +2249,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 27, "{meta:27}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2255,7 +2257,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 28, "{meta:28}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2263,7 +2265,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 29, "{meta:29}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2271,7 +2273,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 30, "{meta:30}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2279,7 +2281,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 31, "{meta:31}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2287,7 +2289,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 32, "{meta:32}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2295,7 +2297,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 33, "{meta:33}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2303,7 +2305,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         createItemStack(ExtraTrees.ID, "planks", 2, 34, "{meta:34}", missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2311,7 +2313,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 17809, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2319,7 +2321,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ThaumicBases.ID, "enderPlanks", 2, 0, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2327,7 +2329,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2335,7 +2337,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(GalaxySpace.ID, "barnardaCplanks", 2, 0, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2343,7 +2345,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(TaintedMagic.ID, "BlockWarpwoodPlanks", 2, 0, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2351,7 +2353,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, 0, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2359,7 +2361,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(TwilightForest.ID, "tile.TFTowerStone", 2, wildcard, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2367,7 +2369,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(TwilightForest.ID, "tile.TFPlank", 2, wildcard, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2375,7 +2377,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
                         getModItem(ForbiddenMagic.ID, "TaintPlank", 2, wildcard, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2385,7 +2387,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 28086, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 23086, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 26086, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "clock", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -2395,33 +2397,33 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 28086, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 23086, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 26086, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "clock", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "leather", 4, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 28032, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "saddle", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(NewHorizonsCoreMod.ID, "item.ArtificialLeather", 4, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 28032, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "saddle", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(TinkerConstruct.ID, "GlassBlock", 1, 0, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "glass", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(TierEU.RECIPE_MV).specialValue(1000).addTo(sBlastRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "glass_pane", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(TierEU.RECIPE_MV).specialValue(1000).addTo(sBlastRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "skull", 1, 0, missing))

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -50,6 +50,7 @@ import java.util.List;
 import com.dreammaster.gthandler.CustomItemList;
 
 import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
@@ -117,21 +118,19 @@ public class ScriptMinecraft implements IScriptLoader {
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Glowstone, 1L)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sExtractorRecipes);
         GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(Minecraft.ID, "clay_ball", 1, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 0, 32306, missing))
+                .itemInputs(getModItem(Minecraft.ID, "clay_ball", 1, 0, missing), ItemList.Shape_Mold_Ingot.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "brick", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(10 * SECONDS).eut(2).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 2807, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 0, 32306, missing))
+                        ItemList.Shape_Mold_Ingot.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "netherbrick", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(10 * SECONDS).eut(2).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BloodArsenal.ID, "glass_shard", 2, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 0, 32308, missing))
+                        ItemList.Shape_Mold_Block.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "glass", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5).eut(64).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
@@ -224,44 +223,38 @@ public class ScriptMinecraft implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 2536, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Charcoal, 1L))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 4, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 2535, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coal, 1L))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 6, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 2022, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sulfur, 1L))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 4, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 2022, missing))
-                .itemOutputs(getModItem(Minecraft.ID, "torch", 6, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(GregTech.ID, "gt.metaitem.01", 4, 17809, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 4L),
                         getModItem(Minecraft.ID, "trapdoor", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_door", 1, 0, missing))
                 .fluidInputs(Materials.Iron.getMolten(16)).noFluidOutputs().duration(20 * SECONDS).eut(4)
                 .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(GregTech.ID, "gt.metaitem.01", 4, 17809, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 4L),
                         getModItem(Minecraft.ID, "trapdoor", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_door", 1, 0, missing))
                 .fluidInputs(Materials.Copper.getMolten(16)).noFluidOutputs().duration(20 * SECONDS).eut(4)
                 .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(GregTech.ID, "gt.metaitem.01", 4, 17032, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 4L),
                         CustomItemList.SteelBars.get(1L))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_door", 1, 0, missing))
                 .fluidInputs(Materials.Steel.getMolten(16)).noFluidOutputs().duration(20 * SECONDS).eut(8)
@@ -277,34 +270,6 @@ public class ScriptMinecraft implements IScriptLoader {
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 4L))
-                .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 6, 0, missing))
-                .fluidInputs(Materials.Steel.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
-                        getModItem(Natura.ID, "natura.stick", 4, wildcard, missing))
-                .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 4, 0, missing))
-                .fluidInputs(Materials.Iron.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
-                        getModItem(Natura.ID, "natura.stick", 4, wildcard, missing))
-                .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 6, 0, missing))
-                .fluidInputs(Materials.Steel.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
-                        getModItem(BiomesOPlenty.ID, "bamboo", 4, 0, missing))
-                .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 4, 0, missing))
-                .fluidInputs(Materials.Iron.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
-                        getModItem(BiomesOPlenty.ID, "bamboo", 4, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 6, 0, missing))
                 .fluidInputs(Materials.Steel.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
                 .addTo(sAssemblerRecipes);
@@ -2307,7 +2272,7 @@ public class ScriptMinecraft implements IScriptLoader {
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
                         getModItem(PamsHarvestCraft.ID, "wovencottonItem", 2, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 2, 17809, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 2L),
                         GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
@@ -2377,35 +2342,25 @@ public class ScriptMinecraft implements IScriptLoader {
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(IndustrialCraft2.ID, "itemPlates", 1, 3, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
                         getModItem(Minecraft.ID, "comparator", 1, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 28086, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 23086, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 26086, missing),
-                        GT_Utility.getIntegratedCircuit(1))
-                .itemOutputs(getModItem(Minecraft.ID, "clock", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17086, missing),
-                        getModItem(Minecraft.ID, "comparator", 1, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 28086, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 23086, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 26086, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Gold, 1L),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Gold, 1L),
+                        GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.Gold, 1L),
                         GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "clock", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "leather", 4, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 2, 28032, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Iron, 2L),
                         GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "saddle", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         CustomItemList.ArtificialLeather.get(4L),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 2, 28032, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Iron, 2L),
                         GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "saddle", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
@@ -2502,13 +2457,11 @@ public class ScriptMinecraft implements IScriptLoader {
                 .itemInputs(
                         getModItem(Minecraft.ID, "blaze_powder", 3, 0, missing),
                         getModItem(Minecraft.ID, "gunpowder", 3, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 3, 2535, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Coal, 3L))
                 .itemOutputs(getModItem(Minecraft.ID, "fire_charge", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(20 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sMixerRecipes);
         GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(Minecraft.ID, "melon_block", 1, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 0, 32398, missing))
+                .itemInputs(getModItem(Minecraft.ID, "melon_block", 1, 0, missing), ItemList.Shape_Slicer_Flat.get(0L))
                 .itemOutputs(getModItem(Minecraft.ID, "melon", 8, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(8).addTo(sSlicerRecipes);
         Module_CustomFuels

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -40,6 +40,9 @@ import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtractorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidExtractionRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMixerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sSlicerRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 
 import java.util.Arrays;
 import java.util.List;
@@ -47,7 +50,11 @@ import java.util.List;
 import net.minecraftforge.fluids.FluidRegistry;
 
 import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
 
 public class ScriptMinecraft implements IScriptLoader {
 
@@ -98,28 +105,28 @@ public class ScriptMinecraft implements IScriptLoader {
                 getModItem(Minecraft.ID, "bread", 1, 0, missing));
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 3, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sExtractorRecipes);
+                .duration(15 * SECONDS).eut(2).addTo(sExtractorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 2, missing))
                 .itemOutputs(getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sExtractorRecipes);
+                .duration(15 * SECONDS).eut(2).addTo(sExtractorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "hay_block", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wheat", 9, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sExtractorRecipes);
+                .duration(15 * SECONDS).eut(2).addTo(sExtractorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(PamsHarvestTheNether.ID, "glowFlower", 2, 0, missing))
-                .itemOutputs(getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sExtractorRecipes);
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Glowstone, 1L)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sExtractorRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "clay_ball", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 0, 32306, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "brick", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(2).addTo(sAlloySmelterRecipes);
+                .duration(10 * SECONDS).eut(2).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 2807, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 0, 32306, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "netherbrick", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(2).addTo(sAlloySmelterRecipes);
+                .duration(10 * SECONDS).eut(2).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BloodArsenal.ID, "glass_shard", 2, 0, missing),
@@ -131,1694 +138,1694 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "iron_ingot", 5, 0, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.MoldHelmet", 0, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_helmet", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(30).addTo(sAlloySmelterRecipes);
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "iron_ingot", 8, 0, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.MoldChestplate", 0, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_chestplate", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(200).eut(30).addTo(sAlloySmelterRecipes);
+                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "iron_ingot", 7, 0, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.MoldLeggings", 0, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_leggings", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(30).addTo(sAlloySmelterRecipes);
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "iron_ingot", 4, 0, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.MoldBoots", 0, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_boots", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(30).addTo(sAlloySmelterRecipes);
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "gold_ingot", 5, 0, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.MoldHelmet", 0, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "golden_helmet", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(30).addTo(sAlloySmelterRecipes);
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "gold_ingot", 8, 0, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.MoldChestplate", 0, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "golden_chestplate", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(200).eut(30).addTo(sAlloySmelterRecipes);
+                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "gold_ingot", 7, 0, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.MoldLeggings", 0, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "golden_leggings", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(200).eut(30).addTo(sAlloySmelterRecipes);
+                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "gold_ingot", 4, 0, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.MoldBoots", 0, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "golden_boots", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(30).addTo(sAlloySmelterRecipes);
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "sand", 1, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "glass", 2, 0, missing)).outputChances(10000)
-                .fluidInputs(FluidRegistry.getFluidStack("oxygen", 2)).noFluidOutputs().duration(20).eut(256)
+                .fluidInputs(FluidRegistry.getFluidStack("oxygen", 2)).noFluidOutputs().duration(1 * SECONDS).eut(256)
                 .addTo(sArcFurnaceRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "sand", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "glass", 2, 0, missing)).outputChances(10000)
-                .fluidInputs(FluidRegistry.getFluidStack("oxygen", 2)).noFluidOutputs().duration(20).eut(256)
+                .fluidInputs(FluidRegistry.getFluidStack("oxygen", 2)).noFluidOutputs().duration(1 * SECONDS).eut(256)
                 .addTo(sArcFurnaceRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "barleyFood", 2, 3, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "string", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(24).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wheat", 9, 0, missing),
                         getModItem(Minecraft.ID, "string", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "hay_block", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(30).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "heatsand", 1, 0, missing),
                         getModItem(Natura.ID, "soil.tainted", 4, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "soul_sand", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("water", 1000)).noFluidOutputs().duration(100).eut(16)
+                .fluidInputs(FluidRegistry.getFluidStack("water", 1000)).noFluidOutputs().duration(5 * SECONDS).eut(16)
                 .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(MagicBees.ID, "miscResources", 6, 4, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "skull", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.thaumium", 216)).noFluidOutputs().duration(200).eut(96)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.thaumium", 216)).noFluidOutputs()
+                .duration(10 * SECONDS).eut(96).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(Minecraft.ID, "wool", 1, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 5, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("creosote", 500)).noFluidOutputs().duration(100).eut(4)
+                .fluidInputs(FluidRegistry.getFluidStack("creosote", 500)).noFluidOutputs().duration(5 * SECONDS).eut(4)
                 .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 2536, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 4, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 2535, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 6, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 2022, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 4, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 2022, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 6, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 17809, missing),
                         getModItem(Minecraft.ID, "trapdoor", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_door", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(400).eut(4)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(20 * SECONDS)
+                .eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 17809, missing),
                         getModItem(Minecraft.ID, "trapdoor", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_door", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.copper", 16)).noFluidOutputs().duration(400).eut(4)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.copper", 16)).noFluidOutputs().duration(20 * SECONDS)
+                .eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 17032, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.SteelBars", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_door", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(400).eut(8)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(20 * SECONDS)
+                .eut(8).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         getModItem(Minecraft.ID, "stick", 4, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 4, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(600).eut(4)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         getModItem(Minecraft.ID, "stick", 4, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 6, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(600).eut(4)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         getModItem(Natura.ID, "natura.stick", 4, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 4, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(600).eut(4)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         getModItem(Natura.ID, "natura.stick", 4, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 6, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(600).eut(4)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         getModItem(BiomesOPlenty.ID, "bamboo", 4, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 4, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(600).eut(4)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         getModItem(BiomesOPlenty.ID, "bamboo", 4, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 6, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(600).eut(4)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "planks", 6, wildcard, missing),
                         getModItem(Minecraft.ID, "book", 3, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bookshelf", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(16).addTo(sAssemblerRecipes);
+                .duration(15 * SECONDS).eut(16).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GalacticraftAmunRa.ID, "tile.log1", 1, 0, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GalacticraftAmunRa.ID, "tile.wood1", 1, 0, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "tree", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "redwood", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "willow", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "bloodwood", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "Rare Tree", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "Dark Tree", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 0, "{meta:0}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 1, "{meta:1}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 2, "{meta:2}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 3, "{meta:3}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 4, "{meta:4}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 5, "{meta:5}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 6, "{meta:6}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 7, "{meta:7}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 8, "{meta:8}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 9, "{meta:9}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 10, "{meta:10}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 11, "{meta:11}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 12, "{meta:12}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 13, "{meta:13}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 14, "{meta:14}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 15, "{meta:15}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 16, "{meta:16}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 17, "{meta:17}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 18, "{meta:18}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 19, "{meta:19}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 20, "{meta:20}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 21, "{meta:21}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 22, "{meta:22}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 23, "{meta:23}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 24, "{meta:24}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 25, "{meta:25}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 26, "{meta:26}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 27, "{meta:27}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 28, "{meta:28}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 29, "{meta:29}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 30, "{meta:30}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 31, "{meta:31}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 32, "{meta:32}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 33, "{meta:33}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 34, "{meta:34}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 35, "{meta:35}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 36, "{meta:36}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 37, "{meta:37}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 38, "{meta:38}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         createItemStack(ExtraTrees.ID, "log", 1, 39, "{meta:39}", missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(PamsHarvestCraft.ID, "pamMaple", 1, 0, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(PamsHarvestCraft.ID, "pamPaperbark", 1, 0, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(PamsHarvestCraft.ID, "pamCinnamon", 1, 0, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ThaumicBases.ID, "genLogs", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Witchery.ID, "witchlog", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GalaxySpace.ID, "barnardaClog", 1, 0, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(TaintedMagic.ID, "BlockWarpwoodLog", 1, 0, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(TwilightForest.ID, "tile.TFLog", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(TwilightForest.ID, "tile.TFMagicLog", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(PamsHarvestTheNether.ID, "netherLog", 1, 0, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ForbiddenMagic.ID, "TaintLog", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(IndustrialCraft2.ID, "blockRubWood", 1, 0, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Thaumcraft.ID, "blockMagicalLog", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "flint", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "crafting_table", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(200).eut(4).addTo(sAssemblerRecipes);
+                .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 2, 0, missing),
                         getModItem(Minecraft.ID, "planks", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "fence_gate", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(8).addTo(sAssemblerRecipes);
+                .duration(15 * SECONDS).eut(8).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log", 2, wildcard, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "log2", 2, wildcard, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs1", 2, wildcard, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs2", 2, wildcard, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs3", 2, wildcard, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "logs4", 2, wildcard, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ExtraTrees.ID, "log", 2, wildcard, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logs", 2, wildcard, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "logsFireproof", 2, wildcard, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockRainforestOakLog", 2, 0, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(ExtraTrees.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(Natura.ID, "planks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GTPlusPlus.ID, "blockPineLogLog", 2, 0, missing),
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "chest", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(Minecraft.ID, "stone_button", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "lever", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(50).eut(16).addTo(sAssemblerRecipes);
+                .duration(2 * SECONDS + 10 * TICKS).eut(16).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(Minecraft.ID, "stone_button", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "lever", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(50).eut(16).addTo(sAssemblerRecipes);
+                .duration(2 * SECONDS + 10 * TICKS).eut(16).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "bamboo", 1, 0, missing),
                         getModItem(Minecraft.ID, "stone_button", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "lever", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(50).eut(16).addTo(sAssemblerRecipes);
+                .duration(2 * SECONDS + 10 * TICKS).eut(16).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BiomesOPlenty.ID, "plants", 1, 8, missing),
                         getModItem(Minecraft.ID, "stone_button", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "lever", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(50).eut(16).addTo(sAssemblerRecipes);
+                .duration(2 * SECONDS + 10 * TICKS).eut(16).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27809, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 2, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(8).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(8).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27032, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 4, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(16).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(16).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 8, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27019, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 32, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(30).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "brick", 8, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "brick_block", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("water", 500)).noFluidOutputs().duration(300).eut(16)
+                .fluidInputs(FluidRegistry.getFluidStack("water", 500)).noFluidOutputs().duration(15 * SECONDS).eut(16)
                 .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32470, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32471, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32472, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32473, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32474, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32475, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32476, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32477, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32478, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32479, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32480, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32481, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32482, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32483, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32484, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32485, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32486, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32487, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32488, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32489, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stick", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32490, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32470, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32471, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32472, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32473, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32474, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32475, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32476, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32477, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32478, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32479, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32480, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32481, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32482, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32483, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32484, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32485, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32486, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32487, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32488, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32489, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32490, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(4).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.02", 2, 32470, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 24032, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_pressure_plate", 2, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(100).eut(8).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(5 * SECONDS).eut(8).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.02", 2, 32470, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 24304, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_pressure_plate", 2, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(100).eut(8).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(5 * SECONDS).eut(8).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stone_slab", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 24032, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "stone_pressure_plate", 2, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(100).eut(8).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(5 * SECONDS).eut(8).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "stone_slab", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 24304, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "stone_pressure_plate", 2, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(100).eut(8).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(5 * SECONDS).eut(8).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1826,7 +1833,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "planks", 2, wildcard, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1834,7 +1841,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1842,7 +1849,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 1, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1850,7 +1857,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 2, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1858,7 +1865,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 3, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1866,7 +1873,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 4, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1874,7 +1881,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 5, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1882,7 +1889,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1890,7 +1897,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 7, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1898,7 +1905,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 8, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1906,7 +1913,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 9, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1914,7 +1921,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 10, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1922,7 +1929,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 11, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1930,7 +1937,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 12, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1938,7 +1945,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 13, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1946,7 +1953,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 14, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1954,7 +1961,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "colorWoodPlanks", 2, 15, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1962,7 +1969,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(GalacticraftAmunRa.ID, "tile.wood1", 2, 3, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1970,7 +1977,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(GalacticraftAmunRa.ID, "tile.wood1", 2, 2, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1978,7 +1985,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1986,7 +1993,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Thaumcraft.ID, "blockWoodenDevice", 2, 7, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -1994,7 +2001,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Natura.ID, "planks", 2, wildcard, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2002,7 +2009,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(BiomesOPlenty.ID, "planks", 2, wildcard, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2010,7 +2017,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Forestry.ID, "planks", 2, wildcard, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2018,7 +2025,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Forestry.ID, "planksFireproof", 2, wildcard, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2026,7 +2033,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 0, "{meta:0}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2034,7 +2041,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 1, "{meta:1}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2042,7 +2049,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 2, "{meta:2}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2050,7 +2057,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 3, "{meta:3}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2058,7 +2065,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 4, "{meta:4}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2066,7 +2073,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 5, "{meta:5}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2074,7 +2081,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 6, "{meta:6}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2082,7 +2089,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 7, "{meta:7}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2090,7 +2097,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 8, "{meta:8}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2098,7 +2105,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 9, "{meta:9}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2106,7 +2113,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 10, "{meta:10}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2114,7 +2121,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 11, "{meta:11}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2122,7 +2129,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 12, "{meta:12}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2130,7 +2137,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 13, "{meta:13}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2138,7 +2145,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 14, "{meta:14}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2146,7 +2153,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 15, "{meta:15}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2154,7 +2161,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 16, "{meta:16}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2162,7 +2169,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 17, "{meta:17}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2170,7 +2177,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 18, "{meta:18}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2178,7 +2185,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 19, "{meta:19}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2186,7 +2193,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 20, "{meta:20}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2194,7 +2201,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 21, "{meta:21}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2202,7 +2209,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 22, "{meta:22}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2210,7 +2217,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 23, "{meta:23}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2218,7 +2225,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 24, "{meta:24}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2226,7 +2233,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 25, "{meta:25}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2234,7 +2241,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 26, "{meta:26}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2242,7 +2249,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 27, "{meta:27}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2250,7 +2257,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 28, "{meta:28}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2258,7 +2265,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 29, "{meta:29}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2266,7 +2273,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 30, "{meta:30}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2274,7 +2281,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 31, "{meta:31}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2282,7 +2289,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 32, "{meta:32}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2290,7 +2297,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 33, "{meta:33}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2298,7 +2305,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         createItemStack(ExtraTrees.ID, "planks", 2, 34, "{meta:34}", missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2306,7 +2313,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 17809, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2314,7 +2321,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ThaumicBases.ID, "enderPlanks", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2322,7 +2329,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Witchery.ID, "witchwood", 2, wildcard, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2330,7 +2337,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(GalaxySpace.ID, "barnardaCplanks", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2338,7 +2345,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(TaintedMagic.ID, "BlockWarpwoodPlanks", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2346,7 +2353,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(PamsHarvestTheNether.ID, "netherPlanks", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2354,7 +2361,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(TwilightForest.ID, "tile.TFTowerStone", 2, wildcard, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2362,7 +2369,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(TwilightForest.ID, "tile.TFPlank", 2, wildcard, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "carpet", 2, wildcard, missing),
@@ -2370,7 +2377,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(ForbiddenMagic.ID, "TaintPlank", 2, wildcard, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "bed", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(IndustrialCraft2.ID, "itemPlates", 1, 3, missing),
@@ -2380,7 +2387,7 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 26086, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "clock", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17086, missing),
@@ -2390,109 +2397,109 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 26086, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "clock", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "leather", 4, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 28032, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "saddle", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(NewHorizonsCoreMod.ID, "item.ArtificialLeather", 4, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 28032, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "saddle", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(24).addTo(sAssemblerRecipes);
+                .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(TinkerConstruct.ID, "GlassBlock", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "glass", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(120).specialValue(1000).addTo(sBlastRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_MV).specialValue(1000).addTo(sBlastRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "glass_pane", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(120).specialValue(1000).addTo(sBlastRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_MV).specialValue(1000).addTo(sBlastRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "skull", 1, 0, missing))
                 .itemOutputs(
                         getModItem(Minecraft.ID, "bone", 8, 0, missing),
                         getModItem(Minecraft.ID, "bone", 6, 0, missing),
                         getModItem(Minecraft.ID, "bone", 4, 0, missing))
                 .outputChances(10000, 7500, 5000).fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000))
-                .noFluidOutputs().duration(200).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "skull", 1, 1, missing))
                 .itemOutputs(
                         getModItem(Minecraft.ID, "coal_block", 2, 0, missing),
                         getModItem(Minecraft.ID, "coal_block", 1, 0, missing),
                         getModItem(Minecraft.ID, "coal_block", 1, 0, missing))
                 .outputChances(10000, 7500, 5000).fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000))
-                .noFluidOutputs().duration(200).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "skull", 1, 4, missing))
                 .itemOutputs(
                         getModItem(Minecraft.ID, "gunpowder", 4, 0, missing),
                         getModItem(Minecraft.ID, "gunpowder", 3, 0, missing),
                         getModItem(Minecraft.ID, "gunpowder", 2, 0, missing))
                 .outputChances(10000, 7500, 5000).fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000))
-                .noFluidOutputs().duration(200).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(HardcoreEnderExpansion.ID, "enderman_head", 1, 0, missing))
                 .itemOutputs(
                         getModItem(Minecraft.ID, "ender_pearl", 1, 0, missing),
                         getModItem(Minecraft.ID, "ender_pearl", 1, 0, missing),
                         getModItem(Minecraft.ID, "ender_pearl", 1, 0, missing))
                 .outputChances(10000, 5000, 2500).fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000))
-                .noFluidOutputs().duration(200).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "skull", 1, 3, missing))
                 .itemOutputs(getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing)).outputChances(1000)
-                .fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000)).noFluidOutputs().duration(200).eut(30)
-                .addTo(sChemicalBathRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000)).noFluidOutputs().duration(10 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "skull", 1, 2, missing))
                 .itemOutputs(
                         getModItem(Minecraft.ID, "rotten_flesh", 4, 0, missing),
                         getModItem(Minecraft.ID, "leather", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 2892, missing))
                 .outputChances(10000, 3000, 5000).fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000))
-                .noFluidOutputs().duration(200).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "wooden_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("water", 4)).noFluidOutputs().duration(50).eut(4)
-                .addTo(sCutterRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("water", 4)).noFluidOutputs()
+                .duration(2 * SECONDS + 10 * TICKS).eut(4).addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "wooden_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("ic2distilledwater", 3)).noFluidOutputs().duration(50).eut(4)
-                .addTo(sCutterRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("ic2distilledwater", 3)).noFluidOutputs()
+                .duration(2 * SECONDS + 10 * TICKS).eut(4).addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "wooden_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("lubricant", 1)).noFluidOutputs().duration(25).eut(4)
-                .addTo(sCutterRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("lubricant", 1)).noFluidOutputs()
+                .duration(1 * SECONDS + 5 * TICKS).eut(4).addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "stone_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "stone_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("water", 4)).noFluidOutputs().duration(50).eut(8)
-                .addTo(sCutterRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("water", 4)).noFluidOutputs()
+                .duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "stone_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "stone_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("ic2distilledwater", 3)).noFluidOutputs().duration(50).eut(8)
-                .addTo(sCutterRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("ic2distilledwater", 3)).noFluidOutputs()
+                .duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "stone_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "stone_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("lubricant", 1)).noFluidOutputs().duration(25).eut(8)
-                .addTo(sCutterRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("lubricant", 1)).noFluidOutputs()
+                .duration(1 * SECONDS + 5 * TICKS).eut(8).addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "sand", 1, wildcard, missing)).noItemOutputs()
-                .noFluidInputs().fluidOutputs(FluidRegistry.getFluidStack("molten.glass", 144)).duration(10000).eut(200)
-                .addTo(sFluidExtractionRecipes);
+                .noFluidInputs().fluidOutputs(FluidRegistry.getFluidStack("molten.glass", 144))
+                .duration(8 * MINUTES + 20 * SECONDS).eut(200).addTo(sFluidExtractionRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "obsidian", 1, 0, missing)).noItemOutputs()
-                .noFluidInputs().fluidOutputs(FluidRegistry.getFluidStack("obsidian.molten", 288)).duration(10000)
-                .eut(600).addTo(sFluidExtractionRecipes);
+                .noFluidInputs().fluidOutputs(FluidRegistry.getFluidStack("obsidian.molten", 288))
+                .duration(8 * MINUTES + 20 * SECONDS).eut(600).addTo(sFluidExtractionRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "sand", 4, wildcard, missing),
                         getModItem(Minecraft.ID, "dirt", 1, wildcard, missing),
                         getModItem(MagicBees.ID, "wax", 4, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "soul_sand", 4, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("water", 1000)).noFluidOutputs().duration(100).eut(16)
+                .fluidInputs(FluidRegistry.getFluidStack("water", 1000)).noFluidOutputs().duration(5 * SECONDS).eut(16)
                 .addTo(sMixerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
@@ -2500,13 +2507,13 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "gunpowder", 3, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 3, 2535, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "fire_charge", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(400).eut(30).addTo(sMixerRecipes);
+                .duration(20 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sMixerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "melon_block", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 0, 32398, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "melon", 8, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(100).eut(8).addTo(sSlicerRecipes);
+                .duration(5 * SECONDS).eut(8).addTo(sSlicerRecipes);
         Module_CustomFuels
                 .registerCustomFuelValue(getModItem(Minecraft.ID, "wooden_pressure_plate", 1, 0, missing), (short) 75);
 

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -1463,18 +1463,6 @@ public class ScriptMinecraft implements IScriptLoader {
                 .duration(2 * SECONDS + 10 * TICKS).eut(16).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Natura.ID, "natura.stick", 1, wildcard, missing),
-                        getModItem(Minecraft.ID, "stone_button", 1, 0, missing))
-                .itemOutputs(getModItem(Minecraft.ID, "lever", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(2 * SECONDS + 10 * TICKS).eut(16).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(BiomesOPlenty.ID, "bamboo", 1, 0, missing),
-                        getModItem(Minecraft.ID, "stone_button", 1, 0, missing))
-                .itemOutputs(getModItem(Minecraft.ID, "lever", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(2 * SECONDS + 10 * TICKS).eut(16).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
                         getModItem(BiomesOPlenty.ID, "plants", 1, 8, missing),
                         getModItem(Minecraft.ID, "stone_button", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "lever", 1, 0, missing)).noFluidInputs().noFluidOutputs()

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -43,13 +43,13 @@ import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sSlicerRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
+import static net.minecraftforge.fluids.FluidRegistry.getFluidStack;
 
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraftforge.fluids.FluidRegistry;
-
 import com.dreammaster.gthandler.CustomItemList;
+
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
@@ -185,16 +185,14 @@ public class ScriptMinecraft implements IScriptLoader {
                 .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAlloySmelterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "sand", 1, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "glass", 2, 0, missing)).outputChances(10000)
-                .fluidInputs(FluidRegistry.getFluidStack("oxygen", 2)).noFluidOutputs().duration(1 * SECONDS).eut(256)
+                .fluidInputs(Materials.Oxygen.getGas(2)).noFluidOutputs().duration(1 * SECONDS).eut(256)
                 .addTo(sArcFurnaceRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "sand", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "glass", 2, 0, missing)).outputChances(10000)
-                .fluidInputs(FluidRegistry.getFluidStack("oxygen", 2)).noFluidOutputs().duration(1 * SECONDS).eut(256)
+                .fluidInputs(Materials.Oxygen.getGas(2)).noFluidOutputs().duration(1 * SECONDS).eut(256)
                 .addTo(sArcFurnaceRecipes);
         GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(Natura.ID, "barleyFood", 2, 3, missing),
-                        GT_Utility.getIntegratedCircuit(1))
+                .itemInputs(getModItem(Natura.ID, "barleyFood", 2, 3, missing), GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "string", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(10 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
@@ -208,21 +206,21 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Natura.ID, "heatsand", 1, 0, missing),
                         getModItem(Natura.ID, "soil.tainted", 4, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "soul_sand", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("water", 1000)).noFluidOutputs().duration(5 * SECONDS).eut(16)
+                .fluidInputs(Materials.Water.getFluid(1000)).noFluidOutputs().duration(5 * SECONDS).eut(16)
                 .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(MagicBees.ID, "miscResources", 6, 4, missing),
                         GT_Utility.getIntegratedCircuit(6))
                 .itemOutputs(getModItem(Minecraft.ID, "skull", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.thaumium", 216)).noFluidOutputs()
-                .duration(10 * SECONDS).eut(96).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Thaumium.getMolten(216)).noFluidOutputs().duration(10 * SECONDS).eut(96)
+                .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(Minecraft.ID, "wool", 1, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 5, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("creosote", 500)).noFluidOutputs().duration(5 * SECONDS).eut(4)
+                .fluidInputs(getFluidStack("creosote", 500)).noFluidOutputs().duration(5 * SECONDS).eut(4)
                 .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
@@ -253,64 +251,64 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 17809, missing),
                         getModItem(Minecraft.ID, "trapdoor", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_door", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(20 * SECONDS)
-                .eut(4).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Iron.getMolten(16)).noFluidOutputs().duration(20 * SECONDS).eut(4)
+                .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 17809, missing),
                         getModItem(Minecraft.ID, "trapdoor", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_door", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.copper", 16)).noFluidOutputs().duration(20 * SECONDS)
-                .eut(4).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Copper.getMolten(16)).noFluidOutputs().duration(20 * SECONDS).eut(4)
+                .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 17032, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.SteelBars", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_door", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(20 * SECONDS)
-                .eut(8).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Steel.getMolten(16)).noFluidOutputs().duration(20 * SECONDS).eut(8)
+                .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 4L))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 4, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(30 * SECONDS)
-                .eut(4).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Iron.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
+                .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 4L))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 6, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(30 * SECONDS)
-                .eut(4).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Steel.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
+                .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         getModItem(Natura.ID, "natura.stick", 4, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 4, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(30 * SECONDS)
-                .eut(4).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Iron.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
+                .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         getModItem(Natura.ID, "natura.stick", 4, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 6, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(30 * SECONDS)
-                .eut(4).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Steel.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
+                .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         getModItem(BiomesOPlenty.ID, "bamboo", 4, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 4, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(30 * SECONDS)
-                .eut(4).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Iron.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
+                .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
                         getModItem(BiomesOPlenty.ID, "bamboo", 4, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 6, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(30 * SECONDS)
-                .eut(4).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Steel.getMolten(16)).noFluidOutputs().duration(30 * SECONDS).eut(4)
+                .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "planks", 6, wildcard, missing),
@@ -1546,11 +1544,9 @@ public class ScriptMinecraft implements IScriptLoader {
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 32, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(Minecraft.ID, "brick", 8, 0, missing),
-                        GT_Utility.getIntegratedCircuit(1))
+                .itemInputs(getModItem(Minecraft.ID, "brick", 8, 0, missing), GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "brick_block", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("water", 500)).noFluidOutputs().duration(15 * SECONDS).eut(16)
+                .fluidInputs(Materials.Water.getFluid(500)).noFluidOutputs().duration(15 * SECONDS).eut(16)
                 .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
@@ -2431,77 +2427,77 @@ public class ScriptMinecraft implements IScriptLoader {
                         getModItem(Minecraft.ID, "bone", 8, 0, missing),
                         getModItem(Minecraft.ID, "bone", 6, 0, missing),
                         getModItem(Minecraft.ID, "bone", 4, 0, missing))
-                .outputChances(10000, 7500, 5000).fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000))
-                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
+                .outputChances(10000, 7500, 5000).fluidInputs(getFluidStack("hell_blood", 1000)).noFluidOutputs()
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "skull", 1, 1, missing))
                 .itemOutputs(
                         getModItem(Minecraft.ID, "coal_block", 2, 0, missing),
                         getModItem(Minecraft.ID, "coal_block", 1, 0, missing),
                         getModItem(Minecraft.ID, "coal_block", 1, 0, missing))
-                .outputChances(10000, 7500, 5000).fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000))
-                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
+                .outputChances(10000, 7500, 5000).fluidInputs(getFluidStack("hell_blood", 1000)).noFluidOutputs()
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "skull", 1, 4, missing))
                 .itemOutputs(
                         getModItem(Minecraft.ID, "gunpowder", 4, 0, missing),
                         getModItem(Minecraft.ID, "gunpowder", 3, 0, missing),
                         getModItem(Minecraft.ID, "gunpowder", 2, 0, missing))
-                .outputChances(10000, 7500, 5000).fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000))
-                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
+                .outputChances(10000, 7500, 5000).fluidInputs(getFluidStack("hell_blood", 1000)).noFluidOutputs()
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(HardcoreEnderExpansion.ID, "enderman_head", 1, 0, missing))
                 .itemOutputs(
                         getModItem(Minecraft.ID, "ender_pearl", 1, 0, missing),
                         getModItem(Minecraft.ID, "ender_pearl", 1, 0, missing),
                         getModItem(Minecraft.ID, "ender_pearl", 1, 0, missing))
-                .outputChances(10000, 5000, 2500).fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000))
-                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
+                .outputChances(10000, 5000, 2500).fluidInputs(getFluidStack("hell_blood", 1000)).noFluidOutputs()
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "skull", 1, 3, missing))
                 .itemOutputs(getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing)).outputChances(1000)
-                .fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000)).noFluidOutputs().duration(10 * SECONDS)
+                .fluidInputs(getFluidStack("hell_blood", 1000)).noFluidOutputs().duration(10 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "skull", 1, 2, missing))
                 .itemOutputs(
                         getModItem(Minecraft.ID, "rotten_flesh", 4, 0, missing),
                         getModItem(Minecraft.ID, "leather", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 2892, missing))
-                .outputChances(10000, 3000, 5000).fluidInputs(FluidRegistry.getFluidStack("hell_blood", 1000))
-                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
+                .outputChances(10000, 3000, 5000).fluidInputs(getFluidStack("hell_blood", 1000)).noFluidOutputs()
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "wooden_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("water", 4)).noFluidOutputs()
-                .duration(2 * SECONDS + 10 * TICKS).eut(4).addTo(sCutterRecipes);
+                .fluidInputs(Materials.Water.getFluid(4)).noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(4)
+                .addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "wooden_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("ic2distilledwater", 3)).noFluidOutputs()
-                .duration(2 * SECONDS + 10 * TICKS).eut(4).addTo(sCutterRecipes);
+                .fluidInputs(getFluidStack("ic2distilledwater", 3)).noFluidOutputs().duration(2 * SECONDS + 10 * TICKS)
+                .eut(4).addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "wooden_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("lubricant", 1)).noFluidOutputs()
-                .duration(1 * SECONDS + 5 * TICKS).eut(4).addTo(sCutterRecipes);
+                .fluidInputs(getFluidStack("lubricant", 1)).noFluidOutputs().duration(1 * SECONDS + 5 * TICKS).eut(4)
+                .addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "stone_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "stone_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("water", 4)).noFluidOutputs()
-                .duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sCutterRecipes);
+                .fluidInputs(Materials.Water.getFluid(4)).noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(8)
+                .addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "stone_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "stone_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("ic2distilledwater", 3)).noFluidOutputs()
-                .duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(sCutterRecipes);
+                .fluidInputs(getFluidStack("ic2distilledwater", 3)).noFluidOutputs().duration(2 * SECONDS + 10 * TICKS)
+                .eut(8).addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "stone_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "stone_button", 2, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("lubricant", 1)).noFluidOutputs()
-                .duration(1 * SECONDS + 5 * TICKS).eut(8).addTo(sCutterRecipes);
+                .fluidInputs(getFluidStack("lubricant", 1)).noFluidOutputs().duration(1 * SECONDS + 5 * TICKS).eut(8)
+                .addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "sand", 1, wildcard, missing)).noItemOutputs()
-                .noFluidInputs().fluidOutputs(FluidRegistry.getFluidStack("molten.glass", 144))
-                .duration(8 * MINUTES + 20 * SECONDS).eut(200).addTo(sFluidExtractionRecipes);
+                .noFluidInputs().fluidOutputs(Materials.Glass.getMolten(144)).duration(8 * MINUTES + 20 * SECONDS)
+                .eut(200).addTo(sFluidExtractionRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "obsidian", 1, 0, missing)).noItemOutputs()
-                .noFluidInputs().fluidOutputs(FluidRegistry.getFluidStack("obsidian.molten", 288))
-                .duration(8 * MINUTES + 20 * SECONDS).eut(600).addTo(sFluidExtractionRecipes);
+                .noFluidInputs().fluidOutputs(Materials.Obsidian.getMolten(288)).duration(8 * MINUTES + 20 * SECONDS)
+                .eut(600).addTo(sFluidExtractionRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "sand", 4, wildcard, missing),
                         getModItem(Minecraft.ID, "dirt", 1, wildcard, missing),
                         getModItem(MagicBees.ID, "wax", 4, 1, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "soul_sand", 4, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("water", 1000)).noFluidOutputs().duration(5 * SECONDS).eut(16)
+                .fluidInputs(Materials.Water.getFluid(1000)).noFluidOutputs().duration(5 * SECONDS).eut(16)
                 .addTo(sMixerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -19,7 +19,6 @@ import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.MagicBees;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Natura;
-import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.enums.Mods.PamsHarvestCraft;
 import static gregtech.api.enums.Mods.PamsHarvestTheNether;
 import static gregtech.api.enums.Mods.Railcraft;
@@ -100,7 +99,7 @@ public class ScriptMinecraft implements IScriptLoader {
         craftingRecipes();
 
         GT_ModHandler.addSmeltingRecipe(
-                getModItem(NewHorizonsCoreMod.ID, "item.UnfiredClayBrick", 1, 0, missing),
+                CustomItemList.UnfiredClayBrick.get(1L),
                 getModItem(Minecraft.ID, "brick", 1, 0, missing));
         GT_ModHandler.addSmeltingRecipe(
                 getModItem(GregTech.ID, "gt.metaitem.02", 1, 32561, missing),
@@ -263,7 +262,7 @@ public class ScriptMinecraft implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 17032, missing),
-                        getModItem(NewHorizonsCoreMod.ID, "item.SteelBars", 1, 0, missing))
+                        CustomItemList.SteelBars.get(1L))
                 .itemOutputs(getModItem(Minecraft.ID, "iron_door", 1, 0, missing))
                 .fluidInputs(Materials.Steel.getMolten(16)).noFluidOutputs().duration(20 * SECONDS).eut(8)
                 .addTo(sAssemblerRecipes);
@@ -2405,7 +2404,7 @@ public class ScriptMinecraft implements IScriptLoader {
                 .duration(5 * SECONDS).eut(24).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(NewHorizonsCoreMod.ID, "item.ArtificialLeather", 4, 0, missing),
+                        CustomItemList.ArtificialLeather.get(4L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 28032, missing),
                         GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "saddle", 1, 0, missing)).noFluidInputs().noFluidOutputs()
@@ -4839,7 +4838,7 @@ public class ScriptMinecraft implements IScriptLoader {
         addShapedRecipe(
                 getModItem(Minecraft.ID, "iron_door", 1, 0, missing),
                 "plateAnyIron",
-                getModItem(NewHorizonsCoreMod.ID, "item.SteelBars", 1, 0, missing),
+                CustomItemList.SteelBars.get(1L),
                 "craftingToolHardHammer",
                 "plateAnyIron",
                 "ringSteel",
@@ -4850,7 +4849,7 @@ public class ScriptMinecraft implements IScriptLoader {
         addShapedRecipe(
                 getModItem(Minecraft.ID, "iron_door", 1, 0, missing),
                 "plateAnyIron",
-                getModItem(NewHorizonsCoreMod.ID, "item.SteelBars", 1, 0, missing),
+                CustomItemList.SteelBars.get(1L),
                 "craftingToolScrewdriver",
                 "plateAnyIron",
                 "ringSteel",

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -217,32 +217,32 @@ public class ScriptMinecraft implements IScriptLoader {
                 .duration(10 * SECONDS).eut(96).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(Minecraft.ID, "wool", 1, wildcard, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 5, 0, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("creosote", 500)).noFluidOutputs().duration(5 * SECONDS).eut(4)
                 .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 2536, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 4, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 2535, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 6, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 2022, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 4, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 2022, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "torch", 6, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
@@ -270,14 +270,14 @@ public class ScriptMinecraft implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
-                        getModItem(Minecraft.ID, "stick", 4, 0, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 4L))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 4, 0, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.iron", 16)).noFluidOutputs().duration(30 * SECONDS)
                 .eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "wooden_slab", 4, 0, missing),
-                        getModItem(Minecraft.ID, "stick", 4, 0, missing))
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 4L))
                 .itemOutputs(getModItem(Minecraft.ID, "trapdoor", 6, 0, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.steel", 16)).noFluidOutputs().duration(30 * SECONDS)
                 .eut(4).addTo(sAssemblerRecipes);
@@ -755,7 +755,7 @@ public class ScriptMinecraft implements IScriptLoader {
                 .duration(10 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 2, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L),
                         getModItem(Minecraft.ID, "planks", 2, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "fence_gate", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(15 * SECONDS).eut(8).addTo(sAssemblerRecipes);
@@ -1493,7 +1493,7 @@ public class ScriptMinecraft implements IScriptLoader {
                 .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(Minecraft.ID, "stone_button", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "lever", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(2 * SECONDS + 10 * TICKS).eut(16).addTo(sAssemblerRecipes);
@@ -1517,28 +1517,28 @@ public class ScriptMinecraft implements IScriptLoader {
                 .duration(2 * SECONDS + 10 * TICKS).eut(16).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 2, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27809, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 2, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(8).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 2, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27032, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 4, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(16).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 2, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 8, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 2, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 2L),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 27019, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "ladder", 32, 0, missing)).noFluidInputs().noFluidOutputs()
@@ -1552,127 +1552,127 @@ public class ScriptMinecraft implements IScriptLoader {
                 .addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32470, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32471, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32472, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32473, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32474, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32475, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32476, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32477, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32478, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32479, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32480, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32481, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32482, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32483, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32484, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32485, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32486, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32487, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32488, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32489, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 32490, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "sign", 3, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(5 * SECONDS).eut(4).addTo(sAssemblerRecipes);
@@ -4333,7 +4333,7 @@ public class ScriptMinecraft implements IScriptLoader {
                 getModItem(GregTech.ID, "gt.metaitem.01", 1, 17500, missing),
                 "craftingToolHardHammer",
                 null,
-                getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                 null);
         addShapedRecipe(
                 getModItem(Minecraft.ID, "diamond_shovel", 1, 0, missing),
@@ -4341,10 +4341,10 @@ public class ScriptMinecraft implements IScriptLoader {
                 getModItem(GregTech.ID, "gt.metaitem.01", 1, 17500, missing),
                 "craftingToolHardHammer",
                 null,
-                getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                 null,
                 null,
-                getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                 null);
         addShapedRecipe(
                 getModItem(Minecraft.ID, "diamond_pickaxe", 1, 0, missing),
@@ -4352,10 +4352,10 @@ public class ScriptMinecraft implements IScriptLoader {
                 getModItem(Minecraft.ID, "diamond", 1, 0, missing),
                 getModItem(Minecraft.ID, "diamond", 1, 0, missing),
                 "craftingToolFile",
-                getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                 "craftingToolHardHammer",
                 null,
-                getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                 null);
         addShapedRecipe(
                 getModItem(Minecraft.ID, "diamond_axe", 1, 0, missing),
@@ -4363,10 +4363,10 @@ public class ScriptMinecraft implements IScriptLoader {
                 getModItem(Minecraft.ID, "diamond", 1, 0, missing),
                 "craftingToolHardHammer",
                 getModItem(GregTech.ID, "gt.metaitem.01", 1, 17500, missing),
-                getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                 null,
                 "craftingToolFile",
-                getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                 null);
         addShapedRecipe(
                 getModItem(Minecraft.ID, "diamond_hoe", 1, 0, missing),
@@ -4374,10 +4374,10 @@ public class ScriptMinecraft implements IScriptLoader {
                 getModItem(Minecraft.ID, "diamond", 1, 0, missing),
                 "craftingToolHardHammer",
                 "craftingToolFile",
-                getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                 null,
                 null,
-                getModItem(Minecraft.ID, "stick", 1, 0, missing),
+                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Wood, 1L),
                 null);
         addShapedRecipe(
                 getModItem(Minecraft.ID, "diamond_helmet", 1, 0, missing),


### PR DESCRIPTION
- use SECONDS and other time units
- use TierEU for voltages
- use customitemlist for coremod items
- use itemlist for gt items
- use gt_oredictunificator for gt materials
- use material.x.getfluid/gas/molten for gt fluids
- remove duplicate recipes

overall much more readable and much fewer gameregistry/fluidregistry queries

tested in game. all seems to work