### PR TITLE
Add a few missing assembler recipes for large-volume items.

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -4085,7 +4085,8 @@ public class AssemblerRecipes implements Runnable {
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 23),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.RedAlloy, 1),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 2),
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 3))
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 3),
+                GT_Utility.getIntegratedCircuit(2))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 25)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
@@ -4095,7 +4096,8 @@ public class AssemblerRecipes implements Runnable {
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 23),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.RedAlloy, 1),
                 GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Platinum, 2),
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 3))
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 3),
+                GT_Utility.getIntegratedCircuit(2))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
@@ -4108,7 +4110,8 @@ public class AssemblerRecipes implements Runnable {
                 // Engineering Processor
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
                 // Fluix Crystal
-                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 7))
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 7),
+                GT_Utility.getIntegratedCircuit(2))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 30)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
@@ -4119,7 +4122,8 @@ public class AssemblerRecipes implements Runnable {
                 // Engineering Processor
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
                 CustomItemList.MysteriousCrystal.get(1L),
-                CustomItemList.AcceleratorLuV.get(1L))
+                CustomItemList.AcceleratorLuV.get(1L),
+                GT_Utility.getIntegratedCircuit(2))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 56)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
@@ -4130,7 +4134,8 @@ public class AssemblerRecipes implements Runnable {
                 // ME Storage Bus
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 220),
                 // ME Level Emitter
-                getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 280))
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 280),
+                GT_Utility.getIntegratedCircuit(2))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 63)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
@@ -4141,7 +4146,8 @@ public class AssemblerRecipes implements Runnable {
                 // 16k ME Storage Component
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 37),
                 // ME Interface
-                getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1, 0))
+                getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1, 0),
+                GT_Utility.getIntegratedCircuit(2))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 54)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -4027,6 +4027,91 @@ public class AssemblerRecipes implements Runnable {
                 .fluidInputs(Materials.Glass.getMolten(288L)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
 
+        // Basic Card
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        // Calculation Processor
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 23),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.RedAlloy, 1),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 2),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 3)
+                )
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 25))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
+        // Advanced Card
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        // Calculation Processor
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 23),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.RedAlloy, 1),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Platinum, 2),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 3)
+                )
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
+        // Acceleration Card
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        // Advanced Card
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
+                        // Logic Processor
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 22),
+                        // Engineering Processor
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
+                        // Fluix Crystal
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 7)
+                )
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 30))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
+        // Hyper-Acceleration Card
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        // Advanced Card
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
+                        // Engineering Processor
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
+                        CustomItemList.MysteriousCrystal.get(1L),
+                        CustomItemList.AcceleratorLuV.get(1L)
+                )
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 56))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
+        // Advanced Blocking Card
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        // Advanced Card
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
+                        // ME Storage Bus
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 220),
+                        // ME Level Emitter
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 280)
+                )
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 63))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
+        // Pattern Capacity Card
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        // Advanced Card
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
+                        // 16k ME Storage Component
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 37),
+                        // ME Interface
+                        getModItem(AppliedEnergistics2.ID, "item.BlockInterface", 1, 0)
+                )
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.ItemMultiMaterial", 1, 54))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
+
         if (AE2FluidCraft.isModLoaded()) {
             // Dual Interface
             GT_Values.RA.stdBuilder()

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1890,10 +1890,8 @@ public class AssemblerRecipes implements Runnable {
                         Materials.Titanium.getPlates(2),
                         ItemList.Electric_Pump_EV.get(1),
                         ItemList.Field_Generator_HV.get(1),
-                        ItemList.Casing_Tank_5.get(1)
-                )
-                .itemOutputs(ItemList.Super_Tank_IV.get(1L))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                        ItemList.Casing_Tank_5.get(1))
+                .itemOutputs(ItemList.Super_Tank_IV.get(1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
 
         // Super Chest V
@@ -1902,10 +1900,8 @@ public class AssemblerRecipes implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Elite), 4),
                         GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, Materials.Titanium, 3),
                         ItemList.Field_Generator_HV.get(1),
