### PR TITLE
Buff Essentia mirror to maintain consistency with the lore

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
@@ -3821,11 +3821,11 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("aqua"), 24).add(Aspect.getAspect("iter"), 32)
                         .add(Aspect.getAspect("permutatio"), 16).add(Aspect.getAspect("vitreus"), 8),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
-                new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L),
+                new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L), });

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
@@ -3821,11 +3821,11 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("aqua"), 24).add(Aspect.getAspect("iter"), 32)
                         .add(Aspect.getAspect("permutatio"), 16).add(Aspect.getAspect("vitreus"), 8),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
-                new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
+                new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tantalum, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tantalum, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L), });


### PR DESCRIPTION
Effectively, our in-pack lore of the essentia mirror and magic mirror is that the magic mirror is supposed to be one tier higher than the essentia mirror, the magic mirror was originally IV, while the essentia mirror was EV, then the magic mirror was buffed in late 2021:

https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/commit/69d5f23c8afa8e838640e66e7ab91e7e1ccf862f

However, when Piky upgraded the magic mirror from IV to HV back in 2021, he forgot to also buff the essentia mirror from EV to MV respectively, as to fit within our own lore, and this has been bugging me ever since.

No, most reasonable players will not be able to unlock this until HV, since infusion is currently HV, so it's effectively HV anyway, but for consistency's sake, this change needs to happen.