### PR TITLE
Add missing endstone variant to chisel

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptChisel.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptChisel.java
@@ -315,6 +315,7 @@ public class ScriptChisel implements IScriptLoader {
         CarvingUtils.getChiselRegistry().removeGroup("end_stone");
         ChiselHelper.addGroup("endstone");
         ChiselHelper.addVariationFromStack("endstone", getModItem(Minecraft.ID, "end_stone", 1, 0, missing));
+        ChiselHelper.addVariationFromStack("endstone", getModItem(Chisel.ID, "end_Stone", 1, 0, missing));
         ChiselHelper.addVariationFromStack("endstone", getModItem(Chisel.ID, "end_Stone", 1, 1, missing));
         ChiselHelper.addVariationFromStack("endstone", getModItem(Chisel.ID, "end_Stone", 1, 2, missing));
         ChiselHelper.addVariationFromStack("endstone", getModItem(Chisel.ID, "end_Stone", 1, 3, missing));


### PR DESCRIPTION
Fixes one aspect of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16045 which might be all it needs, not sure.

In particular, this means you can compress 9 end stone dust to a block (that you can chisel to all the variants).