### PR TITLE
Restore (accidentally?) removed ProjectRed recipes.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,12 +1,12 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.46.05:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.46.09:dev")
     api("com.github.GTNewHorizons:Yamcl:0.6.0:dev")
     api("com.github.GTNewHorizons:Baubles:1.0.4:dev")
 
     compileOnly("com.github.GTNewHorizons:Avaritia:1.49:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:twilightforest:2.6.5:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:twilightforest:2.6.6:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:GalacticGregGT5:1.1.0:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:GTNH-Intergalactic:1.3.4:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:TecTech:5.4.0:dev") { transitive = false }
@@ -16,10 +16,10 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:WitcheryExtras:1.2.2:dev") { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     compileOnly("curse.maven:witchery-69673:2234410") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:GTplusplus:1.12.2:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:GTplusplus:1.12.7:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Chisel:2.14.1-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Botania:1.11.0-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:BloodMagic:1.6.0:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:BloodMagic:1.6.1:dev") { transitive = false }
     compileOnly("curse.maven:extra-utilities-225561:2264384") { transitive = false }
     compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.25:deobf") { transitive = false }
     compileOnly("com.github.GTNewHorizons:amunra:0.5.1:dev") { transitive = false }

--- a/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
@@ -35,6 +35,7 @@ import static gregtech.api.recipe.RecipeMaps.cannerRecipes;
 import static gregtech.api.recipe.RecipeMaps.chemicalBathRecipes;
 import static gregtech.api.recipe.RecipeMaps.circuitAssemblerRecipes;
 import static gregtech.api.recipe.RecipeMaps.formingPressRecipes;
+import static gregtech.api.recipe.RecipeMaps.laserEngraverRecipes;
 import static gregtech.api.recipe.RecipeMaps.maceratorRecipes;
 import static gregtech.api.recipe.RecipeMaps.mixerRecipes;
 import static gregtech.api.recipe.RecipeMaps.packagerRecipes;
@@ -2928,21 +2929,21 @@ public class ScriptProjectRed implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 42, missing),
-                        ItemList.Shape_Mold_Ball.get(0L))
+                        "craftingLensRed", 0)
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 13, missing))
-                .duration(30 * SECONDS).eut(30).addTo(formingPressRecipes);
+                .duration(30 * SECONDS).eut(30).addTo(laserEngraverRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 43, missing),
-                        ItemList.Shape_Mold_Ball.get(0L))
+                        "craftingLensYellow", 0)
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 14, missing))
-                .duration(30 * SECONDS).eut(30).addTo(formingPressRecipes);
+                .duration(30 * SECONDS).eut(30).addTo(laserEngraverRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 58, missing),
-                        ItemList.Shape_Mold_Ball.get(0L))
+                        "craftingLensBlue", 0)
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 59, missing))
-                .duration(30 * SECONDS).eut(30).addTo(formingPressRecipes);
+                .duration(30 * SECONDS).eut(30).addTo(laserEngraverRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(getModItem(ProjectRedExploration.ID, "projectred.exploration.stone", 1, 11, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 9, 56, missing)).outputChances(10000)

--- a/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
@@ -2983,13 +2983,13 @@ public class ScriptProjectRed implements IScriptLoader {
                         ItemList.Circuit_Silicon_Wafer2.get(1L),
                         getModItem(Minecraft.ID, "glowstone_dust", 16, 0, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 43, missing))
-                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
+                .duration(40 * SECONDS).eut(30).addTo(formingPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Circuit_Silicon_Wafer3.get(1L),
                         getModItem(Minecraft.ID, "glowstone_dust", 32, 0, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 43, missing))
-                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
+                .duration(60 * SECONDS).eut(30).addTo(formingPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Circuit_Silicon_Wafer.get(1L),
@@ -3001,13 +3001,13 @@ public class ScriptProjectRed implements IScriptLoader {
                         ItemList.Circuit_Silicon_Wafer2.get(1L),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 16, 56, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 58, missing))
-                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
+                .duration(40 * SECONDS).eut(30).addTo(formingPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Circuit_Silicon_Wafer3.get(1L),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 32, 56, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 58, missing))
-                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
+                .duration(60 * SECONDS).eut(30).addTo(formingPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "iron_ingot", 1, 0, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
@@ -2916,8 +2916,26 @@ public class ScriptProjectRed implements IScriptLoader {
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 0, missing),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 13, missing))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 7, missing))
+                .duration(30 * SECONDS).eut(30).addTo(formingPressRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 0, missing),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 14, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 8, missing))
+                .duration(30 * SECONDS).eut(30).addTo(formingPressRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Silicon, 1L),
+                        ItemList.Shape_Mold_Ball.get(0L))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 12, missing))
+                .duration(10 * SECONDS).eut(30).addTo(formingPressRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 42, missing),
+                        ItemList.Shape_Mold_Ball.get(0L))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 13, missing))
                 .duration(30 * SECONDS).eut(30).addTo(formingPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
@@ -3723,6 +3741,12 @@ public class ScriptProjectRed implements IScriptLoader {
                         GT_Utility.getIntegratedCircuit(8))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 8, 34, missing))
                 .duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(mixerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 12, missing),
