### PR TITLE
Fix sg trophy research conflicts 

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -226,7 +226,7 @@ public class AssemblingLineRecipes implements Runnable {
                         (int) TierEU.RECIPE_UHV);
 
                 TT_recipeAdder.addResearchableAssemblylineRecipe(
-                        com.dreammaster.item.ItemList.GatePlateOrigin.getIS(1),
+                        GT_OreDictUnificator.get(OrePrefixes.block, Materials.Infinity, 1L),
                         192_000,
                         512,
                         2_000_000,
@@ -335,7 +335,7 @@ public class AssemblingLineRecipes implements Runnable {
                         (int) TierEU.RECIPE_UIV);
 
                 TT_recipeAdder.addResearchableAssemblylineRecipe(
-                        com.dreammaster.item.ItemList.GatePlatePolychrome.getIS(1),
+                        com.dreammaster.item.ItemList.ChevronOrigin.getIS(1),
                         32_000_000 * 12,
                         8192,
                         32_000_000,
@@ -471,7 +471,7 @@ public class AssemblingLineRecipes implements Runnable {
                         (int) TierEU.RECIPE_UXV);
 
                 TT_recipeAdder.addResearchableAssemblylineRecipe(
-                        com.dreammaster.item.ItemList.GatePlateDimensional.getIS(1),
+                        com.dreammaster.item.ItemList.ChevronPolychrome.getIS(1),
                         2_000_000_000,
                         32_768,
                         500_000_000,


### PR DESCRIPTION
Fixes the sg plates being used in 2 researches each (leading to conflicts)