### PR TITLE
RA2 conversions, Script Integrations and Cleanup for Compressor recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -1,17 +1,22 @@
 package com.dreammaster.gthandler.recipes;
 
 import static gregtech.api.enums.Mods.AdvancedSolarPanel;
+import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.BloodArsenal;
 import static gregtech.api.enums.Mods.BloodMagic;
 import static gregtech.api.enums.Mods.ExtraTrees;
 import static gregtech.api.enums.Mods.ExtraUtilities;
+import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.enums.Mods.GalacticraftCore;
+import static gregtech.api.enums.Mods.HardcoreEnderExpansion;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Natura;
 import static gregtech.api.enums.Mods.OpenComputers;
+import static gregtech.api.enums.Mods.PamsHarvestCraft;
+import static gregtech.api.enums.Mods.ProjectRedCore;
 import static gregtech.api.enums.Mods.Railcraft;
 import static gregtech.api.enums.Mods.StevesCarts2;
 import static gregtech.api.enums.Mods.Thaumcraft;
@@ -41,10 +46,13 @@ public class CompressorRecipes implements Runnable {
     @Override
     public void run() {
         makeAdvancedSolarPanelRecipes();
+        makeAvaritiaRecipes();
         makeBiomesOPlentyRecipes();
         makeBloodMagicRecipes();
         makeExtraUtilitiesRecipes();
         makeGTPlusPlusRecipes();
+        makeHardcoreEnderExpansionRecipes();
+        makePamsHarvestCraftRecipes();
         makeRailcraftRecipes();
         makeTinkerConstructRecipes();
         makeThaumcraftRecipes();
@@ -175,6 +183,16 @@ public class CompressorRecipes implements Runnable {
         if (GalacticraftCore.isModLoaded()) {
             GT_Values.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "item.cheeseCurd", 9, 0, missing))
                     .itemOutputs(getModItem(GalacticraftCore.ID, "tile.moonBlock", 1, 2, missing)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        }
+        if (ProjectRedCore.isModLoaded()) {
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 57, missing))
+                    .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 55, missing)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        }
+        if (StevesCarts2.isModLoaded()) {
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(StevesCarts2.ID, "ModuleComponents", 9, 46, missing))
+                    .itemOutputs(getModItem(StevesCarts2.ID, "ModuleComponents", 1, 48, missing)).noFluidInputs()
                     .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         }
     }
