### PR TITLE
Fix EMT thaumium drill crafting

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptEMT.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEMT.java
@@ -886,7 +886,7 @@ public class ScriptEMT implements IScriptLoader {
                         "gt.metatool.01",
                         1,
                         102,
-                        "{ench:[0:{lvl:2s,id:35s}],GT.ToolStats:{PrimaryMaterial:\"Thaumium\",SpecialData:-1L,MaxDamage:51200L,Tier:2L,MaxCharge:400000L,Voltage:128L,Electric:1b,SecondaryMaterial:\"Titanium\"},GT.ItemCharge:400000L}",
+                        "{ench:[0:{lvl:2s,id:35s}],GT.ToolStats:{PrimaryMaterial:\"Thaumium\",SpecialData:-1L,MaxDamage:51200L,Tier:2L,MaxCharge:400000L,Voltage:128L,Electric:1b,SecondaryMaterial:\"Aluminium\"},GT.ItemCharge:400000L}",
                         missing),
                 new ItemStack[] { getModItem(GregTech.ID, "gt.metaitem.01", 1, 27028, missing),
                         getModItem(GregTech.ID, "gt.metaitem.01", 1, 17330, missing),


### PR DESCRIPTION
Apprently the GT drills got buffed for whatever reason and use like 2 tier cheaper materials now. well this part was forgotten.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14267