### PR TITLE
new cuttingboard recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptHarvestcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptHarvestcraft.java
@@ -366,15 +366,11 @@ public class ScriptHarvestcraft implements IScriptLoader {
                 "screwIron",
                 "craftingToolHardHammer",
                 "screwIron");
-        addShapelessRecipe(
+        GT_ModHandler.addCraftingRecipe(
                 getModItem(PamsHarvestCraft.ID, "cuttingboardItem", 1, 0, missing),
-                createItemStack(
-                        GregTech.ID,
-                        "gt.metatool.01",
-                        1,
-                        36,
-                        "{ench:[0:{lvl:3s,id:16s},1:{lvl:3s,id:21s}],GT.ToolStats:{PrimaryMaterial:\"StainlessSteel\",MaxDamage:48000L,SecondaryMaterial:\"StainlessSteel\"}}",
-                        missing));
+                GT_ModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS | GT_ModHandler.RecipeBits.BUFFERED,
+                new Object[] { "PPf", "PP ", "SBh", 'S', OrePrefixes.stick.get(Materials.StainlessSteel), 'P',
+                        OrePrefixes.plate.get(Materials.StainlessSteel), 'B', OrePrefixes.plate.get(Materials.Wood) });
         addShapedRecipe(
                 getModItem(PamsHarvestCraft.ID, "mortarandpestleItem", 1, 0, missing),
                 "craftingToolHardHammer",


### PR DESCRIPTION
The current cutting board recipe (just stainless steel butchery knife shapeless) is broken in 2 ways:

1) it actually allows any material, not just stainless steel (older bug, see https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/4234#issuecomment-471341785 not sure if it worked in between with that fix there.)
2) it only uses a bit of durability instead of the full tool (newer bug)

Fixing it seems tricky and not really worth it. Instead I just took the stainless steel butchery knife recipe and added the wooden plank as differentiation and because it fits:

![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/d41ee109-23d4-41e4-9169-00735dc4f1bd)

fixes https://discord.com/channels/181078474394566657/181078474394566657/1206595468683903077