@@ -339,6 +357,48 @@ public class CompressorRecipes implements Runnable {
                 .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "bones", 2, 1, missing))
                 .itemOutputs(getModItem(BiomesOPlenty.ID, "bones", 1, 2, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeAvaritiaRecipes() {
+        if (!Avaritia.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.crafting_table, 9))
+                .itemOutputs(getModItem(Avaritia.ID, "Double_Craft", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Avaritia.ID, "Double_Craft", 9, 0, missing))
+                .itemOutputs(getModItem(Avaritia.ID, "Triple_Craft", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Avaritia.ID, "Resource", 9, 1, missing))
+                .itemOutputs(getModItem(Avaritia.ID, "Crystal_Matrix", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeHardcoreEnderExpansionRecipes() {
+        if (!HardcoreEnderExpansion.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.HeeEndium, 9L))
+                .itemOutputs(getModItem(HardcoreEnderExpansion.ID, "endium_block", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(HardcoreEnderExpansion.ID, "dry_splinter", 9, 0, missing))
+                .itemOutputs(getModItem(HardcoreEnderExpansion.ID, "spooky_log", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makePamsHarvestCraftRecipes() {
+        if (!PamsHarvestCraft.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(PamsHarvestCraft.ID, "silkentofuItem", 1, 0, missing))
+                .itemOutputs(getModItem(PamsHarvestCraft.ID, "firmtofuItem", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(PamsHarvestCraft.ID, "beeswaxItem", 4, 0, missing))
+                .itemOutputs(getModItem(PamsHarvestCraft.ID, "waxItem", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Forestry.ID, "beeswax", 4, 0, missing))
+                .itemOutputs(getModItem(PamsHarvestCraft.ID, "waxItem", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -20,10 +20,15 @@ import static gregtech.api.enums.Mods.ProjectRedCore;
 import static gregtech.api.enums.Mods.Railcraft;
 import static gregtech.api.enums.Mods.StevesCarts2;
 import static gregtech.api.enums.Mods.Thaumcraft;
+import static gregtech.api.enums.Mods.ThaumicBases;
+import static gregtech.api.enums.Mods.ThaumicTinkerer;
 import static gregtech.api.enums.Mods.TinkerConstruct;
+import static gregtech.api.enums.Mods.TinkersDefence;
+import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.WILDCARD;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -52,9 +57,11 @@ public class CompressorRecipes implements Runnable {
         makeExtraUtilitiesRecipes();
         makeGTPlusPlusRecipes();
         makeHardcoreEnderExpansionRecipes();
+        makeNaturaRecipes();
         makePamsHarvestCraftRecipes();
         makeRailcraftRecipes();
         makeTinkerConstructRecipes();
+        makeTinkersDefenceRecipes();
         makeThaumcraftRecipes();
 
         // custom dust to plate compression
@@ -149,10 +156,20 @@ public class CompressorRecipes implements Runnable {
                 .itemOutputs(com.dreammaster.item.ItemList.BioCarbonPlate.getIS(1)).noFluidInputs().noFluidOutputs()
                 .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
-        if (Natura.isModLoaded()) {
-            GT_Values.RA.stdBuilder().itemInputs(getModItem(Natura.ID, "barleyFood", 8, 0))
-                    .itemOutputs(ItemList.IC2_Plantball.get(1)).noFluidInputs().noFluidOutputs().duration(15 * SECONDS)
-                    .eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "reeds", 8, 0, missing))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "sapling", 8, WILDCARD, missing))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(IndustrialCraft2.ID, "blockRubSapling", 8, 0, missing))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        if (TwilightForest.isModLoaded()) {
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(TwilightForest.ID, "tile.TFSapling", 8, WILDCARD, missing))
+                    .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         }
 
         if (StevesCarts2.isModLoaded()) {
@@ -195,6 +212,16 @@ public class CompressorRecipes implements Runnable {
                     .itemOutputs(getModItem(StevesCarts2.ID, "ModuleComponents", 1, 48, missing)).noFluidInputs()
                     .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         }
+        if (ThaumicTinkerer.isModLoaded()) {
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 4, 0, missing))
+                    .itemOutputs(getModItem(ThaumicTinkerer.ID, "darkQuartz", 1, 0, missing)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        }
+        if (Forestry.isModLoaded()) {
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(Forestry.ID, "sapling", 8, WILDCARD, missing))
+                    .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        }
     }
 
     private void makeAdvancedSolarPanelRecipes() {
@@ -210,6 +237,74 @@ public class CompressorRecipes implements Runnable {
         GT_Values.RA.stdBuilder().itemInputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 9L, 9))
                 .itemOutputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeAvaritiaRecipes() {
+        if (!Avaritia.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.crafting_table, 9))
+                .itemOutputs(getModItem(Avaritia.ID, "Double_Craft", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Avaritia.ID, "Double_Craft", 9, 0, missing))
+                .itemOutputs(getModItem(Avaritia.ID, "Triple_Craft", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Avaritia.ID, "Resource", 9, 1, missing))
+                .itemOutputs(getModItem(Avaritia.ID, "Crystal_Matrix", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeBiomesOPlentyRecipes() {
+        if (!BiomesOPlenty.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "packed_ice", 16, 0, missing))
+                .itemOutputs(getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "bones", 2, 0, missing))
+                .itemOutputs(getModItem(BiomesOPlenty.ID, "bones", 1, 1, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "bones", 2, 1, missing))
+                .itemOutputs(getModItem(BiomesOPlenty.ID, "bones", 1, 2, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "saplings", 8, WILDCARD, missing))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "colorizedSaplings", 8, WILDCARD, missing))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeBloodMagicRecipes() {
+        if (!BloodArsenal.isModLoaded() || !BloodMagic.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "blankSlate", 9, 0, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "reinforcedSlate", 9, 0, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "imbuedSlate", 9, 0, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "demonicSlate", 9, 0, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "bloodMagicBaseItems", 9, 27, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 0, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 1, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 1, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 2, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 2, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 3, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 
     private void makeExtraUtilitiesRecipes() {
@@ -236,6 +331,100 @@ public class CompressorRecipes implements Runnable {
         // Double Compressed Glowstone
         GT_Values.RA.stdBuilder().itemInputs(getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 9L, 6))
                 .itemOutputs(getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 7)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeHardcoreEnderExpansionRecipes() {
+        if (!HardcoreEnderExpansion.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.HeeEndium, 9L))
+                .itemOutputs(getModItem(HardcoreEnderExpansion.ID, "endium_block", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(HardcoreEnderExpansion.ID, "dry_splinter", 9, 0, missing))
+                .itemOutputs(getModItem(HardcoreEnderExpansion.ID, "spooky_log", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeNaturaRecipes() {
+        if (!Natura.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Natura.ID, "barleyFood", 8, 0))
+                .itemOutputs(ItemList.IC2_Plantball.get(1)).noFluidInputs().noFluidOutputs().duration(15 * SECONDS)
+                .eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Natura.ID, "florasapling", 8, WILDCARD, missing))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Natura.ID, "Rare Sapling", 8, WILDCARD, missing))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makePamsHarvestCraftRecipes() {
+        if (!PamsHarvestCraft.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(PamsHarvestCraft.ID, "silkentofuItem", 1, 0, missing))
+                .itemOutputs(getModItem(PamsHarvestCraft.ID, "firmtofuItem", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(PamsHarvestCraft.ID, "beeswaxItem", 4, 0, missing))
+                .itemOutputs(getModItem(PamsHarvestCraft.ID, "waxItem", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Forestry.ID, "beeswax", 4, 0, missing))
+                .itemOutputs(getModItem(PamsHarvestCraft.ID, "waxItem", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeRailcraftRecipes() {
+        if (!Railcraft.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "fuel.coke", 9, 0, missing))
+                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "slab", 2, 2, missing))
+                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 1, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "slab", 4, 38, missing))
+                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 8, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(CustomItemList.AdvancedCokeOvenBrick.get(4L))
+                .itemOutputs(getModItem(Railcraft.ID, "machine.alpha", 1, 12, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(CustomItemList.CokeOvenBrick.get(4L))
+                .itemOutputs(getModItem(Railcraft.ID, "machine.alpha", 1, 7, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeThaumcraftRecipes() {
+        if (!Thaumcraft.isModLoaded() || !ThaumicBases.isModLoaded()) {
+            return;
+        }
+        // Arcane Slabs -> Arcane Stone
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "blockCosmeticSlabStone", 4L))
+                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1L, 6)).noFluidInputs().noFluidOutputs()
+                .duration(8 * SECONDS).eut(4).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "ItemResource", 9, 4, missing))
+                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 5, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "rotten_flesh", 9, 0, missing))
+                .itemOutputs(getModItem(Thaumcraft.ID, "blockTaint", 1, 2, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(CustomItemList.ArcaneSlate.get(9L))
+                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "ItemResource", 9, 3, missing))
+                .itemOutputs(getModItem(ThaumicBases.ID, "quicksilverBlock", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "blockCustomPlant", 8, 0, missing))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "blockCustomPlant", 8, 1, missing))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 
@@ -273,132 +462,18 @@ public class CompressorRecipes implements Runnable {
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 
-    private void makeThaumcraftRecipes() {
-        if (!Thaumcraft.isModLoaded()) {
+    private void makeTinkersDefenceRecipes() {
+        if (!TinkersDefence.isModLoaded()) {
             return;
         }
-        // Arcane Slabs -> Arcane Stone
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "blockCosmeticSlabStone", 4L))
-                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1L, 6)).noFluidInputs().noFluidOutputs()
-                .duration(8 * SECONDS).eut(4).addTo(sCompressorRecipes);
-
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "ItemResource", 9, 4, missing))
-                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 5, missing)).noFluidInputs()
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "AeonSteelIngot", 9, 0, missing))
+                .itemOutputs(getModItem(TinkersDefence.ID, "AeonSteelBlock", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "rotten_flesh", 9, 0, missing))
-                .itemOutputs(getModItem(Thaumcraft.ID, "blockTaint", 1, 2, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(CustomItemList.ArcaneSlate.get(9L))
-                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing)).noFluidInputs()
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "QueensGoldIngot", 9, 0, missing))
+                .itemOutputs(getModItem(TinkersDefence.ID, "QueensGoldBlock", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-    }
-
-    private void makeBloodMagicRecipes() {
-        if (!BloodArsenal.isModLoaded() || !BloodMagic.isModLoaded()) {
-            return;
-        }
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "blankSlate", 9, 0, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "reinforcedSlate", 9, 0, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "imbuedSlate", 9, 0, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "demonicSlate", 9, 0, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "bloodMagicBaseItems", 9, 27, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 0, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 1, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 1, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 2, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 2, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 3, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-    }
-
-    private void makeRailcraftRecipes() {
-        if (!Railcraft.isModLoaded()) {
-            return;
-        }
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "fuel.coke", 9, 0, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "slab", 2, 2, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 1, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "slab", 4, 38, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 8, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(CustomItemList.AdvancedCokeOvenBrick.get(4L))
-                .itemOutputs(getModItem(Railcraft.ID, "machine.alpha", 1, 12, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(CustomItemList.CokeOvenBrick.get(4L))
-                .itemOutputs(getModItem(Railcraft.ID, "machine.alpha", 1, 7, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-    }
-
-    private void makeBiomesOPlentyRecipes() {
-        if (!BiomesOPlenty.isModLoaded()) {
-            return;
-        }
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "packed_ice", 16, 0, missing))
-                .itemOutputs(getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "bones", 2, 0, missing))
-                .itemOutputs(getModItem(BiomesOPlenty.ID, "bones", 1, 1, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "bones", 2, 1, missing))
-                .itemOutputs(getModItem(BiomesOPlenty.ID, "bones", 1, 2, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-    }
-
-    private void makeAvaritiaRecipes() {
-        if (!Avaritia.isModLoaded()) {
-            return;
-        }
-        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.crafting_table, 9))
-                .itemOutputs(getModItem(Avaritia.ID, "Double_Craft", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Avaritia.ID, "Double_Craft", 9, 0, missing))
-                .itemOutputs(getModItem(Avaritia.ID, "Triple_Craft", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Avaritia.ID, "Resource", 9, 1, missing))
-                .itemOutputs(getModItem(Avaritia.ID, "Crystal_Matrix", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-    }
-
-    private void makeHardcoreEnderExpansionRecipes() {
-        if (!HardcoreEnderExpansion.isModLoaded()) {
-            return;
-        }
-        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.HeeEndium, 9L))
-                .itemOutputs(getModItem(HardcoreEnderExpansion.ID, "endium_block", 1, 0, missing)).noFluidInputs()
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "DogbeariumIngot", 9, 0, missing))
+                .itemOutputs(getModItem(TinkersDefence.ID, "DogbeariumBlock", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(HardcoreEnderExpansion.ID, "dry_splinter", 9, 0, missing))
-                .itemOutputs(getModItem(HardcoreEnderExpansion.ID, "spooky_log", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-    }
-
-    private void makePamsHarvestCraftRecipes() {
-        if (!PamsHarvestCraft.isModLoaded()) {
-            return;
-        }
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(PamsHarvestCraft.ID, "silkentofuItem", 1, 0, missing))
-                .itemOutputs(getModItem(PamsHarvestCraft.ID, "firmtofuItem", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(PamsHarvestCraft.ID, "beeswaxItem", 4, 0, missing))
-                .itemOutputs(getModItem(PamsHarvestCraft.ID, "waxItem", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Forestry.ID, "beeswax", 4, 0, missing))
-                .itemOutputs(getModItem(PamsHarvestCraft.ID, "waxItem", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -3,12 +3,17 @@ package com.dreammaster.gthandler.recipes;
 import static gregtech.api.enums.Mods.AdvancedSolarPanel;
 import static gregtech.api.enums.Mods.ExtraTrees;
 import static gregtech.api.enums.Mods.GTPlusPlus;
+import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
+import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Natura;
+import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.enums.Mods.OpenComputers;
+import static gregtech.api.enums.Mods.Railcraft;
 import static gregtech.api.enums.Mods.StevesCarts2;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.TinkerConstruct;
+import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
@@ -21,23 +26,34 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
-import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 
 public class CompressorRecipes implements Runnable {
+
+    // todo: move over compression recipes from avaritia, bop, xutils, bm, etc. script files
+    ItemStack missing = new ItemStack(Blocks.fire);
 
     @Override
     public void run() {
         makeAdvancedSolarPanelRecipes();
         makeGTPlusPlusRecipes();
         makeTinkerConstructRecipes();
+        makeThaumcraftRecipes();
 
         // custom dust to plate compression
         Materials[] dustToPlateList = new Materials[] { Materials.CertusQuartz, Materials.NetherQuartz,
-                Materials.Quartzite, Materials.Lazurite, Materials.Sodalite };
+                Materials.Quartzite, Materials.Lazurite, Materials.Sodalite, Materials.CertusQuartzCharged };
         for (Materials material : dustToPlateList) {
             GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, material, 1L))
                     .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, material, 1L)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        }
+
+        // custom dust to ingot compression
+        Materials[] dustToIngotList = new Materials[] { Materials.Carbon, Materials.Ledox };
+        for (Materials material : dustToIngotList) {
+            GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, material, 1L))
+                    .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, material, 1L)).noFluidInputs()
                     .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         }
 