-                        ItemList.Automation_SuperBuffer_IV.get(1)
-                )
-                .itemOutputs(ItemList.Super_Chest_IV.get(1L))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                        ItemList.Automation_SuperBuffer_IV.get(1))
+                .itemOutputs(ItemList.Super_Chest_IV.get(1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
 
         // Super Buffer IV
@@ -1914,10 +1910,8 @@ public class AssemblerRecipes implements Runnable {
                         ItemList.Conveyor_Module_IV.get(1),
                         GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Elite), 1),
                         ItemList.Hull_IV.get(1),
-                        GT_OreDictUnificator.get(OrePrefixes.chest, Materials.Wood, 1)
-                )
-                .itemOutputs(ItemList.Automation_SuperBuffer_IV.get(1L))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                        GT_OreDictUnificator.get(OrePrefixes.chest, Materials.Wood, 1))
+                .itemOutputs(ItemList.Automation_SuperBuffer_IV.get(1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
 
         // Quantum Tank V
@@ -1960,31 +1954,24 @@ public class AssemblerRecipes implements Runnable {
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
         // UV Compressor
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                    ItemList.Hull_UV.get(1),
-                    // UV circuit, but internal naming is SuperconductorUHV?
-                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.SuperconductorUHV, 2),
-                    ItemList.Electric_Piston_UV.get(2),
-                    GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.ElectrumFlux, 4)
-                )
-                .itemOutputs(CustomItemList.CompressorUV.get(1))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_UV)
+        GT_Values.RA.stdBuilder().itemInputs(
+                ItemList.Hull_UV.get(1),
+                // UV circuit, but internal naming is SuperconductorUHV?
+                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.SuperconductorUHV, 2),
+                ItemList.Electric_Piston_UV.get(2),
+                GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.ElectrumFlux, 4))
+                .itemOutputs(CustomItemList.CompressorUV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_UV)
                 .addTo(assemblerRecipes);
 
         // UV Microwave Transmitter
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        ItemList.Hull_UV.get(1),
-                        // UV circuit, but internal naming is SuperconductorUHV?
-                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.SuperconductorUHV, 2),
-                        ItemList.Emitter_UV.get(4),
-                        ItemList.Field_Generator_UV.get(1),
-                        ItemList.Energy_Module.get(1)
-                )
-                .itemOutputs(ItemList.MicroTransmitter_UV.get(1))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_UV)
-                .addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(
+                ItemList.Hull_UV.get(1),
+                // UV circuit, but internal naming is SuperconductorUHV?
+                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.SuperconductorUHV, 2),
+                ItemList.Emitter_UV.get(4),
+                ItemList.Field_Generator_UV.get(1),
+                ItemList.Energy_Module.get(1)).itemOutputs(ItemList.MicroTransmitter_UV.get(1)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_UV).addTo(assemblerRecipes);
 
         if (HardcoreEnderExpansion.isModLoaded()) {
             // Biome Compass
@@ -4093,106 +4080,84 @@ public class AssemblerRecipes implements Runnable {
                 .addTo(assemblerRecipes);
 
         // Basic Card
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        // Calculation Processor
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 23),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.RedAlloy, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 3)
-                )
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 25))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
-                .addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(
+                // Calculation Processor
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 23),
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.RedAlloy, 1),
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 2),
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 3))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 25)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
         // Advanced Card
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        // Calculation Processor
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 23),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.RedAlloy, 1),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Platinum, 2),
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 3)
-                )
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
-                .addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(
+                // Calculation Processor
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 23),
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.RedAlloy, 1),
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Platinum, 2),
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 3))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
         // Acceleration Card
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        // Advanced Card
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
-                        // Logic Processor
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 22),
-                        // Engineering Processor
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
-                        // Fluix Crystal
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 7)
-                )
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 30))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
-                .addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(
+                // Advanced Card
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
+                // Logic Processor
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 22),
+                // Engineering Processor
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
+                // Fluix Crystal
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 7))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 30)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
         // Hyper-Acceleration Card
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        // Advanced Card
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
-                        // Engineering Processor
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
-                        CustomItemList.MysteriousCrystal.get(1L),
-                        CustomItemList.AcceleratorLuV.get(1L)
-                )
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 56))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
-                .addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(
+                // Advanced Card
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
+                // Engineering Processor
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24),
+                CustomItemList.MysteriousCrystal.get(1L),
+                CustomItemList.AcceleratorLuV.get(1L))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 56)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
         // Advanced Blocking Card
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        // Advanced Card
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
-                        // ME Storage Bus
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 220),
-                        // ME Level Emitter
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 280)
-                )
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 63))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
-                .addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(
+                // Advanced Card
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
+                // ME Storage Bus
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 220),
+                // ME Level Emitter
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 280))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 63)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
         // Pattern Capacity Card
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        // Advanced Card
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
-                        // 16k ME Storage Component
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 37),
-                        // ME Interface
-                        getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1, 0)
-                )
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 54))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
-                .addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder().itemInputs(
+                // Advanced Card
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 28),
+                // 16k ME Storage Component
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 37),
+                // ME Interface
+                getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1, 0))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 54)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
         // ME interface (flat version)
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4),
-                        // Fluix Cable
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 2, 16),
-                        // Formation Core
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 43),
-                        // Annihilation Core
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 44),
-                        ItemList.Casing_EV.get(1L),
-                        GT_Utility.getIntegratedCircuit(3)
-                )
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 440))
-                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
-                .addTo(assemblerRecipes);
-
+        GT_Values.RA.stdBuilder().itemInputs(
+                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4),
+                // Fluix Cable
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 2, 16),
+                // Formation Core
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 43),
+                // Annihilation Core
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 44),
+                ItemList.Casing_EV.get(1L),
+                GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 440)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
         if (AE2FluidCraft.isModLoaded()) {
             // Dual Interface

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1882,6 +1882,44 @@ public class AssemblerRecipes implements Runnable {
                     .itemOutputs(GT_ModHandler.getModItem(GalacticraftMars.ID, "item.null", 1, 6)).duration(5 * SECONDS)
                     .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
         }
+
+        // Super Tank V
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Elite), 4),
+                        Materials.Titanium.getPlates(2),
+                        ItemList.Electric_Pump_EV.get(1),
+                        ItemList.Field_Generator_HV.get(1),
+                        ItemList.Casing_Tank_5.get(1)
+                )
+                .itemOutputs(ItemList.Super_Tank_IV.get(1L))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
+        // Super Chest V
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Elite), 4),
+                        GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, Materials.Titanium, 3),
+                        ItemList.Field_Generator_HV.get(1),
+                        ItemList.Automation_SuperBuffer_IV.get(1)
+                )
+                .itemOutputs(ItemList.Super_Chest_IV.get(1L))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
+        // Super Buffer IV
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Conveyor_Module_IV.get(1),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Elite), 1),
+                        ItemList.Hull_IV.get(1),
+                        GT_OreDictUnificator.get(OrePrefixes.chest, Materials.Wood, 1)
+                )
+                .itemOutputs(ItemList.Automation_SuperBuffer_IV.get(1L))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
         // Quantum Tank V
         GT_Values.RA.stdBuilder()
                 .itemInputs(
@@ -1920,6 +1958,33 @@ public class AssemblerRecipes implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.chest, Materials.Wood, 1))
                 .itemOutputs(CustomItemList.Automation_ChestBuffer_UEV.get(1L)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
+
+        // UV Compressor
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                    ItemList.Hull_UV.get(1),
+                    // UV circuit, but internal naming is SuperconductorUHV?
+                    GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.SuperconductorUHV, 2),
+                    ItemList.Electric_Piston_UV.get(2),
+                    GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.ElectrumFlux, 4)
+                )
+                .itemOutputs(CustomItemList.CompressorUV.get(1))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_UV)
+                .addTo(assemblerRecipes);
+
+        // UV Microwave Transmitter
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Hull_UV.get(1),
+                        // UV circuit, but internal naming is SuperconductorUHV?
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.SuperconductorUHV, 2),
+                        ItemList.Emitter_UV.get(4),
+                        ItemList.Field_Generator_UV.get(1),
+                        ItemList.Energy_Module.get(1)
+                )
+                .itemOutputs(ItemList.MicroTransmitter_UV.get(1))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_UV)
+                .addTo(assemblerRecipes);
 
         if (HardcoreEnderExpansion.isModLoaded()) {
             // Biome Compass
@@ -4105,9 +4170,26 @@ public class AssemblerRecipes implements Runnable {
                         // 16k ME Storage Component
                         getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 37),
                         // ME Interface
-                        getModItem(AppliedEnergistics2.ID, "item.BlockInterface", 1, 0)
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1, 0)
                 )
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.ItemMultiMaterial", 1, 54))
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 54))
+                .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
+        // ME interface (flat version)
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4),
+                        // Fluix Cable
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 2, 16),
+                        // Formation Core
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 43),
+                        // Annihilation Core
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 44),
+                        ItemList.Casing_EV.get(1L),
+                        GT_Utility.getIntegratedCircuit(3)
+                )
+                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 440))
                 .duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1904,14 +1904,14 @@ public class AssemblerRecipes implements Runnable {
                 .itemOutputs(ItemList.Super_Chest_IV.get(1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
 
-        // Super Buffer IV
+        // Chest Buffer IV
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Conveyor_Module_IV.get(1),
                         GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Elite), 1),
                         ItemList.Hull_IV.get(1),
                         GT_OreDictUnificator.get(OrePrefixes.chest, Materials.Wood, 1))
