### PR TITLE
Fix a few broken LP recipes using gt++ items

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
@@ -5,7 +5,6 @@ import static gregtech.api.enums.Mods.BartWorks;
 import static gregtech.api.enums.Mods.BuildCraftSilicon;
 import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.Forestry;
-import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.enums.Mods.GalacticraftCore;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.IronChests;
@@ -55,7 +54,6 @@ public class ScriptLogisticPipes implements IScriptLoader {
                 BuildCraftSilicon.ID,
                 ExtraUtilities.ID,
                 Forestry.ID,
-                GTPlusPlus.ID,
                 GalacticraftCore.ID,
                 IndustrialCraft2.ID,
                 IronChests.ID,
@@ -4264,23 +4262,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
-                        getModItem(GTPlusPlus.ID, "itemPlateRedstoneAlloy", 2, 0, missing),
-                        getModItem(Minecraft.ID, "chest", 1, 0, missing),
-                        GT_Utility.getIntegratedCircuit(18))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
-                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
                         GT_OreDictUnificator.get(OrePrefixes.plate, Materials.RedstoneAlloy, 2L),
-                        getModItem(Minecraft.ID, "trapped_chest", 1, 0, missing),
-                        GT_Utility.getIntegratedCircuit(18))
-                .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
-                .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(LogisticsPipes.ID, "item.PipeItemsBasicLogistics", 2, 0, missing),
-                        getModItem(GTPlusPlus.ID, "itemPlateRedstoneAlloy", 2, 0, missing),
                         getModItem(Minecraft.ID, "trapped_chest", 1, 0, missing),
                         GT_Utility.getIntegratedCircuit(18))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeLogisticsChassiMk1", 2, 0, missing))
@@ -4879,7 +4861,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
-                        getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1, 32036, missing),
+                        ItemList.Robot_Arm_LV.get(1L),
                         GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Bronze, 2L),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         GT_Utility.getIntegratedCircuit(5))
@@ -4888,7 +4870,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
-                        getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1, 32036, missing),
+                        ItemList.Robot_Arm_LV.get(1L),
                         GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Bronze, 2L),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         GT_Utility.getIntegratedCircuit(6))
@@ -4897,7 +4879,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
-                        getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1, 32036, missing),
+                        ItemList.Robot_Arm_LV.get(1L),
                         GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Bronze, 2L),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         GT_Utility.getIntegratedCircuit(1))
@@ -4906,7 +4888,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
-                        getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1, 32036, missing),
+                        ItemList.Robot_Arm_LV.get(1L),
                         GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Bronze, 2L),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         GT_Utility.getIntegratedCircuit(2))
@@ -4915,7 +4897,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
-                        getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1, 32036, missing),
+                        ItemList.Robot_Arm_LV.get(1L),
                         GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Bronze, 2L),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         GT_Utility.getIntegratedCircuit(3))
@@ -4924,7 +4906,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.logisticsParts", 4, 4, missing),
-                        getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1, 32036, missing),
+                        ItemList.Robot_Arm_LV.get(1L),
                         GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Bronze, 2L),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 33, missing),
                         GT_Utility.getIntegratedCircuit(4))


### PR DESCRIPTION
Fixes https://discord.com/channels/181078474394566657/401118216228831252/1187451434690678827
Fixes https://discord.com/channels/181078474394566657/401118216228831252/1187456065202294885

Caused by the usual suspects. one by https://github.com/GTNewHorizons/GTplusplus/pull/767 and one by https://github.com/GTNewHorizons/GTplusplus/pull/729

I replace the ulv parts by lv. best I can do.


Now working: 
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/1d0fc102-b7b1-48e1-95e4-118a1dbe722e)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/047f6cd8-9668-4b84-96d5-e830b11c3e02)
(just the 2 recipes)
