### PR TITLE
Fix oredict problems in LP recipes

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
@@ -4318,31 +4318,11 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(Minecraft.ID, "web", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsFirewall", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(
-                getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 2, 17381, missing),
-                createItemStack(Minecraft.ID, "chest", 1, 0, "{display:{Name:\"Invalid OreDictionary Tag\"}}", missing),
-                getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(
-                getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
-                getModItem(GTPlusPlus.ID, "itemPlateRedstoneAlloy", 2, 0, missing),
-                createItemStack(Minecraft.ID, "chest", 1, 0, "{display:{Name:\"Invalid OreDictionary Tag\"}}", missing),
-                getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 17381, missing),
-                        createItemStack(
-                                Minecraft.ID,
-                                "trapped_chest",
-                                1,
-                                0,
-                                "{display:{Name:\"Invalid OreDictionary Tag\"}}",
-                                missing),
+                        getModItem(Minecraft.ID, "chest", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
                 .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
@@ -4350,13 +4330,23 @@ public class ScriptLogisticPipes implements IScriptLoader {
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
                         getModItem(GTPlusPlus.ID, "itemPlateRedstoneAlloy", 2, 0, missing),
-                        createItemStack(
-                                Minecraft.ID,
-                                "trapped_chest",
-                                1,
-                                0,
-                                "{display:{Name:\"Invalid OreDictionary Tag\"}}",
-                                missing),
+                        getModItem(Minecraft.ID, "chest", 1, 0, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 2, 17381, missing),
+                        getModItem(Minecraft.ID, "trapped_chest", 1, 0, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
+                        getModItem(GTPlusPlus.ID, "itemPlateRedstoneAlloy", 2, 0, missing),
+                        getModItem(Minecraft.ID, "trapped_chest", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
                 .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
@@ -4794,49 +4784,11 @@ public class ScriptLogisticPipes implements IScriptLoader {
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(600)
                 .eut(30).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(
-                getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
-                getModItem(NewHorizonsCoreMod.ID, "item.CircuitULV", 1, 0, missing),
-                createItemStack(Minecraft.ID, "chest", 1, 0, "{display:{Name:\"Invalid OreDictionary Tag\"}}", missing),
-                getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
-                getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(
-                getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 32700, missing),
-                createItemStack(Minecraft.ID, "chest", 1, 0, "{display:{Name:\"Invalid OreDictionary Tag\"}}", missing),
-                getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
-                getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(
-                getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
-                getModItem(GregTech.ID, "gt.metaitem.03", 1, 32075, missing),
-                createItemStack(Minecraft.ID, "chest", 1, 0, "{display:{Name:\"Invalid OreDictionary Tag\"}}", missing),
-                getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
-                getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(
-                getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
-                getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 4, missing),
-                createItemStack(Minecraft.ID, "chest", 1, 0, "{display:{Name:\"Invalid OreDictionary Tag\"}}", missing),
-                getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
-                getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitULV", 1, 0, missing),
-                        createItemStack(
-                                Minecraft.ID,
-                                "trapped_chest",
-                                1,
-                                0,
-                                "{display:{Name:\"Invalid OreDictionary Tag\"}}",
-                                missing),
+                        getModItem(Minecraft.ID, "chest", 1, 0, missing),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
@@ -4845,13 +4797,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32700, missing),
-                        createItemStack(
-                                Minecraft.ID,
-                                "trapped_chest",
-                                1,
-                                0,
-                                "{display:{Name:\"Invalid OreDictionary Tag\"}}",
-                                missing),
+                        getModItem(Minecraft.ID, "chest", 1, 0, missing),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
@@ -4860,13 +4806,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32075, missing),
-                        createItemStack(
-                                Minecraft.ID,
-                                "trapped_chest",
-                                1,
-                                0,
-                                "{display:{Name:\"Invalid OreDictionary Tag\"}}",
-                                missing),
+                        getModItem(Minecraft.ID, "chest", 1, 0, missing),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
@@ -4875,13 +4815,43 @@ public class ScriptLogisticPipes implements IScriptLoader {
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 4, missing),
-                        createItemStack(
-                                Minecraft.ID,
-                                "trapped_chest",
-                                1,
-                                0,
-                                "{display:{Name:\"Invalid OreDictionary Tag\"}}",
-                                missing),
+                        getModItem(Minecraft.ID, "chest", 1, 0, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
+                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
+                        getModItem(NewHorizonsCoreMod.ID, "item.CircuitULV", 1, 0, missing),
+                        getModItem(Minecraft.ID, "trapped_chest", 1, 0, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
+                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32700, missing),
+                        getModItem(Minecraft.ID, "trapped_chest", 1, 0, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
+                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.03", 1, 32075, missing),
+                        getModItem(Minecraft.ID, "trapped_chest", 1, 0, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
+                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
+                        getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 4, missing),
+                        getModItem(Minecraft.ID, "trapped_chest", 1, 0, missing),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()

--- a/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
@@ -22,6 +22,7 @@ import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sChemicalBathRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sPressRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,6 +32,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_OreDictUnificator;
 
 public class ScriptLogisticPipes implements IScriptLoader {
@@ -778,8 +780,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -789,8 +791,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -800,8 +802,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -811,8 +813,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -822,8 +824,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -833,8 +835,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -844,8 +846,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -855,8 +857,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -866,8 +868,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -877,8 +879,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -888,8 +890,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -899,8 +901,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -910,8 +912,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -921,8 +923,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -932,8 +934,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -943,8 +945,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -954,8 +956,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -965,8 +967,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -976,8 +978,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -987,8 +989,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -998,8 +1000,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -1009,8 +1011,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -1020,8 +1022,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 21, missing),
@@ -1031,8 +1033,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 27305, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.02", 2, 22305, missing),
@@ -1040,7 +1042,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 2, 19086, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 8, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(100).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.02", 2, 22305, missing),
@@ -1048,7 +1050,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 8, 19086, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 32, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(100).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.02", 2, 22305, missing),
@@ -1056,7 +1058,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 8, 19086, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 32, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(100).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.02", 2, 22019, missing),
@@ -1064,7 +1066,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19086, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 64, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(100).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.02", 1, 22306, missing),
@@ -1072,7 +1074,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19086, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 64, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(100).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 8, 0, missing),
@@ -1082,8 +1084,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 8, 0, missing),
@@ -1093,8 +1095,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 8, 0, missing),
@@ -1104,8 +1106,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 8, 0, missing),
@@ -1115,8 +1117,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 8, 0, missing),
@@ -1126,8 +1128,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 8, 0, missing),
@@ -1137,8 +1139,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 8, 0, missing),
@@ -1148,8 +1150,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 8, 0, missing),
@@ -1159,8 +1161,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 16, 0, missing),
@@ -1170,8 +1172,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 16, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 16, 0, missing),
@@ -1181,8 +1183,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 16, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 16, 0, missing),
@@ -1192,8 +1194,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 16, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 16, 0, missing),
@@ -1203,8 +1205,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 16, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 16, 0, missing),
@@ -1214,8 +1216,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 16, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 32, 0, missing),
@@ -1225,8 +1227,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 32, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 32, 0, missing),
@@ -1236,8 +1238,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 32, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 32, 0, missing),
@@ -1247,8 +1249,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 32, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicTransport", 32, 0, missing),
@@ -1258,8 +1260,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 16, 19054, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 32, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1269,8 +1271,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1280,8 +1282,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1291,8 +1293,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1302,8 +1304,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1313,8 +1315,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1324,8 +1326,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1335,8 +1337,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1346,8 +1348,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1357,8 +1359,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1368,8 +1370,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1379,8 +1381,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1390,50 +1392,50 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
                         getModItem(Minecraft.ID, "enchanted_book", 1, wildcard, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 31, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 31, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 131, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 12, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 12, missing),
                         getModItem(Minecraft.ID, "writable_book", 1, wildcard, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 13, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
                         getModItem(Thaumcraft.ID, "ItemShard", 4, 6, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 30, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 12, missing),
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 1, 2, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 16, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
                         getModItem(ExtraUtilities.ID, "trashcan", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 6, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1443,8 +1445,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1454,8 +1456,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1465,8 +1467,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1476,8 +1478,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1487,8 +1489,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1498,8 +1500,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1509,8 +1511,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1520,8 +1522,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1531,8 +1533,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1542,8 +1544,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1553,8 +1555,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 0, missing),
@@ -1564,14 +1566,14 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 3, 2, missing),
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 3, 502, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1581,8 +1583,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1592,8 +1594,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1603,8 +1605,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1614,8 +1616,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1625,8 +1627,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1636,8 +1638,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1647,8 +1649,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1658,8 +1660,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1669,8 +1671,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1680,8 +1682,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1691,8 +1693,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1702,8 +1704,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1713,8 +1715,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1724,8 +1726,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1735,8 +1737,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1746,8 +1748,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1757,8 +1759,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1768,8 +1770,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1779,8 +1781,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1790,8 +1792,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1801,8 +1803,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1812,8 +1814,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1823,8 +1825,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -1834,104 +1836,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartCircuit", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPlates", 1, 8, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32701, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPlates", 1, 8, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.03", 1, 32078, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPlates", 1, 8, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
-                        getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 5, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPlates", 1, 8, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartCircuit", 1, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17526, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32701, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17526, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.03", 1, 32078, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17526, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
-                        getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 5, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17526, missing),
-                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
-                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1942,8 +1848,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1954,8 +1860,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1966,8 +1872,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1978,8 +1884,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -1990,8 +1896,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2002,8 +1908,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2014,8 +1920,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2026,8 +1932,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2038,8 +1944,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2050,8 +1956,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2062,8 +1968,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2074,8 +1980,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2086,8 +1992,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2098,8 +2004,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2110,8 +2016,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
@@ -2122,14 +2028,110 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
+                        getModItem(IndustrialCraft2.ID, "itemPartCircuit", 1, 0, missing),
+                        getModItem(IndustrialCraft2.ID, "itemPlates", 1, 8, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32701, missing),
+                        getModItem(IndustrialCraft2.ID, "itemPlates", 1, 8, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.03", 1, 32078, missing),
+                        getModItem(IndustrialCraft2.ID, "itemPlates", 1, 8, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
+                        getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 5, missing),
+                        getModItem(IndustrialCraft2.ID, "itemPlates", 1, 8, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
+                        getModItem(IndustrialCraft2.ID, "itemPartCircuit", 1, 0, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17526, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32701, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17526, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.03", 1, 32078, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17526, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(LogisticsPipes.ID, "item.itemModule", 4, 0, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 32651, missing),
+                        getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 5, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 1, 17526, missing),
+                        getModItem(GregTech.ID, "gt.metaitem.01", 8, 26086, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
+                        getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
+                .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 500, missing))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 500, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 6, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2139,8 +2141,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2150,8 +2152,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2161,8 +2163,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2172,8 +2174,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2183,8 +2185,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2194,8 +2196,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2205,8 +2207,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2216,8 +2218,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2227,8 +2229,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2238,8 +2240,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2249,8 +2251,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2260,8 +2262,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2271,8 +2273,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2282,8 +2284,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2293,8 +2295,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2304,8 +2306,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2315,8 +2317,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2326,8 +2328,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2337,8 +2339,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2348,8 +2350,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2359,8 +2361,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2370,8 +2372,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2381,8 +2383,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 0, missing),
@@ -2392,80 +2394,80 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 3, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 103, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 3, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 6, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 203, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 3, missing),
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 1, 3, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 7, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 3, missing),
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 1, 3, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 7, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 3, missing),
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 1, 3, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 7, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 7, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 107, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 103, missing),
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 1, 3, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 107, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 107, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 6, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 207, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 203, missing),
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 1, 3, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 207, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
                         getModItem(IndustrialCraft2.ID, "itemBatREDischarged", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 300, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
                         getModItem(IndustrialCraft2.ID, "itemBatRE", 1, wildcard, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 300, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
     }
 
     private void recipes2() {
@@ -2477,8 +2479,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17305, missing),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 30, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 17, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 1, missing),
@@ -2487,8 +2489,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17305, missing),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 30, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 17, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 1, missing),
@@ -2497,8 +2499,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17305, missing),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 30, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 17, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(600)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2508,8 +2510,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2519,8 +2521,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2530,8 +2532,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2541,8 +2543,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2552,8 +2554,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2563,8 +2565,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2574,8 +2576,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2585,8 +2587,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2596,8 +2598,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2607,8 +2609,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2618,8 +2620,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2629,8 +2631,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2640,8 +2642,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2651,8 +2653,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 2, missing),
@@ -2662,8 +2664,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26334, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2673,8 +2675,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2684,8 +2686,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2695,8 +2697,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2706,8 +2708,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2717,8 +2719,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2728,8 +2730,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2739,8 +2741,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2750,8 +2752,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2761,8 +2763,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2772,8 +2774,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2783,8 +2785,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2794,8 +2796,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 6, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2805,8 +2807,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 16, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 7, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 288)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 288)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2816,8 +2818,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 16, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 7, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 5, missing),
@@ -2827,8 +2829,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 16, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 7, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 72)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 7, missing),
@@ -2838,8 +2840,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 32, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 576)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 576)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 7, missing),
@@ -2849,8 +2851,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 32, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 288)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 288)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 7, missing),
@@ -2860,8 +2862,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 32, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 144)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 144)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -2873,8 +2875,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 2, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeBlockRequestTable", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -2886,8 +2888,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 2, 32702, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeBlockRequestTable", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -2899,8 +2901,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 2, 32079, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeBlockRequestTable", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -2912,8 +2914,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 2, 32080, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeBlockRequestTable", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -2925,8 +2927,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeBlockRequestTable", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -2936,8 +2938,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -2947,8 +2949,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -2958,8 +2960,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -2969,8 +2971,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -2980,8 +2982,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -2991,8 +2993,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3002,8 +3004,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3013,8 +3015,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3024,8 +3026,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3035,8 +3037,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3046,8 +3048,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3057,8 +3059,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3068,8 +3070,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3079,8 +3081,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3090,8 +3092,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3101,8 +3103,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3112,8 +3114,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3123,8 +3125,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3134,8 +3136,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3145,8 +3147,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3156,8 +3158,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3167,8 +3169,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3178,8 +3180,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
@@ -3189,20 +3191,20 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 8, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(900)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 5, missing),
                         getModItem(OpenComputers.ID, "item", 1, 70, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 14, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(120).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
                         getModItem(OpenComputers.ID, "item", 1, 70, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 15, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(120).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3213,8 +3215,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3225,8 +3227,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3237,8 +3239,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3249,8 +3251,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 2, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3263,8 +3265,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3277,8 +3279,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3291,8 +3293,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3305,8 +3307,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3319,8 +3321,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3333,8 +3335,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3347,8 +3349,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3361,14 +3363,14 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 26348, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(900).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(45 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing),
                         getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 25, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 4, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(120).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3379,8 +3381,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.blockmachines", 4, 1367, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3391,8 +3393,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.blockmachines", 4, 1367, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3403,8 +3405,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.blockmachines", 4, 1367, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 12, missing),
@@ -3415,8 +3417,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.blockmachines", 4, 1367, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 5, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3427,8 +3429,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3439,8 +3441,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3451,8 +3453,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3463,8 +3465,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3475,8 +3477,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3487,8 +3489,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3499,8 +3501,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3511,8 +3513,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3523,8 +3525,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3535,8 +3537,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3547,8 +3549,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3559,8 +3561,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3571,8 +3573,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3583,8 +3585,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 5, 0, missing),
@@ -3595,20 +3597,20 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 30, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 5, 600, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 600, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 7, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 601, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1600).eut(1920).addTo(sPressRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_EV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 2, 601, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 8, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 2, 602, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1600).eut(7680).addTo(sPressRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_IV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32681, missing),
@@ -3620,8 +3622,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 27500, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 144)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32681, missing),
@@ -3633,8 +3635,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 27500, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 144)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32681, missing),
@@ -3646,8 +3648,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 27500, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 144)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32681, missing),
@@ -3659,91 +3661,91 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 4, 27500, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 144)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, wildcard, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("chlorine", 1000)).noFluidOutputs()
-                .duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 1, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyeblack", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 2, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyered", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 3, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyegreen", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 4, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyebrown", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 5, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyeblue", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 6, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyepurple", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 7, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyecyan", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 8, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyelightgray", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 9, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyegray", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 10, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyepink", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 11, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyelime", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 12, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyeyellow", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 13, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyelightblue", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 14, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyemagenta", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 15, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyeorange", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 1, 16, missing))
                 .outputChances(10000).fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyewhite", 288))
