### PR TITLE
Fix broken tinkers defence recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -462,14 +462,14 @@ public class CompressorRecipes implements Runnable {
         if (!TinkersDefence.isModLoaded()) {
             return;
         }
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "AeonSteelIngot", 9, 0, missing))
-                .itemOutputs(getModItem(TinkersDefence.ID, "AeonSteelBlock", 1, 0, missing)).duration(15 * SECONDS)
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "AeonSteel Ingot", 9, 0, missing))
+                .itemOutputs(getModItem(TinkersDefence.ID, "aeonsteelblock", 1, 0, missing)).duration(15 * SECONDS)
                 .eut(2).addTo(compressorRecipes);
-        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "QueensGoldIngot", 9, 0, missing))
-                .itemOutputs(getModItem(TinkersDefence.ID, "QueensGoldBlock", 1, 0, missing)).duration(15 * SECONDS)
+        GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "Queen's Gold Ingot", 9, 0, missing))
+                .itemOutputs(getModItem(TinkersDefence.ID, "QueensGoldblock", 1, 0, missing)).duration(15 * SECONDS)
                 .eut(2).addTo(compressorRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(TinkersDefence.ID, "DogbeariumIngot", 9, 0, missing))
-                .itemOutputs(getModItem(TinkersDefence.ID, "DogbeariumBlock", 1, 0, missing)).duration(15 * SECONDS)
+                .itemOutputs(getModItem(TinkersDefence.ID, "Dogbeariumblock", 1, 0, missing)).duration(15 * SECONDS)
                 .eut(2).addTo(compressorRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptTinkersDefence.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTinkersDefence.java
@@ -33,7 +33,7 @@ public class ScriptTinkersDefence implements IScriptLoader {
         TConstructHelper.removeTableRecipe(getModItem(TinkerConstruct.ID, "arrowhead", 1, 202, missing));
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(TinkersDefence.ID, "AeonSteelIngot", 1, 0, missing),
+                        getModItem(TinkersDefence.ID, "AeonSteel Ingot", 1, 0, missing),
                         getModItem(TinkerConstruct.ID, "metalPattern", 0, 25, missing))
                 .itemOutputs(getModItem(TinkerConstruct.ID, "arrowhead", 1, 201, missing))
                 .duration(1 * MINUTES + 28 * SECONDS).eut(120).addTo(extruderRecipes);
@@ -45,7 +45,7 @@ public class ScriptTinkersDefence implements IScriptLoader {
                 .duration(1 * MINUTES + 4 * SECONDS).eut(120).addTo(extruderRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(TinkersDefence.ID, "QueensGoldIngot", 1, 0, missing),
+                        getModItem(TinkersDefence.ID, "Queen's Gold Ingot", 1, 0, missing),
                         getModItem(TinkerConstruct.ID, "metalPattern", 0, 25, missing))
                 .itemOutputs(getModItem(TinkerConstruct.ID, "arrowhead", 1, 202, missing)).duration(10 * SECONDS)
                 .eut(120).addTo(extruderRecipes);


### PR DESCRIPTION
fix incorrect item names in 5 tinkers defence recipes.

fixes the last few point and thus closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15676

![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/ba034b0f-2d92-444a-9c2b-07ba182369fa)
![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/086190e2-82a9-4831-8db4-c30fbe280230)
