### PR TITLE
Add maintenance hatch recipe with advanced glue

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -122,6 +122,11 @@ public class AssemblerRecipes implements Runnable {
                 .itemOutputs(ItemList.Duct_Tape.get(2L)).fluidInputs(Materials.AdvancedGlue.getFluid(200))
                 .duration(6 * SECONDS).eut(TierEU.RECIPE_LV).addTo(sAssemblerRecipes);
 
+        GT_Values.RA.stdBuilder()
+                .itemInputs(ItemList.Hull_LV.get(1), ItemList.Duct_Tape.get(2), GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(ItemList.Hatch_Maintenance.get(1)).fluidInputs(Materials.AdvancedGlue.getFluid(200))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_MV).addTo(sAssemblerRecipes);
+
         // 10,30 and 60K NAK Cells
 
         GT_Values.RA.stdBuilder()


### PR DESCRIPTION
Adds a maintenance hatch recipe with advanced glue (refined glue and super glue both have one already). This recipe is the same as the one with refined glue but uses less glue and has a different circuit:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/38fe4af6-3839-4d80-9d9f-f7fc4b283e2b)

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14872.