-                .noFluidOutputs().duration(1600).eut(30).addTo(sChemicalBathRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sChemicalBathRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(NewHorizonsCoreMod.ID, "item.Display", 1, 0, missing),
                         getModItem(OpenComputers.ID, "keyboard", 1, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.pipeController", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(NewHorizonsCoreMod.ID, "item.Display", 1, 0, missing),
                         getModItem(OpenComputers.ID, "keyboard", 1, 0, missing),
                         getModItem(Minecraft.ID, "sign", 16, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.ItemPipeSignCreator", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 26348, missing),
@@ -3751,8 +3753,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 2, 3, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GalacticraftCore.ID, "item.sensorLens", 1, 0, missing),
@@ -3760,8 +3762,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GalacticraftCore.ID, "item.sensorLens", 1, 0, missing),
@@ -3769,8 +3771,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32702, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GalacticraftCore.ID, "item.sensorLens", 1, 0, missing),
@@ -3778,8 +3780,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32079, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GalacticraftCore.ID, "item.sensorLens", 1, 0, missing),
@@ -3787,8 +3789,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32080, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GalacticraftCore.ID, "item.sensorLens", 1, 0, missing),
@@ -3796,8 +3798,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 1, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.aluminium", 144)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -3806,8 +3808,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("for.honey", 1000)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("for.honey", 1000)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -3816,8 +3818,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32702, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("for.honey", 1000)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("for.honey", 1000)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -3826,8 +3828,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32079, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("for.honey", 1000)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("for.honey", 1000)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -3836,8 +3838,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32080, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("for.honey", 1000)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("for.honey", 1000)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 1, missing),
@@ -3846,21 +3848,21 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("for.honey", 1000)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("for.honey", 1000)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 1, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsApiaristSink", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
                         getModItem(ExtraUtilities.ID, "trashcan", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 11, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1600).eut(120).addTo(sPressRecipes);
