### PR TITLE
Fix UIV extruder recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CustomLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CustomLoader.java
@@ -46,16 +46,17 @@ public class GT_CustomLoader {
         UEV(OrePrefixes.circuit.get(Materials.Bio), OrePrefixes.wireGt04.get(Materials.Bedrockium), Materials.Draconium,
                 OrePrefixes.wireGt02.get(Materials.Draconium), null, null,
                 BartWorks.isModLoaded() ? "blockGlassUEV" : "glassReinforced", Materials.Bedrockium,
-                Materials.Neutronium),
+                Materials.Infinity),
 
         UIV(OrePrefixes.circuit.get(Materials.Optical), OrePrefixes.wireGt08.get(Materials.Bedrockium),
                 Materials.NetherStar, OrePrefixes.wireGt02.get(Materials.NetherStar), null, null,
                 BartWorks.isModLoaded() ? "blockGlassUIV" : "glassReinforced", Materials.CosmicNeutronium,
-                Materials.CosmicNeutronium),
+                MaterialsUEVplus.TranscendentMetal),
+
         UMV(OrePrefixes.circuit.get(Materials.Piko), OrePrefixes.wireGt16.get(Materials.Bedrockium), Materials.Quantium,
                 OrePrefixes.wireGt02.get(Materials.Quantium), null, null,
                 BartWorks.isModLoaded() ? "blockGlassUMV" : "glassReinforced", MaterialsUEVplus.TranscendentMetal,
-                Materials.Infinity);
+                MaterialsUEVplus.SpaceTime);
 
         private Object _mCircuit;
         private Object _mHeatingCoil;


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13592. the pipe didnt exist. Also uses some more tier appropriate metals for the high tier extruders (nothing else seems to use these pipes).