### PR TITLE
Add Non-Vanilla Dye Support to ZTones Blocks within Assembler

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -10,7 +10,7 @@ import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 
-import java.util.List;
+import java.util.*;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -5504,50 +5504,72 @@ public class AssemblerRecipes implements Runnable {
                 "mint", "myst", "reds", "reed", "roen", "sols", "sync", "tank", "vect", "vena" };
         String[] zblockName = { "zane", "zech", "zest", "zeta", "zion", "zkul", "zoea", "zome", "zone", "zorg", "ztyl",
                 "zyth" };
-        ItemStack[] item = { new ItemStack(Items.dye, 1, 7), new ItemStack(Items.dye, 1, 4),
-                new ItemStack(Blocks.wool, 1, 0), new ItemStack(Blocks.hardened_clay, 1, 0),
-                new ItemStack(Items.dye, 1, 3), new ItemStack(Items.dye, 1, 8), new ItemStack(Items.gold_ingot, 1, 0),
-                new ItemStack(Blocks.obsidian, 1, 0), new ItemStack(Blocks.soul_sand, 1, 0),
-                new ItemStack(Blocks.netherrack, 1, 0), new ItemStack(Blocks.ice, 1, 0),
-                new ItemStack(Items.slime_ball, 1, 0), new ItemStack(Blocks.brown_mushroom, 1, 0),
-                new ItemStack(Items.redstone, 1, 0), new ItemStack(Items.reeds, 1, 0),
-                new ItemStack(Blocks.sandstone, 1, 0), new ItemStack(Items.blaze_powder, 1, 0),
-                new ItemStack(Items.emerald, 1, 0), new ItemStack(Items.iron_ingot, 1, 0),
-                new ItemStack(Items.ghast_tear, 1, 0), new ItemStack(Items.ender_pearl, 1, 0) };
-        ItemStack[] zitem = { new ItemStack(Items.dye, 1, 0), new ItemStack(Items.dye, 1, 1),
-                new ItemStack(Items.dye, 1, 2), new ItemStack(Items.dye, 1, 5), new ItemStack(Items.dye, 1, 6),
-                new ItemStack(Items.dye, 1, 9), new ItemStack(Items.dye, 1, 10), new ItemStack(Items.dye, 1, 11),
-                new ItemStack(Items.dye, 1, 12), new ItemStack(Items.dye, 1, 13), new ItemStack(Items.dye, 1, 14),
-                new ItemStack(Items.dye, 1, 15) };
 