+                .noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3871,8 +3873,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3883,8 +3885,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32702, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3895,8 +3897,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32079, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3907,8 +3909,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32080, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3919,8 +3921,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3931,8 +3933,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3943,8 +3945,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32702, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3955,8 +3957,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32079, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3967,8 +3969,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32080, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3979,8 +3981,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -3991,8 +3993,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4003,8 +4005,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32702, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4015,8 +4017,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32079, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4027,8 +4029,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32080, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4039,8 +4041,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 10, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4050,8 +4052,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4061,8 +4063,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32702, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4072,8 +4074,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32079, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4083,8 +4085,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32080, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4094,8 +4096,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4105,8 +4107,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4116,8 +4118,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32702, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4127,8 +4129,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32079, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4138,8 +4140,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32080, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4149,8 +4151,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(1600).eut(120)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(80 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4160,8 +4162,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4171,8 +4173,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32702, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4182,8 +4184,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32079, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
     }
 
     private void recipes3() {
@@ -4196,8 +4198,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32080, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 9, missing),
@@ -4207,50 +4209,50 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(1600)
-                .eut(120).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 1, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 8, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsApiaristAnalyser", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(1600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(80 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 600, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsCraftingLogistics", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsCraftingLogistics", 2, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 7, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsCraftingLogisticsMk2", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 601, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsCraftingLogisticsMk2", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsCraftingLogisticsMk2", 2, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 8, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsCraftingLogisticsMk3", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 602, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsCraftingLogisticsMk3", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 1, 0, missing),
@@ -4259,42 +4261,42 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 4, 1, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsRequestLogistics", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsRequestLogistics", 1, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsRequestLogisticsMk2", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 500, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsProviderLogistics", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsProviderLogistics", 2, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsProviderLogisticsMk2", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 501, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsProviderLogisticsMk2", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
                         getModItem(LogisticsPipes.ID, "item.itemModule", 1, 502, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsSupplierLogistics", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
@@ -4304,20 +4306,20 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17532, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsSatelliteLogistics", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 0, wildcard, missing),
                         getModItem(LogisticsPipes.ID, "item.PipeItemsRequestLogistics", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsRemoteOrdererLogistics", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 1, 0, missing),
                         getModItem(Minecraft.ID, "web", 1, 0, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsFirewall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
@@ -4325,7 +4327,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(Minecraft.ID, "chest", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
@@ -4333,7 +4335,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(Minecraft.ID, "chest", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
@@ -4341,7 +4343,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(Minecraft.ID, "trapped_chest", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
@@ -4349,7 +4351,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(Minecraft.ID, "trapped_chest", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing),
@@ -4357,7 +4359,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IronChests.ID, "BlockIronChest", 1, 3, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk2", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk2", 2, 0, missing),
@@ -4365,7 +4367,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IronChests.ID, "BlockIronChest", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk3", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk3", 2, 0, missing),
@@ -4373,7 +4375,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IronChests.ID, "BlockIronChest", 1, 4, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk4", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk4", 2, 0, missing),
@@ -4381,7 +4383,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IronChests.ID, "BlockIronChest", 1, 1, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk5", 2, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 4, 0, missing),
@@ -4390,7 +4392,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuit", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk2", 4, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 4, 0, missing),
@@ -4399,7 +4401,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32701, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk2", 4, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 4, 0, missing),
@@ -4408,7 +4410,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32078, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk2", 4, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 4, 0, missing),
@@ -4417,7 +4419,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 5, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk2", 4, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 6, 0, missing),
@@ -4426,7 +4428,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk3", 6, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 6, 0, missing),
@@ -4435,7 +4437,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32702, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk3", 6, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 6, 0, missing),
@@ -4444,7 +4446,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32079, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk3", 6, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 6, 0, missing),
@@ -4453,7 +4455,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32080, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk3", 6, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 6, 0, missing),
@@ -4462,7 +4464,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 6, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk3", 6, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing),
@@ -4471,7 +4473,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk4", 8, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing),
@@ -4480,7 +4482,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32703, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk4", 8, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing),
@@ -4489,7 +4491,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32082, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk4", 8, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 8, 0, missing),
@@ -4498,7 +4500,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 7, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk4", 8, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 12, 0, missing),
@@ -4507,7 +4509,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitEV", 1, 0, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk5", 12, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 12, 0, missing),
@@ -4516,7 +4518,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32704, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk5", 12, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 12, 0, missing),
@@ -4525,7 +4527,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32083, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk5", 12, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 12, 0, missing),
@@ -4534,7 +4536,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.03", 1, 32085, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk5", 12, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 12, 0, missing),
@@ -4543,7 +4545,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 1, 8, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk5", 12, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4552,8 +4554,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4562,8 +4564,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4572,8 +4574,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4582,8 +4584,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4592,8 +4594,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4602,8 +4604,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4612,8 +4614,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4622,8 +4624,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4632,8 +4634,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4642,8 +4644,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4652,8 +4654,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4662,8 +4664,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4672,8 +4674,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4682,8 +4684,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4692,8 +4694,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4702,8 +4704,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4712,8 +4714,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(600)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4722,8 +4724,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(600)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4732,8 +4734,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(600)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4742,8 +4744,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19035, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(600)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4752,8 +4754,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(600)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4762,8 +4764,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(600)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4772,8 +4774,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(600)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 0, missing),
@@ -4782,8 +4784,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.02", 4, 19345, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(600)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4792,7 +4794,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4801,7 +4803,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4810,7 +4812,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4819,7 +4821,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4828,7 +4830,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4837,7 +4839,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4846,7 +4848,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4855,7 +4857,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 34, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 44, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4864,7 +4866,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 26, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 25, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4872,8 +4874,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 32, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 20, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("lubricant", 1000)).noFluidOutputs().duration(600).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("lubricant", 1000)).noFluidOutputs().duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4882,7 +4884,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 20, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 24, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 2, 4, missing),
@@ -4891,19 +4893,19 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 33, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 2, 23, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
                         getModItem(IndustrialCraft2.ID, "itemPlates", 1, 1, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 42, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17057, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 42, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sPressRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -4912,7 +4914,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 23, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 21, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -4921,7 +4923,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 33, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 26, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -4931,7 +4933,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 24, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 41, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -4940,7 +4942,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 33, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 21, missing)).noFluidInputs()
