### PR TITLE
Fix and clean up ammonia recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
@@ -329,15 +329,6 @@ public class ChemicalReactorRecipes implements Runnable {
                 true);
 
         GT_Values.RA.addChemicalRecipe(
-                GT_OreDictUnificator.get(Materials.Hydrogen.getCells(3)),
-                GT_Utility.copyAmount(0, GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Magnetite, 1)),
-                Materials.Nitrogen.getGas(1000L),
-                Materials.Ammonia.getGas(1000),
-                ItemList.Cell_Empty.get(3L),
-                320,
-                384);
-
-        GT_Values.RA.addChemicalRecipe(
                 new ItemStack(Items.ghast_tear),
                 GT_Utility.getIntegratedCircuit(1),
                 Materials.Water.getFluid(1000L),


### PR DESCRIPTION
most of them are in gt itself, so do it there and remove the one here.

Needs to be merged together with https://github.com/GTNewHorizons/GT5-Unofficial/pull/2210. See details there.