### PR TITLE
Recipe Conflict + Recipe Fix

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptBiblioCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiblioCraft.java
@@ -756,7 +756,7 @@ public class ScriptBiblioCraft implements IScriptLoader {
             addShapedRecipe(
                     TypeWriterB[i],
                     "plateRubber",
-                    getModItem(OpenComputers.ID, "item", 1, 20),
+                    getModItem(OpenComputers.ID, "keyboard", 1),
                     "plateRubber",
                     "ringIron",
                     color16[i],

--- a/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
@@ -780,7 +780,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuit", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -791,7 +791,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Basic.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -802,7 +802,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Microprocessor.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -813,7 +813,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 5, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -824,7 +824,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuit", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -835,7 +835,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Basic.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -846,7 +846,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Microprocessor.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -857,7 +857,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 5, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.lead", 1152)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -868,7 +868,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuit", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -879,7 +879,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Basic.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -890,7 +890,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Microprocessor.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -901,7 +901,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 5, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -912,7 +912,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuit", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -923,7 +923,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Basic.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -934,7 +934,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Microprocessor.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -945,7 +945,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 5, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.tin", 576)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -956,7 +956,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuit", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -967,7 +967,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Basic.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -978,7 +978,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Microprocessor.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -989,7 +989,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 5, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -1000,7 +1000,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuit", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -1011,7 +1011,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Basic.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -1022,7 +1022,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Microprocessor.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -1033,7 +1033,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 5, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt04, Materials.AnnealedCopper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 8L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 1, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.solderingalloy", 288)).duration(40 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
@@ -2875,7 +2875,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(LogisticsPipes.ID, "item.PipeItemsRequestLogistics", 1, 0, missing),
                         getModItem(IronChests.ID, "BlockIronChest", 1, 3, missing),
                         getModItem(NewHorizonsCoreMod.ID, "item.CircuitMV", 2, 0, missing),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeBlockRequestTable", 1, 0, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -2888,7 +2888,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(LogisticsPipes.ID, "item.PipeItemsRequestLogistics", 1, 0, missing),
                         getModItem(IronChests.ID, "BlockIronChest", 1, 3, missing),
                         ItemList.Circuit_Good.get(2L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeBlockRequestTable", 1, 0, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -2901,7 +2901,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(LogisticsPipes.ID, "item.PipeItemsRequestLogistics", 1, 0, missing),
                         getModItem(IronChests.ID, "BlockIronChest", 1, 3, missing),
                         ItemList.Circuit_Integrated_Good.get(2L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeBlockRequestTable", 1, 0, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -2914,7 +2914,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(LogisticsPipes.ID, "item.PipeItemsRequestLogistics", 1, 0, missing),
                         getModItem(IronChests.ID, "BlockIronChest", 1, 3, missing),
                         ItemList.Circuit_Processor.get(2L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeBlockRequestTable", 1, 0, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -2927,7 +2927,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(LogisticsPipes.ID, "item.PipeItemsRequestLogistics", 1, 0, missing),
                         getModItem(IronChests.ID, "BlockIronChest", 1, 3, missing),
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 6, missing),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeBlockRequestTable", 1, 0, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3215,7 +3215,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 2, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3227,7 +3227,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Computer.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 2, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3239,7 +3239,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Nanoprocessor.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 2, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3251,7 +3251,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 7, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 2, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3265,7 +3265,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 2L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(45 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3279,7 +3279,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Computer.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 2L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(45 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3293,7 +3293,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Nanoprocessor.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 2L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(45 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3307,7 +3307,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 7, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 2L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(45 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3321,7 +3321,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 2L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(45 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3335,7 +3335,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Computer.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 2L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(45 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3349,7 +3349,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         ItemList.Circuit_Nanoprocessor.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 2L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(45 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3363,7 +3363,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 7, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt08, Materials.Copper, 2L),
                         GT_OreDictUnificator.get(OrePrefixes.bolt, Materials.RedSteel, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 3, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(45 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3381,7 +3381,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 8L),
                         getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt02, Materials.Copper, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 5, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3393,7 +3393,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 8L),
                         ItemList.Circuit_Computer.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt02, Materials.Copper, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 5, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3405,7 +3405,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 8L),
                         ItemList.Circuit_Nanoprocessor.get(2L),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt02, Materials.Copper, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 5, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
@@ -3417,7 +3417,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 8L),
                         getModItem(BartWorks.ID, "gt.bwMetaGeneratedItem0", 2, 7, missing),
                         GT_OreDictUnificator.get(OrePrefixes.cableGt02, Materials.Copper, 4L),
-                        GT_Utility.getIntegratedCircuit(18))
+                        GT_Utility.getIntegratedCircuit(24))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "logisticsSolidBlock", 1, 5, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 576)).duration(80 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);


### PR DESCRIPTION
Fixes the BiblioCraft Typewriter recipe by replacing ButtonGroup with Keyboard as mentioned in GTNewHorizons/GT-New-Horizons-Modpack#8174

Fixes the recipe conflict between Crafting Logistics Pipes & Logistics Crafting Table by setting all LogisticsPipes block recipes to use Integrated Circuit 24 as mentioned in GTNewHorizons/GT-New-Horizons-Modpack#12300