### PR TITLE
Add compressor recipe for nether star block from dust

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -9,6 +9,8 @@ import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.StevesCarts2;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.TinkerConstruct;
+import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -18,6 +20,7 @@ import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 
@@ -197,5 +200,9 @@ public class CompressorRecipes implements Runnable {
                     300,
                     2);
         }
+
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 9))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, Materials.NetherStar, 1)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(TierEU.RECIPE_UV).addTo(sCompressorRecipes);
     }
 }


### PR DESCRIPTION
Gives nether star dust a use and alleviates some of the extreme endgame need for nether stars/plates

![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/73182109/8e4411d1-b5fa-48d1-9dc8-3adfc1f9b09e)
