### PR TITLE
Fix moon buggy copy recipe and related fixes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
@@ -454,21 +454,8 @@ public class CircuitAssemblerRecipes implements Runnable {
 
             GT_Values.RA.stdBuilder()
                     .itemInputs(
-                            ItemList.Circuit_Quantumprocessor.get(1L),
                             RocketMaterial[0],
-                            GT_Utility.getIntegratedCircuit(1))
-                    .itemOutputs(RocketChip[0]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L)).requiresCleanRoom()
-                    .duration(7 * MINUTES + 30 * SECONDS).eut(TierEU.RECIPE_HV).addTo(circuitAssemblerRecipes);
-
-            GT_Values.RA.stdBuilder()
-                    .itemInputs(ItemList.Circuit_Data.get(1L), RocketMaterial[0], GT_Utility.getIntegratedCircuit(1))
-                    .itemOutputs(RocketChip[0]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L)).requiresCleanRoom()
-                    .duration(7 * MINUTES + 30 * SECONDS).eut(TierEU.RECIPE_HV).addTo(circuitAssemblerRecipes);
-
-            GT_Values.RA.stdBuilder()
-                    .itemInputs(
-                            ItemList.Circuit_Nanocomputer.get(1L),
-                            RocketMaterial[0],
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 1),
                             GT_Utility.getIntegratedCircuit(1))
                     .itemOutputs(RocketChip[0]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L)).requiresCleanRoom()
                     .duration(7 * MINUTES + 30 * SECONDS).eut(TierEU.RECIPE_HV).addTo(circuitAssemblerRecipes);
@@ -482,7 +469,8 @@ public class CircuitAssemblerRecipes implements Runnable {
                         .itemInputs(
                                 RocketMaterial[(i - 1)],
                                 GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1),
-                                DataStickWScheme.splitStack(0))
+                                DataStickWScheme.splitStack(0),
+                                GT_Utility.getIntegratedCircuit(1))
                         .itemOutputs(RocketChip[(i - 1)]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L))
                         .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[(i - 2)])
                         .addTo(circuitAssemblerRecipes);
@@ -498,7 +486,7 @@ public class CircuitAssemblerRecipes implements Runnable {
                                 RocketMaterial[rocketTier - 1],
                                 GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1),
                                 DataStickWScheme.splitStack(0),
-                                GT_Utility.getIntegratedCircuit(Math.max(i, 1)))
+                                GT_Utility.getIntegratedCircuit(Math.max(i + 1, 2)))
                         .itemOutputs(ExtraChips[i]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L))
                         .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[rocketTier - 2])
                         .addTo(circuitAssemblerRecipes);

--- a/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
@@ -497,7 +497,8 @@ public class CircuitAssemblerRecipes implements Runnable {
                         .itemInputs(
                                 RocketMaterial[rocketTier - 1],
                                 GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1),
-                                DataStickWScheme.splitStack(0))
+                                DataStickWScheme.splitStack(0),
+                                GT_Utility.getIntegratedCircuit(Math.max(i, 1)))
                         .itemOutputs(ExtraChips[i]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L))
                         .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[rocketTier - 2])
                         .addTo(circuitAssemblerRecipes);

--- a/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
@@ -481,39 +481,11 @@ public class CircuitAssemblerRecipes implements Runnable {
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 RocketMaterial[(i - 1)],
-                                ItemList.Circuit_Elite.get(1L),
+                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1),
                                 DataStickWScheme.splitStack(0))
                         .itemOutputs(RocketChip[(i - 1)]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L))
                         .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[(i - 2)])
                         .addTo(circuitAssemblerRecipes);
-
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                RocketMaterial[(i - 1)],
-                                ItemList.Circuit_Elitenanocomputer.get(1L),
-                                DataStickWScheme.splitStack(0))
-                        .itemOutputs(RocketChip[(i - 1)]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L))
-                        .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[(i - 2)])
-                        .addTo(circuitAssemblerRecipes);
-
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                RocketMaterial[(i - 1)],
-                                ItemList.Circuit_Quantumcomputer.get(1L),
-                                DataStickWScheme.splitStack(0))
-                        .itemOutputs(RocketChip[(i - 1)]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L))
-                        .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[(i - 2)])
-                        .addTo(circuitAssemblerRecipes);
-
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                RocketMaterial[(i - 1)],
-                                ItemList.Circuit_Crystalprocessor.get(1L),
-                                DataStickWScheme.splitStack(0))
-                        .itemOutputs(RocketChip[(i - 1)]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L))
-                        .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[(i - 2)])
-                        .addTo(circuitAssemblerRecipes);
-
             }
 
             for (int i = 0; i < 3; ++i) {

--- a/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
@@ -520,29 +520,14 @@ public class CircuitAssemblerRecipes implements Runnable {
                 ItemStack DataStickWScheme = ItemList.Tool_DataStick.get(1L);
                 DataStickWScheme.setTagCompound(
                         GT_Utility.getNBTContainingShort(new NBTTagCompound(), "rocket_tier", (short) (i + 100)));
-
+                int rocketTier = Math.min(i + 2, 3);
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
-                                RocketMaterial[i],
-                                ItemList.Circuit_Quantumprocessor.get(1L),
+                                RocketMaterial[rocketTier - 1],
+                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Elite, 1),
                                 DataStickWScheme.splitStack(0))
                         .itemOutputs(ExtraChips[i]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L))
-                        .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[i])
-                        .addTo(circuitAssemblerRecipes);
-
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(RocketMaterial[i], ItemList.Circuit_Data.get(1L), DataStickWScheme.splitStack(0))
-                        .itemOutputs(ExtraChips[i]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L))
-                        .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[i])
-                        .addTo(circuitAssemblerRecipes);
-
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                RocketMaterial[i],
-                                ItemList.Circuit_Nanocomputer.get(1L),
-                                DataStickWScheme.splitStack(0))
-                        .itemOutputs(ExtraChips[i]).fluidInputs(tMat.getMolten(576L * tMultiplier / 2L))
-                        .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[i])
+                        .requiresCleanRoom().duration(7 * MINUTES + 30 * SECONDS).eut(EUperRecipe[rocketTier - 2])
                         .addTo(circuitAssemblerRecipes);
 
             }


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15611

in more detail:
- changes recipes for the copying of moon buggy/astro miner/cargo rocket schematic to be the same as the equivalent rocket tier schematic it can be exchanged with
- add programmed circuits to the recipes. otherwise they are removed as duplicates! the nbt on the datastick doesnt count. :(
- use oredict for circuits for all these recipes so that the circuits cycle in NEI instead of having 12 separate recipes for the different circuits.