### PR TITLE
Wooden brick form fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 gtnh.settings.blowdryerTag = 0.2.0
 
 # Human-readable mod name, available for mcmod.info population.
-modName = GT: New Horizons
+modName = GT\: New Horizons
 
 # Case-sensitive identifier string, available for mcmod.info population and used for automatic mixin JSON generation.
 # Conventionally lowercase.
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ customArchiveBaseName = GTNewHorizonsCoreMod
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.12'
 }
 
 

--- a/src/main/java/com/dreammaster/item/WoodenBrickForm.java
+++ b/src/main/java/com/dreammaster/item/WoodenBrickForm.java
@@ -46,6 +46,7 @@ public class WoodenBrickForm extends Item implements IExtendedModItem<WoodenBric
         super.setTextureName(String.format("%s:item%s", Refstrings.MODID, _mItemName));
         super.setUnlocalizedName(_mItemName);
         super.setMaxDamage(maxDurability);
+        super.setMaxStackSize(1);
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15495.
And brings the form in line with other gt tools with durability none of which are stackable.

Also makes the mod build again as the BS was broken.