@@ -54,16 +70,82 @@ public class CompressorRecipes implements Runnable {
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.WroughtIron, 1L)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
-        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Carbon, 1L))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Carbon, 1L)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-
         GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 9))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, Materials.NetherStar, 1)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(TierEU.RECIPE_UV).addTo(sCompressorRecipes);
 
+        // todo: clean these up
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.metaitem.01", 9, 11388, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.BlackPlutonium", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.MytrylIngot", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.Mytryl", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.blockgem3", 9, 4, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCharcoal", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "coal_block", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoal", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "cube", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoalCoke", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCharcoal", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCharcoal", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoal", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoal", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoalCoke", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoalCoke", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCharcoal", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCharcoal", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoal", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoal", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoalCoke", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoalCoke", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCharcoal", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCharcoal", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoal", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoal", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoalCoke", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoalCoke", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCharcoal", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuintupleCompressedCharcoal", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoal", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuintupleCompressedCoal", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoalCoke", 9, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuintupleCompressedCoalCoke", 1, 0, missing))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.BioBall", 1, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.CompressedBioBall", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.BioOrganicMesh", 1, 0, missing))
+                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.BioCarbonPlate", 1, 0, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
         if (Natura.isModLoaded()) {
-            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(Natura.ID, "barleyFood", 8, 0))
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(Natura.ID, "barleyFood", 8, 0))
                     .itemOutputs(ItemList.IC2_Plantball.get(1)).noFluidInputs().noFluidOutputs().duration(15 * SECONDS)
                     .eut(2).addTo(sCompressorRecipes);
         }
@@ -71,32 +153,25 @@ public class CompressorRecipes implements Runnable {
         if (StevesCarts2.isModLoaded()) {
             GT_Values.RA.stdBuilder()
                     .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.EnhancedGalgadorian, 9L))
-                    .itemOutputs(GT_ModHandler.getModItem(StevesCarts2.ID, "ModuleComponents", 1L, 48)).noFluidInputs()
+                    .itemOutputs(getModItem(StevesCarts2.ID, "ModuleComponents", 1L, 48)).noFluidInputs()
                     .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        }
-
-        if (Thaumcraft.isModLoaded()) {
-            // Arcane Slabs -> Arcane Stone
-            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(Thaumcraft.ID, "blockCosmeticSlabStone", 4L))
-                    .itemOutputs(GT_ModHandler.getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1L, 6)).noFluidInputs()
-                    .noFluidOutputs().duration(8 * SECONDS).eut(4).addTo(sCompressorRecipes);
         }
 
         if (OpenComputers.isModLoaded()) {
             // Block of Chamelium
-            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(OpenComputers.ID, "item", 9L, 96))
-                    .itemOutputs(GT_ModHandler.getModItem(OpenComputers.ID, "chameliumBlock", 1L, 0)).noFluidInputs()
-                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(OpenComputers.ID, "item", 9L, 96))
+                    .itemOutputs(getModItem(OpenComputers.ID, "chameliumBlock", 1L, 0)).noFluidInputs().noFluidOutputs()
+                    .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         }
 
         if (IndustrialCraft2.isModLoaded()) {
-            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(IndustrialCraft2.ID, "itemWeed", 16L))
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(IndustrialCraft2.ID, "itemWeed", 16L))
                     .itemOutputs(ItemList.IC2_Plantball.get(1L)).noFluidInputs().noFluidOutputs().duration(15 * SECONDS)
                     .eut(2).addTo(sCompressorRecipes);
         }
 
         if (ExtraTrees.isModLoaded()) {
-            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(ExtraTrees.ID, "food", 64L, 24))
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(ExtraTrees.ID, "food", 64L, 24))
                     .itemOutputs(ItemList.IC2_Plantball.get(1L)).noFluidInputs().noFluidOutputs().duration(15 * SECONDS)
                     .eut(2).addTo(sCompressorRecipes);
         }
@@ -107,15 +182,14 @@ public class CompressorRecipes implements Runnable {
             return;
         }
         GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sunnarium, 1L))
-                .itemOutputs(GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+                .itemOutputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Sunnarium, 1L))
-                .itemOutputs(GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 9L, 9))
-                .itemOutputs(GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+                .itemOutputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 9L, 9))
+                .itemOutputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 
     private void makeGTPlusPlusRecipes() {
@@ -124,12 +198,12 @@ public class CompressorRecipes implements Runnable {
         }
         // Compressed Glowstone
         GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.glowstone, 9))
-                .itemOutputs(GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 6)).noFluidInputs()
+                .itemOutputs(getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 6)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
         // Double Compressed Glowstone
-        GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 9L, 6))
-                .itemOutputs(GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 7)).noFluidInputs()
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 9L, 6))
+                .itemOutputs(getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 7)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 
@@ -137,26 +211,50 @@ public class CompressorRecipes implements Runnable {
         if (!TinkerConstruct.isModLoaded()) {
             return;
         }
-        GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 9L, 14))
-                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "MetalBlock", 1L, 7)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 4L, 2))
-                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "Smeltery", 1L, 2)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkerConstruct.ID, "materials", 9L, 14))
+                .itemOutputs(getModItem(TinkerConstruct.ID, "MetalBlock", 1L, 7)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkerConstruct.ID, "materials", 4L, 2))
+                .itemOutputs(getModItem(TinkerConstruct.ID, "Smeltery", 1L, 2)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 1L))
-                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 12)).noFluidInputs()
-                .noFluidOutputs().duration(5 * SECONDS).eut(2).addTo(sCompressorRecipes);
+                .itemOutputs(getModItem(TinkerConstruct.ID, "materials", 1L, 12)).noFluidInputs().noFluidOutputs()
+                .duration(5 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
         // Slime crystals
-        GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 0))
-                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 1)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 2))
-                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 17)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 0))
+                .itemOutputs(getModItem(TinkerConstruct.ID, "materials", 1L, 1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 2))
+                .itemOutputs(getModItem(TinkerConstruct.ID, "materials", 1L, 17)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
         GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Items.paper, 64, 0))
-                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 0)).noFluidInputs()
+                .itemOutputs(getModItem(TinkerConstruct.ID, "materials", 1L, 0)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkerConstruct.ID, "strangeFood", 4, 0, missing))
+                .itemOutputs(getModItem(TinkerConstruct.ID, "slime.gel", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "slime_ball", 4, 0, missing))
+                .itemOutputs(getModItem(TinkerConstruct.ID, "slime.gel", 1, 1, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeThaumcraftRecipes() {
+        if (!Thaumcraft.isModLoaded()) {
+            return;
+        }
+        // Arcane Slabs -> Arcane Stone
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "blockCosmeticSlabStone", 4L))
+                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1L, 6)).noFluidInputs().noFluidOutputs()
+                .duration(8 * SECONDS).eut(4).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "ItemResource", 9, 4, missing))
+                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 5, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "rotten_flesh", 9, 0, missing))
+                .itemOutputs(getModItem(Thaumcraft.ID, "blockTaint", 1, 2, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -32,62 +32,31 @@ public class CompressorRecipes implements Runnable {
         makeGTPlusPlusRecipes();
         makeTinkerConstructRecipes();
 
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.WroughtIron, 9L),
-                GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.WroughtIron, 1L),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.CertusQuartz, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 1L),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherQuartz, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Quartzite, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Quartzite, 1L),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lazurite, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Lazurite, 1L),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sodalite, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Sodalite, 1L),
-                300,
-                2);
+        // custom dust to plate compression
+        Materials[] dustToPlateList = new Materials[] { Materials.CertusQuartz, Materials.NetherQuartz,
+                Materials.Quartzite, Materials.Lazurite, Materials.Sodalite };
+        for (Materials material : dustToPlateList) {
+            GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, material, 1L))
+                    .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.plate, material, 1L)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        }
 
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Carbon, 1L),
-                GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Carbon, 1L),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Cobalt, 9L),
-                GT_OreDictUnificator.get(OrePrefixes.block, Materials.Cobalt, 1L),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Ardite, 9L),
-                GT_OreDictUnificator.get(OrePrefixes.block, Materials.Ardite, 1L),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Manyullyn, 9L),
-                GT_OreDictUnificator.get(OrePrefixes.block, Materials.Manyullyn, 1L),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Alumite, 9L),
-                GT_OreDictUnificator.get(OrePrefixes.block, Materials.Alumite, 1L),
-                300,
-                2);
+        // custom ingot to block compression
+        Materials[] ingotToBlockList = new Materials[] { Materials.Cobalt, Materials.Ardite, Materials.Manyullyn,
+                Materials.Alumite };
+        for (Materials material : ingotToBlockList) {
+            GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.ingot, material, 9L))
+                    .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, material, 1L)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        }
+
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.WroughtIron, 9L))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.WroughtIron, 1L)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Carbon, 1L))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Carbon, 1L)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
         GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 9))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, Materials.NetherStar, 1)).noFluidInputs()

