### PR TITLE
Add stocking hatch recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -3779,6 +3779,16 @@ public class AssemblerRecipes implements Runnable {
                 .itemOutputs(ItemList.Hatch_Input_Bus_ME.get(1)).duration(15 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(sAssemblerRecipes);
 
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Hatch_Input_Multi_2x2_UHV.get(1L),
+                        GT_ModHandler.getModItem(AE2FluidCraft.ID, "part_fluid_interface", 1, 0),
+                        GT_ModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4L, 56),
+                        ItemList.Electric_Pump_UHV.get(1L),
+                        GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(ItemList.Hatch_Input_ME.get(1)).duration(15 * SECONDS).eut(TierEU.RECIPE_UV)
+                .addTo(sAssemblerRecipes);
+
         // Cell Workbench
         GT_Values.RA.stdBuilder()
                 .itemInputs(


### PR DESCRIPTION
Adds a recipe for the stocking input hatch that is gated UHV.
While adding the stocking input hatch in GTNewHorizons/GT5-Unofficial#2322 and some more content on it like GTNewHorizons/GT5-Unofficial#2336 and https://github.com/GTNewHorizons/GT5-Unofficial/pull/2339 we also thought about balancing. While arguably very powerful we don't want it to be gated too far into the late game as it wouldn't make sense with the recipe of the stocking bus. I go more into detail in [this ](https://github.com/GTNewHorizons/GT5-Unofficial/pull/2322#issuecomment-1747539149)comment.

As for the tiering regarding auto pull, the amount of fluids it can pull, and the total amount of fluid I still think it's fine if the full version is unlocked in UHV with downgraded versions potentially getting added later. The hatch tiering in general doesn't matter too much with the amounts you can store in an input hatch in UHV and what you need with the exception being EOH which currently doesn't work with the stocking hatch thus not invalidating the need for the humongous input hatch. Also, functionality like using p2p is not given with the hatch and would require a normal hatch. The rest I discussed in my previously mentioned comment.

In general, the recipe proposed in this PR is not final and should serve as a starting point for a discussion of potential changes but it should also serve as an anchor point so the recipe is not gated way too late into the game like scary comments like [this](https://github.com/GTNewHorizons/GT5-Unofficial/pull/2322#issuecomment-1745488795) suggest. We hope due to the effort we have put into this and the other PRs from https://github.com/Minecraft-TA/ our opinion on this is respected.



The stocking hatch recipe:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/45769595/6737a757-b612-4b1e-887a-d859b025f2f2)
- 1 Quadruple Input Hatch (UHV)
- 1 ME Dual Interface
- 4 Hyper-Acceleration Card
- 1 Electric Pump (UHV)

Stocking bus recipe for reference:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/45769595/bb48066d-5097-4c0c-aace-90ac7b4a20c1)