-                .noFluidOutputs().duration(1200).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(60 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
@@ -4949,7 +4951,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 5, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
@@ -4958,7 +4960,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 1, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
@@ -4967,7 +4969,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 2, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
@@ -4976,7 +4978,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 2, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 3, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
@@ -4985,7 +4987,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 3, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 4, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
@@ -4994,7 +4996,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 4, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 1, 5, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5002,7 +5004,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 5, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 10, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5010,7 +5012,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 5, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 10, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5018,7 +5020,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 11, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5026,7 +5028,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 6, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 11, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5034,7 +5036,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 12, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5042,7 +5044,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 1, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 12, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5050,7 +5052,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 2, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 13, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5058,7 +5060,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 2, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 13, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5066,7 +5068,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 3, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 14, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5074,7 +5076,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 3, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 14, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5082,7 +5084,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 4, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 15, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5090,7 +5092,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 27, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 4, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 15, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(30).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 6, 0, missing),
@@ -5098,8 +5100,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32610, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeFluidBasic", 6, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 144)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 6, 0, missing),
@@ -5107,8 +5109,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32610, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeFluidBasic", 6, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(800).eut(30)
-                .addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 72)).noFluidOutputs().duration(40 * SECONDS)
+                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 6, 0, missing),
@@ -5116,8 +5118,8 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32610, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeFluidBasic", 6, 0, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs().duration(800)
-                .eut(30).addTo(sAssemblerRecipes);
+                .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 36)).noFluidOutputs()
+                .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeFluidBasic", 3, 0, missing),
@@ -5125,7 +5127,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32405, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeFluidSupplierMk2", 3, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeFluidBasic", 3, 0, missing),
@@ -5134,7 +5136,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32405, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsFluidSupplier", 3, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeFluidBasic", 3, 0, missing),
@@ -5142,7 +5144,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32405, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeFluidProvider", 3, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeFluidBasic", 3, 0, missing),
@@ -5150,7 +5152,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32405, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeFluidInsertion", 3, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeFluidBasic", 1, 0, missing),
@@ -5158,7 +5160,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32405, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeFluidRequestLogistics", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidInputs().noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeFluidBasic", 1, 0, missing),
@@ -5168,7 +5170,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17532, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeFluidSatellite", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeFluidBasic", 4, 0, missing),
@@ -5176,7 +5178,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32405, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeFluidExtractor", 4, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 1, 4, missing),
@@ -5184,6 +5186,6 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 32405, missing),
                         getModItem(GregTech.ID, "gt.integrated_circuit", 0, 18, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemUpgrade", 4, 22, missing)).noFluidInputs()
-                .noFluidOutputs().duration(600).eut(120).addTo(sAssemblerRecipes);
+                .noFluidOutputs().duration(30 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
     }
 }


### PR DESCRIPTION
Fixes the following:

![LP recipe bug](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/1928113/97e8559c-5950-4331-884c-9377b422cc2d)

Also refactors the LP recipes to use constants for power usage and duration.