### PR TITLE
Fix wrong meta for barnada C sapling

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -8445,7 +8445,7 @@ public class AssemblerRecipes implements Runnable {
                             getModItem(Botania.ID, "tinyPlanetBlock", 1, 0),
                             getModItem(Minecraft.ID, "stone", 64, 0),
                             getModItem(GalaxySpace.ID, "barnardaCgrass", 64, 0),
-                            getModItem(GalaxySpace.ID, "barnardaCsapling", 1, 0),
+                            getModItem(GalaxySpace.ID, "barnardaCsapling", 1, 1),
                             GT_Utility.getIntegratedCircuit(17))
                     .fluidInputs(FluidRegistry.getFluidStack("unknowwater", 10000))
                     .itemOutputs(getModItem(NEIOrePlugin.ID, "blockDimensionDisplay_BC", 1, 0)).noFluidOutputs()


### PR DESCRIPTION
now works with a sapling dropped from a tree:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/a1b7f17a-5654-446d-be48-f563265bb7a0)

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14163