### PR TITLE
Allow customizing  Tinker's Construct manuals in dreamcraft

### DIFF
--- a/addon.gradle
+++ b/addon.gradle
@@ -1,0 +1,6 @@
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+}

--- a/addon.gradle
+++ b/addon.gradle
@@ -4,3 +4,6 @@ test {
         events "passed", "skipped", "failed"
     }
 }
+configurations {
+    testImplementation.extendsFrom compileOnly
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,4 +27,13 @@ dependencies {
 
     runtimeOnlyNonPublishable("curse.maven:biomes-o-plenty-220318:2499612")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:WailaHarvestability:1.2.0-GTNH:dev")
+
+    // Core unit testing platform
+    testImplementation(platform('org.junit:junit-bom:5.9.2'))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+
+    // Extra unit testing libraries
+    testImplementation('org.assertj:assertj-core:3.+')
+    testImplementation('org.mockito:mockito-core:5.+')
+    testImplementation('org.mockito:mockito-junit-jupiter:5.+')
 }

--- a/src/main/java/com/dreammaster/coremod/transformers/ItemFocusWardingTransformer.java
+++ b/src/main/java/com/dreammaster/coremod/transformers/ItemFocusWardingTransformer.java
@@ -1,6 +1,10 @@
 package com.dreammaster.coremod.transformers;
 
-import static org.objectweb.asm.Opcodes.*;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ARETURN;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.POP;
 
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.tree.AbstractInsnNode;

--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -1,7 +1,16 @@
 package com.dreammaster.main;
 
 import static gregtech.api.enums.Dyes.MACHINE_METAL;
-import static gregtech.api.enums.Mods.*;
+import static gregtech.api.enums.Mods.Avaritia;
+import static gregtech.api.enums.Mods.BartWorks;
+import static gregtech.api.enums.Mods.BloodMagic;
+import static gregtech.api.enums.Mods.GalactiGreg;
+import static gregtech.api.enums.Mods.Railcraft;
+import static gregtech.api.enums.Mods.SGCraft;
+import static gregtech.api.enums.Mods.Thaumcraft;
+import static gregtech.api.enums.Mods.TinkerConstruct;
+import static gregtech.api.enums.Mods.TwilightForest;
+import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.recipe.RecipeMaps.compressorRecipes;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 

--- a/src/main/java/com/dreammaster/mantle/BookDataReader.java
+++ b/src/main/java/com/dreammaster/mantle/BookDataReader.java
@@ -1,0 +1,50 @@
+package com.dreammaster.mantle;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+/**
+ * This class doesn't support loading different XML documents based on Minecraft's currently configured language. Books
+ * are instead intended to be translated through lang files.
+ */
+class BookDataReader {
+
+    private static final DocumentBuilderFactory DB_FACTORY = DocumentBuilderFactory.newInstance();
+
+    @Nonnull
+    Document readBook(String xmlDocumentLocation) {
+        try (InputStream stream = loadBook(xmlDocumentLocation)) {
+            return readBookDocument(stream);
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            throw new IllegalStateException(
+                    "Failed to load book data from " + xmlDocumentLocation + ":\n" + e.getMessage(),
+                    e);
+        }
+    }
+
+    @Nonnull
+    private InputStream loadBook(String path) throws IOException {
+        InputStream inputStream = getClass().getResourceAsStream(path);
+        if (Objects.isNull(inputStream)) {
+            throw new IOException("File " + path + " does not exist.");
+        }
+        return inputStream;
+    }
+
+    @Nonnull
+    private Document readBookDocument(InputStream stream)
+            throws ParserConfigurationException, SAXException, IOException {
+        Document doc = DB_FACTORY.newDocumentBuilder().parse(stream);
+        doc.getDocumentElement().normalize();
+        return doc;
+    }
+
+}

--- a/src/main/java/com/dreammaster/mantle/BookDataStoreProxy.java
+++ b/src/main/java/com/dreammaster/mantle/BookDataStoreProxy.java
@@ -1,0 +1,38 @@
+package com.dreammaster.mantle;
+
+import java.util.Objects;
+
+import com.dreammaster.main.MainRegistry;
+
+import eu.usrv.yamcore.auxiliary.LogHelper;
+import mantle.books.BookData;
+import mantle.books.BookDataStore;
+
+/**
+ * This class helps us avoid issues with books already loaded by another mod.
+ */
+class BookDataStoreProxy {
+
+    private static final BookDataStoreProxy INSTANCE = new BookDataStoreProxy(MainRegistry.Logger);
+
+    static BookDataStoreProxy getInstance() {
+        return INSTANCE;
+    }
+
+    private final LogHelper logger;
+
+    BookDataStoreProxy(LogHelper logger) {
+        Objects.requireNonNull(logger);
+        this.logger = logger;
+
+    }
+
+    void addBook(BookData bookData) {
+        Objects.requireNonNull(bookData);
+        try {
+            BookDataStore.addBook(bookData);
+        } catch (IllegalArgumentException e) {
+            logger.error("Cannot override book " + bookData.unlocalizedName + " which is already defined elsewhere.");
+        }
+    }
+}

--- a/src/main/java/com/dreammaster/mantle/BookLoader.java
+++ b/src/main/java/com/dreammaster/mantle/BookLoader.java
@@ -1,0 +1,16 @@
+package com.dreammaster.mantle;
+
+public interface BookLoader {
+
+    static BookLoader of(String unlocalizedName, String modId, String xmlDocumentPath) {
+        return MantleBookLoader.readBook(unlocalizedName, modId, xmlDocumentPath);
+    }
+
+    BookLoader setTooltip(String tooltip);
+
+    BookLoader setItemImage(String itemImage);
+
+    BookLoader makeTranslatable();
+
+    void addToBookDataStore();
+}

--- a/src/main/java/com/dreammaster/mantle/MantleBookLoader.java
+++ b/src/main/java/com/dreammaster/mantle/MantleBookLoader.java
@@ -15,14 +15,14 @@ import mantle.books.BookData;
 
 final class MantleBookLoader implements BookLoader {
 
-    static final BookDataReader BOOK_DATA_READER = new BookDataReader();
-    static final BookDataStoreProxy BOOK_DATA_STORE_PROXY = BookDataStoreProxy.getInstance();
+    private static final BookDataReader BOOK_DATA_READER = new BookDataReader();
+    private static final BookDataStoreProxy BOOK_DATA_STORE_PROXY = BookDataStoreProxy.getInstance();
     private final BookDataStoreProxy bookDataStoreProxy;
     private final BookData data;
     private final IGT_Mod sideChecker;
     private final BookDataReader bookDataReader;
 
-    public static BookLoader readBook(String unlocalizedName, String modId, String xmlDocumentPath) {
+    static BookLoader readBook(String unlocalizedName, String modId, String xmlDocumentPath) {
         return new MantleBookLoader(BOOK_DATA_STORE_PROXY, BOOK_DATA_READER, GT_Mod.gregtechproxy)
                 .setRequiredData(unlocalizedName, modId, xmlDocumentPath);
     }

--- a/src/main/java/com/dreammaster/mantle/MantleBookLoader.java
+++ b/src/main/java/com/dreammaster/mantle/MantleBookLoader.java
@@ -1,0 +1,79 @@
+package com.dreammaster.mantle;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+
+import gregtech.GT_Mod;
+import gregtech.api.interfaces.internal.IGT_Mod;
+import mantle.books.BookData;
+
+final class MantleBookLoader implements BookLoader {
+
+    static final BookDataReader BOOK_DATA_READER = new BookDataReader();
+    static final BookDataStoreProxy BOOK_DATA_STORE_PROXY = BookDataStoreProxy.getInstance();
+    private final BookDataStoreProxy bookDataStoreProxy;
+    private final BookData data;
+    private final IGT_Mod sideChecker;
+    private final BookDataReader bookDataReader;
+
+    public static BookLoader readBook(String unlocalizedName, String modId, String xmlDocumentPath) {
+        return new MantleBookLoader(BOOK_DATA_STORE_PROXY, BOOK_DATA_READER, GT_Mod.gregtechproxy)
+                .setRequiredData(unlocalizedName, modId, xmlDocumentPath);
+    }
+
+    @VisibleForTesting
+    MantleBookLoader(BookDataStoreProxy bookDataStoreProxy, BookDataReader bookDataReader, IGT_Mod sideChecker) {
+        Stream.of(bookDataStoreProxy, bookDataReader, sideChecker).forEach(Objects::requireNonNull);
+        this.bookDataStoreProxy = bookDataStoreProxy;
+        this.bookDataReader = bookDataReader;
+        this.sideChecker = sideChecker;
+        this.data = new BookData();
+    }
+
+    @VisibleForTesting
+    BookLoader setRequiredData(String unlocalizedName, String modId, String xmlDocumentPath) {
+        Objects.requireNonNull(unlocalizedName);
+        Objects.requireNonNull(modId);
+        Objects.requireNonNull(xmlDocumentPath);
+        this.data.unlocalizedName = unlocalizedName;
+        this.data.modID = modId;
+        if (sideChecker.isClientSide()) {
+            data.doc = bookDataReader.readBook(xmlDocumentPath);
+        }
+        return this;
+    }
+
+    @Override
+    public BookLoader setTooltip(String tooltip) {
+        Objects.requireNonNull(tooltip);
+        data.toolTip = "§o" + StatCollector.translateToLocal(tooltip);
+        return this;
+    }
+
+    @Override
+    public BookLoader setItemImage(String itemImage) {
+        Objects.requireNonNull(itemImage);
+        data.itemImage = new ResourceLocation(data.modID, itemImage);
+        return this;
+    }
+
+    @Override
+    public BookLoader makeTranslatable() {
+        data.isTranslatable = true;
+        return this;
+    }
+
+    @Override
+    public void addToBookDataStore() {
+        if (Strings.isNullOrEmpty(data.unlocalizedName)) {
+            throw new IllegalStateException("You must call setRequiredData before addToBookDataStore.");
+        }
+        bookDataStoreProxy.addBook(data);
+    }
+}

--- a/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
@@ -12,6 +12,7 @@ import static gregtech.api.enums.Mods.GalaxySpace;
 import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.enums.Mods.IguanaTweaksTinkerConstruct;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
+import static gregtech.api.enums.Mods.Mantle;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Natura;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
@@ -33,6 +34,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 
 import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.mantle.BookLoader;
 import com.dreammaster.oredict.OreDictHelper;
 import com.dreammaster.tinkersConstruct.TConstructHelper;
 
@@ -50,6 +52,15 @@ import tconstruct.library.crafting.Smeltery;
 
 public class ScriptTinkersConstruct implements IScriptLoader {
 
+    /**
+     * Purposefully adding this static method here and keeping it private rather than adding onto TConstructHelper to
+     * avoid future proliferation of overloads of this method.
+     */
+    private static void addBook(String bookName, String unlocalizedName, String tooltip, String itemImage) {
+        BookLoader.of(unlocalizedName, TinkerConstruct.ID, "/assets/dreamcraft/tinker/manuals/" + bookName + ".xml")
+                .setTooltip(tooltip).setItemImage(itemImage).makeTranslatable().addToBookDataStore();
+    }
+
     @Override
     public String getScriptName() {
         return "Tinkers Construct";
@@ -59,6 +70,7 @@ public class ScriptTinkersConstruct implements IScriptLoader {
     public List<String> getDependencies() {
         return Arrays.asList(
                 TinkerConstruct.ID,
+                Mantle.ID,
                 RandomThings.ID,
                 TinkersMechworks.ID,
                 BloodArsenal.ID,
@@ -3499,5 +3511,15 @@ public class ScriptTinkersConstruct implements IScriptLoader {
                 .itemOutputs(getModItem(TinkerConstruct.ID, "decoration.stoneladder", 4, 0, missing))
                 .duration(3 * SECONDS).eut(30).addTo(assemblerRecipes);
 
+        addManuals();
     }
+
+    private void addManuals() {
+        addBook("firstday", "tconstruct.manual.beginner", "manual1.tooltip", "tinker:tinkerbook_diary");
+        addBook("materials", "tconstruct.manual.toolstation", "manual2.tooltip", "tinker:tinkerbook_toolstation");
+        addBook("smeltery", "tconstruct.manual.smeltery", "manual3.tooltip", "tinker:tinkerbook_smeltery");
+        addBook("diary", "tconstruct.manual.diary", "manual4.tooltip", "tinker:tinkerbook_blue");
+        addBook("weaponry", "tconstruct.manual.weaponry", "manual5.tooltip", "tinker:tinkerbook_green");
+    }
+
 }

--- a/src/main/resources/assets/dreamcraft/tinker/manuals/diary.xml
+++ b/src/main/resources/assets/dreamcraft/tinker/manuals/diary.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0"?>
+
+<book>
+<page type="text">
+<text>Tinker's Log #1:
+
+Today is a new day. I finally left home and decided to wander around in the wilderness until I find a good place to call my home. 
+
+Tinker's Log #2:
+
+I've decided to keep a log of my creations and machinations, as well as some insights into what I'm doing. I haven't actually built anything yet. There is a small cave I can board up for the night. I created a stone pickaxe affectionately called "Betsy".</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #3:
+
+The night is scary. Creepers are everywhere, the zombies are banging on my door, bats block out the sky... it is not fun being alone out here. I want to hide in the corner and cry until they leave. This log doesn't help take my mind off of anything.
+
+Tinker's Log #4:
+
+Betsy didn't last long. She just crumpled into dust suddenly and the handle shattered. My parents told me this would happen and this was normal, but it still seems so wrong. If I could make the pickaxe a little better perhaps, maybe I could repair it.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #5:
+
+I've spent the past three days looking for paper and ink. Squids were easy enough to find, but the sugar cane was buried deep in a ravine next to a creeper nest. Eventually I dropped rocks on the creepers and watched them explode out of surprise. My eyebrow will grow back in time.
+
+Tinker's Log #6:
+
+Waiting on sugar cane to grow. Not much else today.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #7:
+
+I've sketched out plans for a new workbench. It's a little strange. The center of the workbench is missing, but sturdy, and there are grooves in the top for supplies. I think I will call it a "table".
+
+Tinker's Log #8:
+
+I made a few more tables with different patterns in them. They look useful for different things, so I put different materials and tools by each one. Perhaps I will come up with a use for them in time.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #9:
+
+To make tools, you need to know what you're making. The pickaxe and shovel are easy enough to make with practice, the best crafters in my village told me, but I can't seem to make any good ones. Out of frustration I punched a hole in a wooden board. And another. And a few more. By the end I had something that resembled an axe, and that gave me a few ideas...</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #10:
+
+I punched holes in a few boards carefully in different shapes. I spent a lot of time making them, so they look really good. They all resemble the parts of tools that I can remember: heads, handles, bindings, pieces, and some others. They look really useful, so I placed them by a table for later.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #11:
+
+I grabbed a few of the boards and started to make tool parts using them as an outline. The parts themselves feel sturdy, and when I put them together the end result felt a lot better than Betsy did. They're made completely out of stone, something even the finest crafters could never manage. This feels like a great accomplishment.
+
+Tinker's Log #12:
+
+Perhaps making a tool completely out of stone wasn't the best idea. It didn't last very long. On the upside, instead of shattering into dust only the tip scratched off. I glued a new tip on the head and it seemed good as new.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #13:
+
+I wanted to make a few more tools, but the boards with tool shapes in them went everywhere! I ended up breaking a few out of frustration. They don't fit very well in my chest either. I took a few of them, added a few slots to the bottom of the chest, placed it by my table and called it good. 
+
+I also named them "Patterns", the chest a "Pattern Chest". I'm still angry at them, and it took so long to make new ones...</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #14
+
+Today I learned just how hard it was to shape iron. First you have to dig it out of the earth. A wooden pickaxe will shatter the ore; this I found out the hard way. Once you do get that ore there isn't much to do with it besides throw it in the furnace. Melting the iron and the stone seems inefficient, but I do need the metal more than I care about the waste. 
+
+I shaped a few of the bars into tools, and they felt strong. Much stronger, in fact, than the ones back at the village. I've named the pickaxe "Krug" after some of the stories Nana used to tell me at night. How I miss her...</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #15:
+
+This place holds little for me now. I've packed up my things, grabbed what resources I can carry, and set off. The tables and patterns will have to stay behind. I can't possibly carry them with all the food I have.
+
+Tinker's Log #16:
+
+A week later and I've finally found some others to visit. Some of them seem nice, most don't look like me. A few of them have things I never could have dreamed of. They've pointed me at a patch of land that was quiet and secluded. There I should be able to work, for I have ideas from the journey.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #17:
+
+After three days and nights of fending off zombies, I've finally created a house. It has a few rooms, a basement, but most importantly a workshop. All of the tables and patterns I had before are here, as well as a few others I wanted to try out from the trip. 
+
+There's a round one I can cook food with and one that's just as good as any hoe, but can chop trees or actually dig the ground up. The villagers tell me these are named "Frying Pan" and "Mattock". The Frying Pan seems heavy enough to smack creepers with. I have a sword named "Shimmer" that I want to alter somehow.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #18:
+
+One of the villagers was kind enough to give me some random things. Each one looks useful in their own right. I was lucky enough to find a few diamonds earlier, and I have a few more tools in storage. This should be fun.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #19:
+
+After some heavy experimentation, I've ended up with some things that look amazing and others that look less useful than they actually are. A diamond tip on a pickaxe makes for a wonderfully hard mining tool, and an emerald on a sword hilt somehow makes it stay together longer, but some things don't do anything. 
+
+Adding flowers to a tool does nothing; they don't even stay on the thing. Mushrooms have a similar effect, and adding more material to a tool just makes it heavier. You wouldn't think redstone would do anything. I've coated a shovel so much that it looks deep red. However, it slides through dirt as if the dirt wasn't there.</text>
+</page>
+
+<page type="text">
+<text>Moss is also a strange one. Somehow it seems to be healing the tool, even to the point where it looks like new.
+
+Tinker's Log #20:
+
+I tried to make some tools out of gold, like the crafters in my village used to, but instead it broke the table. Some of the villages laughed at me for such an idea... if only they knew.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #21:
+
+Some of these tools are more useful than I thought. Adding blaze powder to a weapon seems to give it some kind of burning effect. Lapis has this strange quality of being able to find more materials in the same area, even if I know exactly what I'm looking at.
+
+Tinker's Log #22:
+
+I have some ideas for creating tools, but for that I need a large place to create them. The furnace is inadequate, and I need a lot of stone. Combining lava with coal and netherrack seems to instantly cook stone as I mine it, up to the point where I can bypass the furnace entirely.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #23:
+
+Today I made something strange. It's round, wooden, and doesn't look like anything I've ever seen. Someone came by and said it was a "wheel" and that they were great fun to roll around. I wonder what else it could be used for?
+
+Tinker's Log #24:
+
+I made a few more of the wheels to get some practice in. I had some fun rolling them around, rolling them in pairs, and then one ended up beside my boat. It just looked so natural I had to start putting them together.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #25:
+
+I think I'm on to something here. Combining the boat with the wheel made it work something like a minecart, only I can pull it around places. It feels a little small though.
+
+Tinker's Log #26:
+
+I have all these tools laying around with little notes on what each one does. Instead of leaving them scattered about, I think I will create one place to store them.</text>
+</page>
+
+<page type="text">
+<text>Tinker's Log #27:
+
+I went exploring and found some new ores today. They're colors I've never seen before, and they don't shatter on impact like iron does. I wonder what I can do with these?
+
+Tinker's Log #28:
+
+The normal furnace is nice for keeping warm, but it leaves something to be desired for processing metal. I've dug a pit and lined it with some clay, gathered lava nearby, and put ore in the center in an attempt to improve on the design. The results were quite interesting.</text>
+</page>
+
+<page type="text">
+<text>The more lava I fed into the pit the hotter the material became. Eventually the whole thing liquified. I broke open the side of the pit with a cauldron in an attempt to catch the material, but it went everywhere. There were some remnants left in the pit as well.
+
+Raw ore still has parts of stone in it. There must be a way to remove the excess.</text>
+</page>
+</book>

--- a/src/main/resources/assets/dreamcraft/tinker/manuals/firstday.xml
+++ b/src/main/resources/assets/dreamcraft/tinker/manuals/firstday.xml
@@ -1,0 +1,407 @@
+<?xml version="1.0"?>
+
+<book>
+<page type="intro">
+<text>Materials and You
+Surviving the first day and beyond
+
+Volume 1
+By Skyla</text>
+</page>
+
+<page type="contents">
+<text>Table of Contents</text>
+<link>
+ <text>Getting Started</text>
+ <icon>sapling</icon>
+ <jump>3</jump>
+</link>
+<link>
+ <text>Recipes</text>
+ <icon>workbench</icon>
+ <jump>5</jump>
+</link>
+<link>
+ <text>Armor Modifiers</text>
+ <icon>travelvest</icon>
+ <jump>4</jump>
+</link>
+</page>
+
+<page type="text">
+<text>Welcome to the first edition of Materials and You: Surviving the first day and beyond. Within these pages you will find the first steps to making the tools and materials you need to survive.
+
+This book is a magic copy; it updates whenever the original has been modified. Check back occasionally for information on new things.</text>
+</page>
+
+<page type="text">
+<text>The first step in making tools is crafting a blank pattern. It is a blank slate to stamp a shape into, providing a reference for future creations. The patterns are shaped on the Stencil Table or are used as tabletops.
+
+You can then shape a material in a part builder with the pattern, then combine parts in the tool station. Patterns can be stored and accessed in the pattern chest.
+
+Together these make the Tool Workshop. It is recommended you keep all of these nearby when using any of them.</text>
+</page>
+
+<page type="crafting">
+<text>Blank Pattern</text>
+<recipe>
+ <name>blankpattern</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Stencil Table</text>
+<recipe>
+ <name>stenciltable</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Part Crafter</text>
+<recipe>
+ <name>partcrafter</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Pattern Chest</text>
+<recipe>
+ <name>patternchest</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Tool Station</text>
+<recipe>
+ <name>toolstation</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Tool Forge</text>
+<recipe>
+ <name>toolforge</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Drying Rack</text>
+<recipe>
+ <name>dryingrack</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="text">
+<text>Oreberry Bushes
+
+Sometime in your travels you will happen upon the bush known as the Oreberry. They grow underground in dark areas, and require close to complete darkness to produce anything. 
+
+The berries can be melted down into nuggets and ingots, making them an invaluable source of metals.</text>
+</page>
+
+<page type="picture">
+<text>Oreberries in their natural environment</text>
+<location>tinker:manuals/oreberries.png</location>
+</page>
+
+<page type="text">
+<text>Slime Channels
+
+Slime channels are useful for moving items or entities around. They are used as a sort of easily placeable water and can be paired with bounce pads for best effect.</text>
+</page>
+
+<page type="crafting">
+<text>Slime Channel</text>
+<recipe>
+ <name>slimechannel</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Bounce Pad</text>
+<recipe>
+ <name>bouncepad</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="text">
+<text>A few traps or blockades may help with your early survival experience</text>
+</page>
+
+<page type="crafting">
+<text>Punji Stick</text>
+<recipe>
+ <name>punji</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Barricade</text>
+<recipe>
+ <name>barricade</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="text">
+<text>Once you're well established, you can begin to process metals in a more efficient manner. The scope of the smeltery is beyond this volume, but a few recipes will help you get started.
+
+Note: The Smeltery is required to process all metals, including iron.</text>
+</page>
+
+<page type="crafting">
+<text>Grout</text>
+<recipe>
+ <name>grout</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="furnace">
+<text>Seared Brick</text>
+<recipe>searedbrick</recipe>
+</page>
+
+<page type="crafting">
+<text>Seared Bricks</text>
+<recipe>
+ <name>searedbricks</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Smeltery Controller</text>
+<recipe>
+ <name>smelterycontroller</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="text">
+<text>If you ever find yourself without this book, a new one is simple to make. Other books can be made from this one as well.</text>
+</page>
+
+<page type="crafting">
+<text>Book</text>
+<recipe>
+ <name>alternatebook</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Materials and You: v1</text>
+<recipe>
+ <name>patternbook1</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Materials and You: v2</text>
+<recipe>
+ <name>patternbook2</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Mighty Smelting</text>
+<recipe>
+ <name>patternbook3</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="text">
+<text>Armor Modifiers
+
+The following armor modifiers seem to be missing names or in flux. No word is available on the accuracy or new home of these pages.</text>
+</page>
+
+<page type="sectionpage">
+<title>Night Vision</title>
+<text>Apparently carrots and juice are not only good for your eyes, but for your goggles as well.
+The Night Vision Potion also helps.
+
+Effects:
+- Night Vision
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>travelgoggles</tooltype>
+<recipe>nightvision</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Perfect Dodge</title>
+<text>Ninja ninja.
+
+Effects:
+- You're harder to hit
+
+Type: Single-use
+Stackable: yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>travelvest</tooltype>
+<recipe>dodge</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Stealth</title>
+<text>Travelling gear is not very protective. Therefore I mixed some magical items and an Invisibility Potion together, to make myself stealthier!
+
+Effects:
+- Turn invisible while sneaking
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>travelvest</tooltype>
+<recipe>stealth</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Feather Fall</title>
+<text>You already got wings. If chicken can do it, so can you.
+Any slime variant can be used.
+
+Effects:
+- Allows you to glide down slowly in air
+
+Type: Single-use
+Stackable: yes</text>
+</page>
+
+<page type="crafting">
+<text>Tinker Table</text>
+<recipe>
+ <name>featherfall</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Water Walk</title>
+<text>If I put these things on my boots, I'm sure I can walk over water too. What could go wrong?
+
+Effects:
+- Allows you to walk over water
+- Sneak to sink
+- Does not come with a halo
+
+Type: Single-use
+Stackable: no</text>
+</page>
+
+<page type="modifier">
+<tooltype>travelboots</tooltype>
+<recipe>waterwalk</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Lead boots</title>
+<text>This iron block has served me well. I want to take it with me, to the bottom of the ocean.
+Perfect if you want to see where your pet-fish sleeps.
+
+Effects:
+- Allows you to walk under water
+- Prevents you from swimming
+- Blub.
+
+Type: Single-use
+Stackable: no</text>
+</page>
+
+<page type="modifier">
+<tooltype>travelboots</tooltype>
+<recipe>leadboots</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Slimy Soles</title>
+<text>When I jump on slime, I bounce and don't take damage. I should be able to replicate that effect by putting the slime onto my soles.
+
+Effects:
+- Dampens the fall impact
+- Reduces fall damage taken
+
+Type: Single-use
+Stackable: yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>travelboots</tooltype>
+<recipe>slimysoles</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Speed</title>
+<text>Putting redstone on my weapon makes it faster. So why don't I put it on my hands directly!
+
+Effects:
+- Increases mining speed
+
+Type: Multi-use
+Stackable: yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>travelglove</tooltype>
+<recipe>glovehaste</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Auto-Repair</title>
+<text>Attaching moss to an armor infuses it with life. The tool appears to be capable of regenerating wear and tear.
+
+Effects:
+- The tool slowly repairs itself
+- Sunlight speeds up the process
+- Can be applied to all travellers gear
+
+Type: Single-use
+Stackable: yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>travelmulti</tooltype>
+<recipe>moss</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Double Jump</title>
+<text>Infused with the power of a ghast tear and some slime and piston mechanics, I should be able to repel myself even further into the air.
+
+Effects:
+- Jump during jumping to jump
+- Can be applied to wings as well
+
+Type: Single-use
+Stackable: yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>travelmulti</tooltype>
+<recipe>doublejump</recipe>
+</page>
+
+</book>

--- a/src/main/resources/assets/dreamcraft/tinker/manuals/materials.xml
+++ b/src/main/resources/assets/dreamcraft/tinker/manuals/materials.xml
@@ -1,0 +1,1107 @@
+<?xml version="1.0"?>
+
+<book>
+<page type="intro">
+<text>Materials and You
+A Guide to Tools and Abilities
+
+Volume 2
+By Skyla</text>
+</page>
+
+<page type="contents">
+<text>Table of Contents</text>
+<link>
+ <text>Tools</text>
+ <icon>ironpick</icon>
+ <jump>2</jump>
+</link>
+<link>
+ <text>Materials</text>
+ <icon>woodplanks</icon>
+ <jump>4</jump>
+</link>
+<link>
+ <text>Modifiers</text>
+ <icon>lavacrystal</icon>
+ <jump>4</jump>
+</link>
+</page>
+
+<page type="text">
+<text>Welcome to the second edition of Materials and You: A Guide to Tools and Abilities. Within these pages you will details on every known tool, modifier, and material. A detailed breakdown of everything known, and a few unknowns, lie here.
+
+This book is a magic copy; it updates whenever the original has been modified. Check back occasionally for information on new things.</text>
+</page>
+
+<page type="toolpage">
+<title>Pickaxe</title>
+<text>The Pickaxe is a basic mining tool. It is the simplest method of chewing through rock and harvesting ores.</text>
+<text>Class: Precision Tool
+Effective on: Stone or rock, ores, and metal.</text>
+<icon>pickicon</icon>
+<item>
+ <text>Pickaxe Head</text>
+ <icon>pickhead</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+<item>
+ <text>Tool Binding</text>
+ <icon>binding</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Shovel</title>
+<text>The Shovel is a basic digging tool. It is the most common way of moving earth around.</text>
+<text>Class: Precision Tool
+Effective on: Dirt, sand, gravel, and snow.</text>
+<icon>shovelicon</icon>
+<item>
+ <text>Shovel Head</text>
+ <icon>shovelhead</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Hatchet</title>
+<text>The Hatchet is a basic chopping tool. It is the simplest way to shape lumber.</text>
+<text>Class: Precision Tool
+Effective on: Wood, Leaves, and Trees.</text>
+<icon>axeicon</icon>
+<item>
+ <text>Hatchet Head</text>
+ <icon>axehead</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Mattock</title>
+<text>The Cutter Mattock is a versatile farming tool. Its primary purpose is to till soil. It also works somewhat like an axe and a shovel, but is not a replacement for either.</text>
+<text>Class: Multitool
+Effective on: Wood, dirt, and plants.</text>
+<icon>mattockicon</icon>
+<item>
+ <text>Axe Head</text>
+ <icon>axehead</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+<item>
+ <text>Shovel Head</text>
+ <icon>shovelhead</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Broadsword</title>
+<text>The Broadsword is a defensive weapon. It is a favorite of many Tinkers and is useful in a wide variety of situations.</text>
+<text>Right-click: Block
+- Blocking cuts a wide variety of damage types in half.
+
+Class: Melee Weapon
+Effective on webs.</text>
+<icon>swordicon</icon>
+<item>
+ <text>Sword Blade</text>
+ <icon>swordblade</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+<item>
+ <text>Wide Guard</text>
+ <icon>wideguard</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Longsword</title>
+<text>The Longsword is an offensive weapon. It is used for full-speed charges and plowing through enemy lines</text>
+<text>Right-click: Lunge
+- When released, it sends you careening forward at breakneck speed.
+
+Natural Abilities:
+- Charge Boost, does 1.5x damage and knockback while sprinting
+
+Class: Melee Weapon
+Effective on webs.</text>
+<icon>longswordicon</icon>
+<item>
+ <text>Sword Blade</text>
+ <icon>swordblade</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+<item>
+ <text>Hand Guard</text>
+ <icon>handguard</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Rapier</title>
+<text>The Rapier is a special weapon. The dancing swordplay lets you get in and out of battle quickly. While the Rapier's damage is low, it makes up for this with its other abilities.</text>
+<text>Right-click: Backpedal
+- Take a small hop backwards
+
+Natural Abilities:
+- Charge Boost, does 1.5x damage and knockback while sprinting.
+- Armor Pierce, ignores armor and blocking.
+- Quick Strike, the enemy is stunned for less time.
+
+Class: Melee Weapon</text>
+<icon>rapiericon</icon>
+<item>
+ <text>Sword Blade</text>
+ <icon>swordblade</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+<item>
+ <text>Crossbar</text>
+ <icon>crossbar</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Dagger</title>
+<text>The Dagger is a short weapon. It is light and usable as both a striking and throwing weapon.</text>
+<text>Right-click: Throw Dagger
+- Toss the item for a ranged attack
+
+Class: Ranged/Melee Weapon</text>
+<icon>daggerIcon</icon>
+<item>
+ <text>Knife Blade</text>
+ <icon>knifeblade</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+<item>
+ <text>Crossbar</text>
+ <icon>crossbar</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Frying Pan</title>
+<text>The Frying is a heavy weapon that uses sheer weight to stun foes or a place to cook your food. It is common to hunt pigs and cook them with the same pan.</text>
+<text>Right-click: Block
+- Blocking cuts a wide variety of damage types in half.
+
+Shift+Right-click: Place Item
+- The frying pan cooks a large amount of food at a time.
+
+Natural Abilities:
+- Bash, does extra knockback and stuns the foe.</text>
+<icon>frypanicon</icon>
+<item>
+ <text>Pan</text>
+ <icon>pan</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Battlesign</title>
+<text>The Battlesign is an advance in weapon technology worthy of Zombie Pigmen everywhere.</text>
+<text>Right-click: Block
+- Blocking cuts a wide variety of damage types in half.
+
+Shift+Right-click: Place Item
+- The battlesign can show up to five lines of text.
+
+Class: Lethal Joke Weapon</text>
+<icon>battlesignicon</icon>
+<item>
+ <text>Board</text>
+ <icon>board</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Chisel</title>
+<text>The Chisel is an advanced detailing tool for carving shapes into blocks.</text>
+<text>Right-click: Chisel
+- Transforms various blocks into bricks.
+Crafting grid: Chisel
+- Some items can only be chiseled in the crafting grid.
+
+Class: Utility Tool</text>
+<icon>chiselicon</icon>
+<item>
+ <text>Chisel Head</text>
+ <icon>chiselhead</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Hammer</title>
+<text>The Hammer is a heavy mining tool meant for digging out large areas. It is also effective on undead.</text>
+<text>Natural Abilities: 
+- Area of Effect, Mines a 3x3 area. The direction depends on which face is pounded.
+- Smite II, Does 2-4 extra hearts of damage against undead.
+- Huge Durability, this tool has very high durability to make up for the constant beating it will receive.
+
+Class: Broad Mining Tool</text>
+<icon>hammericon</icon>
+<item>
+ <text>Hammer Head</text>
+ <icon>hammerhead</icon>
+</item>
+<item>
+ <text>Large Plate</text>
+ <icon>largeplate</icon>
+</item>
+<item>
+ <text>Tough Rod</text>
+ <icon>toughrod</icon>
+</item>
+<item>
+ <text>Large Plate</text>
+ <icon>largeplate</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Lumber Axe</title>
+<text>The Lumber Axe is capable of bringing down whole trees or clearing large swaths of food in a single swing.</text>
+<text>Natural Abilities:
+Fell Trees
+- Harvests entire trees. It has a max height of 30. Trees are defined as Leaves on top of Logs.
+Area of Effect
+- Mines a 3x3x3 area. This is a fallback if a tree is not found.
+
+Class: Broad Mining Tool</text>
+<icon>lumbericon</icon>
+<item>
+ <text>Broad Axe Head</text>
+ <icon>broadaxehead</icon>
+</item>
+<item>
+ <text>Large Plate</text>
+ <icon>largeplate</icon>
+</item>
+<item>
+ <text>Tough Rod</text>
+ <icon>toughrod</icon>
+</item>
+<item>
+ <text>Tough Binding</text>
+ <icon>toughbinding</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Excavator</title>
+<text>The Excavator is a large digging tool used for clearing out large swaths of land, gravel, or snow.</text>
+<text>Natural Abilities: 
+Area of Effect
+- Mines a 3x3 area. The direction depends on which face is scooped.
+
+Class: Broad Mining Tool</text>
+<icon>excavatoricon</icon>
+<item>
+ <text>Excavator Head</text>
+ <icon>excavatorhead</icon>
+</item>
+<item>
+ <text>Large Plate</text>
+ <icon>largeplate</icon>
+</item>
+<item>
+ <text>Tough Rod</text>
+ <icon>toughrod</icon>
+</item>
+<item>
+ <text>Tough Binding</text>
+ <icon>toughbinding</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Scythe</title>
+<text>The Scythe is well known for its large swinging area. It can be used to harvest crops, leaves, and is a decent weapon.</text>
+<text>Natural Abilities: 
+Area of Effect
+- Attacks mobs in a 3x3x3.
+- Harvests a 3x3x3 area.
+
+Class: Broad Melee Weapon</text>
+<icon>scytheicon</icon>
+<item>
+ <text>Scythe Head</text>
+ <icon>scythehead</icon>
+</item>
+<item>
+ <text>Tough Rod</text>
+ <icon>toughrod</icon>
+</item>
+<item>
+ <text>Tough Binding</text>
+ <icon>toughbinding</icon>
+</item>
+<item>
+ <text>Tough Rod</text>
+ <icon>toughrod</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Cleaver</title>
+<text>The Cleaver is a heavy defensive weapon. The sword is unwieldy, but the sheer weight of the tool crushes foes.</text>
+<text>Right-click: Block
+- Blocking cuts a wide variety of damage types in half.
+
+Natural Abilities: 
+- Beheading II, Beheads mobs. Their head is dropped as loot.
+- Heavy, Base attack is increased at the cost of swing time
+
+Class: Heavy Melee Weapon</text>
+<icon>cleavericon</icon>
+<item>
+ <text>Large Sword Blade</text>
+ <icon>largeswordblade</icon>
+</item>
+<item>
+ <text>Large Plate</text>
+ <icon>largeplate</icon>
+</item>
+<item>
+ <text>Tough Rod</text>
+ <icon>toughrod</icon>
+</item>
+<item>
+ <text>Tough Rod</text>
+ <icon>toughrod</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Battleaxe</title>
+<text>The battleaxe is an offensive melee weapon that can also bring down small trees.</text>
+<text>Right-click: TBD
+- This ability is incomplete
+
+Natural Abilities: 
+- Area of Effect, harvests wood blocks in a 1x9 tower.
+- Bash, knocks the enemy further away than normal.
+
+Class: Heavy Melee Weapon</text>
+<icon>battleaxeicon</icon>
+<item>
+ <text>Broad Axe Head</text>
+ <icon>broadaxehead</icon>
+</item>
+<item>
+ <text>Broad Axe Head</text>
+ <icon>broadaxehead</icon>
+</item>
+<item>
+ <text>Tough Rod</text>
+ <icon>toughrod</icon>
+</item>
+<item>
+ <text>Tough Binding</text>
+ <icon>toughbinding</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Shortbow</title>
+<text>The Shortbow is a weapon used to fire arrows. It has a quick, short range.</text>
+<text>Right-click: Draw bow
+- The further a bow is drawn, the further an arrow flies and the more damage it does.
+
+Class: Ranged Projectile Launcher</text>
+<icon>shortbowIcon</icon>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+<item>
+ <text>Bowstring</text>
+ <icon>bowstring</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+</page>
+
+<page type="toolpage">
+<title>Arrow</title>
+<text>Arrows are fired from bows as projectiles. They can also be used as stabbing weapons in a pinch.</text>
+<text>Class: Ammunition</text>
+<icon>arrowIcon</icon>
+<item>
+ <text>Arrowhead</text>
+ <icon>arrowhead</icon>
+</item>
+<item>
+ <text>Tool Rod</text>
+ <icon>toolrod</icon>
+</item>
+<item>
+ <text>Fletching</text>
+ <icon>fletching</icon>
+</item>
+</page>
+
+<page type="sectionpage">
+<title>Material Traits</title>
+<text>Some materials have traits that augment their natural uses.
+
+- Reinforced: 10% chance per level of not using durability
+- Stonebound: The tool mines faster as it wears out, but does less damage
+- Jagged: The tool attacks with does more damage as it wears out, but mines slower
+- Writable: One extra modifier per piece
+- Tasty: Sometimes drops food items</text>
+</page>
+
+<page type="materialstats">
+<title>Wood</title>
+<icon>woodaxe</icon>
+<text>It seems to grow everywhere.</text>
+<material>
+ <main>woodplanks</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Stone</title>
+<icon>stonepick</icon>
+<text>One of the most common materials in the world.</text>
+<material>
+ <main>stoneblock</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Iron</title>
+<icon>ironpick</icon>
+<text>A staple for tools, it can be refined and processed.
+- Requires the Smeltery</text>
+<material>
+ <main>ironingot</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Flint</title>
+<icon>flintshovel</icon>
+<text>More durable than stone. The material of choice for cavemen.</text>
+<material>
+ <main>flint</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Cactus</title>
+<icon>cactussword</icon>
+<text>A form of wood found only in the desert.</text>
+<material>
+ <main>cactus</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Bone</title>
+<icon>bonerapier</icon>
+<text>A material with many uses, dead or alive.</text>
+<material>
+ <main>bone</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Obsidian</title>
+<icon>bonefrypan</icon>
+<text>Tough as nails, but fragile when shaped.</text>
+<material>
+ <main>obsidian</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Alumite</title>
+<icon>alumitepick</icon>
+<text>An uncommon alloy. It seems to be quite durable.
+- Requires the Smeltery</text>
+<material>
+ <main>alumiteingot</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Netherrack</title>
+<icon>netherrackmattock</icon>
+<text>This is made of what?!</text>
+<material>
+ <main>netherrack</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Blue Slime</title>
+<icon>blueslimebattlesign</icon>
+<text>Converting it from food has made it stronger.</text>
+<toolmaterial>BlueSlime</toolmaterial>
+<material>
+ <main>blueslimecrystal</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Green Slime</title>
+<icon>slimebattlesign</icon>
+<text>Soft and springy, it seems to last forever.</text>
+<toolmaterial>Slime</toolmaterial>
+<material>
+ <main>slimecrystal</main>
+</material>
+</page>
+
+<page type="crafting">
+<text>Slimy Mud</text>
+<recipe>
+ <name>slimymud</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="furnace">
+<text>Slime Crystal</text>
+<recipe>slimecrystal</recipe>
+</page>
+
+<page type="materialstats">
+<title>Paper</title>
+<icon>paperpick</icon>
+<text>It's very weak, but can take a lot of modification.</text>
+<material>
+ <main>paperstack</main>
+</material>
+</page>
+
+<page type="crafting">
+<text>Paper Stack</text>
+<recipe>
+ <name>paperstack</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="materialstats">
+<title>Cobalt</title>
+<icon>cobaltlongsword</icon>
+<text>One of the nether materials. It's bright blue.
+- Requires the Smeltery</text>
+<material>
+ <main>cobaltingot</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Ardite</title>
+<icon>arditelongsword</icon>
+<text>One of the nether materials. It seems to mine faster as it wears out.
+- Requires the Smeltery</text>
+<material>
+ <main>arditeingot</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Manyullyn</title>
+<icon>manyullynlongsword</icon>
+<text>The nether alloy. It's stronger than diamond.
+- Requires the Smeltery</text>
+<material>
+ <main>manyullyningot</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Copper</title>
+<icon>copperaxe</icon>
+<text>A common metal found in the ground.
+- Requires the Smeltery</text>
+<material>
+ <main>copperingot</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Bronze</title>
+<icon>bronzeaxe</icon>
+<text>A common alloy. It's a bit better than iron.
+- Requires the Smeltery</text>
+<material>
+ <main>bronzeingot</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Steel</title>
+<icon>steelsword</icon>
+<text>An Iron alloy. The method for obtaining this is unknown.
+- Requires the Smeltery</text>
+<material>
+ <main>steelingot</main>
+</material>
+</page>
+
+<page type="materialstats">
+<title>Pig Iron</title>
+<icon>pigironsword</icon>
+<toolmaterial>PigIron</toolmaterial>
+<text>An Iron alloy. It seems to be made of blood, iron, and emeralds.
+- Requires the Smeltery</text>
+<material>
+ <main>pigironingot</main>
+</material>
+</page>
+
+<page type="blank">
+</page>
+
+<page type="sectionpage">
+<title>Diamond</title>
+<text>Adding a diamond to the edge of a tool seems to make it more resilient.
+
+Effects:
+- 500 extra durability
+- Mining level increased to level 3
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>diamondmod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Emerald</title>
+<text>Affixing an emerald to a tool's weakest point appears to make it more resilient.
+
+Effects:
+- 50% more durability
+- Mining level increased to level 2
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>emeraldmod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Speed</title>
+<text>Adding redstone to a tool seems to increase its mining speed.
+
+Effects:
+- Each redstone dust increases mining speed by 0.08.
+- At 50/50 the boost is 4.0, making a wood pickaxe equivalent in speed to iron.
+- Not useful on weapons
+
+Type: Multi-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>redstonemod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Auto-Repair</title>
+<text>Attaching moss to a tool infuses it with life. The tool appears to be capable of regenerating wear and tear.
+
+Effects:
+- The tool slowly repairs itself
+- Sunlight speeds up the process
+
+Type: Single-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>mossmod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Auto-Smelt</title>
+<text>Melting a lava crystal onto the end of a tool gives it the power of a furnace.
+
+Effects:
+- Smelts blocks as they're harvested
+- Sets mobs on fire for 3 seconds
+- Stacks with Luck
+- Not compatible with Silky
+
+Type: Multi-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>lavacrystalmod</recipe>
+</page>
+
+<page type="crafting">
+<text>Ball of Moss</text>
+<recipe>
+ <name>mossball</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Lava Crystal</text>
+<recipe>
+ <name>lavacrystal</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Luck</title>
+<text>Encrusting lapis on tools is a gift to the gods of luck. They will bless your tool with great fortune and loot.
+
+Effects:
+- Adds fortune or looting, depends on tool type
+- Increases level at a maximum threshold, but has a chance of increasing before
+- Sometimes adds extra luck to the tool
+- Not compatible with Silky
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>lapismod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Sharpness</title>
+<text>Adding quartz to the edge of a tool seems to make it sharper.
+
+Effects:
+- Increases attack damage
+- Has less of an effect on tools with piercing properties
+
+Type: Multi-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>weapon</tooltype>
+<recipe>quartzmod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Fiery</title>
+<text>Adding blaze powder to a tool gives it a fiery tinge.
+
+Effects:
+- Sets enemies on fire
+- Every 5 powder adds another second to the flame.
+
+Type: Multi-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>weapon</tooltype>
+<recipe>blazemod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Necrotic</title>
+<text>Placing the bone of a Wither Skeleton on a tool gives it nefarious life-stealing powers.
+
+Effects:
+- Heals the player every time a monster is attacked
+- Heals one heart per bone
+
+Type: Single-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>weapon</tooltype>
+<recipe>necroticmod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Silky</title>
+<text>Adding a large glob of aluminum brass or gold and a bunch of string seems to give the tool silky-smooth properties.
+
+Effects:
+- Allows blocks to be harvested directly
+- Scythes modified with Silky act as shears on blocks
+- Not compatible with Luck or Auto-Smelt
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>silkymod</recipe>
+</page>
+
+<page type="crafting">
+<text>Silky Cloth</text>
+<recipe>
+ <name>silkycloth</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Silky Jewel</text>
+<recipe>
+ <name>silkyjewel</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Reinforced</title>
+<text>Adding a reinforced plate to the tool seems to help with its durability.
+
+Effects:
+- Adds the material trait Reinforced to the tool
+- Stacks with previous levels of Reinforced
+
+Type: Single-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>reinforcedmod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Knockback</title>
+<text>Attaching a piston to the tool and activating it at the right time seems to throw mobs further away.
+
+Effects:
+- Adds extra knockback to the tool.
+
+Type: Multi-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>weapon</tooltype>
+<recipe>pistonmod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Beheading</title>
+<text>Working an ender pearl and some obsidian on a weapon has the curious effect of separating the target's head from its body.
+
+Effects:
+- Beheads mobs. Enemies drop their heads as a result.
+
+Type: Single-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>weapon</tooltype>
+<recipe>beheadingmod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Bane of Arthropods</title>
+<text>Striking a spider with its own eyeball causes it to recoil in fear.
+
+Effects:
+- Does extra damage to spiders.
+- 1-2 hearts per level.
+
+Type: Multi-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>weapon</tooltype>
+<recipe>spidermod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Smite</title>
+<text>The raw power of consecrated soil empowers your weapon, smiting enemies from on high.
+
+Effects:
+- Does extra damage to undead.
+- 1-2 hearts per level.
+
+Type: Multi-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>weapon</tooltype>
+<recipe>smitemod</recipe>
+</page>
+
+<page type="crafting">
+<text>Graveyard Soil</text>
+<recipe>
+ <name>graveyardsoil</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="furnace">
+<text>Consecrated Soil</text>
+<recipe>consecratedsoil</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Flux</title>
+<text>Adding a Hardened Flux Capacitor or Leadstone Energy Cell gives a tool energy. The tool still functions properly when the Cell/Capacitor has no charge.
+
+Effects:
+- Allows the tool to be charged with Redstone Flux
+- Uses energy instead of durability while charged
+- Available from Thermal Expansion
+- Tools must have at least 1/1000th of the batteries capacity in durability
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>fluxmod</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Flux</title>
+<text>Adding a Hardened Flux Capacitor or Leadstone Energy Cell gives a tool energy. The tool still functions properly when the Cell/Capacitor has no charge.
+
+Effects:
+- Allows the tool to be charged with Redstone Flux
+- Uses energy instead of durability while charged
+- Available from Thermal Expansion
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>fluxmod2</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Additional Modifiers</title>
+<text>Working the tool with a block of gold and a diamond makes the tool more malleable, allowing for more modification.
+
+Effects:
+- Adds an additional modifier slot to the tool
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>tier1free</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Additional Modifiers</title>
+<text>Attaching a solid gold apple and encrusting the tool with a block of diamond warps the tool in places you did not notice before.
+
+Effects:
+- Adds an additional modifier slot to the tool
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>tier1.5free</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Additional Modifiers</title>
+<text>Working the tool with a nether star gives it the ability to attach parts they would not otherwise stay.
+
+Effects:
+- Adds an additional modifier slot to the tool
+
+Type: Single-use
+Stackable: No</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>tier2free</recipe>
+</page>
+
+<page type="sectionpage">
+<title>Additional Modifiers</title>
+<text>For the creative types or the map makers in the world, this item is for you.
+
+Effects:
+- Adds an additional modifier slot to the tool
+- If it has a target lock, it will only work on that tool.
+
+Type: Single-use
+Stackable: Yes</text>
+</page>
+
+<page type="modifier">
+<tooltype>tool</tooltype>
+<recipe>creativefree</recipe>
+</page>
+
+</book>

--- a/src/main/resources/assets/dreamcraft/tinker/manuals/smeltery.xml
+++ b/src/main/resources/assets/dreamcraft/tinker/manuals/smeltery.xml
@@ -1,0 +1,296 @@
+<?xml version="1.0"?>
+
+<book>
+<page type="intro">
+<text>Mighty Smelting
+Make the most of your metals
+
+By Thruul M'gon</text>
+</page>
+
+<page type="contents">
+<text>Table of Contents</text>
+<link>
+ <text>Introduction</text>
+ <icon>smelterybook</icon>
+ <jump>3</jump>
+</link>
+<link>
+ <text>Casting</text>
+ <icon>castingtable</icon>
+ <jump>8</jump>
+</link>
+<link>
+ <text>Construction</text>
+ <icon>smeltery</icon>
+ <jump>5</jump>
+</link>
+<link>
+ <text>Alloys</text>
+ <icon>liquidiron</icon>
+ <jump>9</jump>
+</link>
+<link>
+ <text>Recipes</text>
+ <icon>blankcast</icon>
+ <jump>9</jump>
+</link>
+</page>
+
+<page type="text">
+<text>Welcome to the world of metalcraft. Within these pages you will learn the secrets of crafting rare and precious metals into usable materials.
+
+You will learn how to cast everything from the softest Iron to the hardest Manyullyn into whatever shape you desire and create alloy mixes from obscure materials. As always, experimentation is key!
+
+The main structure for melting metals is called the Smeltery. It is larger than structures you may be familiar with, but the method for construction is relatively simple. It operates much like a furnace with a drain.</text>
+</page>
+
+<page type="text">
+<text>When working with the Smeltery, there are a few things to keep in mind:
+
+* The Smeltery functions as a large liquid tank. It is capable of melting metals and mixing various things.
+
+* Drains function as input/output for the tank. If you need to get liquids back into the structure, simply pour them into a drain.
+
+* Ores naturally have more material than processed versions, such as ingots. The Smeltery will preserve the full value of the ores - roughly twice as much as a regular furnace would provide.</text>
+</page>
+
+<page type="text">
+<text>* Mixing two or more metals in the Smeltery may result in an alloy. The process happens automatically.
+
+* If you need more space to process metal, add more layers.
+
+* Casts are made differently from Patterns. Details are found later.</text>
+</page>
+
+<page type="sidebar">
+<text>The Smeltery is a multi-block structure. You will need the following materials to get started.</text>
+<item>
+ <text>1 Smeltery Controller</text>
+ <icon>smeltery</icon>
+</item>
+<item>
+ <text>1 Seared Tank</text>
+ <icon>lavatank</icon>
+</item>
+<item>
+ <text>9 Seared Bricks</text>
+ <icon>searedbrick</icon>
+</item>
+<item>
+ <text>Any combination of 10 Seared Bricks, Seared Tanks, or Drains
+ </text>
+ <icon>drain</icon>
+</item>
+<item>
+ <text>1 Faucet</text>
+ <icon>faucet</icon>
+</item>
+<item>
+ <text>1 Casting Table</text>
+ <icon>castingtable</icon>
+</item>
+</page>
+
+<page type="text">
+<text>Begin construction by laying a 3x3 bed of seared bricks. Leave any space above these bricks open; you will be constructing a shell around a 3x3 hollow inside. 
+
+Place the Controller one layer up and the lava tank anywhere on the same level. Fill in the rest of the space with seared bricks, lava tanks, or drains as you like. 
+
+The small end of drains should be facing the outside. If you're successful, the Controller will light up and start working. Fill the tank with lava, the Smeltery with metal, and watch it go.
+
+The structure must be a 5x5 shell due to the amount of heat lava gives off. There are no vertical restrictions to the size of the Smeltery. </text>
+</page>
+
+<page type="text">
+<text>Larger Smelteries will hold more metal, of course, and the Controller can be on any level so long as there is a lava tank to match.
+
+When you are ready to pour liquid metal from the Smeltery, put a faucet on a drain and a casting table below it.
+
+Other liquid removal objects will work, but are frowned upon. An example picture is provided for your convenience.</text>
+</page>
+
+<page type="picture">
+<text>Figure 1a</text>
+<location>tinker:manuals/smelterysmall.png</location>
+</page>
+
+<page type="sidebar">
+<text>Alloys are made when two or more metals are mixed in precise proportions. Currently known alloys are:</text>
+<item>
+ <text>Bronze, made from Copper(3) and Tin(1)</text>
+ <icon>bronzeingot</icon>
+</item>
+<item>
+ <text>Aluminum Brass, made from Aluminum(3) and Copper(1)</text>
+ <icon>alubrassingot</icon>
+</item>
+<item>
+ <text>Manyullyn, made from Cobalt(2) and Ardite(2)</text>
+ <icon>manyullyningot</icon>
+</item>
+<item>
+ <text>Alumite, made from Aluminum(5), Iron(2), and Obsidian(2)</text>
+ <icon>alumiteingot</icon>
+</item>
+<item>
+ <text>Pig Iron, made from Iron(1), Blood(1), and Emeralds(1)</text>
+ <icon>pigironingot</icon>
+</item>
+</page>
+
+<page type="sidebar">
+<text>There exist a few liquids that are gained through strange means. Currently known liquids are:</text>
+<item>
+ <text>Blood, damaging entities in the Smeltery</text>
+ <icon>bloodbucket</icon>
+</item>
+<item>
+ <text>Liquified Emeralds, melting down emeralds or villagers</text>
+ <icon>emeraldbucket</icon>
+</item>
+<item>
+ <text>Glue, melting down horses in the Smeltery</text>
+ <icon>gluebucket</icon>
+</item>
+<item>
+ <text>Slime, found on slime islands. It functions as a spawner</text>
+ <icon>slimebucket</icon>
+</item>
+<item>
+ <text>Ender, either melting down ender pearls or endermen</text>
+ <icon>enderbucket</icon>
+</item>
+</page>
+
+<page type="text">
+<text>Blank casts are made by pouring aluminum brass or gold into an empty casting table. These are used in crafting recipes and can be re-melted.
+
+Part casts must be created by pouring metal around existing parts, like a pickaxe head.</text>
+</page>
+
+<page type="picture">
+<text>Forming a Cast</text>
+<location>tinker:manuals/casting.png</location>
+</page>
+
+<page type="crafting">
+<text>Grout</text>
+<recipe>
+ <name>grout</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="furnace">
+<text>Seared Brick</text>
+<recipe>searedbrick</recipe>
+</page>
+
+<page type="crafting">
+<text>Seared Bricks</text>
+<recipe>
+ <name>searedbricks</name>
+ <size>two</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Smeltery Controller</text>
+<recipe>
+ <name>smelterycontroller</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Smeltery Drain</text>
+<recipe>
+ <name>smelterydrain</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Seared Tank</text>
+<recipe>
+ <name>smelterytank1</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Seared Glass</text>
+<recipe>
+ <name>smelterytank2</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Seared Window</text>
+<recipe>
+ <name>smelterytank3</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Seared Faucet</text>
+<recipe>
+ <name>smelteryfaucet</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Casting Channel</text>
+<recipe>
+ <name>castingchannel</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Casting Table</text>
+<recipe>
+ <name>smelterytable</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="crafting">
+<text>Casting Basin</text>
+<recipe>
+ <name>smelterybasin</name>
+ <size>three</size>
+</recipe>
+</page>
+
+<page type="blockcast">
+<text>Brownstone</text>
+<recipe>brownstone</recipe>
+</page>
+
+<page type="blockcast">
+<text>Clear Glass</text>
+<recipe>clearglass</recipe>
+</page>
+
+<page type="blockcast">
+<text>Seared Stone</text>
+<recipe>searedstone</recipe>
+</page>
+
+<page type="blockcast">
+<text>Endstone</text>
+<recipe>endstone</recipe>
+</page>
+
+<page type="blockcast">
+<text>Glueball</text>
+<recipe>glueball</recipe>
+</page>
+
+
+</book>

--- a/src/main/resources/assets/dreamcraft/tinker/manuals/weaponry.xml
+++ b/src/main/resources/assets/dreamcraft/tinker/manuals/weaponry.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0"?>
+
+<book>
+<page type="intro">
+<text>Tinkers' Weaponry
+Brings the hurt whole new places
+
+By Sheriff Bownana</text>
+</page>
+
+<page type="contents">
+<text>Table of Contents</text>
+<link>
+ <text>Introduction</text>
+ <icon>weaponrybook</icon>
+ <jump>3</jump>
+</link>
+<link>
+ <text>Throwing Weapons</text>
+ <icon>throwingknifeIcon</icon>
+ <jump>5</jump>
+</link>
+<link>
+ <text>Projectile Weapons</text>
+ <icon>shortbowIcon</icon>
+ <jump>7</jump>
+</link>
+<link>
+ <text>Projectiles</text>
+ <icon>arrowIcon</icon>
+ <jump>10</jump>
+</link>
+</page>
+
+<page type="text">
+<text>Why walk up to hit stuff, when you can do that while standing here!
+
+A tinkerer knows how to create varied ranged weapons. There are two big categories: Thrown weapons and weapons that shoot projectiles.
+
+Both types utilize an ammo system. Instead of having several items, these ranged weapons consist of one item that contains many of it. Why carry around 2 stacks of arrows, when you can have 200 in one stack!
+These Ammo-Items don't have a durability, but use up their ammo for each projectile thrown/shot.</text>
+</page>
+
+<page type="text">
+<text>Throwing Weapons:
+* Throwing Knife
+* Shuriken
+* Javelin
+
+Projectile Weapons:
+* Shortbow
+* Longbow
+* Crossbow
+
+Projectiles:
+* Arrows
+* Bolts</text>
+</page>
+
+<page type="text">
+<text>Throwing Weapons
+
+Throwing Knifes:
+These knifes are crafted from a knife blade and a handle.
+Hold right-click to take aim, and release it to throw a knife.
+Throwing knifes stack up to a moderate amount, and deal moderate damage.
+
+Shuriken:
+Small delicate projectiles put together from 4 parts, that are thrown from the wrist. Because of this you don't need to take aim and can throw them directly.
+Since they're so small you can carry many of them, however they don't deal much damage.</text>
+</page>
+
+<page type="text">
+<text>
+
+Javelin:
+This is a hybrid between a melee and a ranged weapon, consisting of an arrow head on two tough tool rods. It deals moderate damage as a melee weapon, but to unleash its true potential you have to throw it at your enemy.
+The throwing has a small windup. Because of their size you can only carry a few, but they pack a punch.</text>
+</page>
+
+<page type="text">
+<text>Projectile Weapons
+
+Shortbow:
+Put together from two bow limbs and a bowstring, this weapon is a fast and handy bow. Keep in mind that inflexible materials like stone can hardly be drawn back and can't accelerate projectiles well. Organic materials are favoured for quick bows, while metals require lots of strength to draw back, but provide more power.
+The bow requires arrows as ammo.
+Offensive modifiers on bows do not count for arrows. The only modifiers affecting its ranged performance are Redstone and lapis.</text>
+</page>
+
+<page type="text">
+<text>
+
+Longbow:
+The big brother. This bow is much bigger, requiring more time to pull it back, but boy oh boy are those arrows fast.
+Because of this the longbow performs slightly better against armored targets. Furthermore this makes the longbow less accurate with very light arrows.
+The longbow is constructed from two bow limbs, a bowstring and a large plate.</text>
+</page>
+
+<page type="text">
+<text>
+
+Crossbow:
+Those pesky metals are such a pain to pull back. Luckily a tinkerer knows how to help himself! The crossbow allows you to pre-load it with a bolt, and have it ready instantly to fire. Since this allows for much more power, it can shoot heavier projectiles, resulting in more damage and armor penetration.
+To load a crossbow simply right-click and wait until the animation is done. The loading process can be stopped by pressing right-click while sneaking. The crossbow can be unloaded in the same way.</text>
+</page>
+
+<page type="text">
+<text>Projectiles
+For these projectiles goes: The heavier the projectile, the more damage carries through armor.
+
+Arrows:
+The bread and butter of every ranger. Arrows can be built from many different materials. It needs an arrow head, a shaft and a fletching.
+The choice of materials allows a balance between damage, arrow-count, accuracy and fragility. The head material is crucial for its weight.
+A fragile arrow has a chance to break on impact with terrain. Arrows always break when they hit a target, however the reinforced trait gives a chance for the arrow to survive the impact.</text>
+</page>
+
+<page type="text">
+<text>
+
+Valid Shaft Materials:
+* Stick
+* Sugarcane
+* Bone
+* Blaze Rod
+
+Valid Fletching Materials:
+* Leaves
+* Slimeleaves
+* Feathers
+* Slime</text>
+</page>
+
+<page type="text">
+<text>
+
+Bolts:
+Crafting bolts is a delicate process. First you need a core in the form of a tool rod.
+Take this tool rod to a smeltery and put it into a Casting Table. Pour some metal onto it to coat the tip with a more damaging material.
+After this process, add a fletching and your bolts are ready to be used.
+
+Since the bolts consist of a harder core and tip they carry more weight than regular arrows, making them perfect to fight armored targets.</text>
+</page>
+
+</book>

--- a/src/test/java/com/dreammaster/mantle/BookDataReaderTest.java
+++ b/src/test/java/com/dreammaster/mantle/BookDataReaderTest.java
@@ -1,0 +1,51 @@
+package com.dreammaster.mantle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+class BookDataReaderTest {
+
+    private static final String TEST_BOOKS_LOCATION = "/assets/dreamcraft/mantle/";
+
+    @Test
+    void instanciate() {
+        assertThatCode(BookDataReader::new).doesNotThrowAnyException();
+    }
+
+    @Test
+    void readValidBook() {
+        BookDataReader bookDataReader = new BookDataReader();
+        String bookName = TEST_BOOKS_LOCATION + "test-book.xml";
+
+        Document document = bookDataReader.readBook(bookName);
+
+        assertThat(document).extracting(Node::getFirstChild).extracting(Node::getNodeName).isEqualTo("book");
+
+    }
+
+    @Test
+    void readMissingBook() {
+        BookDataReader bookDataReader = new BookDataReader();
+        String bookName = TEST_BOOKS_LOCATION + "missing-book.xml";
+
+        assertThatThrownBy(() -> bookDataReader.readBook(bookName)).isInstanceOf(IllegalStateException.class)
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    void readInvalidBook() {
+        BookDataReader bookDataReader = new BookDataReader();
+        String bookName = TEST_BOOKS_LOCATION + "blank-book.xml";
+
+        assertThatThrownBy(() -> bookDataReader.readBook(bookName)).isInstanceOf(IllegalStateException.class)
+                .hasCauseInstanceOf(SAXException.class);
+    }
+}

--- a/src/test/java/com/dreammaster/mantle/BookDataStoreProxyTest.java
+++ b/src/test/java/com/dreammaster/mantle/BookDataStoreProxyTest.java
@@ -1,0 +1,75 @@
+package com.dreammaster.mantle;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import eu.usrv.yamcore.auxiliary.LogHelper;
+import mantle.books.BookData;
+import mantle.books.BookDataStore;
+
+@ExtendWith(MockitoExtension.class)
+class BookDataStoreProxyTest {
+
+    @Mock
+    LogHelper LOGGER;
+
+    @Mock
+    BookData BOOKDATA;
+
+    @Test
+    void instanciateWithNull() {
+        assertThatThrownBy(() -> new BookDataStoreProxy(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void instanciate() {
+        assertThatCode(() -> new BookDataStoreProxy(LOGGER)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void addNullBook() {
+        BookDataStoreProxy bookDataStoreProxy = new BookDataStoreProxy(LOGGER);
+
+        assertThatThrownBy(() -> bookDataStoreProxy.addBook(null)).isInstanceOf(NullPointerException.class);
+        verify(LOGGER, never()).error(anyString());
+    }
+
+    @Test
+    void addValidBook() {
+        try (MockedStatic<BookDataStore> bookDataStore = mockStatic(BookDataStore.class)) {
+            BookDataStoreProxy bookDataStoreProxy = new BookDataStoreProxy(LOGGER);
+
+            bookDataStoreProxy.addBook(BOOKDATA);
+
+            bookDataStore.verify(() -> BookDataStore.addBook(BOOKDATA));
+            verify(LOGGER, never()).error(anyString());
+        }
+    }
+
+    /**
+     * BookDataStore will throw an IllegalArgumentException if it already contains a book. We catch and log it to
+     * increase interoperability.
+     */
+    @Test
+    void addDuplicateBook() {
+        try (MockedStatic<BookDataStore> bookDataStore = mockStatic(BookDataStore.class)) {
+            bookDataStore.when(() -> BookDataStore.addBook(BOOKDATA)).thenThrow(new IllegalArgumentException());
+            BookDataStoreProxy bookDataStoreProxy = new BookDataStoreProxy(LOGGER);
+
+            bookDataStoreProxy.addBook(BOOKDATA);
+
+            bookDataStore.verify(() -> BookDataStore.addBook(BOOKDATA));
+            verify(LOGGER).error(anyString());
+        }
+    }
+}

--- a/src/test/java/com/dreammaster/mantle/MantleBookLoaderTest.java
+++ b/src/test/java/com/dreammaster/mantle/MantleBookLoaderTest.java
@@ -1,0 +1,170 @@
+package com.dreammaster.mantle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import net.minecraft.util.ResourceLocation;
+
+import org.assertj.core.api.ObjectAssert;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.w3c.dom.Document;
+
+import gregtech.api.interfaces.internal.IGT_Mod;
+import mantle.books.BookData;
+
+@ExtendWith(MockitoExtension.class)
+class MantleBookLoaderTest {
+
+    private static final String PATH = "/somewhere/over/the/rainbow";
+    private static final String MOD_ID = "modid";
+    private static final String UNLOCALIZED_NAME = "testBook";
+    private static final String TOOLTIP = "tooltip";
+    private static final String ITEM_IMAGE = "itemImage.png";
+    @Mock
+    BookDataStoreProxy BOOK_DATA_STORE_PROXY;
+
+    @Mock
+    BookDataReader BOOK_DATA_READER;
+
+    @Mock
+    IGT_Mod SIDE_CHECKER;
+
+    @Mock
+    Document DOCUMENT;
+
+    @Captor
+    ArgumentCaptor<BookData> bookDataArgumentCaptor;
+
+    private MantleBookLoader fixture;
+
+    @BeforeEach
+    void BeforeEach() {
+        fixture = new MantleBookLoader(BOOK_DATA_STORE_PROXY, BOOK_DATA_READER, SIDE_CHECKER);
+    }
+
+    private void buildBookAndAddToBookDataStore(Stream<Consumer<BookLoader>> bookBuilderOperation) {
+        fixture.setRequiredData(UNLOCALIZED_NAME, MOD_ID, PATH);
+        bookBuilderOperation.forEach(operation -> operation.accept(fixture));
+        fixture.addToBookDataStore();
+    }
+
+    @Test
+    void instanciateWithNullBookDataStoreProxy() {
+        ThrowingCallable code = () -> new MantleBookLoader(null, BOOK_DATA_READER, SIDE_CHECKER);
+
+        assertThatThrownBy(code).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void instanciateWithNullBookDataReader() {
+        ThrowingCallable code = () -> new MantleBookLoader(BOOK_DATA_STORE_PROXY, null, SIDE_CHECKER);
+
+        assertThatThrownBy(code).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void instanciateWithNullSideChecker() {
+        ThrowingCallable code = () -> new MantleBookLoader(BOOK_DATA_STORE_PROXY, BOOK_DATA_READER, null);
+
+        assertThatThrownBy(code).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void instanciateProperly() {
+        ThrowingCallable code = () -> new MantleBookLoader(BOOK_DATA_STORE_PROXY, BOOK_DATA_READER, SIDE_CHECKER);
+
+        assertThatCode(code).doesNotThrowAnyException();
+    }
+
+    /**
+     * This test case shouldn't be possible under the current implementation.
+     */
+    @Test
+    void addToBookDataStorePrematurely() {
+        ThrowingCallable code = fixture::addToBookDataStore;
+
+        assertThatThrownBy(code).isInstanceOf(IllegalStateException.class);
+        verify(BOOK_DATA_STORE_PROXY, never()).addBook(any());
+    }
+
+    @Test
+    void addToBookDataStoreWithDefaultsServerside() {
+        when(SIDE_CHECKER.isClientSide()).thenReturn(false);
+
+        buildBookAndAddToBookDataStore(Stream.empty());
+
+        verify(BOOK_DATA_READER, never()).readBook(PATH);
+        assertBaseAddedBookData();
+    }
+
+    private ObjectAssert<BookData> assertBaseAddedBookData() {
+        verify(BOOK_DATA_STORE_PROXY).addBook(bookDataArgumentCaptor.capture());
+        return assertThat(bookDataArgumentCaptor.getValue())
+                .hasFieldOrPropertyWithValue("fullUnlocalizedName", MOD_ID + ":" + UNLOCALIZED_NAME);
+    }
+
+    @Test
+    void addToBookDataStoreWithDefaultsClientside() {
+        when(SIDE_CHECKER.isClientSide()).thenReturn(true);
+        when(BOOK_DATA_READER.readBook(PATH)).thenReturn(DOCUMENT);
+
+        buildBookAndAddToBookDataStore(Stream.empty());
+
+        assertBaseAddedBookData().hasFieldOrPropertyWithValue("doc", DOCUMENT);
+    }
+
+    @Test
+    void addToBookDataStoreWithToolTip() {
+        buildBookAndAddToBookDataStore(Stream.of((bookLoader) -> bookLoader.setTooltip(TOOLTIP)));
+
+        assertBaseAddedBookData().hasFieldOrPropertyWithValue("toolTip", "§o" + TOOLTIP);
+    }
+
+    @Test
+    void addToBookDataStoreWithNullToolTip() {
+        ThrowingCallable code = () -> buildBookAndAddToBookDataStore(
+                Stream.of((bookLoader) -> bookLoader.setTooltip(null)));
+
+        assertThatThrownBy(code).isInstanceOf(NullPointerException.class);
+    }
+
+    // Not mocking ResourceLocation, API assumed stable
+    @Test
+    void addToBookDataStoreWithItemImage() {
+        buildBookAndAddToBookDataStore(Stream.of((bookLoader) -> bookLoader.setItemImage(ITEM_IMAGE)));
+
+        assertBaseAddedBookData().extracting((bookData -> bookData.itemImage))
+                .isEqualTo(new ResourceLocation(MOD_ID, ITEM_IMAGE));
+    }
+
+    @Test
+    void addToBookDataStoreWithNullItemImage() {
+        ThrowingCallable code = () -> buildBookAndAddToBookDataStore(
+                Stream.of((bookLoader) -> bookLoader.setItemImage(null)));
+
+        assertThatThrownBy(code).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void addToBookDataStoreAsTranslatable() {
+        buildBookAndAddToBookDataStore(Stream.of(BookLoader::makeTranslatable));
+
+        assertBaseAddedBookData().hasFieldOrPropertyWithValue("isTranslatable", true);
+    }
+
+}

--- a/src/test/resources/assets/dreamcraft/mantle/test-book.xml
+++ b/src/test/resources/assets/dreamcraft/mantle/test-book.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+
+<book>
+</book>


### PR DESCRIPTION
This PR is unfinished  pending the inclusion the required lang file keys to allow for translation.

Actual customization might happen in a different PR, or in this one.  More is done but it is not yet cleaned up for review. In the current state the en-US books are kept as is to serve as a base on which to compare the content changes.