### PR TITLE
fix compressed dual desh plates

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/ImplosionCompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ImplosionCompressorRecipes.java
@@ -155,7 +155,7 @@ public class ImplosionCompressorRecipes implements Runnable {
                     .noFluidInputs().noFluidOutputs().duration(20 * TICKS).eut(TierEU.RECIPE_LV)
                     .metadata(ADDITIVE_AMOUNT, 2).addTo(sImplosionRecipes);
 
-            GT_Values.RA.stdBuilder().noItemInputs()
+            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(GalacticraftMars.ID, "item.null", 2L, 5))
                     .itemOutputs(
                             CustomItemList.DeshDualCompressedPlates.get(1L),
                             GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Ash, 2L))


### PR DESCRIPTION
was another ra2 conversion error. fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14165

recipes now:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/53e0f268-e9ff-4f2c-b01c-af99567c8779)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/4147d2c9-2cd5-411f-b019-bbab19ca8eb9)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/27c07662-396b-4edc-9d79-cac15b5d5bdf)
