### PR TITLE
Unstable ingot fixes

### DIFF
--- a/src/main/java/com/dreammaster/recipes/CustomItem.java
+++ b/src/main/java/com/dreammaster/recipes/CustomItem.java
@@ -56,6 +56,8 @@ public interface CustomItem {
         private NBTTagCompound nbt;
         private boolean exact = false;
 
+        private boolean noValues = false;
+
         public NBTItem() {}
 
         public NBTItem(ItemStack stack) {
@@ -74,7 +76,7 @@ public interface CustomItem {
             for (String key : (Set<String>) nbt.func_150296_c()) {
                 NBTBase v = nbt.getTag(key);
                 if (!stack.stackTagCompound.hasKey(key, v.getId())) return false;
-                if (!stack.stackTagCompound.getTag(key).equals(v)) return false;
+                if ((!noValues) && (!stack.stackTagCompound.getTag(key).equals(v))) return false;
             }
             return true;
         }
@@ -120,6 +122,11 @@ public interface CustomItem {
 
         public NBTItem matchExact() {
             exact = true;
+            return this;
+        }
+
+        public NBTItem noValues() {
+            noValues = true;
             return this;
         }
 

--- a/src/main/java/com/dreammaster/recipes/RecipeRemover.java
+++ b/src/main/java/com/dreammaster/recipes/RecipeRemover.java
@@ -3037,18 +3037,9 @@ public class RecipeRemover {
                         getModItem("EnderZoo", "enderFragment", 1, 0, missing) },
                 new Object[] { null, getModItem("EnderZoo", "enderFragment", 1, 0, missing), null });
         removeRecipeShapedDelayed(
-                getModItem("ExtraUtilities", "unstableingot", 1, 0, missing)/*
-                                                                             * createItemStack("ExtraUtilities",
-                                                                             * "unstableingot", 1, 0, "{Bug:1b}",
-                                                                             * missing)
-                                                                             */,
+                getModItem("ExtraUtilities", "unstableingot", 1, 0, missing),
                 new Object[] { getModItem("minecraft", "iron_ingot", 1, 0, missing) },
-                new Object[] { getModItem("ExtraUtilities", "divisionSigil", 1, 0, missing)/*
-                                                                                            * createItemStack(
-                                                                                            * "ExtraUtilities",
-                                                                                            * "divisionSigil", 1, 0,
-                                                                                            * "{damage:256}", missing)
-                                                                                            */ },
+                new Object[] { getModItem("ExtraUtilities", "divisionSigil", 1, 0, missing) },
                 new Object[] { getModItem("minecraft", "diamond", 1, 0, missing) });
         removeRecipeShapedDelayed(
                 getModItem("ForbiddenMagic", "FMResource", 9, 0, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
@@ -43,6 +43,7 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
 import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.recipes.CustomItem;
 import com.dreammaster.thaumcraft.TCHelper;
 import com.dreammaster.tinkersConstruct.TConstructHelper;
 import com.rwtema.extrautils.tileentity.enderconstructor.EnderConstructorRecipesHandler;
@@ -873,11 +874,30 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 null,
                 getModItem(RandomThings.ID, "ingredient", 1, 1, missing),
                 null);
+
         addShapedRecipe(
                 getModItem(ExtraUtilities.ID, "unstableingot", 1, 0, missing),
                 getModItem(Minecraft.ID, "iron_ingot", 1, 0, missing),
-                createItemStack(ExtraUtilities.ID, "divisionSigil", 1, 0, "{damage:256}", missing),
-                getModItem(Minecraft.ID, "diamond", 1, 0, missing));
+                null,
+                null,
+                new CustomItem.NBTItem(getModItem(ExtraUtilities.ID, "divisionSigil", 1, 0)).setNBT("{damage:256}")
+                        .noValues(),
+                null,
+                null,
+                getModItem(Minecraft.ID, "diamond", 1, 0, missing),
+                null,
+                null);
+        addShapedRecipe(
+                getModItem(ExtraUtilities.ID, "unstableingot", 1, 2, missing),
+                getModItem(Minecraft.ID, "iron_ingot", 1, 0, missing),
+                null,
+                null,
+                new CustomItem.NBTItem(getModItem(ExtraUtilities.ID, "divisionSigil", 1, 0)).setNBT("{stable:1b}"),
+                null,
+                null,
+                getModItem(Minecraft.ID, "diamond", 1, 0, missing),
+                null,
+                null);
 
         // mods.extraUtils.QED.removeRecipe(<*>); // <- scripts
         EnderConstructorRecipesHandler.recipes.clear();


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14075
actually fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/5416

Fixes several aspects of unstable ingot crafting:
- couldnt craft the mobius ingot at all. one would get the regular unstable ingot instead
- could craft the regular unstable ingot without activating the sigil
- the shape of the recipe was wrong

Does NOT fix: stack crafting bypasses the explosion mechanic. (idea: maybe we can overwrite the maximum stacksize and set it to 1?)


![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/bbb06025-e066-4f0d-946b-32085fb93eb2)
activated sigil: correctly uses durability and correctly gets the 10s cooldown to explosion (if crafted one at a time)

![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/40274384/36c208fd-caba-41f9-bee2-43eac73085de)
pseudo-inversion sigil: does not use durability and makes the mobius ingot.
