### PR TITLE
Fix modpack name in the dialog that downloads mods on first startup… 

### DIFF
--- a/src/main/java/com/dreammaster/coremod/DownloadProgressDialog.java
+++ b/src/main/java/com/dreammaster/coremod/DownloadProgressDialog.java
@@ -13,7 +13,7 @@ class DownloadProgressDialog extends JDialog {
      */
     private static final long serialVersionUID = 6041491111144915139L;
 
-    public static final String WINDOW_TITLE = "GregTech: New Horizon";
+    public static final String WINDOW_TITLE = "GT: New Horizons";
     private Thread netThread;
     private JProgressBar progressBar;
 


### PR DESCRIPTION
… when installed from CurseForge