### PR TITLE
Remove non-existent ores from DD voidminer

### DIFF
--- a/src/main/java/com/dreammaster/bartworksHandler/VoidMinerLoader.java
+++ b/src/main/java/com/dreammaster/bartworksHandler/VoidMinerLoader.java
@@ -30,7 +30,7 @@ public class VoidMinerLoader {
     private static final int DEEPDARK_ID = 100;
 
     private static boolean hasOres(Materials materials) {
-        return ((materials.mTypes & 8) != 0) && (materials.mMetaItemSubID > 0);
+        return ((materials.mTypes & 8) != 0) && (materials.mMetaItemSubID > 0) && materials.mHasParentMod;
     }
 
     private static boolean hasOres(Werkstoff werkstoff) {


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13687

technically buffs the DD void miner as drops are relative to total weight.