### PR TITLE
Remove broken HSLA recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptGregtech.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGregtech.java
@@ -389,17 +389,6 @@ public class ScriptGregtech implements IScriptLoader {
                 getModItem(GregTech.ID, "gt.metaitem.01", 1, 1890, missing),
                 "craftingToolMortar",
                 getModItem(BloodArsenal.ID, "glass_shard", 1, 0, missing));
-        addShapelessRecipe(
-                getModItem(GregTech.ID, "gt.metaitem.01", 2, 2322, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 2305, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 10, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 1047, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 1345, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 1034, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 1029, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 1030, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 1048, missing),
-                getModItem(GregTech.ID, "gt.metaitem.01", 1, 1028, missing));
         addShapedRecipe(
                 getModItem(GregTech.ID, "gt.blockcasings2", 1, 10, missing),
                 "itemCasingStainlessSteel",


### PR DESCRIPTION
we dont use rotarycraft, so we dont use HSLA, so this recipe is just broken:
![image](https://github.com/GTNewHorizons/GT5-Unofficial/assets/40274384/ef336eb5-4a8d-4c6d-8960-76471cd9aaa7)

2 PRs because the recipe was added twice. The other is https://github.com/GTNewHorizons/GT5-Unofficial/pull/2241