### PR TITLE
Fix fences for piston assembler recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -7671,7 +7671,9 @@ public class AssemblerRecipes implements Runnable {
     private void makePistonRecipes() {
         // Vanilla Piston Assembler recipe
         List<ItemStack> fenceWood = OreDictionary.getOres("fenceWood");
-        for (ItemStack stack : fenceWood) {
+        for (ItemStack oreStack : fenceWood) {
+
+            ItemStack stack = oreStack.splitStack(1);
 
             GT_Values.RA.stdBuilder()
                     .itemInputs(


### PR DESCRIPTION
was broken by transform to RA2:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/414f0403-1458-49ae-b988-a6da2e9476ff)

now fixed:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/2b7a21ab-7fe3-4853-a785-18f3a669b3d6)
