### PR TITLE
Allow arbitrary charge level for GraviChestPlate inputs

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -4,6 +4,7 @@ import static gregtech.api.enums.Mods.GraviSuite;
 import static gregtech.api.util.GT_RecipeBuilder.HOURS;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.WILDCARD;
 import static gregtech.api.util.GT_RecipeConstants.AssemblyLine;
 import static gregtech.api.util.GT_RecipeConstants.RESEARCH_ITEM;
 import static gregtech.api.util.GT_RecipeConstants.RESEARCH_TIME;
@@ -136,9 +137,9 @@ public class AssemblingLineRecipes implements Runnable {
                     .metadata(RESEARCH_ITEM, GT_ModHandler.getIC2Item("quantumBodyarmor", 1L, GT_Values.W))
                     .metadata(RESEARCH_TIME, 2 * HOURS)
                     .itemInputs(
-                            GT_ModHandler.getIC2Item("quantumBodyarmor", 1L, 1),
+                            GT_ModHandler.getIC2Item("quantumBodyarmor", 1L, WILDCARD),
                             ItemList.Transformer_ZPM_LuV.get(1L),
-                            GT_ModHandler.getModItem(GraviSuite.ID, "ultimateLappack", 1, 1),
+                            GT_ModHandler.getModItem(GraviSuite.ID, "ultimateLappack", 1, WILDCARD),
                             GT_ModHandler.getModItem(GraviSuite.ID, "itemSimpleItem", 6, 1),
                             GT_ModHandler.getModItem(GraviSuite.ID, "itemSimpleItem", 2, 2),
                             GT_ModHandler.getModItem(GraviSuite.ID, "itemSimpleItem", 2, 3),


### PR DESCRIPTION
This allows the lappack and quantumsuit to have arbitrary charge level for the craft. The output of course still has 0EU charge.

The nbt seems to be ignored, so charge is just checked of the meta. wildcard lets us allow any. 

tested successfully with 
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/e4be13d4-0ec0-4d1b-a5e4-2e759f4bf634)


