### PR TITLE
Fix meta data for EV Lapotron Crystal recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -931,14 +931,12 @@ public class AssemblerRecipes implements Runnable {
                 GT_ModHandler.getModItem(IronTanks.ID, "goldDiamondUpgrade", 1L, 0),
                 600,
                 120);
-
-        GT_Values.RA.addAssemblerRecipe(
-                new ItemStack[] { CustomItemList.RawLapotronCrystal.get(1L),
-                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 2L) },
-                GT_Values.NF,
-                GT_ModHandler.getIC2Item("lapotronCrystal", 1L),
-                600,
-                1024);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        CustomItemList.RawLapotronCrystal.get(1L),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 2L))
+                .itemOutputs(GT_ModHandler.getIC2Item("lapotronCrystal", 1L, 26)).noFluidInputs().noFluidOutputs()
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_EV / 2).addTo(sAssemblerRecipes);
 
         GT_Values.RA.addAssemblerRecipe(
                 ItemList.Firebrick.get(24),

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -936,7 +936,7 @@ public class AssemblerRecipes implements Runnable {
                         CustomItemList.RawLapotronCrystal.get(1L),
                         GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 2L))
                 .itemOutputs(GT_ModHandler.getIC2Item("lapotronCrystal", 1L, 26)).noFluidInputs().noFluidOutputs()
-                .duration(30 * SECONDS).eut(TierEU.RECIPE_EV / 2).addTo(sAssemblerRecipes);
+                .duration(16 * SECONDS).eut(TierEU.RECIPE_EV).addTo(sAssemblerRecipes);
 
         GT_Values.RA.addAssemblerRecipe(
                 ItemList.Firebrick.get(24),


### PR DESCRIPTION
As most players in IV+ know, you cant just make a pattern for the EV lapo from nei, as then the result wont be recognized but you have to do it manually. This is in fact caused by a small mistake in the recipe.

the recipe is defined without a meta value which defaults to null and actually crafting in the game one gets an item with negative durability (it fixes itself when used but wont be recognized by a normal automation)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/3c9158bb-28d8-4a3e-b09e-9e8043ec9dcf)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/8803af26-92eb-4836-89f8-1a4c626ee4a4)
it also shows incorrectly as full in NEI:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/db8c284d-4a95-4e22-8989-d0995f72506e)


With this fix instead one gets the correct meta value of 26 corresponding to an empty crystal (durability 1): 
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/a4e6ec23-9386-4db5-ac3c-998e35fde6e3)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/a8fcc669-8f61-4103-a73a-d853c704b523)
it also shows correctly in NEI:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/df0b0059-2d01-44ce-8a90-4c7bc91cd0ba)


But not just that, I tested the interaction with NEI and AE2: using the ? to define a pattern from NEI does in fact now work without any adjustments!


