### PR TITLE
New clay electrolysis recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/ElectrolyzerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ElectrolyzerRecipes.java
@@ -1,11 +1,14 @@
 package com.dreammaster.gthandler.recipes;
 
 import static gregtech.api.enums.Mods.TwilightForest;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sElectrolyzerRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 
@@ -239,20 +242,14 @@ public class ElectrolyzerRecipes implements Runnable {
                 160,
                 120);
         // Clay
-        GT_Values.RA.addElectrolyzerRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Clay, 13L),
-                ItemList.Cell_Empty.get(12L),
-                GT_Values.NF,
-                Materials.Oxygen.getFluid(3000L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 2L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lithium, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Aluminiumoxide, 5L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Silicon, 2L),
-                GT_OreDictUnificator.get(OrePrefixes.cell, Materials.Hydrogen, 12L),
-                GT_Values.NI,
-                null,
-                156,
-                120);
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Clay, 16L))
+                .itemOutputs(
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodium, 2L),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lithium, 1L),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Aluminiumoxide, 5L),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SiliconDioxide, 6L))
+                .noFluidInputs().fluidOutputs(Materials.Water.getFluid(2000L)).duration(8 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(sElectrolyzerRecipes);
         // Emerald
         GT_Values.RA.addElectrolyzerRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Emerald, 29L),


### PR DESCRIPTION
Follow-up to https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/562 specifically for clay.

With this PR Clay electrolysis gets chem balance, a slightly more realistic composition, and no more cheap hydrogen. But it keeps the alumina that was desired when the change was made in https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/562.

New formula is 16 Na2LiAl2Si2O7(H2O)2 -> 2Na + Li + 5 Al2O3 + 6 SiO2 + 2000L H2O.

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13862

goes together with https://github.com/GTNewHorizons/GT5-Unofficial/pull/2114


![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/1568265a-3105-4f82-a4cb-f27a26957a0a)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/8361d5cd-2d06-4a15-9b83-f9f90d207b24)
