### PR TITLE
Fix 10 recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1664,17 +1664,15 @@ public class AssemblerRecipes implements Runnable {
                     .itemInputs(
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Bedrockium, 9L),
                             GT_Utility.getIntegratedCircuit(1))
-                    .itemOutputs(GT_ModHandler.getModItem(ExtraUtilities.ID, "bedrockiumIngot", 1L, 0))
-                    .fluidInputs(Materials.UUMatter.getFluid(1000L)).noFluidOutputs().duration(1 * TICKS)
-                    .eut(TierEU.RECIPE_ZPM).addTo(sAssemblerRecipes);
+                    .itemOutputs(GT_ModHandler.getModItem(ExtraUtilities.ID, "bedrockiumIngot", 1L, 0)).noFluidInputs()
+                    .noFluidOutputs().duration(1 * TICKS).eut(TierEU.RECIPE_ZPM).addTo(sAssemblerRecipes);
 
             GT_Values.RA.stdBuilder()
                     .itemInputs(
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Unstable, 9L),
                             GT_Utility.getIntegratedCircuit(1))
-                    .itemOutputs(GT_ModHandler.getModItem(ExtraUtilities.ID, "unstableingot", 1L, 2))
-                    .fluidInputs(Materials.UUMatter.getFluid(1000L)).noFluidOutputs().duration(1 * TICKS)
-                    .eut(TierEU.RECIPE_ZPM).addTo(sAssemblerRecipes);
+                    .itemOutputs(GT_ModHandler.getModItem(ExtraUtilities.ID, "unstableingot", 1L, 2)).noFluidInputs()
+                    .noFluidOutputs().duration(1 * TICKS).eut(TierEU.RECIPE_ZPM).addTo(sAssemblerRecipes);
 
         }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1665,7 +1665,7 @@ public class AssemblerRecipes implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Bedrockium, 9L),
                             GT_Utility.getIntegratedCircuit(1))
                     .itemOutputs(GT_ModHandler.getModItem(ExtraUtilities.ID, "bedrockiumIngot", 1L, 0))
-                    .fluidInputs(Materials.UUMatter.getMolten(1000L)).noFluidOutputs().duration(1 * TICKS)
+                    .fluidInputs(Materials.UUMatter.getFluid(1000L)).noFluidOutputs().duration(1 * TICKS)
                     .eut(TierEU.RECIPE_ZPM).addTo(sAssemblerRecipes);
 
             GT_Values.RA.stdBuilder()
@@ -1673,7 +1673,7 @@ public class AssemblerRecipes implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Unstable, 9L),
                             GT_Utility.getIntegratedCircuit(1))
                     .itemOutputs(GT_ModHandler.getModItem(ExtraUtilities.ID, "unstableingot", 1L, 2))
