### PR TITLE
Fix flat interface assembler recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -4159,7 +4159,7 @@ public class AssemblerRecipes implements Runnable {
                 // Formation Core
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 43),
                 // Annihilation Core
-                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 2, 44),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 44),
                 ItemList.Casing_EV.get(1L),
                 GT_Utility.getIntegratedCircuit(3))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 440)).duration(5 * SECONDS)


### PR DESCRIPTION
Fix the flat AE2 interface assembler recipe costing 1 more annihilation core than it should.

![image](https://github.com/GTNewHorizons/NewHorizonsCoreMod/assets/26485755/67268cae-5157-4ac9-9d0d-b033b7b2bfe0)