--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -1,6 +1,8 @@
 package com.dreammaster.gthandler.recipes;
 
 import static gregtech.api.enums.Mods.AdvancedSolarPanel;
+import static gregtech.api.enums.Mods.BloodArsenal;
+import static gregtech.api.enums.Mods.BloodMagic;
 import static gregtech.api.enums.Mods.ExtraTrees;
 import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.GTPlusPlus;
@@ -37,6 +39,7 @@ public class CompressorRecipes implements Runnable {
     @Override
     public void run() {
         makeAdvancedSolarPanelRecipes();
+        makeBloodMagicRecipes();
         makeExtraUtilitiesRecipes();
         makeGTPlusPlusRecipes();
         makeTinkerConstructRecipes();
@@ -257,6 +260,40 @@ public class CompressorRecipes implements Runnable {
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "rotten_flesh", 9, 0, missing))
                 .itemOutputs(getModItem(Thaumcraft.ID, "blockTaint", 1, 2, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(CustomItemList.ArcaneSlate.get(9L))
+                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeBloodMagicRecipes() {
+        if (!BloodArsenal.isModLoaded() || !BloodMagic.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "blankSlate", 9, 0, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "reinforcedSlate", 9, 0, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "imbuedSlate", 9, 0, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "demonicSlate", 9, 0, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "bloodMagicBaseItems", 9, 27, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 0, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 1, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 1, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 2, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 2, missing))
+                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 3, missing)).noFluidInputs().noFluidOutputs()
                 .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -1,11 +1,13 @@
 package com.dreammaster.gthandler.recipes;
 
 import static gregtech.api.enums.Mods.AdvancedSolarPanel;
+import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.BloodArsenal;
 import static gregtech.api.enums.Mods.BloodMagic;
 import static gregtech.api.enums.Mods.ExtraTrees;
 import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.GTPlusPlus;
+import static gregtech.api.enums.Mods.GalacticraftCore;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Natura;
@@ -39,9 +41,11 @@ public class CompressorRecipes implements Runnable {
     @Override
     public void run() {
         makeAdvancedSolarPanelRecipes();
+        makeBiomesOPlentyRecipes();
         makeBloodMagicRecipes();
         makeExtraUtilitiesRecipes();
         makeGTPlusPlusRecipes();
+        makeRailcraftRecipes();
         makeTinkerConstructRecipes();
         makeThaumcraftRecipes();
 
@@ -167,6 +171,11 @@ public class CompressorRecipes implements Runnable {
             GT_Values.RA.stdBuilder().itemInputs(getModItem(ExtraTrees.ID, "food", 64L, 24))
                     .itemOutputs(ItemList.IC2_Plantball.get(1L)).noFluidInputs().noFluidOutputs().duration(15 * SECONDS)
                     .eut(2).addTo(sCompressorRecipes);
+        }
+        if (GalacticraftCore.isModLoaded()) {
+            GT_Values.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "item.cheeseCurd", 9, 0, missing))
+                    .itemOutputs(getModItem(GalacticraftCore.ID, "tile.moonBlock", 1, 2, missing)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         }
     }
 
@@ -294,6 +303,42 @@ public class CompressorRecipes implements Runnable {
                 .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 2, missing))
                 .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 3, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeRailcraftRecipes() {
+        if (!Railcraft.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "fuel.coke", 9, 0, missing))
+                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "slab", 2, 2, missing))
+                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 1, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "slab", 4, 38, missing))
+                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 8, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(CustomItemList.AdvancedCokeOvenBrick.get(4L))
+                .itemOutputs(getModItem(Railcraft.ID, "machine.alpha", 1, 12, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(CustomItemList.CokeOvenBrick.get(4L))
+                .itemOutputs(getModItem(Railcraft.ID, "machine.alpha", 1, 7, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeBiomesOPlentyRecipes() {
+        if (!BiomesOPlenty.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "packed_ice", 16, 0, missing))
+                .itemOutputs(getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "bones", 2, 0, missing))
+                .itemOutputs(getModItem(BiomesOPlenty.ID, "bones", 1, 1, missing)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "bones", 2, 1, missing))
+                .itemOutputs(getModItem(BiomesOPlenty.ID, "bones", 1, 2, missing)).noFluidInputs().noFluidOutputs()
                 .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -63,51 +63,42 @@ public class CompressorRecipes implements Runnable {
                 .noFluidOutputs().duration(15 * SECONDS).eut(TierEU.RECIPE_UV).addTo(sCompressorRecipes);
 
         if (Natura.isModLoaded()) {
-            GT_ModHandler.addCompressionRecipe(
-                    GT_ModHandler.getModItem(Natura.ID, "barleyFood", 8, 0),
-                    ItemList.IC2_Plantball.get(1));
+            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(Natura.ID, "barleyFood", 8, 0))
+                    .itemOutputs(ItemList.IC2_Plantball.get(1)).noFluidInputs().noFluidOutputs().duration(15 * SECONDS)
+                    .eut(2).addTo(sCompressorRecipes);
         }
 
         if (StevesCarts2.isModLoaded()) {
-            GT_Values.RA.addCompressorRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.EnhancedGalgadorian, 9L),
-                    GT_ModHandler.getModItem(StevesCarts2.ID, "ModuleComponents", 1L, 48),
-                    300,
-                    2);
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.EnhancedGalgadorian, 9L))
+                    .itemOutputs(GT_ModHandler.getModItem(StevesCarts2.ID, "ModuleComponents", 1L, 48)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         }
 
         if (Thaumcraft.isModLoaded()) {
             // Arcane Slabs -> Arcane Stone
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(Thaumcraft.ID, "blockCosmeticSlabStone", 4L),
-                    GT_ModHandler.getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1L, 6),
-                    160,
-                    4);
+            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(Thaumcraft.ID, "blockCosmeticSlabStone", 4L))
+                    .itemOutputs(GT_ModHandler.getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1L, 6)).noFluidInputs()
+                    .noFluidOutputs().duration(8 * SECONDS).eut(4).addTo(sCompressorRecipes);
         }
 
         if (OpenComputers.isModLoaded()) {
             // Block of Chamelium
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(OpenComputers.ID, "item", 9L, 96),
-                    GT_ModHandler.getModItem(OpenComputers.ID, "chameliumBlock", 1L, 0),
-                    300,
-                    2);
+            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(OpenComputers.ID, "item", 9L, 96))
+                    .itemOutputs(GT_ModHandler.getModItem(OpenComputers.ID, "chameliumBlock", 1L, 0)).noFluidInputs()
+                    .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         }
 
         if (IndustrialCraft2.isModLoaded()) {
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(IndustrialCraft2.ID, "itemWeed", 16L),
-                    ItemList.IC2_Plantball.get(1L),
-                    300,
-                    2);
+            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(IndustrialCraft2.ID, "itemWeed", 16L))
+                    .itemOutputs(ItemList.IC2_Plantball.get(1L)).noFluidInputs().noFluidOutputs().duration(15 * SECONDS)
+                    .eut(2).addTo(sCompressorRecipes);
         }
 
         if (ExtraTrees.isModLoaded()) {
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(ExtraTrees.ID, "food", 64L, 24),
-                    ItemList.IC2_Plantball.get(1L),
-                    300,
-                    2);
+            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(ExtraTrees.ID, "food", 64L, 24))
+                    .itemOutputs(ItemList.IC2_Plantball.get(1L)).noFluidInputs().noFluidOutputs().duration(15 * SECONDS)
+                    .eut(2).addTo(sCompressorRecipes);
         }
     }
 
