### PR TITLE
fix: Restore walkway recipes that were dropped in 2.3.0

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -1719,6 +1719,18 @@ public class ScriptGalacticraft implements IScriptLoader {
                         GT_OreDictUnificator.get(OrePrefixes.wireFine, Materials.Steel, 3L))
                 .itemOutputs(getModItem(GalacticraftCore.ID, "item.parachute", 1, 0, missing)).duration(15 * SECONDS)
                 .eut(480).addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GalacticraftCore.ID, "tile.oxygenPipe", 1, 0, missing),
+                        getModItem(GalacticraftMars.ID, "tile.walkway", 1, 0, missing))
+                .itemOutputs(getModItem(GalacticraftMars.ID, "tile.walkwayOxygenPipe", 1, 0, missing))
+                .duration(1 * SECONDS).eut(120).addTo(assemblerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GalacticraftCore.ID, "tile.aluminumWire", 1, 0, missing),
+                        getModItem(GalacticraftMars.ID, "tile.walkway", 1, 0, missing))
+                .itemOutputs(getModItem(GalacticraftMars.ID, "tile.walkwayWire", 1, 0, missing)).duration(1 * SECONDS)
+                .eut(120).addTo(assemblerRecipes);
     }
 
     private void blastFurnaceRecipes() {


### PR DESCRIPTION
Restore missing recipes as assembler recipes.
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13982

![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/8459776/f4edae93-4c26-48bf-9857-121909b7c1f9)

![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/8459776/6cbeda68-e379-4082-92cc-13a0bcda6020)
