### PR TITLE
More optical CPU recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -19,6 +19,7 @@ import com.gtnewhorizons.gtnhintergalactic.recipe.IG_RecipeAdder;
 import gregtech.api.enums.*;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gtPlusPlus.core.material.ELEMENT;
 
 public class SpaceAssemblerRecipes implements Runnable {
 
@@ -54,6 +55,51 @@ public class SpaceAssemblerRecipes implements Runnable {
                         (int) TierEU.RECIPE_UHV,
                         null,
                         null);
+
+                IG_RecipeAdder.addSpaceAssemblerRecipe(
+                        new ItemStack[] { ItemList.Circuit_Chip_Optical.get(4L),
+                                ItemList.Optical_Cpu_Containment_Housing.get(4L),
+                                GT_OreDictUnificator
+                                        .get(OrePrefixes.screw, Materials.Longasssuperconductornameforuhvwire, 8L),
+                                GT_OreDictUnificator.get(OrePrefixes.screw, Materials.TengamAttuned, 8L),
+                                GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.DraconiumAwakened, 8L),
+                                CustomItemList.DATApipe.get(4L),
+                                // Precious Metals Alloy screw
+                                GT_ModHandler.getModItem(BartWorks.ID, "gt.bwMetaGeneratedscrew", 8L, 10109),
+                                // Enriched Naquadah Alloy screw
+                                GT_ModHandler.getModItem(BartWorks.ID, "gt.bwMetaGeneratedscrew", 8L, 10110) },
+                        new FluidStack[] { new FluidStack(solderUEV, 576) },
+                        ItemList.Optically_Perfected_CPU.get(4L),
+                        2,
+                        20 * 20,
+                        (int) TierEU.RECIPE_UEV,
+                        null,
+                        null);
+
+                if (GTPlusPlus.isModLoaded()) {
+                    IG_RecipeAdder
+                            .addSpaceAssemblerRecipe(
+                                    new ItemStack[] { ItemList.Circuit_Chip_Optical.get(16L),
+                                            ItemList.Optical_Cpu_Containment_Housing.get(16L),
+                                            ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getScrew(16),
+                                            GT_OreDictUnificator
+                                                    .get(OrePrefixes.screw, MaterialsUEVplus.SpaceTime, 16L),
+                                            GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Tritanium, 16L),
+                                            CustomItemList.DATApipe.get(16L),
+                                            // Enriched Naquadah Alloy screw
+                                            GT_ModHandler
+                                                    .getModItem(BartWorks.ID, "gt.bwMetaGeneratedscrew", 16L, 10110),
+                                            // Shirabon screw
+                                            GT_ModHandler
+                                                    .getModItem(BartWorks.ID, "gt.bwMetaGeneratedscrew", 16L, 10112) },
+                                    new FluidStack[] { new FluidStack(solderUEV, 1152) },
+                                    ItemList.Optically_Perfected_CPU.get(16L),
+                                    2,
+                                    20 * 20,
+                                    (int) TierEU.RECIPE_UIV,
+                                    null,
+                                    null);
+                }
             }
             if (GTPlusPlus.isModLoaded()) {
                 // Alternate Energy Module Recipe


### PR DESCRIPTION
Adds two higher tier optical CPU recipes akin to the optical memory.
These recipes aim to address space assembler speed issues and incentivise higher tier material usage.

First alternate recipe for uiv tier:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/93287602/430fc913-758c-40a2-8daf-2db440bd1f25)
Second alternate recipe for umv tier:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/93287602/989b1f8f-49a7-4080-aae7-167d097462f3)