@@ -115,21 +106,16 @@ public class CompressorRecipes implements Runnable {
         if (!AdvancedSolarPanel.isModLoaded()) {
             return;
         }
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sunnarium, 1L),
-                GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Sunnarium, 1L),
-                GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 9L, 9),
-                GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0),
-                300,
-                2);
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sunnarium, 1L))
+                .itemOutputs(GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Sunnarium, 1L))
+                .itemOutputs(GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 9L, 9))
+                .itemOutputs(GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0))
+                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 
     private void makeGTPlusPlusRecipes() {
@@ -137,56 +123,40 @@ public class CompressorRecipes implements Runnable {
             return;
         }
         // Compressed Glowstone
-        GT_Values.RA.addCompressorRecipe(
-                new ItemStack(Blocks.glowstone, 9),
-                GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 6),
-                300,
-                2);
+        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.glowstone, 9))
+                .itemOutputs(GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 6)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
         // Double Compressed Glowstone
-        GT_Values.RA.addCompressorRecipe(
-                GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 9L, 6),
-                GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 7),
-                300,
-                2);
+        GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 9L, 6))
+                .itemOutputs(GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 7)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 
     private void makeTinkerConstructRecipes() {
         if (!TinkerConstruct.isModLoaded()) {
             return;
         }
-        GT_Values.RA.addCompressorRecipe(
-                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 9L, 14),
-                GT_ModHandler.getModItem(TinkerConstruct.ID, "MetalBlock", 1L, 7),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 4L, 2),
-                GT_ModHandler.getModItem(TinkerConstruct.ID, "Smeltery", 1L, 2),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 1L),
-                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 12),
-                100,
-                2);
+        GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 9L, 14))
+                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "MetalBlock", 1L, 7)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 4L, 2))
+                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "Smeltery", 1L, 2)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 1L))
+                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 12)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
         // Slime crystals
-        GT_Values.RA.addCompressorRecipe(
-                GT_ModHandler.getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 0),
-                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 1),
-                300,
-                2);
-        GT_Values.RA.addCompressorRecipe(
-                GT_ModHandler.getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 2),
-                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 17),
-                300,
-                2);
+        GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 0))
+                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 1)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 2))
+                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 17)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
-        GT_Values.RA.addCompressorRecipe(
-                new ItemStack(Items.paper, 64, 0),
-                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 0),
-                300,
-                2);
+        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Items.paper, 64, 0))
+                .itemOutputs(GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 0)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -2,12 +2,11 @@ package com.dreammaster.gthandler.recipes;
 
 import static gregtech.api.enums.Mods.AdvancedSolarPanel;
 import static gregtech.api.enums.Mods.ExtraTrees;
+import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.GTPlusPlus;
-import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Natura;
-import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.Railcraft;
 import static gregtech.api.enums.Mods.StevesCarts2;
@@ -21,6 +20,9 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import com.dreammaster.block.BlockList;
+import com.dreammaster.gthandler.CustomItemList;
+
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -30,12 +32,12 @@ import gregtech.api.util.GT_OreDictUnificator;
 
 public class CompressorRecipes implements Runnable {
 
-    // todo: move over compression recipes from avaritia, bop, xutils, bm, etc. script files
     ItemStack missing = new ItemStack(Blocks.fire);
 
     @Override
     public void run() {
         makeAdvancedSolarPanelRecipes();
+        makeExtraUtilitiesRecipes();
         makeGTPlusPlusRecipes();
         makeTinkerConstructRecipes();
         makeThaumcraftRecipes();
@@ -74,75 +76,63 @@ public class CompressorRecipes implements Runnable {
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, Materials.NetherStar, 1)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(TierEU.RECIPE_UV).addTo(sCompressorRecipes);
 
-        // todo: clean these up
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.metaitem.01", 9, 11388, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.BlackPlutonium", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.MytrylIngot", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.Mytryl", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.blockgem3", 9, 4, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCharcoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "coal_block", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoal", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        // compressed coal variants
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.block, Materials.Charcoal, 9))
+                .itemOutputs(BlockList.CompressedCharcoal.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.block, Materials.Coal, 9))
+                .itemOutputs(BlockList.CompressedCoal.getIS(1)).noFluidInputs().noFluidOutputs().duration(15 * SECONDS)
+                .eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "cube", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoalCoke", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCharcoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCharcoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoalCoke", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoalCoke", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCharcoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCharcoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoalCoke", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoalCoke", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCharcoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCharcoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoalCoke", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoalCoke", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCharcoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuintupleCompressedCharcoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuintupleCompressedCoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoalCoke", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuintupleCompressedCoalCoke", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.BioBall", 1, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.CompressedBioBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.BioOrganicMesh", 1, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.BioCarbonPlate", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+                .itemOutputs(BlockList.CompressedCoalCoke.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.CompressedCharcoal.getIS(9))
+                .itemOutputs(BlockList.DoubleCompressedCharcoal.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.CompressedCoal.getIS(9))
+                .itemOutputs(BlockList.DoubleCompressedCoal.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.CompressedCoalCoke.getIS(9))
+                .itemOutputs(BlockList.DoubleCompressedCoalCoke.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.DoubleCompressedCharcoal.getIS(9))
+                .itemOutputs(BlockList.TripleCompressedCharcoal.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.DoubleCompressedCoal.getIS(9))
+                .itemOutputs(BlockList.TripleCompressedCoal.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.DoubleCompressedCoalCoke.getIS(9))
+                .itemOutputs(BlockList.TripleCompressedCoalCoke.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.TripleCompressedCharcoal.getIS(9))
+                .itemOutputs(BlockList.QuadrupleCompressedCharcoal.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.TripleCompressedCoal.getIS(9))
+                .itemOutputs(BlockList.QuadrupleCompressedCoal.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.TripleCompressedCoalCoke.getIS(9))
+                .itemOutputs(BlockList.QuadrupleCompressedCoalCoke.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.QuadrupleCompressedCharcoal.getIS(9))
+                .itemOutputs(BlockList.QuintupleCompressedCharcoal.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.QuadrupleCompressedCoal.getIS(9))
+                .itemOutputs(BlockList.QuintupleCompressedCoal.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(BlockList.QuadrupleCompressedCoalCoke.getIS(9))
+                .itemOutputs(BlockList.QuintupleCompressedCoalCoke.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+
+        GT_Values.RA.stdBuilder().itemInputs(CustomItemList.BioBall.get(1L))
+                .itemOutputs(com.dreammaster.item.ItemList.CompressedBioBall.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(com.dreammaster.item.ItemList.BioOrganicMesh.getIS(1))
+                .itemOutputs(com.dreammaster.item.ItemList.BioCarbonPlate.getIS(1)).noFluidInputs().noFluidOutputs()
+                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
         if (Natura.isModLoaded()) {
             GT_Values.RA.stdBuilder().itemInputs(getModItem(Natura.ID, "barleyFood", 8, 0))
@@ -189,6 +179,18 @@ public class CompressorRecipes implements Runnable {
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 9L, 9))
                 .itemOutputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+    }
+
+    private void makeExtraUtilitiesRecipes() {
+        if (!ExtraUtilities.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(ExtraUtilities.ID, "unstableingot", 9, 2, missing))
+                .itemOutputs(getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 5, missing)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(ExtraUtilities.ID, "unstableingot", 9, 0, missing))
+                .itemOutputs(getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 5, missing)).noFluidInputs()
                 .noFluidOutputs().duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
     }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -28,55 +28,10 @@ public class CompressorRecipes implements Runnable {
 
     @Override
     public void run() {
-        if (GTPlusPlus.isModLoaded()) {
-            // Compressed Glowstone
-            GT_Values.RA.addCompressorRecipe(
-                    new ItemStack(Blocks.glowstone, 9),
-                    GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 6),
-                    300,
-                    2);
+        makeAdvancedSolarPanelRecipes();
+        makeGTPlusPlusRecipes();
+        makeTinkerConstructRecipes();
 
-            // Double Compressed Glowstone
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 9L, 6),
-                    GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 7),
-                    300,
-                    2);
-        }
-
-        if (IndustrialCraft2.isModLoaded()) {
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(IndustrialCraft2.ID, "itemWeed", 16L),
-                    ItemList.IC2_Plantball.get(1L),
-                    300,
-                    2);
-        }
-
-        if (ExtraTrees.isModLoaded()) {
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(ExtraTrees.ID, "food", 64L, 24),
-                    ItemList.IC2_Plantball.get(1L),
-                    300,
-                    2);
-        }
-
-        if (AdvancedSolarPanel.isModLoaded()) {
-            GT_Values.RA.addCompressorRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sunnarium, 1L),
-                    GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0),
-                    300,
-                    2);
-            GT_Values.RA.addCompressorRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Sunnarium, 1L),
-                    GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9),
-                    300,
-                    2);
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 9L, 9),
-                    GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0),
-                    300,
-                    2);
-        }
         GT_Values.RA.addCompressorRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.WroughtIron, 9L),
                 GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.WroughtIron, 1L),
