### PR TITLE
Add lapotronic energy orb cluster space assembler recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -108,6 +108,26 @@ public class SpaceAssemblerRecipes implements Runnable {
                 }
             }
             if (GTPlusPlus.isModLoaded()) {
+
+                // Alternate Energy Orb Cluster Recipe
+                IG_RecipeAdder.addSpaceAssemblerRecipe(
+                        new ItemStack[] { ItemList.Circuit_Board_Multifiberglass.get(1L),
+                                GT_OreDictUnificator.get(OrePrefixes.foil, Materials.NaquadahAlloy, 64L),
+                                GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Master), 4L),
+                                ItemList.Circuit_Parts_Crystal_Chip_Master.get(64L),
+                                ItemList.Circuit_Parts_Crystal_Chip_Master.get(8L), ItemList.Circuit_Chip_HPIC.get(64L),
+                                ItemList.Circuit_Parts_DiodeASMD.get(8L), ItemList.Circuit_Parts_CapacitorASMD.get(8L),
+                                ItemList.Circuit_Parts_ResistorASMD.get(8L),
+                                ItemList.Circuit_Parts_TransistorASMD.get(8L),
+                                GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Platinum, 64) },
+                        new FluidStack[] { new FluidStack(solderIndalloy, 720) },
+                        ItemList.Energy_LapotronicOrb2.get(1),
+                        1,
+                        50 * 20,
+                        (int) TierEU.RECIPE_ZPM,
+                        null,
+                        null);
+
                 // Alternate Energy Module Recipe
                 IG_RecipeAdder.addSpaceAssemblerRecipe(
                         new ItemStack[] { ItemList.Circuit_Board_Wetware_Extreme.get(1),


### PR DESCRIPTION
Adds a space assembler recipe for lapotronic energy orb clusters to keep it consistent with the other energy orbs and to make faster than 1 tick production of these possible.

![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/93287602/a36a2f62-eaa7-4f87-be8d-3dd4c8199b43)
