### PR TITLE
Fix accidental nerf to super chest V recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1900,7 +1900,7 @@ public class AssemblerRecipes implements Runnable {
                         GT_OreDictUnificator.get(OrePrefixes.circuit.get(Materials.Elite), 4),
                         GT_OreDictUnificator.get(OrePrefixes.plateQuadruple, Materials.Titanium, 3),
                         ItemList.Field_Generator_HV.get(1),
-                        ItemList.Automation_SuperBuffer_IV.get(1))
+                        ItemList.Automation_ChestBuffer_IV.get(1))
                 .itemOutputs(ItemList.Super_Chest_IV.get(1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
 


### PR DESCRIPTION
In #827, I added assembler recipes for a few large volume items, but accidentally used an IV Super Buffer instead of IV Chest Buffer for Super Chest V. This is especially unhelpful because the Super Buffer does not have an assembler recipe, making the fix entirely useless :)

This PR changes the recipe back to a Chest Buffer