### PR TITLE
Remove duplicate TF portal gen recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -927,14 +927,10 @@ public class AssemblerRecipes implements Runnable {
                         GT_Utility.getIntegratedCircuit(4))
                 .itemOutputs(ItemList.Casing_Tank_10.get(1L)).duration(5 * SECONDS).eut(16).addTo(assemblerRecipes);
 
-        GT_Values.RA.stdBuilder().itemInputs(new ItemStack(Items.diamond, 1, 0), ItemList.Circuit_Basic.get(4L))
-                .itemOutputs(CustomItemList.TwilightCrystal.get(1L)).duration(30 * SECONDS).eut(16)
-                .addTo(assemblerRecipes);
-
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         new ItemStack(Items.diamond, 1, 0),
-                        GT_ModHandler.getModItem(IndustrialCraft2.ID, "itemPartCircuit", 4L, 0))
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Basic, 4L))
                 .itemOutputs(CustomItemList.TwilightCrystal.get(1L)).duration(30 * SECONDS).eut(16)
                 .addTo(assemblerRecipes);
 


### PR DESCRIPTION
Removes the redundant recipe (that uses itemlist to suppress unification) as the other is unified anyway. Made that one a bit more clear with GT_OreDictUnificator but that is just cosmetics.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15911