### PR TITLE
Add assembler recipes for more ae2 items 

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -3992,7 +3992,8 @@ public class AssemblerRecipes implements Runnable {
                         getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 44),
                         GT_Utility.getIntegratedCircuit(3))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockMolecularAssembler", 1))
-                .fluidInputs(Materials.Glass.getMolten(288L)).noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+                .fluidInputs(Materials.Glass.getMolten(288L)).noFluidOutputs().duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
 
         if (AE2FluidCraft.isModLoaded()) {
             // Dual Interface

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -3987,7 +3987,7 @@ public class AssemblerRecipes implements Runnable {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(GregTech.ID, "gt.blockmachines", 1, 214),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 2L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4L),
                         getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 43),
                         getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 44),
                         GT_Utility.getIntegratedCircuit(3))

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -3818,6 +3818,248 @@ public class AssemblerRecipes implements Runnable {
                 .fluidInputs(Materials.Titanium.getMolten(36L)).noFluidOutputs().duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
 
+        // Controller
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 2L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 24),
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockFluix", 1, 0),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockController", 1)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Energy Cells
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 2L),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Fluix, 1),
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockFluix", 1, 0),
+                        GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Aluminium, 1),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockEnergyCell", 1)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Master, 2L),
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockEnergyCell", 5, 0),
+                        ItemList.Battery_Buffer_4by4_EV.get(1L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockDenseEnergyCell", 1)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Void Cell
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.screw, Materials.CertusQuartz, 2L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 1L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tungsten, 3L),
+                        GT_OreDictUnificator.get(OrePrefixes.gem, Materials.EnderEye, 1),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemVoidStorageCell", 1)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Quantum Link
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockEnergyCell", 1, 0),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 22),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 16),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockQuantumRing", 1)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4, 9),
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockQuartzGlass", 1, 0),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockQuantumLinkChamber", 1)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Spatial Pylon
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 2, 16),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Fluix, 2L),
+                        GT_OreDictUnificator.get(OrePrefixes.gem, Materials.Fluix, 1L),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockSpatialPylon", 1)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Spatial IO
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 2, 16),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockSpatialPylon", 1),
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockIOPort", 1),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockSpatialIOPort", 1)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // ME IO Port
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 3L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 3, 16),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 22),
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockDrive", 2, 0),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockIOPort", 1)).noFluidInputs().noFluidOutputs()
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // ME Chest
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 4L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 2, 16),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Good, 2L),
+                        getModItem(IronChests.ID, "BlockIronChest", 1, 4),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockChest", 1)).noFluidInputs().noFluidOutputs()
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+
+        // ME Drive
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 2, 16),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 1L),
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockChest", 1),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockDrive", 1)).noFluidInputs().noFluidOutputs()
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Interface
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 2, 16),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 43),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 44),
+                        ItemList.Casing_EV.get(1L),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Crafting Unit
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 2L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 22),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 23),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
+                        GT_Utility.getIntegratedCircuit(2))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Formation Core
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.CertusQuartz, 4L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4, 22),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 12),
+                        GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 43)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Annihilation Core
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.NetherQuartz, 4L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4, 22),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 12),
+                        GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 44)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Wireless Receiver
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.stick, Materials.EnderEye, 1L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 2L),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Advanced, 1L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 2, 140),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 9),
+                        GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 41)).noFluidInputs()
+                .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        // Molecular Assembler
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GregTech.ID, "gt.blockmachines", 1, 214),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 2L),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 43),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 44),
+                        GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockMolecularAssembler", 1))
+                .fluidInputs(Materials.Glass.getMolten(288L)).noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+
+        if (AE2FluidCraft.isModLoaded()) {
+            // Dual Interface
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 4L),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Lapis, 2L),
+                            getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1),
+                            getModItem(NewHorizonsCoreMod.ID, "item.EngineeringProcessorFluidDiamondCore", 1),
+                            GT_Utility.getIntegratedCircuit(2))
+                    .itemOutputs(getModItem(AE2FluidCraft.ID, "fluid_interface", 1, 0)).noFluidInputs().noFluidOutputs()
+                    .duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+            // Fluid Storage Housing
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.screw, Materials.CertusQuartz, 2L),
+                            GT_Utility.getIntegratedCircuit(3))
+                    .itemOutputs(getModItem(AE2FluidCraft.ID, "fluid_storage_housing", 1, 0)).noFluidInputs()
+                    .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Neutronium, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Infinity, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.screw, Materials.CertusQuartz, 2L),
+                            GT_Utility.getIntegratedCircuit(3))
+                    .itemOutputs(getModItem(AE2FluidCraft.ID, "fluid_storage_housing", 1, 1)).noFluidInputs()
+                    .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+            // Multi Fluid Storage Housing
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.screw, Materials.CertusQuartz, 2L),
+                            GT_Utility.getIntegratedCircuit(3))
+                    .itemOutputs(getModItem(AE2FluidCraft.ID, "fluid_storage_housing", 1, 2)).noFluidInputs()
+                    .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Neutronium, 2L),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 1L),
+                            GT_OreDictUnificator.get(OrePrefixes.screw, Materials.CertusQuartz, 2L),
+                            GT_Utility.getIntegratedCircuit(3))
+                    .itemOutputs(getModItem(AE2FluidCraft.ID, "fluid_storage_housing", 1, 3)).noFluidInputs()
+                    .noFluidOutputs().duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+
+        }
+        if (AE2Stuff.isModLoaded()) {
+            // Wireless Connector
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 2L),
+                            getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4, 12),
+                            getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 24),
+                            getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 41),
+                            GT_Utility.getIntegratedCircuit(2))
+                    .itemOutputs(getModItem(AE2Stuff.ID, "Wireless", 1)).noFluidInputs().noFluidOutputs()
+                    .duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);
+        }
+
         if (TinkerConstruct.isModLoaded()) {
             GT_Values.RA.stdBuilder()
                     .itemInputs(

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -4002,7 +4002,7 @@ public class AssemblerRecipes implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 4L),
                             GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Lapis, 2L),
                             getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1),
