### PR TITLE
Fix wrong Mehen Belt ChunkProvider class

### DIFF
--- a/src/main/java/com/dreammaster/galacticgreg/SpaceDimRegisterer.java
+++ b/src/main/java/com/dreammaster/galacticgreg/SpaceDimRegisterer.java
@@ -402,7 +402,7 @@ public class SpaceDimRegisterer {
 
         ModDimensionDef dimMehenBelt = new ModDimensionDef(
                 "Mehen Belt",
-                "de.katzenpapst.amunra.world.asteroidWorld.AmunRaAsteroidsChunkProvider",
+                "de.katzenpapst.amunra.world.mehen.MehenChunkProvider",
                 Enums.DimensionType.Asteroid);
         dimMehenBelt.addAsteroidMaterial(GTOreTypes.BlackGranite);
         modAmunRa.addDimensionDef(dimMehenBelt);


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14008 and GT ores completely missing in the Mehen Belt dimension.