### PR TITLE
Swap Void Miner and T4 MBM recipe frames

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -723,7 +723,7 @@ public class AssemblerRecipes implements Runnable {
                 30720);
         GT_Values.RA.addAssemblerRecipe(
                 new ItemStack[] { ItemList.OreDrill3.get(1L),
-                        GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Tritanium, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Europium, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Ultimate, 4L),
                         ItemList.Electric_Motor_ZPM.get(4L), ItemList.Electric_Pump_ZPM.get(4L),
                         ItemList.Conveyor_Module_ZPM.get(4L),


### PR DESCRIPTION
Changes the recipe for the tier 4 ore drill to use europium frames as opposed to tritanium. The frames for void miner will be changed to instead use tritanium frames for its recipe. The gate for the void miner is the exact same so it won't affect balance.

This allows the last ore drill to see at least a bit of use before void miners are available, as opposed to being primarily a crafting component.

Should be merged with: https://github.com/GTNewHorizons/bartworks/pull/341

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13979
