### PR TITLE
fix mistake in brick electrolyze recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/ElectrolyzerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ElectrolyzerRecipes.java
@@ -128,7 +128,7 @@ public class ElectrolyzerRecipes implements Runnable {
                 GT_Values.NF,
                 GT_Values.NF,
                 GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Aluminiumoxide, 5L),
-                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Silicon, 12L),
+                GT_OreDictUnificator.get(OrePrefixes.dust, Materials.SiliconDioxide, 12L),
                 GT_Values.NI,
                 GT_Values.NI,
                 GT_Values.NI,


### PR DESCRIPTION
In the previous PR about brick electrolyze recipe I made a mistake and put Silicon instead of SiliconDioxide. This should fix oxygen magically turning into silicon