-        for (int j = 0; j < 21; j++) {
-            for (int i = 0; i < 16; i++) {
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                GT_ModHandler.getModItem(ZTones.ID, "stoneTile", 4L, 0),
-                                item[j],
-                                GT_Utility.getIntegratedCircuit(i == 0 ? 24 : i))
-                        .itemOutputs(GT_ModHandler.getModItem(ZTones.ID, "tile." + blockName[j] + "Block", 8L, i))
-                        .duration(10 * SECONDS).eut(16).addTo(assemblerRecipes);
+        Map<String, List<ItemStack>> itemMap = new HashMap<>();
+        itemMap.put(blockName[0], OreDictionary.getOres("dyeLightGray")); // agon
+        itemMap.put(blockName[1], OreDictionary.getOres("dyeBlue")); // azur
+        itemMap.put(blockName[2], new ArrayList<>(Arrays.asList(new ItemStack(Blocks.wool, 1, 0)))); // bitt
+        itemMap.put(blockName[3], new ArrayList<>(Arrays.asList(new ItemStack(Blocks.hardened_clay, 1, 0)))); // cray
+        itemMap.put(blockName[4], OreDictionary.getOres("dyeBrown")); // fort
+        itemMap.put(blockName[5], OreDictionary.getOres("dyeGray")); // iszm
+        itemMap.put(blockName[6], new ArrayList<>(Arrays.asList(new ItemStack(Items.gold_ingot, 1, 0))));// jelt
+        itemMap.put(blockName[7], new ArrayList<>(Arrays.asList(new ItemStack(Blocks.obsidian, 1, 0)))); // korp
+        itemMap.put(blockName[8], new ArrayList<>(Arrays.asList(new ItemStack(Blocks.soul_sand, 1, 0))));// kryp
+        itemMap.put(blockName[9], new ArrayList<>(Arrays.asList(new ItemStack(Blocks.netherrack, 1, 0))));// lair
+        itemMap.put(blockName[10], new ArrayList<>(Arrays.asList(new ItemStack(Blocks.ice, 1, 0))));// lave
+        itemMap.put(blockName[11], new ArrayList<>(Arrays.asList(new ItemStack(Items.slime_ball, 1, 0))));// mint
+        itemMap.put(blockName[12], new ArrayList<>(Arrays.asList(new ItemStack(Blocks.brown_mushroom, 1, 0))));// myst
+        itemMap.put(blockName[13], new ArrayList<>(Arrays.asList(new ItemStack(Items.redstone, 1, 0))));// reds
+        itemMap.put(blockName[14], new ArrayList<>(Arrays.asList(new ItemStack(Items.reeds, 1, 0))));// reed
+        itemMap.put(blockName[15], new ArrayList<>(Arrays.asList(new ItemStack(Blocks.sandstone, 1, 0))));// roen
+        itemMap.put(blockName[16], new ArrayList<>(Arrays.asList(new ItemStack(Items.blaze_powder, 1, 0))));// sols
+        itemMap.put(blockName[17], new ArrayList<>(Arrays.asList(new ItemStack(Items.emerald, 1, 0))));// sync
+        itemMap.put(blockName[18], new ArrayList<>(Arrays.asList(new ItemStack(Items.iron_ingot, 1, 0))));// tank
+        itemMap.put(blockName[19], new ArrayList<>(Arrays.asList(new ItemStack(Items.ghast_tear, 1, 0))));// vect
+        itemMap.put(blockName[20], new ArrayList<>(Arrays.asList(new ItemStack(Items.ender_pearl, 1, 0))));// vena
+        Map<String, List<ItemStack>> zitemMap = new HashMap<>();
+        zitemMap.put(zblockName[0], OreDictionary.getOres("dyeBlack")); // zane
+        zitemMap.put(zblockName[1], OreDictionary.getOres("dyeRed")); // zech
+        zitemMap.put(zblockName[2], OreDictionary.getOres("dyeBlack")); // zest
+        zitemMap.put(zblockName[3], OreDictionary.getOres("dyePurple")); // zeta
+        zitemMap.put(zblockName[4], OreDictionary.getOres("dyeCyan")); // zion
+        zitemMap.put(zblockName[5], OreDictionary.getOres("dyePink")); // zkul
+        zitemMap.put(zblockName[6], OreDictionary.getOres("dyeLime")); // zoea
+        zitemMap.put(zblockName[7], OreDictionary.getOres("dyeYellow")); // zome
+        zitemMap.put(zblockName[8], OreDictionary.getOres("dyeLightBlue")); // zone
+        zitemMap.put(zblockName[9], OreDictionary.getOres("dyeMagenta")); // zorg
+        zitemMap.put(zblockName[10], OreDictionary.getOres("dyeOrange")); // ztyl
+        zitemMap.put(zblockName[11], OreDictionary.getOres("dyeWhite")); // zyth
+
+        final int ztoneVariants = 16;
+
+        for (String name : blockName) {
+            for (int i = 0; i < ztoneVariants; i++) {
+                for (ItemStack ingredient : itemMap.get(name)) {
+                    GT_Values.RA.stdBuilder()
+                            .itemInputs(
+                                    GT_ModHandler.getModItem(ZTones.ID, "stoneTile", 4L, 0),
+                                    ingredient,
+                                    GT_Utility.getIntegratedCircuit(i == 0 ? 24 : i))
+                            .itemOutputs(GT_ModHandler.getModItem(ZTones.ID, "tile." + name + "Block", 8L, i))
+                            .duration(10 * SECONDS).eut(16).addTo(assemblerRecipes);
+                }
             }
         }
-
-        for (int j = 0; j < 12; j++) {
-            for (int i = 0; i < 16; i++) {
-
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                GT_ModHandler.getModItem(ZTones.ID, "auroraBlock", 4L, 0),
-                                zitem[j],
-                                GT_Utility.getIntegratedCircuit(i == 0 ? 24 : i))
-                        .itemOutputs(GT_ModHandler.getModItem(ZTones.ID, "tile." + zblockName[j] + "Block", 8L, i))
-                        .duration(10 * SECONDS).eut(16).addTo(assemblerRecipes);
-
+        for (String name : zblockName) {
+            for (int i = 0; i < ztoneVariants; i++) {
+                for (ItemStack ingredient : zitemMap.get(name)) {
+                    GT_Values.RA.stdBuilder()
+                            .itemInputs(
+                                    GT_ModHandler.getModItem(ZTones.ID, "auroraBlock", 4L, 0),
+                                    ingredient,
+                                    GT_Utility.getIntegratedCircuit(i == 0 ? 24 : i))
+                            .itemOutputs(GT_ModHandler.getModItem(ZTones.ID, "tile." + name + "Block", 8L, i))
+                            .duration(10 * SECONDS).eut(16).addTo(assemblerRecipes);
+                }
             }
         }
-
-        for (int i = 0; i < 16; i++) {
-
+        for (int i = 0; i < ztoneVariants; i++) {
             GT_Values.RA.stdBuilder()
                     .itemInputs(
                             GT_ModHandler.getModItem(ZTones.ID, "auroraBlock", 4L, 0),
@@ -5555,7 +5577,6 @@ public class AssemblerRecipes implements Runnable {
                             GT_Utility.getIntegratedCircuit(i == 0 ? 24 : i))
                     .itemOutputs(GT_ModHandler.getModItem(ZTones.ID, "tile.glaxx", 8L, i)).duration(10 * SECONDS)
                     .eut(16).addTo(assemblerRecipes);
-
         }
     }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -6,7 +6,9 @@ import static gregtech.api.enums.GT_Values.W;
 import static gregtech.api.enums.Mods.*;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.util.GT_ModHandler.getModItem;
-import static gregtech.api.util.GT_RecipeBuilder.*;
+import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
+import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
+import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,7 +29,14 @@ import com.dreammaster.gthandler.CustomItemList;
 import com.dreammaster.gthandler.GT_CoreModSupport;
 import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
 
-import gregtech.api.enums.*;
+import gregtech.api.enums.GT_Values;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.MaterialsKevlar;
+import gregtech.api.enums.MaterialsUEVplus;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.SubTag;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1,13 +1,19 @@
 package com.dreammaster.gthandler.recipes;
 
-import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.gthandler.GT_CoreModSupport;
-import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
-import gregtech.api.enums.*;
-import gregtech.api.util.GT_ModHandler;
-import gregtech.api.util.GT_OreDictUnificator;
-import gregtech.api.util.GT_Utility;
-import gregtech.common.items.GT_MetaGenerated_Tool_01;
+import static com.dreammaster.bartworksHandler.BartWorksMaterials.getBartWorksMaterialByIGNName;
+import static com.dreammaster.gthandler.GT_CoreModSupport.Xenoxene;
+import static gregtech.api.enums.GT_Values.W;
+import static gregtech.api.enums.Mods.*;
+import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
+import static gregtech.api.util.GT_ModHandler.getModItem;
+import static gregtech.api.util.GT_RecipeBuilder.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -17,15 +23,15 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
-import java.util.*;
+import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.gthandler.GT_CoreModSupport;
+import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
 
-import static com.dreammaster.bartworksHandler.BartWorksMaterials.getBartWorksMaterialByIGNName;
-import static com.dreammaster.gthandler.GT_CoreModSupport.Xenoxene;
-import static gregtech.api.enums.GT_Values.W;
-import static gregtech.api.enums.Mods.*;
-import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
-import static gregtech.api.util.GT_ModHandler.getModItem;
-import static gregtech.api.util.GT_RecipeBuilder.*;
+import gregtech.api.enums.*;
+import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
+import gregtech.common.items.GT_MetaGenerated_Tool_01;
 
 public class AssemblerRecipes implements Runnable {
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1,17 +1,13 @@
 package com.dreammaster.gthandler.recipes;
 
-import static com.dreammaster.bartworksHandler.BartWorksMaterials.getBartWorksMaterialByIGNName;
-import static com.dreammaster.gthandler.GT_CoreModSupport.Xenoxene;
-import static gregtech.api.enums.GT_Values.W;
-import static gregtech.api.enums.Mods.*;
-import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
-import static gregtech.api.util.GT_ModHandler.getModItem;
-import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
-import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
-import static gregtech.api.util.GT_RecipeBuilder.TICKS;
-
-import java.util.*;
-
+import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.gthandler.GT_CoreModSupport;
+import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
+import gregtech.api.enums.*;
+import gregtech.api.util.GT_ModHandler;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Utility;
+import gregtech.common.items.GT_MetaGenerated_Tool_01;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -21,22 +17,15 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
-import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.gthandler.GT_CoreModSupport;
-import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
+import java.util.*;
 
-import gregtech.api.enums.GT_Values;
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.MaterialsKevlar;
-import gregtech.api.enums.MaterialsUEVplus;
-import gregtech.api.enums.OrePrefixes;
-import gregtech.api.enums.SubTag;
-import gregtech.api.enums.TierEU;
-import gregtech.api.util.GT_ModHandler;
-import gregtech.api.util.GT_OreDictUnificator;
-import gregtech.api.util.GT_Utility;
-import gregtech.common.items.GT_MetaGenerated_Tool_01;
+import static com.dreammaster.bartworksHandler.BartWorksMaterials.getBartWorksMaterialByIGNName;
+import static com.dreammaster.gthandler.GT_CoreModSupport.Xenoxene;
+import static gregtech.api.enums.GT_Values.W;
+import static gregtech.api.enums.Mods.*;
+import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
+import static gregtech.api.util.GT_ModHandler.getModItem;
+import static gregtech.api.util.GT_RecipeBuilder.*;
 
 public class AssemblerRecipes implements Runnable {
 


### PR DESCRIPTION
In response to: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13921

![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/37894528/9ce5c4b8-8a20-4ee0-8e5a-ae8bf47808e0)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/37894528/85a823de-0db5-4cd4-a199-9ba0d97f0f4a)

I rewrote the Ztones recipes to better allow for additional ingredients to be usable in assembling. 

This is my first PR for GregTech: New Horizons - my friends and I encountered this issue in our own playthrough, so I gave it a go at fixing. 