### PR TITLE
Fix amber light research text

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptAutomagy.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAutomagy.java
@@ -623,7 +623,7 @@ public class ScriptAutomagy implements IScriptLoader {
                 'i',
                 "plateInfusedGold");
         TCHelper.clearPages("NITORLIGHT");
-        TCHelper.addResearchPage("NITORLIGHT", new ResearchPage("Automagy.research_page.REDSTONETHEORY.1"));
+        TCHelper.addResearchPage("NITORLIGHT", new ResearchPage("Automagy.research_page.NITORLIGHT.1"));
         TCHelper.setResearchAspects(
                 "NITORLIGHT",
                 new AspectList().add(Aspect.getAspect("lux"), 12).add(Aspect.getAspect("ignis"), 9)


### PR DESCRIPTION
Just had the incorrect text (for years). Now fixed:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/6a2c29b2-6975-4d9d-9a88-b7d4edb2637b)