@@ -107,13 +62,6 @@ public class CompressorRecipes implements Runnable {
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Sodalite, 1L),
                 300,
                 2);
-        if (StevesCarts2.isModLoaded()) {
-            GT_Values.RA.addCompressorRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.EnhancedGalgadorian, 9L),
-                    GT_ModHandler.getModItem(StevesCarts2.ID, "ModuleComponents", 1L, 48),
-                    300,
-                    2);
-        }
 
         GT_Values.RA.addCompressorRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Carbon, 1L),
@@ -141,10 +89,22 @@ public class CompressorRecipes implements Runnable {
                 300,
                 2);
 
+        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 9))
+                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, Materials.NetherStar, 1)).noFluidInputs()
+                .noFluidOutputs().duration(15 * SECONDS).eut(TierEU.RECIPE_UV).addTo(sCompressorRecipes);
+
         if (Natura.isModLoaded()) {
             GT_ModHandler.addCompressionRecipe(
                     GT_ModHandler.getModItem(Natura.ID, "barleyFood", 8, 0),
                     ItemList.IC2_Plantball.get(1));
+        }
+
+        if (StevesCarts2.isModLoaded()) {
+            GT_Values.RA.addCompressorRecipe(
+                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.EnhancedGalgadorian, 9L),
+                    GT_ModHandler.getModItem(StevesCarts2.ID, "ModuleComponents", 1L, 48),
+                    300,
+                    2);
         }
 
         if (Thaumcraft.isModLoaded()) {
@@ -165,44 +125,99 @@ public class CompressorRecipes implements Runnable {
                     2);
         }
 
-        if (TinkerConstruct.isModLoaded()) {
+        if (IndustrialCraft2.isModLoaded()) {
             GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 9L, 14),
-                    GT_ModHandler.getModItem(TinkerConstruct.ID, "MetalBlock", 1L, 7),
-                    300,
-                    2);
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 4L, 2),
-                    GT_ModHandler.getModItem(TinkerConstruct.ID, "Smeltery", 1L, 2),
-                    300,
-                    2);
-            GT_Values.RA.addCompressorRecipe(
-                    GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 1L),
-                    GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 12),
-                    100,
-                    2);
-
-            // Slime crystals
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 0),
-                    GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 1),
-                    300,
-                    2);
-            GT_Values.RA.addCompressorRecipe(
-                    GT_ModHandler.getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 2),
-                    GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 17),
-                    300,
-                    2);
-
-            GT_Values.RA.addCompressorRecipe(
-                    new ItemStack(Items.paper, 64, 0),
-                    GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 0),
+                    GT_ModHandler.getModItem(IndustrialCraft2.ID, "itemWeed", 16L),
+                    ItemList.IC2_Plantball.get(1L),
                     300,
                     2);
         }
 
-        GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 9))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.block, Materials.NetherStar, 1)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(TierEU.RECIPE_UV).addTo(sCompressorRecipes);
+        if (ExtraTrees.isModLoaded()) {
+            GT_Values.RA.addCompressorRecipe(
+                    GT_ModHandler.getModItem(ExtraTrees.ID, "food", 64L, 24),
+                    ItemList.IC2_Plantball.get(1L),
+                    300,
+                    2);
+        }
+    }
+
+    private void makeAdvancedSolarPanelRecipes() {
+        if (!AdvancedSolarPanel.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.addCompressorRecipe(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Sunnarium, 1L),
+                GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0),
+                300,
+                2);
+        GT_Values.RA.addCompressorRecipe(
+                GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Sunnarium, 1L),
+                GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 9),
+                300,
+                2);
+        GT_Values.RA.addCompressorRecipe(
+                GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 9L, 9),
+                GT_ModHandler.getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1L, 0),
+                300,
+                2);
+    }
+
+    private void makeGTPlusPlusRecipes() {
+        if (!GTPlusPlus.isModLoaded()) {
+            return;
+        }
+        // Compressed Glowstone
+        GT_Values.RA.addCompressorRecipe(
+                new ItemStack(Blocks.glowstone, 9),
+                GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 6),
+                300,
+                2);
+
+        // Double Compressed Glowstone
+        GT_Values.RA.addCompressorRecipe(
+                GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 9L, 6),
+                GT_ModHandler.getModItem(GTPlusPlus.ID, "blockCompressedObsidian", 1L, 7),
+                300,
+                2);
+    }
+
+    private void makeTinkerConstructRecipes() {
+        if (!TinkerConstruct.isModLoaded()) {
+            return;
+        }
+        GT_Values.RA.addCompressorRecipe(
+                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 9L, 14),
+                GT_ModHandler.getModItem(TinkerConstruct.ID, "MetalBlock", 1L, 7),
+                300,
+                2);
+        GT_Values.RA.addCompressorRecipe(
+                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 4L, 2),
+                GT_ModHandler.getModItem(TinkerConstruct.ID, "Smeltery", 1L, 2),
+                300,
+                2);
+        GT_Values.RA.addCompressorRecipe(
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 1L),
+                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 12),
+                100,
+                2);
+
+        // Slime crystals
+        GT_Values.RA.addCompressorRecipe(
+                GT_ModHandler.getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 0),
+                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 1),
+                300,
+                2);
+        GT_Values.RA.addCompressorRecipe(
+                GT_ModHandler.getModItem(TinkerConstruct.ID, "CraftedSoil", 4L, 2),
+                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 17),
+                300,
+                2);
+
+        GT_Values.RA.addCompressorRecipe(
+                new ItemStack(Items.paper, 64, 0),
+                GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 0),
+                300,
+                2);
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptAvaritia.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAvaritia.java
@@ -26,7 +26,6 @@ import static gregtech.api.enums.Mods.UniversalSingularities;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtractorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtruderRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
@@ -858,15 +857,6 @@ public class ScriptAvaritia implements IScriptLoader {
                         getModItem(Minecraft.ID, "nether_star", 2, 0, missing))
                 .itemOutputs(getModItem(Avaritia.ID, "Resource", 1, 1, missing)).noFluidInputs().noFluidOutputs()
                 .duration(1200).eut(480).addTo(sAssemblerRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Blocks.crafting_table, 9))
-                .itemOutputs(getModItem(Avaritia.ID, "Double_Craft", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Avaritia.ID, "Double_Craft", 9, 0, missing))
-                .itemOutputs(getModItem(Avaritia.ID, "Triple_Craft", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Avaritia.ID, "Resource", 9, 1, missing))
-                .itemOutputs(getModItem(Avaritia.ID, "Crystal_Matrix", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Avaritia.ID, "Double_Craft", 1, 0))
                 .itemOutputs(new ItemStack(Blocks.crafting_table, 9)).noFluidInputs().noFluidOutputs().duration(300)
                 .eut(2).addTo(sExtractorRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptBiomesOPlenty.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiomesOPlenty.java
@@ -12,7 +12,6 @@ import static gregtech.api.enums.Mods.PamsHarvestCraft;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtractorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidCannerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidExtractionRecipes;
@@ -163,15 +162,6 @@ public class ScriptBiomesOPlenty implements IScriptLoader {
                 getModItem(BiomesOPlenty.ID, "driedDirt", 1, 0, missing),
                 getModItem(Minecraft.ID, "dirt", 1, 0, missing));
         Module_CustomFuels.registerCustomFuelValue(getModItem(BiomesOPlenty.ID, "bamboo", 1, 0, missing), (short) 100);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "packed_ice", 16, 0, missing))