-                            getModItem(NewHorizonsCoreMod.ID, "item.EngineeringProcessorFluidDiamondCore", 1),
+                            getModItem(NewHorizonsCoreMod.ID, "item.EngineeringProcessorFluidDiamondCore", 2),
                             GT_Utility.getIntegratedCircuit(2))
                     .itemOutputs(getModItem(AE2FluidCraft.ID, "fluid_interface", 1, 0)).noFluidInputs().noFluidOutputs()
                     .duration(5 * SECONDS).eut(TierEU.RECIPE_HV).addTo(sAssemblerRecipes);


### PR DESCRIPTION
Adds assembler recipes for most of the stuff listed here: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13570
Does however not add recipes for the upgrade cards and small interfaces.
Most of the blocks are on circuit 2 and the crafting components on circuit 3.
I didn't spot any recipe conflicts, but i might need glasses idk
<details>
  <summary>Recipe pictures</summary>
  Annihilation Core

![anicore](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/473af1d6-ad29-4d6c-9402-b9f41ed22b2e)

Formation Core

![formcore](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/ff239dbf-c3b5-4ca8-a6b7-123830eda6cf)

ME Controller
![controller](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/a68ea8bf-5869-45e9-a423-f39e34dc1476)
Crafting Unit
![craftunit](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/4586c35a-2c3c-4841-b122-1576872dc1b6)
Energy Cell
![energycell](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/951f2b54-ecdf-4c65-9141-64893d8516ad)
Dense Energy Cell
![denseenergy](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/d148efcd-b298-48e8-ac8c-18d0fa7d6c2a)
Dual Interface
![dualinterface](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/a5c7e182-2938-489f-bd43-fcb3a94d059b)
Interface
![interface](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/eed5e029-b58a-424b-89b7-30f943d9c817)
IO Port
![ioport](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/f4f713b7-c914-4d4f-adbc-40aeb65bf77e)
ME Chest
![mechest](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/0454bc23-479b-44b7-ba02-3bd0cc25e098)
ME Drive
![me drive](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/a9c36592-e9fc-4fc0-92c3-8bde15696e9a)
Quantum Ring
![quantum1](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/422fc97d-0cfa-4833-8044-5d710ad92435)
![quantum2](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/8fbb466c-4ce1-4346-8d0d-9262859042ee)
Spatial Pylon
![spatial](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/e9e1c4e3-2670-4222-adc7-97376c21a797)
Spatial IO Port
![spatialio](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/3765d99b-2695-42d7-856e-67f746c8545e)
ME Void cell
![voidcell](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/8d1de8aa-ce2f-444a-a8e8-d7223965ac73)
Wireless Connector
![wireless](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/d7682e7e-b3ef-4579-bbaf-5d99427d2b1e)
Wireless Receiver
![wirelessrec](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/d98f6e44-e005-40c2-a6cf-0554380503e0)

Fluid Housing
![housing1](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/95a6ab3a-1fab-4896-8e9b-43febd9e3d9c)
Adv Fluid Housing
![housing2](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/7f083e81-ce1e-4674-8a5c-19e087c5ae8d)
Multi Fluid Housing
![housing3](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/de73d8d9-7854-4a87-ade5-ab91de90220c)
Adv Multi Fluid Housing
![housing4](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/127234178/96acba0f-6a9b-4e95-ac86-45e30db612ac)


Forgot to take picture of molecular assembler :)
</details>

I also haven't got a clue if this is the right file to put them in or if they go in their individual script classes. If they need to be moved or if those isModLoaded() are wrong just let me know. 

