### PR TITLE
Fix heavy rocket fin recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -5471,7 +5471,11 @@ public class AssemblerRecipes implements Runnable {
                 .itemOutputs(GT_ModHandler.getModItem(GalacticraftCore.ID, "item.rocketFins", 1L, 0)).noFluidInputs()
                 .noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
 
-        GT_Values.RA.stdBuilder().noItemInputs()
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_ModHandler.getModItem(GalacticraftMars.ID, "item.null", 2L, 3),
+                        GT_ModHandler.getModItem(GalacticraftMars.ID, "item.itemBasicAsteroids", 4L, 0),
+                        GT_Utility.getIntegratedCircuit(5))
                 .itemOutputs(GT_ModHandler.getModItem(GalacticraftMars.ID, "item.itemBasicAsteroids", 1L, 2))
                 .noFluidInputs().noFluidOutputs().duration(2 * SECONDS + 10 * TICKS).eut(TierEU.RECIPE_MV)
                 .addTo(sAssemblerRecipes);


### PR DESCRIPTION
The inputs were empty after the recent refactor. This was causing thausands of recipe conflicts naturally. (including in the NEI custom diagram debug)

Now works again:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/500d4efd-8f3a-4db7-b9a7-1c6498145583)
