### PR TITLE
More dark steel chests recipe tweaks

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptAvaritiaAddons.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAvaritiaAddons.java
@@ -55,17 +55,6 @@ public class ScriptAvaritiaAddons implements IScriptLoader {
     public void loadRecipes() {
         addShapedRecipe(
                 getModItem(AvaritiaAddons.ID, "CompressedChest", 1),
-                "plateDenseObsidian",
-                "plateDenseObsidian",
-                "plateDenseObsidian",
-                "chestDiamond",
-                ItemList.Electric_Piston_HV.get(1),
-                "chestDiamond",
-                "plateDenseObsidian",
-                "plateDenseObsidian",
-                "plateDenseObsidian");
-        addShapedRecipe(
-                getModItem(AvaritiaAddons.ID, "CompressedChest", 1),
                 "stickObsidian",
                 ItemList.Electric_Piston_HV.get(1),
                 "stickObsidian",
@@ -73,25 +62,16 @@ public class ScriptAvaritiaAddons implements IScriptLoader {
                 "chestObsidian",
                 "plateDenseObsidian",
                 "craftingToolWrench",
-                "chestDiamond",
+                getModItem(IronChests.ID, "BlockIronChest", 1, 9, missing),
                 "craftingToolScrewdriver");
 
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(IronChests.ID, "BlockIronChest", 2, 2),
-                        ItemList.Electric_Piston_HV.get(1),
-                        GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Obsidian, 4),
-                        GT_Utility.getIntegratedCircuit(1))
-                .itemOutputs(getModItem(AvaritiaAddons.ID, "CompressedChest", 1)).duration(30 * SECONDS)
-                .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
-
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
                         getModItem(IronChests.ID, "BlockIronChest", 1, 6),
-                        getModItem(IronChests.ID, "BlockIronChest", 1, 2),
+                        getModItem(IronChests.ID, "BlockIronChest", 1, 9),
                         ItemList.Electric_Piston_HV.get(1),
                         GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.Obsidian, 1),
-                        GT_Utility.getIntegratedCircuit(3))
+                        GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(AvaritiaAddons.ID, "CompressedChest", 1)).duration(30 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 


### PR DESCRIPTION
Better integration for https://github.com/GTNewHorizons/ironchest/pull/16.

Uses dark steel chests for compressed chests, to integrate them more properly in the progression.

Specifically, compressed chest recipes are now:
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/d29d7492-a18b-4ef0-9033-87122be28410)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/ea468461-7148-4289-9867-852e7e38d24a)

note, that this now even has correct math for slots. 108 (obsidian) + 135 (dark steel) = 243 (compressed).