### PR TITLE
Fixes molten glass and other fluid extraction recipes

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptBiomesOPlenty.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiomesOPlenty.java
@@ -18,6 +18,8 @@ import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidCannerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidExtractionRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import java.util.Arrays;
 import java.util.List;
@@ -281,12 +283,12 @@ public class ScriptBiomesOPlenty implements IScriptLoader {
                 .itemOutputs(getModItem(BiomesOPlenty.ID, "mudball", 4, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(100).eut(8).addTo(sExtractorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "jarFilled", 1, 1, missing))
-                .itemOutputs(getModItem(BiomesOPlenty.ID, "jarEmpty", 1, 0, missing)).outputChances(2).noFluidInputs()
-                .fluidOutputs(FluidRegistry.getFluidStack("poison", 1000)).duration(10000).eut(20)
+                .itemOutputs(getModItem(BiomesOPlenty.ID, "jarEmpty", 1, 0, missing)).outputChances(10000)
+                .noFluidInputs().fluidOutputs(FluidRegistry.getFluidStack("poison", 1000)).duration(1 * SECONDS).eut(2)
                 .addTo(sFluidExtractionRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "honeyBlock", 1, 0, missing)).noItemOutputs()
-                .noFluidInputs().fluidOutputs(FluidRegistry.getFluidStack("for.honey", 1000)).duration(10000).eut(1200)
-                .addTo(sFluidExtractionRecipes);
+                .noFluidInputs().fluidOutputs(FluidRegistry.getFluidStack("for.honey", 1000)).duration(1 * MINUTES)
+                .eut(40).addTo(sFluidExtractionRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "misc", 1, 2, missing))
                 .itemOutputs(getModItem(BiomesOPlenty.ID, "food", 1, 9, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("for.honey", 100)).noFluidOutputs().duration(1).eut(1)

--- a/src/main/java/com/dreammaster/scripts/ScriptEMT.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEMT.java
@@ -20,6 +20,7 @@ import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidExtractionRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sPressRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +34,7 @@ import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_OreDictUnificator;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
@@ -108,7 +110,7 @@ public class ScriptEMT implements IScriptLoader {
                 .addTo(sFluidSolidficationRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(ElectroMagicTools.ID, "EMTItems", 1, 8, missing))
                 .noItemOutputs().noFluidInputs().fluidOutputs(FluidRegistry.getFluidStack("refinedglue", 288))
-                .duration(10000).eut(100).addTo(sFluidExtractionRecipes);
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_LV / 2).addTo(sFluidExtractionRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 2880, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -39,7 +39,6 @@ import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtractorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidExtractionRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMixerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sSlicerRecipes;
-import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static net.minecraftforge.fluids.FluidRegistry.getFluidStack;
@@ -2428,11 +2427,8 @@ public class ScriptMinecraft implements IScriptLoader {
                 .fluidInputs(getFluidStack("lubricant", 1)).noFluidOutputs().duration(1 * SECONDS + 5 * TICKS).eut(8)
                 .addTo(sCutterRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "sand", 1, wildcard, missing)).noItemOutputs()
-                .noFluidInputs().fluidOutputs(Materials.Glass.getMolten(144)).duration(8 * MINUTES + 20 * SECONDS)
-                .eut(200).addTo(sFluidExtractionRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "obsidian", 1, 0, missing)).noItemOutputs()
-                .noFluidInputs().fluidOutputs(Materials.Obsidian.getMolten(288)).duration(8 * MINUTES + 20 * SECONDS)
-                .eut(600).addTo(sFluidExtractionRecipes);
+                .noFluidInputs().fluidOutputs(Materials.Glass.getMolten(144)).duration(10 * SECONDS).eut(48)
+                .addTo(sFluidExtractionRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "sand", 4, wildcard, missing),


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13752

It was just a mix up of 'chance', 'time', and 'eu/t' when converting from scripts. sand for molten glass, poison from bop, and honey block from bop. The obsidian fluid extraction isnt fixed but removed as it never appears ingame anyway. It has a automatically generated recipe.