### PR TITLE
Improve chronic singularity recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptAvaritiaAddons.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAvaritiaAddons.java
@@ -158,10 +158,10 @@ public class ScriptAvaritiaAddons implements IScriptLoader {
             GT_Values.RA.stdBuilder()
                     .itemInputs(
                             getModItem(EternalSingularity.ID, "eternal_singularity", 8, 0, missing),
-                            ItemList.Timepiece.get(2))
+                            ItemList.Timepiece.get(1))
                     .itemOutputs(getModItem(EternalSingularity.ID, "combined_singularity", 1, 15, missing))
                     .fluidInputs(
-                            MaterialsUEVplus.MagnetohydrodynamicallyConstrainedStarMatter.getMolten(576),
+                            MaterialsUEVplus.MagnetohydrodynamicallyConstrainedStarMatter.getMolten(288),
                             MaterialsUEVplus.ExcitedDTSC.getFluid(10000))
                     .fluidOutputs(Materials.Hydrogen.getPlasma(576), Materials.Helium.getPlasma(576))
                     .duration(5 * SECONDS).eut(TierEU.RECIPE_UXV).addTo(hammerRecipes);


### PR DESCRIPTION
As discussed in meta dev and proposed in https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16297, this PR increases the amount of attempts for the start of the eternity loop from 2 -> 5 by decreasing the required amount of timepieces from 2 -> 1 and proportionally decreasing the mhdcsm input from 576 -> 288L as well. 
This brings the chance of complete failure down to less than 0.1%, without even accounting for the extra timepieces one can get from those 5 tries, which allow for more tries.