-                .itemOutputs(getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "bones", 2, 0, missing))
-                .itemOutputs(getModItem(BiomesOPlenty.ID, "bones", 1, 1, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "bones", 2, 1, missing))
-                .itemOutputs(getModItem(BiomesOPlenty.ID, "bones", 1, 2, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Forestry.ID, "beeswax", 2, 0, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptBloodArsenal.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBloodArsenal.java
@@ -11,7 +11,6 @@ import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLatheRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
@@ -686,15 +685,6 @@ public class ScriptBloodArsenal implements IScriptLoader {
         TConstructHelper.removeTableRecipe(getModItem(TinkerConstruct.ID, "scytheBlade", 1, 251, missing));
         TConstructHelper.removeTableRecipe(getModItem(TinkerConstruct.ID, "binding", 1, 251, missing));
         TConstructHelper.removeTableRecipe(getModItem(TinkerConstruct.ID, "toolRod", 1, 251, missing));
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 0, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 1, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 1, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 2, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 4, 2, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_money", 1, 3, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
 
         GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodArsenal.ID, "blood_money", 1, 1, missing))
                 .itemOutputs(

--- a/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
@@ -31,7 +31,6 @@ import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
 
 import java.util.Arrays;
@@ -297,24 +296,6 @@ public class ScriptBloodMagic implements IScriptLoader {
         orbRecipes();
         altarAlchemyRecipes();
 
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.ArcaneSlate", 9, 0, missing))
-                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "blankSlate", 9, 0, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "reinforcedSlate", 9, 0, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "imbuedSlate", 9, 0, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "demonicSlate", 9, 0, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BloodMagic.ID, "bloodMagicBaseItems", 9, 27, missing))
-                .itemOutputs(getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(BloodMagic.ID, "blankSlate", 4, 0, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptCoreMod.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptCoreMod.java
@@ -26,7 +26,6 @@ import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAutoclaveRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBrewingRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sDistilleryRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtractorRecipes;
@@ -965,81 +964,7 @@ public class ScriptCoreMod implements IScriptLoader {
                 7,
                 500,
                 FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.LedoxDust", 1, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.LedoxIngot", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.metaitem.01", 9, 11388, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.BlackPlutonium", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.MytrylIngot", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.Mytryl", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.blockgem3", 9, 4, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCharcoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "coal_block", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoal", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "cube", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoalCoke", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCharcoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCharcoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.CompressedCoalCoke", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoalCoke", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCharcoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCharcoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.DoubleCompressedCoalCoke", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoalCoke", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCharcoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCharcoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.TripleCompressedCoalCoke", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoalCoke", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCharcoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuintupleCompressedCharcoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoal", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuintupleCompressedCoal", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuadrupleCompressedCoalCoke", 9, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "tile.QuintupleCompressedCoalCoke", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzDust", 1, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.ChargedCertusQuartzPlate", 1, 0, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.BioBall", 1, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.CompressedBioBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.BioOrganicMesh", 1, 0, missing))
-                .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.BioCarbonPlate", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
+
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "machine.alpha", 1, 7, missing))
                 .itemOutputs(getModItem(NewHorizonsCoreMod.ID, "item.CokeOvenBrick", 4, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(300).eut(2).addTo(sExtractorRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
@@ -24,7 +24,6 @@ import static gregtech.api.enums.Mods.WirelessRedstoneCBELogic;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtractorRecipes;
 
 import java.util.Arrays;
@@ -1032,12 +1031,7 @@ public class ScriptExtraUtilities implements IScriptLoader {
                         getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 1, missing),
                         'h',
                         getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 1, missing)));
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(ExtraUtilities.ID, "unstableingot", 9, 2, missing))
-                .itemOutputs(getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 5, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(ExtraUtilities.ID, "unstableingot", 9, 0, missing))
-                .itemOutputs(getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 5, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
+
         GT_Values.RA.stdBuilder().itemInputs(getModItem(ExtraUtilities.ID, "cobblestone_compressed", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "cobblestone", 9, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(300).eut(2).addTo(sExtractorRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -20,7 +20,6 @@ import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sArcFurnaceRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBlastRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCannerRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtruderRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidCannerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
@@ -1249,12 +1248,6 @@ public class ScriptGalacticraft implements IScriptLoader {
                 getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 0, missing),
                 16,
                 0);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.metaitem.01", 9, 11340, missing))
-                .itemOutputs(getModItem(GalacticraftCore.ID, "tile.gcBlockCore", 1, 12, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "item.cheeseCurd", 9, 0, missing))
-                .itemOutputs(getModItem(GalacticraftCore.ID, "tile.moonBlock", 1, 2, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
 
         arcFurnaceRecipes();
         assemblerRecipes();

--- a/src/main/java/com/dreammaster/scripts/ScriptHardcoreEnderExpansion.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptHardcoreEnderExpansion.java
@@ -11,7 +11,6 @@ import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtractorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sHammerRecipes;
@@ -442,12 +441,6 @@ public class ScriptHardcoreEnderExpansion implements IScriptLoader {
         GT_ModHandler.addSmeltingRecipe(
                 getModItem(HardcoreEnderExpansion.ID, "sphalerite", 1, 0, missing),
                 getModItem(GregTech.ID, "gt.metaitem.01", 1, 11036, missing));
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(HardcoreEnderExpansion.ID, "endium_ingot", 9, 0, missing))
-                .itemOutputs(getModItem(HardcoreEnderExpansion.ID, "endium_block", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(HardcoreEnderExpansion.ID, "dry_splinter", 9, 0, missing))
-                .itemOutputs(getModItem(HardcoreEnderExpansion.ID, "spooky_log", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(HardcoreEnderExpansion.ID, "death_flower", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "dye", 4, 13, missing)).noFluidInputs().noFluidOutputs()
                 .duration(300).eut(2).addTo(sExtractorRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptHarvestcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptHarvestcraft.java
@@ -13,7 +13,6 @@ import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.enums.Mods.PamsHarvestCraft;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtractorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMixerRecipes;
@@ -730,15 +729,6 @@ public class ScriptHarvestcraft implements IScriptLoader {
                 getModItem(PamsHarvestCraft.ID, "chocolatebarItem", 1, 0, missing),
                 getModItem(BiomesOPlenty.ID, "food", 1, 9, missing));
 
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(PamsHarvestCraft.ID, "silkentofuItem", 1, 0, missing))
-                .itemOutputs(getModItem(PamsHarvestCraft.ID, "firmtofuItem", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(PamsHarvestCraft.ID, "beeswaxItem", 4, 0, missing))
-                .itemOutputs(getModItem(PamsHarvestCraft.ID, "waxItem", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Forestry.ID, "beeswax", 4, 0, missing))
-                .itemOutputs(getModItem(PamsHarvestCraft.ID, "waxItem", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(PamsHarvestCraft.ID, "soybeanItem", 1, 0, missing))
                 .itemOutputs(getModItem(PamsHarvestCraft.ID, "soymilkItem", 1, 0, missing)).noFluidInputs()
                 .noFluidOutputs().duration(300).eut(2).addTo(sExtractorRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
@@ -18,7 +18,6 @@ import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBlastRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtruderRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidCannerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes;
@@ -1328,43 +1327,6 @@ public class ScriptIndustrialCraft implements IScriptLoader {
                 getModItem(GregTech.ID, "gt.blockcasings2", 1, 3, missing),
                 'h',
                 getModItem(GregTech.ID, "gt.metaitem.01", 1, 32602, missing));
-
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(IndustrialCraft2.ID, "itemUran238", 9, 0, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "blockMetal", 1, 3, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "reeds", 8, 0, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "sapling", 8, wildcard, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "saplings", 8, wildcard, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "colorizedSaplings", 8, wildcard, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(IndustrialCraft2.ID, "blockRubSapling", 8, 0, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Forestry.ID, "sapling", 8, wildcard, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Natura.ID, "florasapling", 8, wildcard, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Natura.ID, "Rare Sapling", 8, wildcard, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "blockCustomPlant", 8, 0, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "blockCustomPlant", 8, 1, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(TwilightForest.ID, "tile.TFSapling", 8, wildcard, missing))
-                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
 
         GT_Values.RA.stdBuilder()
                 .itemInputs(

--- a/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
@@ -34,7 +34,6 @@ import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBoxinatorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCannerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCircuitAssemblerRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMixerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sPressRecipes;
@@ -130,12 +129,6 @@ public class ScriptProjectRed implements IScriptLoader {
                 FluidRegistry.getFluidStack("redmetal.molten", 144),
                 FluidRegistry.getFluidStack("redstone.molten", 576),
                 FluidRegistry.getFluidStack("copper.molten", 144));
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(GregTech.ID, "gt.metaitem.01", 9, 2812, missing))
-                .itemOutputs(getModItem(ProjectRedExploration.ID, "projectred.exploration.stone", 1, 11, missing))
-                .noFluidInputs().noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 57, missing))
-                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 55, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
         ChiselHelper.addVariationFromStack("ruby", getModItem(BiomesOPlenty.ID, "gemOre", 1, 3, missing));
         ChiselHelper.addVariationFromStack("ruby", getModItem(GregTech.ID, "gt.blockgem2", 1, 11, missing));
         ChiselHelper.addVariationFromStack(

--- a/src/main/java/com/dreammaster/scripts/ScriptRailcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptRailcraft.java
@@ -19,8 +19,6 @@ import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sHammerRecipes;
@@ -1639,23 +1637,6 @@ public class ScriptRailcraft implements IScriptLoader {
                 'i',
                 getModItem(Forestry.ID, "craftingMaterial", 1, 3, missing));
         GT_Values.RA.addFuel(Materials.Creosote.getCells(1), null, 8, 0);
-
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "fuel.coke", 9, 0, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "slab", 2, 2, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 1, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "slab", 4, 38, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 8, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.AdvancedCokeOvenBrick", 4, 0, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "machine.alpha", 1, 12, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.CokeOvenBrick", 4, 0, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "machine.alpha", 1, 7, missing)).noFluidInputs().noFluidOutputs()
-                .duration(15 * SECONDS).eut(2).addTo(sCompressorRecipes);
 
         RailcraftHelper.removeRollingRecipe(getModItem(Railcraft.ID, "part.plate", 4, 0, missing));
         RailcraftHelper.removeRollingRecipe(getModItem(Railcraft.ID, "part.plate", 4, 1, missing));

--- a/src/main/java/com/dreammaster/scripts/ScriptRailcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptRailcraft.java
@@ -20,7 +20,6 @@ import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCentrifugeRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sFluidSolidficationRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sHammerRecipes;
@@ -1636,22 +1635,6 @@ public class ScriptRailcraft implements IScriptLoader {
                 'i',
                 getModItem(Forestry.ID, "craftingMaterial", 1, 3, missing));
         GT_Values.RA.addFuel(Materials.Creosote.getCells(1), null, 8, 0);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "fuel.coke", 9, 0, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 0, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "slab", 2, 2, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 1, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "slab", 4, 38, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 8, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.AdvancedCokeOvenBrick", 4, 0, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "machine.alpha", 1, 12, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.CokeOvenBrick", 4, 0, missing))
-                .itemOutputs(getModItem(Railcraft.ID, "machine.alpha", 1, 7, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "cube", 1, 0, missing))
                 .itemOutputs(getModItem(Railcraft.ID, "fuel.coke", 1, 0, missing)).noFluidInputs().noFluidOutputs()
                 .duration(400).eut(5).addTo(sCentrifugeRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptStevesCarts.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptStevesCarts.java
@@ -27,7 +27,6 @@ import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sBlastRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
 import static gregtech.api.util.GT_RecipeConstants.UniversalChemical;
@@ -1364,10 +1363,6 @@ public class ScriptStevesCarts implements IScriptLoader {
                 getModItem(StevesCarts2.ID, "upgrade", 1, 18, missing),
                 'f',
                 getModItem(IndustrialCraft2.ID, "blockReactorChamber", 1, 0, missing));
-
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(StevesCarts2.ID, "ModuleComponents", 9, 46, missing))
-                .itemOutputs(getModItem(StevesCarts2.ID, "ModuleComponents", 1, 48, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
 
         GT_Values.RA.stdBuilder()
                 .itemInputs(

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
@@ -29,7 +29,6 @@ import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAutoclaveRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLaserEngraverRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sMaceratorRecipes;
@@ -1683,10 +1682,6 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
                 "craftingToolMortar",
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing));
-
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "ItemResource", 9, 4, missing))
-                .itemOutputs(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 5, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
 
         GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing))
                 .itemOutputs(getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing)).outputChances(10000)
@@ -4023,10 +4018,6 @@ public class ScriptThaumcraft implements IScriptLoader {
 
     private void golemancy() {
         // GOLEMANCY
-
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "rotten_flesh", 9, 0, missing))
-                .itemOutputs(getModItem(Thaumcraft.ID, "blockTaint", 1, 2, missing)).noFluidInputs().noFluidOutputs()
-                .duration(300).eut(2).addTo(sCompressorRecipes);
 
         TCHelper.removeArcaneRecipe(getModItem(Thaumcraft.ID, "blockChestHungry", 1, 0, missing));
         TCHelper.removeInfusionRecipe(getModItem(Thaumcraft.ID, "TrunkSpawner", 1, 0, missing));

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicBases.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicBases.java
@@ -14,7 +14,6 @@ import static gregtech.api.enums.Mods.ThaumicBases;
 import static gregtech.api.enums.Mods.ThaumicTinkerer;
 import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.util.GT_ModHandler.getModItem;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
 
 import java.util.Arrays;
@@ -69,10 +68,6 @@ public class ScriptThaumicBases implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
                 getModItem(ThaumicBases.ID, "relocator", 1, 0, missing),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing));
-
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Thaumcraft.ID, "ItemResource", 9, 3, missing))
-                .itemOutputs(getModItem(ThaumicBases.ID, "quicksilverBlock", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
 
         OreDictHelper.removeOreDict("gravel", getModItem(ThaumicBases.ID, "oldGravel", 1, 0, missing));
 

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
@@ -14,7 +14,6 @@ import static gregtech.api.enums.Mods.StevesCarts2;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.ThaumicTinkerer;
 import static gregtech.api.util.GT_ModHandler.getModItem;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCutterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sLaserEngraverRecipes;
 
@@ -72,10 +71,6 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         GT_ModHandler.addSmeltingRecipe(
                 getModItem(GregTech.ID, "gt.blockmetal8", 1, 13, missing),
                 getModItem(GregTech.ID, "gt.metaitem.01", 2, 11978, missing));
-
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 4, 0, missing))
-                .itemOutputs(getModItem(ThaumicTinkerer.ID, "darkQuartz", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
 
         GT_Values.RA.stdBuilder().itemInputs(getModItem(ThaumicTinkerer.ID, "darkQuartz", 1, 0, missing))
                 .itemOutputs(getModItem(ThaumicTinkerer.ID, "darkQuartzSlab", 2, 0, missing))

--- a/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
@@ -23,7 +23,6 @@ import static gregtech.api.enums.Mods.TinkersMechworks;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAlloySmelterRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sAssemblerRecipes;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 
 import java.util.Arrays;
 import java.util.List;
@@ -3298,12 +3297,6 @@ public class ScriptTinkersConstruct implements IScriptLoader {
                 getModItem(GregTech.ID, "gt.metaitem.01", 1, 32305, missing),
                 false,
                 200);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkerConstruct.ID, "strangeFood", 4, 0, missing))