-                .itemOutputs(ItemList.Automation_SuperBuffer_IV.get(1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .itemOutputs(ItemList.Automation_ChestBuffer_IV.get(1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
 
         // Quantum Tank V

--- a/src/main/java/com/dreammaster/scripts/ScriptGregtech.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGregtech.java
@@ -1216,6 +1216,16 @@ public class ScriptGregtech implements IScriptLoader {
                 .addTo(assemblerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
+                        ItemList.Electric_Piston_EV.get(2, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Data, 2),
+                        ItemList.Electric_Motor_EV.get(2, missing),
+                        ItemList.Hull_EV.get(1, missing),
+                        GT_OreDictUnificator.get(OrePrefixes.cableGt01, Materials.Aluminium, missing, 1L),
+                        GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(ItemList.Machine_EV_Bender.get(1, missing)).duration(10 * SECONDS).eut(1920)
+                .addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.Tin, 9L),
                         GT_OreDictUnificator.get(OrePrefixes.nugget, Materials.Copper, 27L))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Bronze, 4L)).duration(10 * SECONDS)

--- a/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
@@ -1691,6 +1691,51 @@ public class ScriptIndustrialCraft implements IScriptLoader {
                         GT_Utility.getIntegratedCircuit(2))
                 .itemOutputs(getModItem(IndustrialCraft2.ID, "blockCrop", 16, 0, missing))
                 .duration(7 * SECONDS + 10 * TICKS).eut(30).addTo(assemblerRecipes);
+
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.itemCasing, Materials.Steel, 2L),
+                        getModItem(IndustrialCraft2.ID, "itemBatREDischarged", 3, 0, missing),
+                        ItemList.Hull_MV.get(1L),
+                        getModItem(IndustrialCraft2.ID, "itemPartCircuit", 1, 0, missing),
+                        getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 5, missing),
+                        ItemList.Electric_Motor_MV.get(1L),
+                        GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "blockGenerator", 1, 8, missing)).duration(30 * SECONDS)
+                .eut(120).addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 4L),
+                        getModItem(IndustrialCraft2.ID, "itemPartCarbonPlate", 2, 0, missing),
+                        getModItem(IndustrialCraft2.ID, "itemPartAlloy", 2, 0, missing),
+                        getModItem(IndustrialCraft2.ID, "blockMachine", 1, 0, missing),
+                        GT_Utility.getIntegratedCircuit(1))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "blockMachine", 1, 12, missing))
+                .duration(1 * SECONDS + 5 * TICKS).eut(16).addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Rubber, missing, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Copper, missing, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Silver, missing, 1L),
+                        GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 5, missing)).duration(30 * SECONDS)
+                .eut(30).addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Silicone, missing, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Copper, missing, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Silver, missing, 1L),
+                        GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 5, missing)).duration(30 * SECONDS)
+                .eut(30).addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StyreneButadieneRubber, missing, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Copper, missing, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Silver, missing, 1L),
+                        GT_Utility.getIntegratedCircuit(3))
+                .itemOutputs(getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 5, missing)).duration(30 * SECONDS)
+                .eut(30).addTo(assemblerRecipes);
         GT_Values.RA.stdBuilder().itemInputs(getModItem(NewHorizonsCoreMod.ID, "item.BioChunk", 1, 0, missing))
                 .itemOutputs(getModItem(IndustrialCraft2.ID, "itemPartCoalChunk", 1, 0, missing)).duration(1 * MINUTES)
                 .eut(120).specialValue(1000).addTo(blastFurnaceRecipes);


### PR DESCRIPTION
This PR adds assembler recipes for a few items that are used in large volumes.

AE2 related stuff:
- AE2 basic and advanced card
- Advanced blocking card
- Pattern capacity card
- Acceleration card
- Hyper-Acceleration card
- Flat ME interface (this uses the same recipe as a regular interface but with a different circuit number, as suggested in GTNewHorizons/GT-New-Horizons-Modpack#15276)

DTPF casings:
- Super Chest V
- Super Tank V
- IV Chest Buffer
- UV Microwave Transmitter

Yottank cells/EOH parts
- UV compressor

Dyson related stuff (by @C0bra5)
- IC2 Advanced Machine Casing
- IC2 Stirling Generator
- IC2 Heat Component

Various
- EV bending machine (used by bending machine multi) by @C0bra5