### PR TITLE
fix glass bottle exploit

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
@@ -3298,7 +3298,7 @@ public class ScriptTinkersConstruct implements IScriptLoader {
                 FluidRegistry.getFluidStack("ender", 2250));
         TConstructRegistry.getTableCasting().addCastingRecipe(
                 getModItem(Minecraft.ID, "glass_bottle", 1, 0, missing),
-                FluidRegistry.getFluidStack("glass.molten", 144),
+                FluidRegistry.getFluidStack("glass.molten", 1000),
                 ItemList.Shape_Mold_Bottle.get(1L),
                 false,
                 200);


### PR DESCRIPTION
The ratios based on all other recipes are
1 glass bottle = 1 glass dust = 144L GT molten glass = 1000L tinker molten glass.

This one recipe did not follow that, hence the fix. Without the fix one can loop for infinite glass.