### PR TITLE
Add normal dust recipes for OC cables

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -3564,6 +3564,21 @@ public class AssemblerRecipes implements Runnable {
                 GT_ModHandler.getModItem(OpenComputers.ID, "cable", 1L, 0),
                 200,
                 120);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.Gold, 9),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.RedstoneAlloy, 1),
+                        GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(GT_ModHandler.getModItem(OpenComputers.ID, "cable", 9L, 0)).noFluidInputs()
+                .noFluidOutputs().duration(90 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.Gold, 9),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Emerald, 1),
+                        GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(GT_ModHandler.getModItem(OpenComputers.ID, "cable", 9L, 0)).noFluidInputs()
+                .noFluidOutputs().duration(90 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
+
         // keyboard
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] { new ItemStack(Blocks.stone_button, 64), new ItemStack(Blocks.stone_button, 40),


### PR DESCRIPTION
Left the existing tiny dust recipes so as not to break players' existing patterns, but we should be using full dusts wherever possible these days
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/73182109/7182e4d0-9f73-44c9-a58c-02c78b405429)