-                    .fluidInputs(Materials.UUMatter.getMolten(1000L)).noFluidOutputs().duration(1 * TICKS)
+                    .fluidInputs(Materials.UUMatter.getFluid(1000L)).noFluidOutputs().duration(1 * TICKS)
                     .eut(TierEU.RECIPE_ZPM).addTo(sAssemblerRecipes);
 
         }

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -8246,7 +8246,7 @@ public class AssemblerRecipes implements Runnable {
             GT_Values.RA.stdBuilder()
                     .itemInputs(
                             getModItem(Botania.ID, "tinyPlanetBlock", 1, 0),
-                            getModItem(GalaxySpace.ID, "acentauribbgrunt", 64, 0),
+                            getModItem(Minecraft.ID, "cobblestone", 64, 0),
                             GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Dilithium, 64),
                             GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Pumice, 64),
                             GT_Utility.getIntegratedCircuit(17))

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -4584,7 +4584,7 @@ public class AssemblerRecipes implements Runnable {
                         GT_ModHandler.getModItem(OpenComputers.ID, "item", 1L, 48),
                         GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(GT_ModHandler.getModItem(OpenComputers.ID, "item", 2L, 51))
-                .fluidInputs(Materials.EnderEye.getMolten(288L)).noFluidOutputs().duration(20 * SECONDS)
+                .fluidInputs(FluidRegistry.getFluidStack("ender", 250)).noFluidOutputs().duration(20 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
         // Manual
 
@@ -4935,7 +4935,7 @@ public class AssemblerRecipes implements Runnable {
                         ItemList.Circuit_Parts_Transistor.get(1L),
                         GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(GT_ModHandler.getModItem(OpenSecurity.ID, "opensecurity.magCard", 2L, 0))
-                .fluidInputs(Materials.Glue.getMolten(144L)).noFluidOutputs().duration(7 * SECONDS + 10 * TICKS).eut(64)
+                .fluidInputs(Materials.Glue.getFluid(144L)).noFluidOutputs().duration(7 * SECONDS + 10 * TICKS).eut(64)
                 .addTo(sAssemblerRecipes);
         // RFID Card
 
@@ -4947,7 +4947,7 @@ public class AssemblerRecipes implements Runnable {
                         ItemList.Circuit_Parts_Transistor.get(1L),
                         GT_Utility.getIntegratedCircuit(2))
                 .itemOutputs(GT_ModHandler.getModItem(OpenSecurity.ID, "opensecurity.rfidCard", 2L, 0))
-                .fluidInputs(Materials.Glue.getMolten(144L)).noFluidOutputs().duration(7 * SECONDS + 10 * TICKS).eut(64)
+                .fluidInputs(Materials.Glue.getFluid(144L)).noFluidOutputs().duration(7 * SECONDS + 10 * TICKS).eut(64)
                 .addTo(sAssemblerRecipes);
         // RFID Reader Card
 
@@ -5428,8 +5428,8 @@ public class AssemblerRecipes implements Runnable {
                         GT_ModHandler.getModItem(GalacticraftCore.ID, "item.heavyPlating", 4L, 0),
                         GT_Utility.getIntegratedCircuit(4))
                 .itemOutputs(GT_ModHandler.getModItem(GalacticraftCore.ID, "item.noseCone", 1L, 0))
-                .fluidInputs(Materials.StainlessSteel.getFluid(36L)).noFluidOutputs().duration(2 * SECONDS + 10 * TICKS)
-                .eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.StainlessSteel.getMolten(36L)).noFluidOutputs()
+                .duration(2 * SECONDS + 10 * TICKS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
 
         GT_Values.RA.stdBuilder()
                 .itemInputs(
@@ -5437,7 +5437,7 @@ public class AssemblerRecipes implements Runnable {
                         GT_ModHandler.getModItem(GalacticraftMars.ID, "item.itemBasicAsteroids", 4L, 0),
                         GT_Utility.getIntegratedCircuit(4))
                 .itemOutputs(GT_ModHandler.getModItem(GalacticraftMars.ID, "item.heavyNoseCone", 1L, 0))
-                .fluidInputs(Materials.Titanium.getFluid(36L)).noFluidOutputs().duration(2 * SECONDS + 10 * TICKS)
+                .fluidInputs(Materials.Titanium.getMolten(36L)).noFluidOutputs().duration(2 * SECONDS + 10 * TICKS)
                 .eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
 
         GT_Values.RA.stdBuilder()
@@ -8246,7 +8246,7 @@ public class AssemblerRecipes implements Runnable {
             GT_Values.RA.stdBuilder()
                     .itemInputs(
                             getModItem(Botania.ID, "tinyPlanetBlock", 1, 0),
-                            getModItem(Minecraft.ID, "acentauribbgrunt", 64, 0),
+                            getModItem(GalaxySpace.ID, "acentauribbgrunt", 64, 0),
                             GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Dilithium, 64),
                             GT_OreDictUnificator.get(OrePrefixes.ore, Materials.Pumice, 64),
                             GT_Utility.getIntegratedCircuit(17))

--- a/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
@@ -219,22 +219,6 @@ public class MixerRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        GT_OreDictUnificator.get(OrePrefixes.dustImpure, Materials.Biotite, 3L),
-                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SodiumHydroxide, 3L),
-                        GT_Utility.getIntegratedCircuit(5))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SodiumAluminate, 12L)).noFluidInputs()
-                .noFluidOutputs().duration(15 * SECONDS).eut(48).addTo(sMixerRecipes);
-
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        GT_OreDictUnificator.get(OrePrefixes.dustPure, Materials.Biotite, 3L),
-                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SodiumHydroxide, 3L),
-                        GT_Utility.getIntegratedCircuit(5))
-                .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SodiumAluminate, 12L)).noFluidInputs()
-                .noFluidOutputs().duration(10 * SECONDS).eut(48).addTo(sMixerRecipes);
-
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Lazurite, 3L),
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SodiumHydroxide, 3L),
                         GT_Utility.getIntegratedCircuit(5))


### PR DESCRIPTION
well more precisely, fix 8 and remove 2.

- fixed fluid inputs for nose cone, heavy nose cone, bedrockium ingot (assembler recipe), unstable ingot (assembler recipe), linked card, magnet strip card, and Interweb. for the 2 ingots the fluid was just removed for good as its been broken for 7 years and people are used to it.
- fixed solid input for DD planet recipe.
- removed the 2 recipes for Sodium Aluminate based on impure and pure Biotite as those dont exist. all the other recipes for Sodium Aluminate are of course still around including the one from regular Biotite.

Some of these might slightly affect balance. but they are intended this way and all look fine. (just to explain the tag)

All tested in full game.