### PR TITLE
Time <-> Space conversion recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -579,14 +579,13 @@ public class DTPFRecipes implements Runnable {
                         .duration(80 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500)
                         .addTo(sPlasmaForgeRecipes);
 
-                //Time to Space
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                //Spacetime Continuum Ripper
-                                getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 10),
-                                ItemList.EnergisedTesseract.get(2),
-                                // Quantum Anomaly
-                                GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 16, 32105))
+                // Time to Space
+                GT_Values.RA.stdBuilder().itemInputs(
+                        // Spacetime Continuum Ripper
+                        getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 10),
+                        ItemList.EnergisedTesseract.get(2),
+                        // Quantum Anomaly
+                        GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 16, 32105))
                         .itemOutputs(ItemList.Tesseract.get(1))
                         .fluidInputs(
                                 MaterialsUEVplus.Time.getMolten(9216L * 64),
@@ -598,14 +597,12 @@ public class DTPFRecipes implements Runnable {
                         .duration(10 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500)
                         .addTo(sPlasmaForgeRecipes);
 
-                //Space to Time
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                //Spacetime Continuum Ripper
-                                getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 10),
-                                ItemList.EnergisedTesseract.get(2),
-                                ItemList.Timepiece.get(16))
-                        .itemOutputs(ItemList.Tesseract.get(1))
+                // Space to Time
+                GT_Values.RA.stdBuilder().itemInputs(
+                        // Spacetime Continuum Ripper
+                        getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 10),
+                        ItemList.EnergisedTesseract.get(2),
+                        ItemList.Timepiece.get(16)).itemOutputs(ItemList.Tesseract.get(1))
                         .fluidInputs(
                                 MaterialsUEVplus.Space.getMolten(9216L * 64),
                                 MaterialsUEVplus.SpaceTime.getMolten(9216L * 16),

--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -578,6 +578,43 @@ public class DTPFRecipes implements Runnable {
                                 MaterialsUEVplus.Space.getMolten(18432L * 8))
                         .duration(80 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500)
                         .addTo(sPlasmaForgeRecipes);
+
+                //Time to Space
+                GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                                //Spacetime Continuum Ripper
+                                getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 10),
+                                ItemList.EnergisedTesseract.get(2),
+                                // Quantum Anomaly
+                                GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 16, 32105))
+                        .itemOutputs(ItemList.Tesseract.get(1))
+                        .fluidInputs(
+                                MaterialsUEVplus.Time.getMolten(9216L * 64),
+                                MaterialsUEVplus.SpaceTime.getMolten(9216L * 16),
+                                MaterialsUEVplus.ExcitedDTSC.getFluid(1000L))
+                        .fluidOutputs(
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L * 2),
+                                MaterialsUEVplus.Space.getMolten(9216L * 64))
+                        .duration(10 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500)
+                        .addTo(sPlasmaForgeRecipes);
+
+                //Space to Time
+                GT_Values.RA.stdBuilder()
+                        .itemInputs(
+                                //Spacetime Continuum Ripper
+                                getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 10),
+                                ItemList.EnergisedTesseract.get(2),
+                                ItemList.Timepiece.get(16))
+                        .itemOutputs(ItemList.Tesseract.get(1))
+                        .fluidInputs(
+                                MaterialsUEVplus.Space.getMolten(9216L * 64),
+                                MaterialsUEVplus.SpaceTime.getMolten(9216L * 16),
+                                MaterialsUEVplus.ExcitedDTSC.getFluid(1000L))
+                        .fluidOutputs(
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L * 2),
+                                MaterialsUEVplus.Time.getMolten(9216L * 64))
+                        .duration(10 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500)
+                        .addTo(sPlasmaForgeRecipes);
             }
 
             if (Avaritia.isModLoaded()) {


### PR DESCRIPTION
Adds conversion recipe for time to space and vice versa.

Molten space and molten time are sourced from the same recipe which yields both, and a lot of times one ends up with too much of either one. Plus the eternity qft recipe yields excess molten time which just sits there because you also get it when crafting molten space. This is especially noticeable very late into the game when primordial matter becomes a relevant crafting ingredient and molten space usage becomes higher than molten time usage.

These recipes aim to address these issues by adding a way to convert the two fluids into one another.

Time to Space:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/93287602/7fe3373d-aa85-4ba2-8efd-4382a33298ae)

Space to Time:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/93287602/6369a42c-79cc-4e22-986f-8afd1d42f3c2)