+                        getModItem(Minecraft.ID, "redstone", 8, 0, missing))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 42, missing))
+                .duration(20 * SECONDS).eut(30).addTo(mixerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedTransmission.ID, "projectred.transmission.wire", 1, 0, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
@@ -2955,22 +2955,58 @@ public class ScriptProjectRed implements IScriptLoader {
                 .duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 12, missing),
+                        ItemList.Circuit_Silicon_Wafer.get(1L),
                         getModItem(Minecraft.ID, "redstone", 8, 0, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 42, missing))
-                .duration(20 * SECONDS).eut(30).addTo(mixerRecipes);
+                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Silicon, 1L),
+                        ItemList.Circuit_Silicon_Wafer2.get(1L),
+                        getModItem(Minecraft.ID, "redstone", 16, 0, missing))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 42, missing))
+                .duration(40 * SECONDS).eut(30).addTo(formingPressRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Silicon_Wafer3.get(1L),
+                        getModItem(Minecraft.ID, "redstone", 32, 0, missing))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 42, missing))
+                .duration(60 * SECONDS).eut(30).addTo(formingPressRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Silicon_Wafer.get(1L),
                         getModItem(Minecraft.ID, "glowstone_dust", 8, 0, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 43, missing))
-                .duration(20 * SECONDS).eut(30).addTo(mixerRecipes);
+                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Silicon, 1L),
+                        ItemList.Circuit_Silicon_Wafer2.get(1L),
+                        getModItem(Minecraft.ID, "glowstone_dust", 16, 0, missing))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 43, missing))
+                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Silicon_Wafer3.get(1L),
+                        getModItem(Minecraft.ID, "glowstone_dust", 32, 0, missing))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 43, missing))
+                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Silicon_Wafer.get(1L),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 8, 56, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 58, missing))
-                .duration(20 * SECONDS).eut(30).addTo(mixerRecipes);
+                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Silicon_Wafer2.get(1L),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 16, 56, missing))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 58, missing))
+                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Silicon_Wafer3.get(1L),
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 32, 56, missing))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 4, 58, missing))
+                .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "iron_ingot", 1, 0, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
@@ -2927,12 +2927,6 @@ public class ScriptProjectRed implements IScriptLoader {
                 .duration(30 * SECONDS).eut(30).addTo(formingPressRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Silicon, 1L),
-                        ItemList.Shape_Mold_Ball.get(0L))
-                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 12, missing))
-                .duration(10 * SECONDS).eut(30).addTo(formingPressRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 42, missing),
                         ItemList.Shape_Mold_Ball.get(0L))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 13, missing))

--- a/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
@@ -2955,6 +2955,12 @@ public class ScriptProjectRed implements IScriptLoader {
                 .duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
+                        getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 12, missing),
+                        getModItem(Minecraft.ID, "redstone", 8, 0, missing))
+                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 42, missing))
+                .duration(20 * SECONDS).eut(30).addTo(mixerRecipes);
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
                         GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Silicon, 1L),
                         getModItem(Minecraft.ID, "glowstone_dust", 8, 0, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 43, missing))
