### PR TITLE
coremod bending recipe cleanup

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/BendingMachineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BendingMachineRecipes.java
@@ -42,7 +42,7 @@ public class BendingMachineRecipes implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Obsidian, 1L),
                         GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L)).noFluidInputs()
-                .noFluidOutputs().duration(20 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sBenderRecipes);
+                .noFluidOutputs().duration(20 * SECONDS).eut(24).addTo(sBenderRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Obsidian, 9L),

--- a/src/main/java/com/dreammaster/gthandler/recipes/BendingMachineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BendingMachineRecipes.java
@@ -39,10 +39,22 @@ public class BendingMachineRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
                 .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Obsidian, 1L),
+                        GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L)).noFluidInputs()
+                .noFluidOutputs().duration(20 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sBenderRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Obsidian, 9L),
+                        GT_Utility.getIntegratedCircuit(9))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Obsidian, 1L)).noFluidInputs()
+                .noFluidOutputs().duration(3 * MINUTES).eut(TierEU.RECIPE_MV).addTo(sBenderRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 9L),
                         GT_Utility.getIntegratedCircuit(9))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Obsidian, 1L)).noFluidInputs()
-                .noFluidOutputs().duration(3 * MINUTES).eut(TierEU.RECIPE_MV * 3 / 4).addTo(sBenderRecipes);
+                .noFluidOutputs().duration(3 * MINUTES).eut(TierEU.RECIPE_MV).addTo(sBenderRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Lapis, 9L),

--- a/src/main/java/com/dreammaster/gthandler/recipes/BendingMachineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BendingMachineRecipes.java
@@ -1,12 +1,14 @@
 package com.dreammaster.gthandler.recipes;
 
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBenderRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import com.dreammaster.gthandler.CustomItemList;
 
 import gregtech.api.enums.*;
 import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
 
 public class BendingMachineRecipes implements Runnable {
 
@@ -23,5 +25,18 @@ public class BendingMachineRecipes implements Runnable {
                         ItemList.Circuit_Integrated.getWithDamage(0, 1))
                 .itemOutputs(ItemList.Shape_Empty.get(1L)).noFluidInputs().noFluidOutputs().duration(10 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(sBenderRecipes);
+
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 9L),
+                        GT_Utility.getIntegratedCircuit(9))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Obsidian, 1L)).noFluidInputs()
+                .noFluidOutputs().duration(3 * MINUTES).eut(TierEU.RECIPE_MV * 3 / 4).addTo(sBenderRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Lapis, 9L),
+                        GT_Utility.getIntegratedCircuit(9))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Lapis, 1L)).noFluidInputs()
+                .noFluidOutputs().duration(3 * MINUTES).eut(TierEU.RECIPE_MV * 3 / 4).addTo(sBenderRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/BendingMachineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BendingMachineRecipes.java
@@ -1,12 +1,21 @@
 package com.dreammaster.gthandler.recipes;
 
+import static gregtech.api.enums.Mods.GalacticraftCore;
+import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBenderRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+
 import com.dreammaster.gthandler.CustomItemList;
 
-import gregtech.api.enums.*;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
 
@@ -14,6 +23,8 @@ public class BendingMachineRecipes implements Runnable {
 
     @Override
     public void run() {
+        ItemStack missing = new ItemStack(Blocks.fire);
+
         GT_Values.RA.stdBuilder()
                 .itemInputs(CustomItemList.MicaInsulatorSheet.get(1L), ItemList.Circuit_Integrated.getWithDamage(0, 1))
                 .itemOutputs(CustomItemList.MicaInsulatorFoil.get(4L)).noFluidInputs().noFluidOutputs()
@@ -38,5 +49,27 @@ public class BendingMachineRecipes implements Runnable {
                         GT_Utility.getIntegratedCircuit(9))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Lapis, 1L)).noFluidInputs()
                 .noFluidOutputs().duration(3 * MINUTES).eut(TierEU.RECIPE_MV * 3 / 4).addTo(sBenderRecipes);
+
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Plastic, 1L),
+                        GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.spring, Materials.Plastic, 1L)).noFluidInputs()
+                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV / 2).addTo(sBenderRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Plastic, 1L),
+                        GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.spring, Materials.Plastic, 1L)).noFluidInputs()
+                .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV / 2).addTo(sBenderRecipes);
+
+        if (GalacticraftCore.isModLoaded()) {
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "item.basicItem", 2, 7, missing))
+                    .itemOutputs(getModItem(GalacticraftCore.ID, "item.canister", 1, 0, missing)).noFluidInputs()
+                    .noFluidOutputs().duration(200).eut(8).addTo(sBenderRecipes);
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "item.basicItem", 2, 6, missing))
+                    .itemOutputs(getModItem(GalacticraftCore.ID, "item.canister", 1, 1, missing)).noFluidInputs()
+                    .noFluidOutputs().duration(200).eut(8).addTo(sBenderRecipes);
+        }
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/BendingMachineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BendingMachineRecipes.java
@@ -76,12 +76,18 @@ public class BendingMachineRecipes implements Runnable {
                 .noFluidOutputs().duration(10 * SECONDS).eut(TierEU.RECIPE_LV / 2).addTo(sBenderRecipes);
 
         if (GalacticraftCore.isModLoaded()) {
-            GT_Values.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "item.basicItem", 2, 7, missing))
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            getModItem(GalacticraftCore.ID, "item.basicItem", 2, 7, missing),
+                            GT_Utility.getIntegratedCircuit(2))
                     .itemOutputs(getModItem(GalacticraftCore.ID, "item.canister", 1, 0, missing)).noFluidInputs()
