### PR TITLE
Fix planet glowstone recipe loop.

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -2709,38 +2709,38 @@ public class ScriptGalacticraft implements IScriptLoader {
         // Glowstone dusts
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        new ItemStack(Items.glowstone_dust, 1),
-                        GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CeresStoneDust", 1),
+                        new ItemStack(Items.glowstone_dust, 2),
+                        GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.CeresStoneDust", 2),
                         GT_Utility.getIntegratedCircuit(8))
-                .itemOutputs(GT_ModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 2, 0))
+                .itemOutputs(GT_ModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1, 0))
                 .duration(4 * SECONDS).eut(TierEU.RECIPE_HV).addTo(mixerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        new ItemStack(Items.glowstone_dust, 1),
-                        GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.IoStoneDust", 1),
+                        new ItemStack(Items.glowstone_dust, 2),
+                        GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.IoStoneDust", 2),
                         GT_Utility.getIntegratedCircuit(8))
-                .itemOutputs(GT_ModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 2, 1))
+                .itemOutputs(GT_ModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1, 1))
                 .duration(4 * SECONDS).eut(TierEU.RECIPE_HV).addTo(mixerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        new ItemStack(Items.glowstone_dust, 1),
-                        GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.EnceladusStoneDust", 1),
+                        new ItemStack(Items.glowstone_dust, 2),
+                        GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.EnceladusStoneDust", 2),
                         GT_Utility.getIntegratedCircuit(8))
-                .itemOutputs(GT_ModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 2, 2))
+                .itemOutputs(GT_ModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1, 2))
                 .duration(4 * SECONDS).eut(TierEU.RECIPE_HV).addTo(mixerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        new ItemStack(Items.glowstone_dust, 1),
-                        GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.ProteusStoneDust", 1),
+                        new ItemStack(Items.glowstone_dust, 2),
+                        GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.ProteusStoneDust", 2),
                         GT_Utility.getIntegratedCircuit(8))
-                .itemOutputs(GT_ModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 2, 3))
+                .itemOutputs(GT_ModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1, 3))
                 .duration(4 * SECONDS).eut(TierEU.RECIPE_HV).addTo(mixerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        new ItemStack(Items.glowstone_dust, 1),
-                        GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.PlutoStoneDust", 1),
+                        new ItemStack(Items.glowstone_dust, 2),
+                        GT_ModHandler.getModItem(NewHorizonsCoreMod.ID, "item.PlutoStoneDust", 2),
                         GT_Utility.getIntegratedCircuit(8))
-                .itemOutputs(GT_ModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 2, 4))
+                .itemOutputs(GT_ModHandler.getModItem(GalaxySpace.ID, "item.GlowstoneDusts", 1, 4))
                 .duration(4 * SECONDS).eut(TierEU.RECIPE_HV).addTo(mixerRecipes);
     }
 }


### PR DESCRIPTION
It is currently possible to craft planet-specific glowstone from GalaxySpace using 1 glowstone dust and 1 [planet] stone dust to make 2 [planet] glowstone dusts. One [planet] glowstone dust can also be centrifuged into 2 glowstone dusts and a chance-based output of [planet] stone dusts. This allows for infinite creation of glowstone and planet stone.

This PR changes the [planet] glowstone dust recipes to take 2 glowstone dusts and 2 [planet] stone dusts to craft 1 [planet] glowstone dust. This means that centrifuging the [planet] glowstone dust returns all of the glowstone, and has a chance to return the [planet] stone dust used. It is no longer resource positive.

Thanks to **@\_pix3lated\_** on discord for reporting this.