@@ -3741,12 +3747,6 @@ public class ScriptProjectRed implements IScriptLoader {
                         GT_Utility.getIntegratedCircuit(8))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 8, 34, missing))
                 .duration(2 * SECONDS + 10 * TICKS).eut(8).addTo(mixerRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 12, missing),
-                        getModItem(Minecraft.ID, "redstone", 8, 0, missing))
-                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 42, missing))
-                .duration(20 * SECONDS).eut(30).addTo(mixerRecipes);
         GT_Values.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedTransmission.ID, "projectred.transmission.wire", 1, 0, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
@@ -47,8 +47,10 @@ import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import java.util.Arrays;
 import java.util.List;
 
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.oredict.OreDictionary;
 
 import com.dreammaster.chisel.ChiselHelper;
 import com.dreammaster.tinkersConstruct.TConstructHelper;
@@ -2926,32 +2928,36 @@ public class ScriptProjectRed implements IScriptLoader {
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 14, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 8, missing))
                 .duration(30 * SECONDS).eut(30).addTo(formingPressRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 42, missing),
-                        "craftingLensRed", 0)
-                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 13, missing))
-                .duration(30 * SECONDS).eut(30).addTo(laserEngraverRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 43, missing),
-                        "craftingLensYellow", 0)
-                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 14, missing))
-                .duration(30 * SECONDS).eut(30).addTo(laserEngraverRecipes);
-        GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 58, missing),
-                        "craftingLensBlue", 0)
-                .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 59, missing))
-                .duration(30 * SECONDS).eut(30).addTo(laserEngraverRecipes);
+        for (ItemStack itemStack : OreDictionary.getOres("craftingLensRed")) {
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 42, missing),
+                            GT_Utility.copyAmount(0, itemStack))
+                    .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 13, missing))
+                    .duration(30 * SECONDS).eut(30).addTo(laserEngraverRecipes);
+        }
+        for (ItemStack itemStack : OreDictionary.getOres("craftingLensYellow")) {
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 43, missing),
+                            GT_Utility.copyAmount(0, itemStack))
+                    .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 14, missing))
+                    .duration(30 * SECONDS).eut(30).addTo(laserEngraverRecipes);
+        }
+        for (ItemStack itemStack : OreDictionary.getOres("craftingLensBlue")) {
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 58, missing),
+                            GT_Utility.copyAmount(0, itemStack))
+                    .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 59, missing))
+                    .duration(30 * SECONDS).eut(30).addTo(laserEngraverRecipes);
+        }
         GT_Values.RA.stdBuilder()
                 .itemInputs(getModItem(ProjectRedExploration.ID, "projectred.exploration.stone", 1, 11, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 9, 56, missing)).outputChances(10000)
                 .duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);
         GT_Values.RA.stdBuilder()
-                .itemInputs(
-                        ItemList.Circuit_Silicon_Wafer.get(1L),
-                        getModItem(Minecraft.ID, "redstone", 8, 0, missing))
+                .itemInputs(ItemList.Circuit_Silicon_Wafer.get(1L), getModItem(Minecraft.ID, "redstone", 8, 0, missing))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 42, missing))
                 .duration(20 * SECONDS).eut(30).addTo(formingPressRecipes);
         GT_Values.RA.stdBuilder()


### PR DESCRIPTION
In https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/840, Project Red Transportation has been downtiered and many recipes changed. However, in this PR, recipes for several PR parts have been completely removed: Silicon, Red Silicon Compound, Infused Silicon, and Silicon Chip. These recipes make up a crafting chain, and the Silicon Chip is used to craft several PR logic gates, which are unobtainable otherwise. This PR restores the four removed recipes.

We talked about this with @chochem on discord, and I believe this removal was accidental, as I see no reason for it. I suspect @Dream-Master simply did not notice that the chips have other uses than logistic pipes and thought them redundant. If there is any legitimate reason to remove these recipes, then an alternate way of crafting the affected gates should be added instead.