-                .itemOutputs(getModItem(TinkerConstruct.ID, "slime.gel", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "slime_ball", 4, 0, missing))
-                .itemOutputs(getModItem(TinkerConstruct.ID, "slime.gel", 1, 1, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
         TConstructRegistry.getTableCasting().addCastingRecipe(
                 getModItem(IndustrialCraft2.ID, "itemArmorBronzeHelmet", 1, 0, missing),
                 FluidRegistry.getFluidStack("bronze.molten", 720),

--- a/src/main/java/com/dreammaster/scripts/ScriptTinkersDefence.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTinkersDefence.java
@@ -3,7 +3,6 @@ package com.dreammaster.scripts;
 import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.enums.Mods.TinkersDefence;
 import static gregtech.api.util.GT_ModHandler.getModItem;
-import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sCompressorRecipes;
 import static gregtech.api.util.GT_Recipe.GT_Recipe_Map.sExtruderRecipes;
 
 import java.util.Arrays;
@@ -30,15 +29,6 @@ public class ScriptTinkersDefence implements IScriptLoader {
         TConstructHelper.removeTableRecipe(getModItem(TinkerConstruct.ID, "arrowhead", 1, 201, missing));
         TConstructHelper.removeTableRecipe(getModItem(TinkerConstruct.ID, "arrowhead", 1, 203, missing));
         TConstructHelper.removeTableRecipe(getModItem(TinkerConstruct.ID, "arrowhead", 1, 202, missing));
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "AeonSteelIngot", 9, 0, missing))
-                .itemOutputs(getModItem(TinkersDefence.ID, "AeonSteelBlock", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "QueensGoldIngot", 9, 0, missing))
-                .itemOutputs(getModItem(TinkersDefence.ID, "QueensGoldBlock", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "DogbeariumIngot", 9, 0, missing))
-                .itemOutputs(getModItem(TinkersDefence.ID, "DogbeariumBlock", 1, 0, missing)).noFluidInputs()
-                .noFluidOutputs().duration(300).eut(2).addTo(sCompressorRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(TinkersDefence.ID, "AeonSteelIngot", 1, 0, missing),


### PR DESCRIPTION
- converts the recipes to RA2
- integrates recipes from scriptfiles
- fixes some ismodloaded checks
- deletes some duplicate recipes that are generated by GT anyway
- uses SECONDS for times
- use some submethods for better organization
- directly use GT and coremod items instead of using the item registry