-                    .noFluidOutputs().duration(200).eut(8).addTo(sBenderRecipes);
-            GT_Values.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "item.basicItem", 2, 6, missing))
+                    .noFluidOutputs().duration(10 * SECONDS).eut(8).addTo(sBenderRecipes);
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            getModItem(GalacticraftCore.ID, "item.basicItem", 2, 6, missing),
+                            GT_Utility.getIntegratedCircuit(2))
                     .itemOutputs(getModItem(GalacticraftCore.ID, "item.canister", 1, 1, missing)).noFluidInputs()
-                    .noFluidOutputs().duration(200).eut(8).addTo(sBenderRecipes);
+                    .noFluidOutputs().duration(10 * SECONDS).eut(8).addTo(sBenderRecipes);
         }
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptCoreMod.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptCoreMod.java
@@ -25,7 +25,6 @@ import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAutoclaveRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBenderRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBrewingRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
@@ -2063,22 +2062,6 @@ public class ScriptCoreMod implements IScriptLoader {
                 .itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzRod", 2, 0, missing))
                 .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzDust", 1, 0, missing))
                 .outputChances(10000).noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sMaceratorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.QuantinumPlate", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.QuantinumDensePlate", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(120).addTo(sBenderRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.MytrylPlate", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.MytrylDensePlate", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(120).addTo(sBenderRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.LedoxPlate", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.LedoxDensePlate", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(400).eut(120).addTo(sBenderRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.BlackPlutoniumPlate", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.BlackPlutoniumDensePlate", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(1200).eut(480).addTo(sBenderRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.metaitem.01", 1, 11804, missing))
-                .itemOutputs(getModItem(GregTech.ID, "gt.metaitem.01", 1, 17804, missing)).noFluidInputs()
-                .noFluidOutputs().duration(400).eut(24).addTo(sBenderRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 55, missing))
                 .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.ElectrotineWire", 2, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(100).eut(4).addTo(sWiremillRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -18,7 +18,6 @@ import static gregtech.api.enums.Mods.ProjectRedIllumination;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sArcFurnaceRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBenderRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBlastRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCannerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
@@ -1264,7 +1263,6 @@ public class ScriptGalacticraft implements IScriptLoader {
         fluidCannerRecipes();
         maceratorRecipes();
         plasmaArcFurnaceRecipes();
-        benderRecipes();
     }
 
     private void arcFurnaceRecipes() {
@@ -2557,14 +2555,5 @@ public class ScriptGalacticraft implements IScriptLoader {
                 .fluidOutputs(FluidRegistry.getFluidStack("argon", 3)).duration(65).eut(30)
                 .addTo(sPlasmaArcFurnaceRecipes);
 
-    }
-
-    private void benderRecipes() {
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "item.basicItem", 2, 7, missing))
-                .itemOutputs(getModItem(GalacticraftCore.ID, "item.canister", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(200).eut(8).addTo(sBenderRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "item.basicItem", 2, 6, missing))
-                .itemOutputs(getModItem(GalacticraftCore.ID, "item.canister", 1, 1, missing)).noFluidInputs()
-                .noFluidOutputs().duration(200).eut(8).addTo(sBenderRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptGregtech.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGregtech.java
@@ -24,7 +24,6 @@ import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAutoclaveRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBenderRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtractorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtruderRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sHammerRecipes;
@@ -1605,15 +1604,5 @@ public class ScriptGregtech implements IScriptLoader {
         GT_ModHandler.addSmeltingRecipe(
                 getModItem(GregTech.ID, "gt.blockores", 1, 4870, missing),
                 getModItem(Minecraft.ID, "iron_ingot", 1, 0, missing));
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.metaitem.02", 1, 22874, missing))
-                .itemOutputs(getModItem(GregTech.ID, "gt.metaitem.02", 1, 24874, missing)).noFluidInputs()
-                .noFluidOutputs().duration(200).eut(16).addTo(sBenderRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.metaitem.01", 1, 23028, missing))
-                .itemOutputs(getModItem(GregTech.ID, "gt.metaitem.02", 1, 23028, missing)).noFluidInputs()
-                .noFluidOutputs().duration(200).eut(8).addTo(sBenderRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkerConstruct.ID, "materials", 1, 18, missing))
-                .itemOutputs(getModItem(GregTech.ID, "gt.metaitem.01", 1, 17804, missing)).noFluidInputs()
-                .noFluidOutputs().duration(400).eut(24).addTo(sBenderRecipes);
-
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
@@ -17,7 +17,6 @@ import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBenderRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBlastRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sChemicalBathRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
@@ -2043,12 +2042,6 @@ public class ScriptIndustrialCraft implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 23500, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 1500, missing))
                 .noFluidInputs().noFluidOutputs().duration(3830).eut(16).addTo(sLatheRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.metaitem.01", 9, 17804, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemDensePlates", 1, 7, missing)).noFluidInputs()
-                .noFluidOutputs().duration(3600).eut(96).addTo(sBenderRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.metaitem.01", 9, 17526, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemDensePlates", 1, 8, missing)).noFluidInputs()
-                .noFluidOutputs().duration(3600).eut(96).addTo(sBenderRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(IndustrialCraft2.ID, "blockBasalt", 1, 0, missing))
                 .itemOutputs(getModItem(GregTech.ID, "gt.metaitem.01", 1, 2844, missing)).outputChances(10000)
                 .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sMaceratorRecipes);


### PR DESCRIPTION
- moves all the bending recipes from scripts to the bending file
- remove duplicate recipes that never were in the game as they were replaced by the automatically generated one
- readded important circuits to recipes that got lost when script files were moved to code
- replaced ids with oredictunificator
- **added one new recipe**: 9 obsidian ingot -> 1 dense plate (it was always the only material that didnt have this)
- use tiereu and seconds/minutes

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13693