### PR TITLE
Add missing resistor recipes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.146:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.148:dev")
     api("com.github.GTNewHorizons:Yamcl:0.6.0:dev")
     api("com.github.GTNewHorizons:Baubles:1.0.4:dev")
 
@@ -10,7 +10,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:GalacticGregGT5:1.1.0:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:GTNH-Intergalactic:1.3.2:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:TecTech:5.3.45:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:bartworks:0.9.17:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:bartworks:0.9.18:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Mantle:0.4.1:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.11.14-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:WitcheryExtras:1.2.2:dev") { transitive = false }

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -438,6 +438,11 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
             GT_ModHandler.addCraftingRecipe(
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Lignite),
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1, 36) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Coal), 'R',
                             GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 0) });
             GT_ModHandler.addCraftingRecipe(
@@ -453,6 +458,11 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
             GT_ModHandler.addCraftingRecipe(
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Lignite),
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 0) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Coal), 'R',
                             GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
             GT_ModHandler.addCraftingRecipe(
@@ -464,6 +474,11 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Charcoal),
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Lignite),
                             'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
         }
         GT_ModHandler.addCraftingRecipe(

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -424,22 +424,62 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Coal), 'R',
-                            GT_OreDictUnificator.get("slimeball", 1) });
+                            GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1, 36) });
             GT_ModHandler.addCraftingRecipe(
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Carbon),
-                            'R', GT_OreDictUnificator.get("slimeball", 1) });
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1, 36) });
             GT_ModHandler.addCraftingRecipe(
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Charcoal),
-                            'R', GT_OreDictUnificator.get("slimeball", 1) });
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1, 36) });
             GT_ModHandler.addCraftingRecipe(
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Lignite),
-                            'R', GT_OreDictUnificator.get("slimeball", 1) });
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1, 36) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Coal), 'R',
+                            GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 0) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Carbon),
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 0) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Charcoal),
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 0) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Lignite),
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 0) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Coal), 'R',
+                            GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Carbon),
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Charcoal),
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
+            GT_ModHandler.addCraftingRecipe(
+                    ItemList.Circuit_Parts_Resistor.get(1, o),
+                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
+                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Lignite),
+                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
         }
         GT_ModHandler.addCraftingRecipe(
                 ItemList.Circuit_Board_Coated_Basic.get(1, o),

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -424,62 +424,22 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Coal), 'R',
-                            GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1, 36) });
+                            GT_OreDictUnificator.get("slimeball", 1) });
             GT_ModHandler.addCraftingRecipe(
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Carbon),
-                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1, 36) });
+                            'R', GT_OreDictUnificator.get("slimeball", 1) });
             GT_ModHandler.addCraftingRecipe(
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Charcoal),
-                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1, 36) });
+                            'R', GT_OreDictUnificator.get("slimeball", 1) });
             GT_ModHandler.addCraftingRecipe(
                     ItemList.Circuit_Parts_Resistor.get(1, o),
                     new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
                             OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Lignite),
-                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "materials", 1, 36) });
-            GT_ModHandler.addCraftingRecipe(
-                    ItemList.Circuit_Parts_Resistor.get(1, o),
-                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
-                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Coal), 'R',
-                            GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 0) });
-            GT_ModHandler.addCraftingRecipe(
-                    ItemList.Circuit_Parts_Resistor.get(1, o),
-                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
-                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Carbon),
-                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 0) });
-            GT_ModHandler.addCraftingRecipe(
-                    ItemList.Circuit_Parts_Resistor.get(1, o),
-                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
-                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Charcoal),
-                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 0) });
-            GT_ModHandler.addCraftingRecipe(
-                    ItemList.Circuit_Parts_Resistor.get(1, o),
-                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
-                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Lignite),
-                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 0) });
-            GT_ModHandler.addCraftingRecipe(
-                    ItemList.Circuit_Parts_Resistor.get(1, o),
-                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
-                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Coal), 'R',
-                            GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
-            GT_ModHandler.addCraftingRecipe(
-                    ItemList.Circuit_Parts_Resistor.get(1, o),
-                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
-                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Carbon),
-                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
-            GT_ModHandler.addCraftingRecipe(
-                    ItemList.Circuit_Parts_Resistor.get(1, o),
-                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
-                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Charcoal),
-                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
-            GT_ModHandler.addCraftingRecipe(
-                    ItemList.Circuit_Parts_Resistor.get(1, o),
-                    new Object[] { "RPR", "FCF", " P ", 'F', OrePrefixes.wireGt01.get(Materials.Copper), 'P',
-                            OrePrefixes.wireFine.get(Materials.Copper), 'C', OrePrefixes.dust.get(Materials.Lignite),
-                            'R', GT_ModHandler.getModItem(TinkerConstruct.ID, "strangeFood", 1, 1) });
+                            'R', GT_OreDictUnificator.get("slimeball", 1) });
         }
         GT_ModHandler.addCraftingRecipe(
                 ItemList.Circuit_Board_Coated_Basic.get(1, o),


### PR DESCRIPTION
This PR fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14627 by adding the missing recipes (TC slime items + Lignite)

Marked as draft since commit 6579f42d2539cc3082ffab110fe2519ff3d1f9fe (simplify recipes by using the oredict for `slimeball`) does not work.

Is it intended that using the oredict for input items does not work? In the recipe for `iron_bars`, `stickAnyIron` (`OrePrefixes.stick, Materials.AnyIron`) is used, which is also ignored and simplified to only the default `iron rod`

Ifit is not intended to use oredict names for input items, we can revert the last commit and un-draft.