### PR TITLE
Fix draconic chestplate recipe inconsistency

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptDraconicEvolution.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptDraconicEvolution.java
@@ -494,9 +494,9 @@ public class ScriptDraconicEvolution implements IScriptLoader {
                 'b',
                 "plateDraconiumAwakened",
                 'c',
-                getModItem(DraconicEvolution.ID, "awakenedCore", 1, 0, missing),
-                'd',
                 getModItem(DraconicEvolution.ID, "draconiumEnergyCore", 1, 1, missing),
+                'd',
+                getModItem(DraconicEvolution.ID, "awakenedCore", 1, 0, missing),
                 'e',
                 getModItem(DraconicEvolution.ID, "wyvernChest", 1, 0, missing));
         ExtremeCraftingManager.getInstance().addExtremeShapedOreRecipe(


### PR DESCRIPTION
The draconic chestplate recipe had 2 draconic energy cores and 1 awakened core in its recipe while all other wyvern and draconic armor parts have 1 energy core and 2 cores
This PR swaps the draconic energy cores and awakened cores in the draconic chestplate recipe to make it consistent with the other armor pieces.

Draconic chestplate recipe pre-fix:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/93287602/52299f05-cd75-495e-8d36-9b06cbc67276)

Wyvern chestplate recipe (as an example for 2 cores, 1 energy core):
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/93287602/0542d843-349a-45ba-8c74-e7f2f6cad11d)



This technically affects balance but in an extremely minor way with basically no consequences.