### PR TITLE
Add calculator for DTPF recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/DTPFCalculator.java
+++ b/src/main/java/com/dreammaster/gthandler/DTPFCalculator.java
@@ -21,6 +21,7 @@ public class DTPFCalculator {
     public DTPFCalculator() {};
 
     protected long duration = -1;
+    protected ItemStack customInput = null;
     protected ItemStack[] itemInputs = new ItemStack[0];
     protected FluidStack[] fluidInputs = new FluidStack[0];
     protected long ebfEUpertick = 0;
@@ -32,6 +33,11 @@ public class DTPFCalculator {
     protected long totalBaseEU = 0;
     protected long minCatalystTier = 0;
     protected long maxCatalystTier = 4;
+    protected long catalystDiscount = 0;
+    protected long processingTimeDiscount = 0;
+    protected long recipeDuration = 0;
+    protected long scalingFactor = 2;
+    protected float EUtMultiplier = 1f;
     Collection<GT_Recipe> ebfRecipes = blastFurnaceRecipes.getAllRecipes();
     Collection<GT_Recipe> freezerRecipes = vacuumFreezerRecipes.getAllRecipes();
     private int[] catalyst_amounts = new int[5];
@@ -46,15 +52,26 @@ public class DTPFCalculator {
         determineEBFParams(material);
         determineFreezerParams(material);
         calculateBaseDTPFPowerConsumption();
-        calculateCatalystAmounts();
+        calculateCatalystAmounts(ebfDuration);
+        return this;
+    }
+
+    public DTPFCalculator calculateNonEBFRecipe(long base_voltage, long base_duration) {
+        recipeDuration = base_duration;
+        calculateNonEBFBaseDTPFPowerConsumption(base_voltage, base_duration);
+        calculateCatalystAmounts(base_duration);
         return this;
     }
 
     private void determineEBFParams(Materials material) {
         ArrayList<GT_Recipe> foundEBFRecipes = new ArrayList<>();
+        ItemStack input = material.getDust(1);
+        if (customInput != null) {
+            input = customInput;
+        }
         // Find correct ebf recipes
         for (GT_Recipe recipe : ebfRecipes) {
-            if (GT_Utility.areStacksEqual(material.getDust(1), recipe.mInputs[0])) {
+            if (GT_Utility.areStacksEqual(input, recipe.mInputs[0])) {
                 foundEBFRecipes.add(recipe);
             }
         }
@@ -69,6 +86,7 @@ public class DTPFCalculator {
                 break;
             }
         }
+        recipeDuration = ebfDuration;
     }
 
     private void determineFreezerParams(Materials material) {
@@ -87,13 +105,25 @@ public class DTPFCalculator {
     private void calculateBaseDTPFPowerConsumption() {
         totalBaseEU = (freezerEUpertick * freezerDuration + ebfEUpertick * ebfDuration) * baseParallel;
         DTPFEUt = totalBaseEU / ebfDuration / 10;
+        while (DTPFEUt > (Integer.MAX_VALUE / Math.pow(scalingFactor, maxCatalystTier - minCatalystTier))) {
+            DTPFEUt /= scalingFactor;
+        }
     }
 
-    private void calculateCatalystAmounts() {
+    private void calculateNonEBFBaseDTPFPowerConsumption(long base_voltage, long base_duration) {
+        totalBaseEU = base_voltage * base_duration * baseParallel;
+        DTPFEUt = totalBaseEU / base_duration / 10;
+        while (DTPFEUt > (Integer.MAX_VALUE / Math.pow(scalingFactor, maxCatalystTier - minCatalystTier))) {
+            DTPFEUt /= scalingFactor;
+        }
+    }
+
+    private void calculateCatalystAmounts(long recipe_duration) {
         for (long i = 0; i <= (maxCatalystTier - minCatalystTier); i++) {
-            catalyst_amounts[(int) (minCatalystTier + i)] = (int) (((totalBaseEU * (0.8 - i * 0.1) * Math.pow(2, i)
-                    - DTPFEUt * Math.pow(2, i) * (ebfDuration / Math.pow(2, i + 1)))
-                    / CATALYST_ENERGY_VALUES[(int) (minCatalystTier + i)]));
+            catalyst_amounts[(int) (minCatalystTier
+                    + i)] = (int) (((totalBaseEU * (0.8 - i * 0.1) * Math.pow(scalingFactor, i)
+                            - DTPFEUt * Math.pow(scalingFactor, i) * (recipe_duration / Math.pow(scalingFactor, i + 1)) / EUtMultiplier)
+                            / CATALYST_ENERGY_VALUES[(int) (minCatalystTier + i)]) * (1 - catalystDiscount / 100f));
         }
     }
 
@@ -112,17 +142,43 @@ public class DTPFCalculator {
         return this;
     }
 
+    public DTPFCalculator setCatalystDiscount(long discount) {
+        this.catalystDiscount = discount;
+        return this;
+    }
+
+    public DTPFCalculator setProcessingTimeDiscount(long discount) {
+        this.processingTimeDiscount = discount;
+        return this;
+    }
+
+    public DTPFCalculator setEUtMultiplier(float multiplier) {
+        this.EUtMultiplier = multiplier;
+        return this;
+    }
+
+    public DTPFCalculator setCustomEBFinputItem(ItemStack item) {
+        this.customInput = item;
+        return this;
+    }
+
+    public DTPFCalculator setScalingFactor(long factor) {
+        this.scalingFactor = factor;
+        return this;
+    }
+
     public DTPFCalculator fluidInputs(FluidStack... fluidInputs) {
         this.fluidInputs = fluidInputs;
         return this;
     }
 
     public long getDuration(int catalystTier) {
-        return (long) (ebfDuration / Math.pow(2, catalystTier + 1));
+        return (long) ((recipeDuration / Math.pow(scalingFactor, catalystTier + 1 - minCatalystTier))
+                * (1 - processingTimeDiscount / 100f));
     }
 
     public long getEUt(int catalystTier) {
-        return (long) (DTPFEUt * Math.pow(2, catalystTier));
+        return (long) (DTPFEUt * Math.pow(scalingFactor, catalystTier - minCatalystTier) / EUtMultiplier);
     }
 
     public long getCatalystAmount(int catalystTier) {

--- a/src/main/java/com/dreammaster/gthandler/DTPFCalculator.java
+++ b/src/main/java/com/dreammaster/gthandler/DTPFCalculator.java
@@ -37,7 +37,7 @@ public class DTPFCalculator {
     protected long processingTimeDiscount = 0;
     protected long recipeDuration = 0;
     protected long scalingFactor = 2;
-    protected float EUtMultiplier = 1f;
+    protected float EUtDivisor = 1f;
     Collection<GT_Recipe> ebfRecipes = blastFurnaceRecipes.getAllRecipes();
     Collection<GT_Recipe> freezerRecipes = vacuumFreezerRecipes.getAllRecipes();
     private int[] catalyst_amounts = new int[5];
@@ -124,7 +124,7 @@ public class DTPFCalculator {
                     + i)] = (int) (((totalBaseEU * (0.8 - i * 0.1) * Math.pow(scalingFactor, i)
                             - DTPFEUt * Math.pow(scalingFactor, i)
                                     * (recipe_duration / Math.pow(scalingFactor, i + 1))
-                                    / EUtMultiplier)
+                                    / EUtDivisor)
                             / CATALYST_ENERGY_VALUES[(int) (minCatalystTier + i)]) * (1 - catalystDiscount / 100f));
         }
     }
@@ -154,8 +154,8 @@ public class DTPFCalculator {
         return this;
     }
 
-    public DTPFCalculator setEUtMultiplier(float multiplier) {
-        this.EUtMultiplier = multiplier;
+    public DTPFCalculator setEUtDivisor(float Divisor) {
+        this.EUtDivisor = Divisor;
         return this;
     }
 
@@ -180,7 +180,7 @@ public class DTPFCalculator {
     }
 
     public long getEUt(int catalystTier) {
-        return (long) (DTPFEUt * Math.pow(scalingFactor, catalystTier - minCatalystTier) / EUtMultiplier);
+        return (long) (DTPFEUt * Math.pow(scalingFactor, catalystTier - minCatalystTier) / EUtDivisor);
     }
 
     public long getCatalystAmount(int catalystTier) {

--- a/src/main/java/com/dreammaster/gthandler/DTPFCalculator.java
+++ b/src/main/java/com/dreammaster/gthandler/DTPFCalculator.java
@@ -1,0 +1,123 @@
+package com.dreammaster.gthandler;
+
+import static gregtech.api.recipe.RecipeMaps.blastFurnaceRecipes;
+import static gregtech.api.recipe.RecipeMaps.vacuumFreezerRecipes;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.MaterialsUEVplus;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Recipe;
+import gregtech.api.util.GT_Utility;
+
+public class DTPFCalculator {
+
+    public DTPFCalculator() {};
+
+    protected long duration = -1;
+    protected ItemStack[] itemInputs = new ItemStack[0];
+    protected FluidStack[] fluidInputs = new FluidStack[0];
+    protected long ebfEUpertick = 0;
+    protected long ebfDuration = 0;
+    protected long freezerEUpertick = 0;
+    protected long freezerDuration = 0;
+    protected long baseParallel = 0;
+    protected long DTPFEUt = 0;
+    protected long minCatalystTier = 0;
+    protected long maxCatalystTier = 4;
+    Collection<GT_Recipe> ebfRecipes = blastFurnaceRecipes.getAllRecipes();
+    Collection<GT_Recipe> freezerRecipes = vacuumFreezerRecipes.getAllRecipes();
+    private static final FluidStack[] CATALYSTS = new FluidStack[] { MaterialsUEVplus.ExcitedDTCC.getFluid(1),
+            MaterialsUEVplus.ExcitedDTPC.getFluid(1), MaterialsUEVplus.ExcitedDTRC.getFluid(1),
+            MaterialsUEVplus.ExcitedDTEC.getFluid(1), MaterialsUEVplus.ExcitedDTSC.getFluid(1) };
+    // These were calculated based on their respective mixer + laser engraver recipes & their plasma energy values
+    private static final long[] CATALYST_ENERGY_VALUES = new long[] { 14_514_983L, 66_768_460L, 269_326_451L, 1_073_007_393L, 4_276_767_521L };
+
+    public DTPFCalculator calculateGenericEBFBasedRecipe(Materials material) {
+        determineEBFParams(material);
+        determineFreezerParams(material);
+        calculateBaseDTPFPowerConsumption();
+        return this;
+    }
+
+    private void determineEBFParams(Materials material) {
+        ArrayList<GT_Recipe> foundEBFRecipes = new ArrayList<>();
+        // Find correct ebf recipes
+        for (GT_Recipe recipe : ebfRecipes) {
+            if (GT_Utility.areStacksEqual(material.getDust(1), recipe.mInputs[0])) {
+                foundEBFRecipes.add(recipe);
+            }
+        }
+        // Determine oganesson recipe stats
+        for (GT_Recipe recipe : foundEBFRecipes) {
+            if (recipe.mFluidInputs.length == 0) {
+                ebfDuration = (long) (recipe.mDuration * 0.3);
+                ebfEUpertick = recipe.mEUt;
+            } else if (recipe.mFluidInputs[0].isFluidEqual(Materials.Radon.getGas(1000L))) {
+                ebfDuration = (long) (recipe.mDuration / 0.7 * 0.3);
+                ebfEUpertick = recipe.mEUt;
+                break;
+            }
+        }
+    }
+
+    private void determineFreezerParams(Materials material) {
+        // Find correct freezer recipe
+        for (GT_Recipe recipe : freezerRecipes) {
+            if (recipe.mInputs.length != 0 && GT_Utility
+                    .areStacksEqual(GT_OreDictUnificator.get(OrePrefixes.ingotHot, material, 1L), recipe.mInputs[0])) {
+                // There's only one freezer recipe per material
+                freezerDuration = recipe.mDuration;
+                freezerEUpertick = recipe.mEUt;
+                break;
+            }
+        }
+    }
+
+    private void calculateBaseDTPFPowerConsumption() {
+        DTPFEUt = (freezerEUpertick + ebfEUpertick) * baseParallel / ebfDuration / 10;
+    }
+
+    public DTPFCalculator setBaseParallel(long parallel) {
+        this.baseParallel = parallel;
+        return this;
+    }
+
+    public DTPFCalculator setLowestCatalystTier(long tier) {
+        this.minCatalystTier = tier;
+        return this;
+    }
+
+    public DTPFCalculator setHighestCatalystTier(long tier) {
+        this.maxCatalystTier = tier;
+        return this;
+    }
+
+    public DTPFCalculator fluidInputs(FluidStack... fluidInputs) {
+        this.fluidInputs = fluidInputs;
+        return this;
+    }
+
+    public long getBaseDuration() {
+        return ebfDuration / 2;
+    }
+
+    public long getBaseEUt() {
+        return DTPFEUt;
+    }
+
+    public long getCrudeAmount() {
+        return DTPFEUt;
+    }
+
+    public static DTPFCalculator dtpfCalculator() {
+        return new DTPFCalculator();
+    }
+
+}

--- a/src/main/java/com/dreammaster/gthandler/DTPFCalculator.java
+++ b/src/main/java/com/dreammaster/gthandler/DTPFCalculator.java
@@ -22,17 +22,15 @@ public class DTPFCalculator {
 
     protected long duration = -1;
     protected ItemStack customInput = null;
-    protected ItemStack[] itemInputs = new ItemStack[0];
-    protected FluidStack[] fluidInputs = new FluidStack[0];
     protected long ebfEUpertick = 0;
     protected long ebfDuration = 0;
     protected long freezerEUpertick = 0;
     protected long freezerDuration = 0;
-    protected long baseParallel = 0;
+    protected long baseParallel = 1;
     protected long DTPFEUt = 0;
     protected long totalBaseEU = 0;
     protected long minCatalystTier = 0;
-    protected long maxCatalystTier = 4;
+    protected long maxCatalystTier = 3;
     protected long catalystDiscount = 0;
     protected long processingTimeDiscount = 0;
     protected long recipeDuration = 0;
@@ -48,6 +46,13 @@ public class DTPFCalculator {
     private static final long[] CATALYST_ENERGY_VALUES = new long[] { 14_514_983L, 66_768_460L, 269_326_451L,
             1_073_007_393L, 4_276_767_521L };
 
+    /**
+     * Calculates the dtpf recipe parameters for a material based on its blast furnace and vacuum freezer recipes. Only
+     * checks for ebf recipes with radon or no gas as input fluids, if these do not exist for the material use
+     * calculateNonEBFRecipe instead.
+     * 
+     * @param material The material to generate dtpf recipes for
+     */
     public DTPFCalculator calculateGenericEBFBasedRecipe(Materials material) {
         determineEBFParams(material);
         determineFreezerParams(material);
@@ -56,6 +61,15 @@ public class DTPFCalculator {
         return this;
     }
 
+    /**
+     * Calculates the dtpf recipe parameters for any recipe based on its voltage and duration. If a recipe produces more
+     * than 1 ingot/dust/molten equivalent at once, it is recommended to normalize recipe time to reflect 1
+     * ingot/dust/molten equivalent. For recipes containing more than 1 relevant output, it is recommended to choose one
+     * main output and normalize voltage and recipe time to one unit of that output (see molten quantum as an example).
+     *
+     * @param base_voltage  Recipe voltage
+     * @param base_duration Recipe duration in ticks
+     */
     public DTPFCalculator calculateNonEBFRecipe(long base_voltage, long base_duration) {
         recipeDuration = base_duration;
         calculateNonEBFBaseDTPFPowerConsumption(base_voltage, base_duration);
@@ -129,64 +143,123 @@ public class DTPFCalculator {
         }
     }
 
+    /**
+     * Sets the parallel for the first recipe in its set. Default is 1.
+     * 
+     * @param parallel Number of parallel
+     */
     public DTPFCalculator setBaseParallel(long parallel) {
         this.baseParallel = parallel;
         return this;
     }
 
+    /**
+     * Sets the lowest catalyst tier for this material. Default is 0 (Crude).
+     * 
+     * @param tier Catalyst tier, from 0 (Crude) to 4 (Stellar)
+     */
     public DTPFCalculator setLowestCatalystTier(long tier) {
         this.minCatalystTier = tier;
         return this;
     }
 
+    /**
+     * Sets the highest catalyst tier for this material. Default is 3 (Exotic).
+     * 
+     * @param tier Catalyst tier, from 0 (Crude) to 4 (Stellar)
+     */
     public DTPFCalculator setHighestCatalystTier(long tier) {
         this.maxCatalystTier = tier;
         return this;
     }
 
+    /**
+     * Sets a discount for catalyst consumption that gets applied after regular calculations. Default is 0.
+     * 
+     * @param discount Discount in % (e.g. 15 = 15%)
+     */
     public DTPFCalculator setCatalystDiscount(long discount) {
         this.catalystDiscount = discount;
         return this;
     }
 
+    /**
+     * Sets a discount for processing time that gets applied after regular calculations. Default is 0.
+     * 
+     * @param discount Discount in % (e.g. 15 = 15%)
+     */
     public DTPFCalculator setProcessingTimeDiscount(long discount) {
         this.processingTimeDiscount = discount;
         return this;
     }
 
-    public DTPFCalculator setEUtDivisor(float Divisor) {
-        this.EUtDivisor = Divisor;
+    /**
+     * Sets a divisor for recipe voltage. The difference of energy between pre- and post-division gets added to the
+     * recipe in form of catalyst instead. Default is 1.
+     * 
+     * @param divisor Voltage divisor as a float (e.g. 2 = half voltage)
+     */
+    public DTPFCalculator setEUtDivisor(float divisor) {
+        this.EUtDivisor = divisor;
         return this;
     }
 
+    /**
+     * Use if the ebf recipe for the given material does not use its respective dust as input (e.g. neutronium needs raw
+     * neutronium dust instead of regular neutronium dust).
+     *
+     * @param item The input item for the material's ebf recipe
+     */
     public DTPFCalculator setCustomEBFinputItem(ItemStack item) {
         this.customInput = item;
         return this;
     }
 
+    /**
+     * Sets the scaling factor for dtpf recipes. This factor determines both the parallel increase and recipe time
+     * decrease per catalyst tier (e.g. a factor of 2 means double parallel and half recipe time for each increase in
+     * catalyst tier). Default is 2.
+     *
+     * @param factor The input item for the material's ebf recipe
+     */
     public DTPFCalculator setScalingFactor(long factor) {
         this.scalingFactor = factor;
         return this;
     }
 
-    public DTPFCalculator fluidInputs(FluidStack... fluidInputs) {
-        this.fluidInputs = fluidInputs;
-        return this;
-    }
-
+    /**
+     * Gets the recipe duration for the given catalyst tier.
+     *
+     * @param catalystTier Catalyst tier of the recipe
+     */
     public long getDuration(int catalystTier) {
         return (long) ((recipeDuration / Math.pow(scalingFactor, catalystTier + 1 - minCatalystTier))
                 * (1 - processingTimeDiscount / 100f));
     }
 
+    /**
+     * Gets the recipe voltage for the given catalyst tier.
+     *
+     * @param catalystTier Catalyst tier of the recipe
+     */
     public long getEUt(int catalystTier) {
         return (long) (DTPFEUt * Math.pow(scalingFactor, catalystTier - minCatalystTier) / EUtDivisor);
     }
 
+    /**
+     * Gets the amount of catalyst used for the given catalyst tier.
+     *
+     * @param catalystTier Catalyst tier of the recipe
+     */
     public long getCatalystAmount(int catalystTier) {
         return catalyst_amounts[catalystTier];
     }
 
+    /**
+     * Gets the amount of residue produced for the given catalyst tier.
+     *
+     * @param catalystTier Catalyst tier of the recipe
+     */
     public long getResidueAmount(int catalystTier) {
         return (long) (catalyst_amounts[catalystTier] * (Math.pow(2, catalystTier) / 8));
     }

--- a/src/main/java/com/dreammaster/gthandler/DTPFCalculator.java
+++ b/src/main/java/com/dreammaster/gthandler/DTPFCalculator.java
@@ -122,7 +122,9 @@ public class DTPFCalculator {
         for (long i = 0; i <= (maxCatalystTier - minCatalystTier); i++) {
             catalyst_amounts[(int) (minCatalystTier
                     + i)] = (int) (((totalBaseEU * (0.8 - i * 0.1) * Math.pow(scalingFactor, i)
-                            - DTPFEUt * Math.pow(scalingFactor, i) * (recipe_duration / Math.pow(scalingFactor, i + 1)) / EUtMultiplier)
+                            - DTPFEUt * Math.pow(scalingFactor, i)
+                                    * (recipe_duration / Math.pow(scalingFactor, i + 1))
+                                    / EUtMultiplier)
                             / CATALYST_ENERGY_VALUES[(int) (minCatalystTier + i)]) * (1 - catalystDiscount / 100f));
         }
     }

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -16,7 +16,6 @@ import com.dreammaster.gthandler.recipes.CircuitAssemblerRecipes;
 import com.dreammaster.gthandler.recipes.CompressorRecipes;
 import com.dreammaster.gthandler.recipes.CrackingRecipes;
 import com.dreammaster.gthandler.recipes.CuttingMachineRecipes;
-import com.dreammaster.gthandler.recipes.DTPFRecipes;
 import com.dreammaster.gthandler.recipes.DistillationRecipes;
 import com.dreammaster.gthandler.recipes.ElectrolyzerRecipes;
 import com.dreammaster.gthandler.recipes.ExtractorRecipes;
@@ -61,7 +60,6 @@ public class GT_MachineRecipeLoader implements Runnable {
         new CompressorRecipes().run();
         new CuttingMachineRecipes().run();
         new DistillationRecipes().run();
-        new DTPFRecipes().run();
         new ElectrolyzerRecipes().run();
         new ExtractorRecipes().run();
         new ExtruderRecipes().run();

--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -1,12 +1,10 @@
 package com.dreammaster.gthandler.recipes;
 
-import static gregtech.api.GregTech_API.mGTPlusPlus;
 import static gregtech.api.enums.Mods.*;
 import static gregtech.api.recipe.RecipeMaps.plasmaForgeRecipes;
 import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
-import static gregtech.api.util.GT_RecipeBuilder.TICKS;
 import static gregtech.api.util.GT_RecipeConstants.COIL_HEAT;
 
 import net.minecraft.item.ItemStack;
@@ -15,6 +13,7 @@ import net.minecraftforge.fluids.FluidStack;
 
 import com.dreammaster.block.BlockList;
 import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.gthandler.DTPFCalculator;
 import com.dreammaster.gthandler.GT_CoreModSupport;
 
 import goodgenerator.util.ItemRefer;
@@ -58,61 +57,63 @@ public class DTPFRecipes implements Runnable {
                 long base_quantity = 512L;
                 long tier_up_multiplier = 2L;
 
-                int base_time = 2500;
+                DTPFCalculator neutronium = new DTPFCalculator().setBaseParallel(base_quantity)
+                        .setCustomEBFinputItem(CustomItemList.RawNeutronium.get(1L)).setHighestCatalystTier(3)
+                        .calculateGenericEBFBasedRecipe(Materials.Neutronium);
 
                 long tier_1_quantity = 144L * base_quantity;
-                long fuel_quantity_1 = 65017L;
 
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTCC.getFluid(fuel_quantity_1),
+                                MaterialsUEVplus.ExcitedDTCC.getFluid(neutronium.getCatalystAmount(0)),
                                 Materials.Iron.getMolten(tier_1_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 8),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(neutronium.getResidueAmount(0)),
                                 Materials.Neutronium.getMolten(tier_1_quantity))
-                        .duration(base_time).eut(25_165_824).metadata(COIL_HEAT, awakened_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(neutronium.getDuration(0)).eut(neutronium.getEUt(0))
+                        .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
 
                 long tier_2_quantity = 144L * base_quantity * tier_up_multiplier;
-                long fuel_quantity_2 = 25442L;
 
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTPC.getFluid(fuel_quantity_2),
+                                MaterialsUEVplus.ExcitedDTPC.getFluid(neutronium.getCatalystAmount(1)),
                                 Materials.Iron.getMolten(tier_2_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2 / 4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(neutronium.getResidueAmount(1)),
                                 Materials.Neutronium.getMolten(tier_2_quantity))
-                        .duration(base_time / 2).eut(50_331_648).metadata(COIL_HEAT, infinity_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(neutronium.getDuration(1)).eut(neutronium.getEUt(1))
+                        .metadata(COIL_HEAT, infinity_heat).addTo(plasmaForgeRecipes);
 
                 long tier_3_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
-                long fuel_quantity_3 = 10979L;
 
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_3),
+                                MaterialsUEVplus.ExcitedDTRC.getFluid(neutronium.getCatalystAmount(2)),
                                 Materials.Iron.getMolten(tier_3_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(neutronium.getResidueAmount(2)),
                                 Materials.Neutronium.getMolten(tier_3_quantity))
-                        .duration(base_time / 4).eut(100_663_296).metadata(COIL_HEAT, hypogen_heat)
+                        .duration(neutronium.getDuration(2)).eut(neutronium.getEUt(2)).metadata(COIL_HEAT, hypogen_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_4_quantity = 144L * base_quantity
                         * tier_up_multiplier
                         * tier_up_multiplier
                         * tier_up_multiplier;
-                long fuel_quantity_4 = 4632L;
 
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_4),
+                                MaterialsUEVplus.ExcitedDTEC.getFluid(neutronium.getCatalystAmount(3)),
                                 Materials.Iron.getMolten(tier_4_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(neutronium.getResidueAmount(3)),
                                 Materials.Neutronium.getMolten(tier_4_quantity))
-                        .duration(base_time / 8).eut(201_326_592).metadata(COIL_HEAT, eternal_heat)
+                        .duration(neutronium.getDuration(3)).eut(neutronium.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
             }
 
@@ -122,132 +123,137 @@ public class DTPFRecipes implements Runnable {
                 long base_quantity = 512L;
                 long tier_up_multiplier = 2L;
 
+                DTPFCalculator cosmic_neutronium_bee = new DTPFCalculator().setBaseParallel(base_quantity)
+                        .setHighestCatalystTier(3).setCatalystDiscount(15).setProcessingTimeDiscount(50)
+                        .calculateGenericEBFBasedRecipe(Materials.CosmicNeutronium);
+
                 int base_time = 4200;
-                int base_time_bee = 2100;
 
                 long tier_1_quantity = 144L * base_quantity;
                 // Bee Recipes
-                long fuel_quantity_bee_1 = (long) (30883L * 0.85);
 
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(GregTech.ID, "gt.comb", 1L, 117),
                                 GT_Utility.getIntegratedCircuit(1))
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTCC.getFluid(fuel_quantity_bee_1),
+                                MaterialsUEVplus.ExcitedDTCC.getFluid(cosmic_neutronium_bee.getCatalystAmount(0)),
                                 Materials.Copper.getMolten(tier_1_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_bee_1 / 8),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(cosmic_neutronium_bee.getResidueAmount(0)),
                                 Materials.CosmicNeutronium.getMolten(tier_1_quantity))
-                        .duration(base_time_bee).eut(7_115_337).metadata(COIL_HEAT, awakened_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(cosmic_neutronium_bee.getDuration(0)).eut(cosmic_neutronium_bee.getEUt(0))
+                        .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
 
                 long tier_2_bee_quantity = 144L * base_quantity * tier_up_multiplier;
-                long fuel_quantity_bee_2 = (long) (12085L * 0.85);
 
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(GregTech.ID, "gt.comb", 1L, 117),
                                 GT_Utility.getIntegratedCircuit(1))
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTPC.getFluid(fuel_quantity_bee_2),
+                                MaterialsUEVplus.ExcitedDTPC.getFluid(cosmic_neutronium_bee.getCatalystAmount(1)),
                                 Materials.Copper.getMolten(tier_2_bee_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_bee_2 / 4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(cosmic_neutronium_bee.getResidueAmount(1)),
                                 Materials.CosmicNeutronium.getMolten(tier_2_bee_quantity))
-                        .duration(base_time_bee / 2).eut(14_230_674).metadata(COIL_HEAT, infinity_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(cosmic_neutronium_bee.getDuration(1)).eut(cosmic_neutronium_bee.getEUt(1))
+                        .metadata(COIL_HEAT, infinity_heat).addTo(plasmaForgeRecipes);
 
                 long tier_3_bee_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
-                long fuel_quantity_bee_3 = (long) (5215L * 0.85);
 
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(GregTech.ID, "gt.comb", 1L, 117),
                                 GT_Utility.getIntegratedCircuit(1))
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_bee_3),
+                                MaterialsUEVplus.ExcitedDTRC.getFluid(cosmic_neutronium_bee.getCatalystAmount(2)),
                                 Materials.Copper.getMolten(tier_3_bee_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_bee_3 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(cosmic_neutronium_bee.getResidueAmount(2)),
                                 Materials.CosmicNeutronium.getMolten(tier_3_bee_quantity))
-                        .duration(base_time_bee / 4).eut(28_461_349).metadata(COIL_HEAT, hypogen_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(cosmic_neutronium_bee.getDuration(2)).eut(cosmic_neutronium_bee.getEUt(2))
+                        .metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
 
                 long tier_4_bee_quantity = 144L * base_quantity
                         * tier_up_multiplier
                         * tier_up_multiplier
                         * tier_up_multiplier;
-                long fuel_quantity_bee_4 = (long) (2200L * 0.85);
 
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(GregTech.ID, "gt.comb", 1L, 117),
                                 GT_Utility.getIntegratedCircuit(1))
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_bee_4),
+                                MaterialsUEVplus.ExcitedDTEC.getFluid(cosmic_neutronium_bee.getCatalystAmount(3)),
                                 Materials.Copper.getMolten(tier_4_bee_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_bee_4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(cosmic_neutronium_bee.getResidueAmount(3)),
                                 Materials.CosmicNeutronium.getMolten(tier_4_bee_quantity))
-                        .duration(base_time_bee / 8).eut(56_922_697).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(cosmic_neutronium_bee.getDuration(3)).eut(cosmic_neutronium_bee.getEUt(3))
+                        .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
 
                 // normal ones
 
-                long fuel_quantity_1 = 30883L;
+                DTPFCalculator cosmic_neutronium = new DTPFCalculator().setBaseParallel(base_quantity)
+                        .setHighestCatalystTier(3).calculateGenericEBFBasedRecipe(Materials.CosmicNeutronium);
 
                 GT_Values.RA.stdBuilder().itemInputs(GT_Utility.getIntegratedCircuit(4))
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTCC.getFluid(fuel_quantity_1),
+                                MaterialsUEVplus.ExcitedDTCC.getFluid(cosmic_neutronium.getCatalystAmount(0)),
                                 Materials.Copper.getMolten(tier_1_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 8),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(cosmic_neutronium.getResidueAmount(0)),
                                 Materials.CosmicNeutronium.getMolten(tier_1_quantity))
-                        .duration(base_time).eut(7_115_337).metadata(COIL_HEAT, awakened_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(cosmic_neutronium.getDuration(0)).eut(cosmic_neutronium.getEUt(0))
+                        .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
 
                 long tier_2_quantity = 144L * base_quantity * tier_up_multiplier;
-                long fuel_quantity_2 = 12085L;
 
                 GT_Values.RA.stdBuilder().itemInputs(GT_Utility.getIntegratedCircuit(4))
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTPC.getFluid(fuel_quantity_2),
+                                MaterialsUEVplus.ExcitedDTPC.getFluid(cosmic_neutronium.getCatalystAmount(1)),
                                 Materials.Copper.getMolten(tier_2_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2 / 4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(cosmic_neutronium.getResidueAmount(1)),
                                 Materials.CosmicNeutronium.getMolten(tier_2_quantity))
-                        .duration(base_time / 2).eut(14_230_674).metadata(COIL_HEAT, infinity_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(cosmic_neutronium.getDuration(1)).eut(cosmic_neutronium.getEUt(1))
+                        .metadata(COIL_HEAT, infinity_heat).addTo(plasmaForgeRecipes);
 
                 long tier_3_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
-                long fuel_quantity_3 = 5215L;
 
                 GT_Values.RA.stdBuilder().itemInputs(GT_Utility.getIntegratedCircuit(4))
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_3),
+                                MaterialsUEVplus.ExcitedDTRC.getFluid(cosmic_neutronium.getCatalystAmount(2)),
                                 Materials.Copper.getMolten(tier_3_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(cosmic_neutronium.getResidueAmount(2)),
                                 Materials.CosmicNeutronium.getMolten(tier_3_quantity))
-                        .duration(base_time / 4).eut(28_461_349).metadata(COIL_HEAT, hypogen_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(cosmic_neutronium.getDuration(2)).eut(cosmic_neutronium.getEUt(2))
+                        .metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
 
                 long tier_4_quantity = 144L * base_quantity
                         * tier_up_multiplier
                         * tier_up_multiplier
                         * tier_up_multiplier;
-                long fuel_quantity_4 = 2200L;
 
                 GT_Values.RA.stdBuilder().itemInputs(GT_Utility.getIntegratedCircuit(4))
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_4),
+                                MaterialsUEVplus.ExcitedDTEC.getFluid(cosmic_neutronium.getCatalystAmount(3)),
                                 Materials.Copper.getMolten(tier_4_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(cosmic_neutronium.getResidueAmount(3)),
                                 Materials.CosmicNeutronium.getMolten(tier_4_quantity))
-                        .duration(base_time / 8).eut(56_922_697).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(cosmic_neutronium.getDuration(3)).eut(cosmic_neutronium.getEUt(3))
+                        .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
             }
 
             {
@@ -256,445 +262,462 @@ public class DTPFRecipes implements Runnable {
                 long base_quantity = 2048L;
                 long tier_up_multiplier = 2L;
 
-                int base_time = 3360;
+                DTPFCalculator bedrockium = new DTPFCalculator().setBaseParallel(base_quantity)
+                        .setHighestCatalystTier(3).calculateGenericEBFBasedRecipe(Materials.Bedrockium);
 
                 long tier_1_quantity = 144L * base_quantity;
-                long fuel_quantity_1 = 102987L;
 
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTCC.getFluid(fuel_quantity_1),
+                                MaterialsUEVplus.ExcitedDTCC.getFluid(bedrockium.getCatalystAmount(0)),
                                 Materials.Steel.getMolten(tier_1_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 8),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(bedrockium.getResidueAmount(0)),
                                 Materials.Bedrockium.getMolten(tier_1_quantity))
-                        .duration(base_time).eut(29_659_721).metadata(COIL_HEAT, awakened_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(bedrockium.getDuration(0)).eut(bedrockium.getEUt(0))
+                        .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
 
                 long tier_2_quantity = tier_1_quantity * tier_up_multiplier;
-                long fuel_quantity_2 = 40299L;
 
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTPC.getFluid(fuel_quantity_2),
+                                MaterialsUEVplus.ExcitedDTPC.getFluid(bedrockium.getCatalystAmount(1)),
                                 Materials.Steel.getMolten(tier_2_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2 / 4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(bedrockium.getResidueAmount(1)),
                                 Materials.Bedrockium.getMolten(tier_2_quantity))
-                        .duration(base_time / 2).eut(59_319_442).metadata(COIL_HEAT, infinity_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(bedrockium.getDuration(1)).eut(bedrockium.getEUt(1))
+                        .metadata(COIL_HEAT, infinity_heat).addTo(plasmaForgeRecipes);
 
                 long tier_3_quantity = tier_2_quantity * tier_up_multiplier;
-                long fuel_quantity_3 = 17391L;
 
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_3),
+                                MaterialsUEVplus.ExcitedDTRC.getFluid(bedrockium.getCatalystAmount(2)),
                                 Materials.Steel.getMolten(tier_3_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(bedrockium.getResidueAmount(2)),
                                 Materials.Bedrockium.getMolten(tier_3_quantity))
-                        .duration(base_time / 4).eut(118_638_885).metadata(COIL_HEAT, hypogen_heat)
+                        .duration(bedrockium.getDuration(2)).eut(bedrockium.getEUt(2)).metadata(COIL_HEAT, hypogen_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_4_quantity = tier_3_quantity * tier_up_multiplier;
-                long fuel_quantity_4 = 7337L;
 
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_4),
+                                MaterialsUEVplus.ExcitedDTEC.getFluid(bedrockium.getCatalystAmount(3)),
                                 Materials.Steel.getMolten(tier_4_quantity))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(bedrockium.getResidueAmount(3)),
                                 Materials.Bedrockium.getMolten(tier_4_quantity))
-                        .duration(base_time / 8).eut(237_277_769).metadata(COIL_HEAT, eternal_heat)
+                        .duration(bedrockium.getDuration(3)).eut(bedrockium.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
             }
 
-            if (mGTPlusPlus) {
-                // Hypogen v1
+            // Hypogen v1
+            GT_Values.RA.stdBuilder()
+                    .fluidInputs(
+                            new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 144),
+                            Materials.Neutronium.getMolten(5760L),
+                            new FluidStack(ALLOY.QUANTUM.getFluid(), 5760),
+                            Materials.Infinity.getMolten(1440L),
+                            MaterialsUEVplus.ExcitedDTPC.getFluid(1000))
+                    .fluidOutputs(
+                            new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 1584),
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L / 4))
+                    .duration(1 * MINUTES + 15 * SECONDS).eut(800_000_000).metadata(COIL_HEAT, infinity_heat)
+                    .addTo(plasmaForgeRecipes);
+
+            // Hypogen v2
+            GT_Values.RA.stdBuilder()
+                    .fluidInputs(
+                            Materials.Neutronium.getMolten(5760L),
+                            new FluidStack(ALLOY.QUANTUM.getFluid(), 5760),
+                            Materials.Infinity.getMolten(1440L),
+                            MaterialsUEVplus.ExcitedDTRC.getFluid(1000))
+                    .fluidOutputs(
+                            new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 2880),
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L / 2))
+                    .duration(1 * MINUTES + 15 * SECONDS).eut(1_200_000_000).metadata(COIL_HEAT, hypogen_heat)
+                    .addTo(plasmaForgeRecipes);
+
+            // Hypogen v3
+            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 0L, 32100))
+                    .fluidInputs(
+                            Materials.Neutronium.getMolten(5760L),
+                            new FluidStack(ALLOY.QUANTUM.getFluid(), 5760),
+                            Materials.Infinity.getMolten(1440L),
+                            MaterialsUEVplus.ExcitedDTEC.getFluid(1000))
+                    .fluidOutputs(
+                            new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 5760),
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L))
+                    .duration(1 * MINUTES + 15 * SECONDS).eut(1_600_000_000).metadata(COIL_HEAT, eternal_heat)
+                    .addTo(plasmaForgeRecipes);
+
+            // Hypogen v4
+            GT_Values.RA.stdBuilder().itemInputs(GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 0L, 32100))
+                    .fluidInputs(
+                            Materials.Neutronium.getMolten(5760L * 2),
+                            new FluidStack(ALLOY.QUANTUM.getFluid(), 5760),
+                            Materials.Infinity.getMolten(1440L),
+                            MaterialsUEVplus.ExcitedDTSC.getFluid(1000))
+                    .fluidOutputs(
+                            new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 5760 * 2),
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(2000L))
+                    .duration(1 * MINUTES + 15 * SECONDS).eut(2_000_000_000).metadata(COIL_HEAT, eternal_heat)
+                    .addTo(plasmaForgeRecipes);
+
+            {
+                // Chromatic Glass
+
+                long base_quantity = 256L;
+                long tier_up_multiplier = 2L;
+
+                DTPFCalculator chromatic_glass = new DTPFCalculator().setBaseParallel(base_quantity)
+                        .setHighestCatalystTier(3).calculateNonEBFRecipe(1_966_080, 6_000);
+
+                long tier_1_quantity = 144L * base_quantity;
+
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
-                                new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 144),
-                                Materials.Neutronium.getMolten(5760L),
-                                new FluidStack(ALLOY.QUANTUM.getFluid(), 5760),
-                                Materials.Infinity.getMolten(1440L),
-                                MaterialsUEVplus.ExcitedDTPC.getFluid(1000))
+                                MaterialsUEVplus.ExcitedDTCC.getFluid(chromatic_glass.getCatalystAmount(0)),
+                                Materials.Glass.getMolten(tier_1_quantity))
                         .fluidOutputs(
-                                new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 1584),
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L / 4))
-                        .duration(1 * MINUTES + 15 * SECONDS).eut(800_000_000).metadata(COIL_HEAT, infinity_heat)
-                        .addTo(plasmaForgeRecipes);
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(chromatic_glass.getResidueAmount(0)),
+                                new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), (int) tier_1_quantity))
+                        .duration(chromatic_glass.getDuration(0)).eut(chromatic_glass.getEUt(0))
+                        .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
 
-                // Hypogen v2
+                long tier_2_quantity = tier_1_quantity * tier_up_multiplier;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
-                                Materials.Neutronium.getMolten(5760L),
-                                new FluidStack(ALLOY.QUANTUM.getFluid(), 5760),
-                                Materials.Infinity.getMolten(1440L),
-                                MaterialsUEVplus.ExcitedDTRC.getFluid(1000))
+                                MaterialsUEVplus.ExcitedDTPC.getFluid(chromatic_glass.getCatalystAmount(1)),
+                                Materials.Glass.getMolten(tier_2_quantity))
                         .fluidOutputs(
-                                new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 2880),
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L / 2))
-                        .duration(1 * MINUTES + 15 * SECONDS).eut(1_200_000_000).metadata(COIL_HEAT, hypogen_heat)
-                        .addTo(plasmaForgeRecipes);
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(chromatic_glass.getResidueAmount(1)),
+                                new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), (int) tier_2_quantity))
+                        .duration(chromatic_glass.getDuration(1)).eut(chromatic_glass.getEUt(1))
+                        .metadata(COIL_HEAT, infinity_heat).addTo(plasmaForgeRecipes);
 
-                // Hypogen v3
+                long tier_3_quantity = tier_2_quantity * tier_up_multiplier;
                 GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 0L, 32100))
                         .fluidInputs(
-                                Materials.Neutronium.getMolten(5760L),
-                                new FluidStack(ALLOY.QUANTUM.getFluid(), 5760),
-                                Materials.Infinity.getMolten(1440L),
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(1000))
+                                MaterialsUEVplus.ExcitedDTRC.getFluid(chromatic_glass.getCatalystAmount(2)),
+                                Materials.Glass.getMolten(tier_3_quantity))
                         .fluidOutputs(
-                                new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 5760),
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L))
-                        .duration(1 * MINUTES + 15 * SECONDS).eut(1_600_000_000).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(chromatic_glass.getResidueAmount(2)),
+                                new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), (int) tier_3_quantity))
+                        .duration(chromatic_glass.getDuration(2)).eut(chromatic_glass.getEUt(2))
+                        .metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
 
-                // Hypogen v4
+                long tier_4_quantity = tier_3_quantity * tier_up_multiplier;
                 GT_Values.RA.stdBuilder()
-                        .itemInputs(GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 0L, 32100))
                         .fluidInputs(
-                                Materials.Neutronium.getMolten(5760L * 2),
-                                new FluidStack(ALLOY.QUANTUM.getFluid(), 5760),
-                                Materials.Infinity.getMolten(1440L),
-                                MaterialsUEVplus.ExcitedDTSC.getFluid(1000))
+                                MaterialsUEVplus.ExcitedDTEC.getFluid(chromatic_glass.getCatalystAmount(3)),
+                                Materials.Glass.getMolten(tier_4_quantity))
                         .fluidOutputs(
-                                new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 5760 * 2),
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(2000L))
-                        .duration(1 * MINUTES + 15 * SECONDS).eut(2_000_000_000).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
-
-                {
-                    // Chromatic Glass
-
-                    long base_quantity = 256L;
-                    long tier_up_multiplier = 2L;
-
-                    int base_time = 3000;
-
-                    long tier_1_quantity = 144L * base_quantity;
-                    long fuel_quantity_1 = 156040L;
-
-                    GT_Values.RA.stdBuilder()
-                            .fluidInputs(
-                                    MaterialsUEVplus.ExcitedDTCC.getFluid(fuel_quantity_1),
-                                    Materials.Glass.getMolten(tier_1_quantity))
-                            .fluidOutputs(
-                                    MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 8),
-                                    new FluidStack(
-                                            FluidRegistry.getFluid("molten.chromaticglass"),
-                                            (int) tier_1_quantity))
-                            .duration(base_time).eut(50_331_648).metadata(COIL_HEAT, awakened_heat)
-                            .addTo(plasmaForgeRecipes);
-
-                    long tier_2_quantity = tier_1_quantity * tier_up_multiplier;
-                    long fuel_quantity_2 = 61060L;
-
-                    GT_Values.RA.stdBuilder()
-                            .fluidInputs(
-                                    MaterialsUEVplus.ExcitedDTPC.getFluid(fuel_quantity_2),
-                                    Materials.Glass.getMolten(tier_2_quantity))
-                            .fluidOutputs(
-                                    MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2 / 4),
-                                    new FluidStack(
-                                            FluidRegistry.getFluid("molten.chromaticglass"),
-                                            (int) tier_2_quantity))
-                            .duration(base_time / 2).eut(100_663_296).metadata(COIL_HEAT, infinity_heat)
-                            .addTo(plasmaForgeRecipes);
-
-                    long tier_3_quantity = tier_2_quantity * tier_up_multiplier;
-                    long fuel_quantity_3 = 26350L;
-                    GT_Values.RA.stdBuilder()
-                            .fluidInputs(
-                                    MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_3),
-                                    Materials.Glass.getMolten(tier_3_quantity))
-                            .fluidOutputs(
-                                    MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3 / 2),
-                                    new FluidStack(
-                                            FluidRegistry.getFluid("molten.chromaticglass"),
-                                            (int) tier_3_quantity))
-                            .duration(base_time / 4).eut(201_326_592).metadata(COIL_HEAT, hypogen_heat)
-                            .addTo(plasmaForgeRecipes);
-
-                    long tier_4_quantity = tier_3_quantity * tier_up_multiplier;
-                    long fuel_quantity_4 = 11117L;
-                    GT_Values.RA.stdBuilder()
-                            .fluidInputs(
-                                    MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_4),
-                                    Materials.Glass.getMolten(tier_4_quantity))
-                            .fluidOutputs(
-                                    MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_4),
-                                    new FluidStack(
-                                            FluidRegistry.getFluid("molten.chromaticglass"),
-                                            (int) tier_4_quantity))
-                            .duration(base_time / 8).eut(402_653_184).metadata(COIL_HEAT, eternal_heat)
-                            .addTo(plasmaForgeRecipes);
-                }
-
-                // SpaceTime v1
-                GT_Values.RA.stdBuilder().itemInputs(ItemList.EnergisedTesseract.get(1))
-                        .fluidInputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(10000L),
-                                Materials.Infinity.getMolten(2304L),
-                                new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 1152))
-                        .fluidOutputs(MaterialsUEVplus.SpaceTime.getMolten(144L)).duration(40 * SECONDS)
-                        .eut(1_000_000_000).metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
-
-                // Spacetime v2
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                ItemList.EnergisedTesseract.get(1),
-                                GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 0L, 32100))
-                        .fluidInputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(5000L),
-                                Materials.Infinity.getMolten(1152L))
-                        .fluidOutputs(MaterialsUEVplus.SpaceTime.getMolten(576L)).duration(20 * SECONDS)
-                        .eut(2_000_000_000).metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
-
-                // Raw Tesseract recipe
-                // 16 Vertices, 24 faces and 32 edges.
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.CosmicNeutronium, 8L),
-                                GT_ModHandler.getModItem(GTPlusPlus.ID, "itemRodOctiron", 8L),
-                                GT_ModHandler.getModItem(BartWorks.ID, "gt.bwMetaGeneratedstick", 8L, 10106),
-                                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Sunnarium, 8L),
-                                GT_ModHandler.getModItem(GTPlusPlus.ID, "itemPlateAbyssalAlloy", 24L),
-                                GT_ModHandler.getModItem(GTPlusPlus.ID, "itemScrewBotmium", 16L),
-                                GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Ultimate, 1L))
-                        .itemOutputs(ItemList.Tesseract.get(4)).fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(1000))
-                        .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000 / 2))
-                        .duration(40 * SECONDS).eut(32_000_000).metadata(COIL_HEAT, infinity_heat)
-                        .addTo(plasmaForgeRecipes);
-
-                // Raw Tesseract v2
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                GT_OreDictUnificator.get(OrePrefixes.stick, Materials.CosmicNeutronium, 12L),
-                                GT_ModHandler.getModItem(BartWorks.ID, "gt.bwMetaGeneratedstick", 12L, 10106),
-                                GT_OreDictUnificator.get(OrePrefixes.stick, MaterialsUEVplus.TranscendentMetal, 8L),
-                                GT_ModHandler.getModItem(GTPlusPlus.ID, "itemPlateBotmium", 24L),
-                                GT_ModHandler.getModItem(GTPlusPlus.ID, "itemScrewArcanite", 16L),
-                                GT_ModHandler.getModItem(SuperSolarPanels.ID, "enderquantumcomponent", 1L))
-                        .itemOutputs(ItemList.Tesseract.get(8)).fluidInputs(MaterialsUEVplus.ExcitedDTEC.getFluid(1000))
-                        .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000))
-                        .duration(40 * SECONDS).eut(128_000_000).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
-
-                // Raw Tesseract v3
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                GT_OreDictUnificator.get(OrePrefixes.stick, MaterialsUEVplus.TranscendentMetal, 32L),
-                                ALLOY.BLACK_TITANIUM.getPlate(24),
-                                ALLOY.ZERON_100.getScrew(16),
-                                GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1L, 32105))
-                        .itemOutputs(ItemList.Tesseract.get(16))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTSC.getFluid(1000))
-                        .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(2000))
-                        .duration(40 * SECONDS).eut(512_000_000).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
-
-                // Transcendent metal
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(ItemList.Tesseract.get(32), GT_OreDictUnificator.get("blockCosmicNeutronium", 40))
-                        .itemOutputs(
-                                MaterialsUEVplus.TranscendentMetal.getBlocks(40),
-                                MaterialsUEVplus.TranscendentMetal.getDust(24))
-                        .fluidInputs(
-                                ALLOY.TITANSTEEL.getFluidStack(144 * 40 * 9),
-                                Materials.CallistoIce.getMolten(144 * 20 * 9),
-                                Materials.Ledox.getMolten(144 * 20 * 9),
-                                Materials.Tungsten.getMolten(144 * 40 * 9),
-                                MaterialsUEVplus.ExcitedDTSC.getFluid(5632))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(5632 * 2),
-                                ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getFluidStack(144 * 20 * 9))
-                        .duration(40 * SECONDS).eut(256_000_000).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
-
-                // Quantum + Astral Titanium
-                GT_Values.RA.stdBuilder().itemInputs(
-                        CI.getEnergyCore(9, 0),
-                        BlockList.Quantinum.getIS(2),
-                        // Quantum Anomaly
-                        GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 2, 32105))
-                        .itemOutputs(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getBlock(2))
-                        .fluidInputs(
-                                ALLOY.BLACK_TITANIUM.getFluidStack(144 * 320 * 7 / 10),
-                                Materials.Americium.getMolten(144 * 320 / 10),
-                                Materials.Bismuth.getMolten(144 * 320 / 10),
-                                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(144 * 320 / 10),
-                                Materials.Titanium.getPlasma(144 * 9 * 2 * 2),
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(8547))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(8547),
-                                ALLOY.QUANTUM.getFluidStack(144 * 320))
-                        .duration(27 * SECONDS).eut(1_543_932_302).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
-
-                // Quantum + Astral Titanium v2
-                GT_Values.RA.stdBuilder().itemInputs(
-                        CI.getEnergyCore(9, 0),
-                        BlockList.Quantinum.getIS(4),
-                        // Quantum Anomaly
-                        GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 3, 32105))
-                        .itemOutputs(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getBlock(4))
-                        .fluidInputs(
-                                ALLOY.BLACK_TITANIUM.getFluidStack(144 * 640 * 7 / 10),
-                                Materials.Americium.getMolten(144 * 640 / 10),
-                                Materials.Bismuth.getMolten(144 * 640 / 10),
-                                ELEMENT.STANDALONE.HYPOGEN.getFluidStack(144 * 640 / 10),
-                                Materials.Titanium.getPlasma(144 * 9 * 4 * 2),
-                                MaterialsUEVplus.ExcitedDTSC.getFluid(3801))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(3801 * 2),
-                                ALLOY.QUANTUM.getFluidStack(144 * 640))
-                        .duration(13 * SECONDS + 10 * TICKS).eut(1_543_932_303).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
-
-                // Timepiece
-                GT_Values.RA.stdBuilder()
-                        .itemInputs(
-                                getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 14),
-                                GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.DarkIron, 1L),
-                                Materials.Dilithium.getGems(32),
-                                MaterialsUEVplus.Universium.getNanite(1))
-                        .itemOutputs(ItemList.Timepiece.get(3))
-                        .fluidInputs(
-                                MaterialsUEVplus.Time.getMolten(18432L * 8),
-                                MaterialsUEVplus.ExcitedDTSC.getFluid(100000L))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(100000L * 2),
-                                MaterialsUEVplus.Space.getMolten(18432L * 8))
-                        .duration(80 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500)
-                        .addTo(plasmaForgeRecipes);
-
-                // Time to Space
-                GT_Values.RA.stdBuilder().itemInputs(
-                        // Spacetime Continuum Ripper
-                        getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 10),
-                        ItemList.EnergisedTesseract.get(2),
-                        // Quantum Anomaly
-                        GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 16, 32105))
-                        .itemOutputs(ItemList.Tesseract.get(1))
-                        .fluidInputs(
-                                MaterialsUEVplus.Time.getMolten(9216L * 64),
-                                MaterialsUEVplus.SpaceTime.getMolten(9216L * 16),
-                                MaterialsUEVplus.ExcitedDTSC.getFluid(1000L))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L * 2),
-                                MaterialsUEVplus.Space.getMolten(9216L * 64))
-                        .duration(10 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500)
-                        .addTo(plasmaForgeRecipes);
-
-                // Space to Time
-                GT_Values.RA.stdBuilder().itemInputs(
-                        // Spacetime Continuum Ripper
-                        getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 10),
-                        ItemList.EnergisedTesseract.get(2),
-                        ItemList.Timepiece.get(16)).itemOutputs(ItemList.Tesseract.get(1))
-                        .fluidInputs(
-                                MaterialsUEVplus.Space.getMolten(9216L * 64),
-                                MaterialsUEVplus.SpaceTime.getMolten(9216L * 16),
-                                MaterialsUEVplus.ExcitedDTSC.getFluid(1000L))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L * 2),
-                                MaterialsUEVplus.Time.getMolten(9216L * 64))
-                        .duration(10 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500)
-                        .addTo(plasmaForgeRecipes);
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(chromatic_glass.getResidueAmount(3)),
+                                new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), (int) tier_4_quantity))
+                        .duration(chromatic_glass.getDuration(3)).eut(chromatic_glass.getEUt(3))
+                        .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
             }
+
+            // SpaceTime v1
+            GT_Values.RA.stdBuilder().itemInputs(ItemList.EnergisedTesseract.get(1))
+                    .fluidInputs(
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(10000L),
+                            Materials.Infinity.getMolten(2304L),
+                            new FluidStack(ELEMENT.STANDALONE.HYPOGEN.getFluid(), 1152))
+                    .fluidOutputs(MaterialsUEVplus.SpaceTime.getMolten(144L)).duration(40 * SECONDS).eut(1_000_000_000)
+                    .metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
+
+            // Spacetime v2
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            ItemList.EnergisedTesseract.get(1),
+                            GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 0L, 32100))
+                    .fluidInputs(
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(5000L),
+                            Materials.Infinity.getMolten(1152L))
+                    .fluidOutputs(MaterialsUEVplus.SpaceTime.getMolten(576L)).duration(20 * SECONDS).eut(2_000_000_000)
+                    .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
+
+            // Raw Tesseract recipe
+            // 16 Vertices, 24 faces and 32 edges.
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.CosmicNeutronium, 8L),
+                            GT_ModHandler.getModItem(GTPlusPlus.ID, "itemRodOctiron", 8L),
+                            GT_ModHandler.getModItem(BartWorks.ID, "gt.bwMetaGeneratedstick", 8L, 10106),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.Sunnarium, 8L),
+                            GT_ModHandler.getModItem(GTPlusPlus.ID, "itemPlateAbyssalAlloy", 24L),
+                            GT_ModHandler.getModItem(GTPlusPlus.ID, "itemScrewBotmium", 16L),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.Ultimate, 1L))
+                    .itemOutputs(ItemList.Tesseract.get(4)).fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(1000))
+                    .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000 / 2))
+                    .duration(40 * SECONDS).eut(32_000_000).metadata(COIL_HEAT, infinity_heat)
+                    .addTo(plasmaForgeRecipes);
+
+            // Raw Tesseract v2
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, Materials.CosmicNeutronium, 12L),
+                            GT_ModHandler.getModItem(BartWorks.ID, "gt.bwMetaGeneratedstick", 12L, 10106),
+                            GT_OreDictUnificator.get(OrePrefixes.stick, MaterialsUEVplus.TranscendentMetal, 8L),
+                            GT_ModHandler.getModItem(GTPlusPlus.ID, "itemPlateBotmium", 24L),
+                            GT_ModHandler.getModItem(GTPlusPlus.ID, "itemScrewArcanite", 16L),
+                            GT_ModHandler.getModItem(SuperSolarPanels.ID, "enderquantumcomponent", 1L))
+                    .itemOutputs(ItemList.Tesseract.get(8)).fluidInputs(MaterialsUEVplus.ExcitedDTEC.getFluid(1000))
+                    .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000))
+                    .duration(40 * SECONDS).eut(128_000_000).metadata(COIL_HEAT, eternal_heat)
+                    .addTo(plasmaForgeRecipes);
+
+            // Raw Tesseract v3
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.stick, MaterialsUEVplus.TranscendentMetal, 32L),
+                            ALLOY.BLACK_TITANIUM.getPlate(24),
+                            ALLOY.ZERON_100.getScrew(16),
+                            GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 1L, 32105))
+                    .itemOutputs(ItemList.Tesseract.get(16)).fluidInputs(MaterialsUEVplus.ExcitedDTSC.getFluid(1000))
+                    .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(2000))
+                    .duration(40 * SECONDS).eut(512_000_000).metadata(COIL_HEAT, eternal_heat)
+                    .addTo(plasmaForgeRecipes);
+
+            // Transcendent metal
+
+            long total_EU_per_ingot = 113_246_208_000L + 629_145_600L;
+            long recipe_time = 180 * 20;
+            DTPFCalculator transcendent_metal = new DTPFCalculator().setBaseParallel(360).setLowestCatalystTier(4)
+                    .setScalingFactor(8).setHighestCatalystTier(4)
+                    .calculateNonEBFRecipe(total_EU_per_ingot / recipe_time, recipe_time);
+
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(ItemList.Tesseract.get(32), GT_OreDictUnificator.get("blockCosmicNeutronium", 40))
+                    .itemOutputs(
+                            MaterialsUEVplus.TranscendentMetal.getBlocks(40),
+                            MaterialsUEVplus.TranscendentMetal.getDust(24))
+                    .fluidInputs(
+                            ALLOY.TITANSTEEL.getFluidStack(144 * 40 * 9),
+                            Materials.CallistoIce.getMolten(144 * 20 * 9),
+                            Materials.Ledox.getMolten(144 * 20 * 9),
+                            Materials.Tungsten.getMolten(144 * 40 * 9),
+                            MaterialsUEVplus.ExcitedDTSC.getFluid(transcendent_metal.getCatalystAmount(4)))
+                    .fluidOutputs(
+                            MaterialsUEVplus.DimensionallyTranscendentResidue
+                                    .getFluid(transcendent_metal.getResidueAmount(4)),
+                            ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getFluidStack(144 * 20 * 9))
+                    .duration(transcendent_metal.getDuration(4)).eut(transcendent_metal.getEUt(4))
+                    .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
+
+            // Quantum + Astral Titanium
+
+            // Based on quantum abs recipe
+            long total_EU_per_quantum_ingot = (long) (9_437_184_000L * 0.9);
+            // Laser engraver recipe
+            long total_EU_per_astral_dust = 4_718_592_000L;
+            // Astral titanium ebf
+            long total_EU_per_astral_ingot_ebf = 22_118_400_000L;
+            // Astral titanium freezer
+            long total_EU_per_astral_ingot_freezer = 1_639_710_720;
+            // 2 astral titanium blocks per 320 quantum ingots
+            float astral_ingots_per_quantum_ingot = 18 / 320f;
+            // Based on quantum abs including coil discount
+            long recipe_time_per_quantum_ingot = (long) (600 * 20 / 10 * 0.9);
+            DTPFCalculator quantum = new DTPFCalculator().setBaseParallel(320).setLowestCatalystTier(3)
+                    .setHighestCatalystTier(4).calculateNonEBFRecipe(
+                            total_EU_per_quantum_ingot + (long) (astral_ingots_per_quantum_ingot
+                                    * (total_EU_per_astral_dust + total_EU_per_astral_ingot_ebf
+                                            + total_EU_per_astral_ingot_freezer))
+                                    / recipe_time_per_quantum_ingot,
+                            recipe_time_per_quantum_ingot);
+            GT_Values.RA.stdBuilder().itemInputs(
+                    CI.getEnergyCore(9, 0),
+                    BlockList.Quantinum.getIS(2),
+                    // Quantum Anomaly
+                    GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 2, 32105))
+                    .itemOutputs(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getBlock(2))
+                    .fluidInputs(
+                            ALLOY.BLACK_TITANIUM.getFluidStack(144 * 320 * 7 / 10),
+                            Materials.Americium.getMolten(144 * 320 / 10),
+                            Materials.Bismuth.getMolten(144 * 320 / 10),
+                            ELEMENT.STANDALONE.HYPOGEN.getFluidStack(144 * 320 / 10),
+                            Materials.Titanium.getPlasma(144 * 9 * 2 * 2),
+                            MaterialsUEVplus.ExcitedDTEC.getFluid(quantum.getCatalystAmount(3)))
+                    .fluidOutputs(
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(quantum.getResidueAmount(3)),
+                            ALLOY.QUANTUM.getFluidStack(144 * 320))
+                    .duration(quantum.getDuration(3)).eut(quantum.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
+                    .addTo(plasmaForgeRecipes);
+
+            // Quantum + Astral Titanium v2
+            GT_Values.RA.stdBuilder().itemInputs(
+                    CI.getEnergyCore(9, 0),
+                    BlockList.Quantinum.getIS(4),
+                    // Quantum Anomaly
+                    GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 3, 32105))
+                    .itemOutputs(ELEMENT.STANDALONE.ASTRAL_TITANIUM.getBlock(4))
+                    .fluidInputs(
+                            ALLOY.BLACK_TITANIUM.getFluidStack(144 * 640 * 7 / 10),
+                            Materials.Americium.getMolten(144 * 640 / 10),
+                            Materials.Bismuth.getMolten(144 * 640 / 10),
+                            ELEMENT.STANDALONE.HYPOGEN.getFluidStack(144 * 640 / 10),
+                            Materials.Titanium.getPlasma(144 * 9 * 4 * 2),
+                            MaterialsUEVplus.ExcitedDTSC.getFluid(quantum.getCatalystAmount(4)))
+                    .fluidOutputs(
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(quantum.getResidueAmount(4)),
+                            ALLOY.QUANTUM.getFluidStack(144 * 640))
+                    .duration(quantum.getDuration(4)).eut(quantum.getEUt(4)).metadata(COIL_HEAT, eternal_heat)
+                    .addTo(plasmaForgeRecipes);
+
+            // Timepiece
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 14),
+                            GT_OreDictUnificator.get(OrePrefixes.plateDense, Materials.DarkIron, 1L),
+                            Materials.Dilithium.getGems(32),
+                            MaterialsUEVplus.Universium.getNanite(1))
+                    .itemOutputs(ItemList.Timepiece.get(3))
+                    .fluidInputs(
+                            MaterialsUEVplus.Time.getMolten(18432L * 8),
+                            MaterialsUEVplus.ExcitedDTSC.getFluid(100000L))
+                    .fluidOutputs(
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(100000L * 2),
+                            MaterialsUEVplus.Space.getMolten(18432L * 8))
+                    .duration(80 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500).addTo(plasmaForgeRecipes);
+
+            // Time to Space
+            GT_Values.RA.stdBuilder().itemInputs(
+                    // Spacetime Continuum Ripper
+                    getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 10),
+                    ItemList.EnergisedTesseract.get(2),
+                    // Quantum Anomaly
+                    GT_ModHandler.getModItem(GTPlusPlus.ID, "MU-metaitem.01", 16, 32105))
+                    .itemOutputs(ItemList.Tesseract.get(1))
+                    .fluidInputs(
+                            MaterialsUEVplus.Time.getMolten(9216L * 64),
+                            MaterialsUEVplus.SpaceTime.getMolten(9216L * 16),
+                            MaterialsUEVplus.ExcitedDTSC.getFluid(1000L))
+                    .fluidOutputs(
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L * 2),
+                            MaterialsUEVplus.Space.getMolten(9216L * 64))
+                    .duration(10 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500).addTo(plasmaForgeRecipes);
+
+            // Space to Time
+            GT_Values.RA.stdBuilder().itemInputs(
+                    // Spacetime Continuum Ripper
+                    getModItem(GTPlusPlus.ID, "gtplusplus.blockcasings.5", 0, 10),
+                    ItemList.EnergisedTesseract.get(2),
+                    ItemList.Timepiece.get(16)).itemOutputs(ItemList.Tesseract.get(1))
+                    .fluidInputs(
+                            MaterialsUEVplus.Space.getMolten(9216L * 64),
+                            MaterialsUEVplus.SpaceTime.getMolten(9216L * 16),
+                            MaterialsUEVplus.ExcitedDTSC.getFluid(1000L))
+                    .fluidOutputs(
+                            MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1000L * 2),
+                            MaterialsUEVplus.Time.getMolten(9216L * 64))
+                    .duration(10 * SECONDS).eut(TierEU.RECIPE_MAX).metadata(COIL_HEAT, 13500).addTo(plasmaForgeRecipes);
 
             if (Avaritia.isModLoaded()) {
                 // Plasma forge infinity Smelting.
 
-                int base_time = 5_000;
+                long base_time = 10_000;
+                long base_quantity = 64L;
+
+                DTPFCalculator infinity_bee = new DTPFCalculator().setBaseParallel(base_quantity)
+                        .setLowestCatalystTier(2).setHighestCatalystTier(4).setCatalystDiscount(15)
+                        .setProcessingTimeDiscount(50).setEUtMultiplier(2).calculateNonEBFRecipe(32_000_000, base_time);
 
                 // Bee comb catalyst recipes for infinity
-                long fuel_quantity_5 = (long) (11_373 * 0.9);
 
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 4L, 5),
                                 GT_ModHandler.getModItem(GregTech.ID, "gt.comb", 1L, 119),
                                 GT_Utility.getIntegratedCircuit(3))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTSC.getFluid(fuel_quantity_5))
+                        .fluidInputs(MaterialsUEVplus.ExcitedDTSC.getFluid(infinity_bee.getCatalystAmount(4)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_5 * 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(infinity_bee.getResidueAmount(4)),
                                 Materials.Infinity.getMolten(256L * 144L))
-                        .duration(base_time / 8).eut(409_600_000).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
-
-                long fuel_quantity_3 = (long) (26_244 * 0.85);
+                        .duration(infinity_bee.getDuration(4)).eut(infinity_bee.getEUt(4))
+                        .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
 
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 2L, 5),
                                 GT_ModHandler.getModItem(GregTech.ID, "gt.comb", 1L, 119),
                                 GT_Utility.getIntegratedCircuit(3))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_3))
+                        .fluidInputs(MaterialsUEVplus.ExcitedDTEC.getFluid(infinity_bee.getCatalystAmount(3)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(infinity_bee.getResidueAmount(3)),
                                 Materials.Infinity.getMolten(128L * 144L))
-                        .duration(base_time / 4).eut(204_800_000).metadata(COIL_HEAT, eternal_heat)
-                        .addTo(plasmaForgeRecipes);
-
-                long fuel_quantity_4 = (long) (58_932 * 0.85);
+                        .duration(infinity_bee.getDuration(3)).eut(infinity_bee.getEUt(3))
+                        .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
 
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 1L, 5),
                                 GT_ModHandler.getModItem(GregTech.ID, "gt.comb", 1L, 119),
                                 GT_Utility.getIntegratedCircuit(2))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_4))
+                        .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(infinity_bee.getCatalystAmount(2)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_4 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(infinity_bee.getResidueAmount(2)),
                                 Materials.Infinity.getMolten(64L * 144L))
-                        .duration(base_time / 2).eut(102_400_000).metadata(COIL_HEAT, hypogen_heat)
-                        .addTo(plasmaForgeRecipes);
-
-                long fuel_quantity_special_bee = (long) ((58_932L / 64) * 0.75);
+                        .duration(infinity_bee.getDuration(2)).eut(infinity_bee.getEUt(2))
+                        .metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
 
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 1L, 5),
                                 GT_ModHandler.getModItem(GregTech.ID, "gt.comb", 1L, 119),
                                 GT_Utility.getIntegratedCircuit(3))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_special_bee))
+                        .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(infinity_bee.getCatalystAmount(2) / 64))
                         .fluidOutputs(
                                 MaterialsUEVplus.DimensionallyTranscendentResidue
-                                        .getFluid(fuel_quantity_special_bee / 2),
+                                        .getFluid(infinity_bee.getResidueAmount(2) / 64),
                                 Materials.Infinity.getMolten(144L))
-                        .duration(base_time / 256).eut(102_400_000 / 64).metadata(COIL_HEAT, awakened_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(infinity_bee.getDuration(2) / 128).eut(infinity_bee.getEUt(2) / 64)
+                        .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
 
                 // normal recipes
 
-                long fuel_quantity_special = 58_932L / 64;
+                DTPFCalculator infinity = new DTPFCalculator().setBaseParallel(base_quantity).setLowestCatalystTier(2)
+                        .setHighestCatalystTier(4).setEUtMultiplier(2).calculateNonEBFRecipe(32_000_000, base_time);
 
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 1L, 5),
                                 GT_Utility.getIntegratedCircuit(4))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_special))
+                        .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(infinity.getCatalystAmount(2) / 64))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_special / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(infinity.getResidueAmount(2) / 64),
                                 Materials.Infinity.getMolten(144L))
-                        .duration(base_time / 128).eut(102_400_000 / 64).metadata(COIL_HEAT, awakened_heat)
-                        .addTo(plasmaForgeRecipes);
+                        .duration(infinity.getDuration(2) / 128).eut(infinity.getEUt(2) / 64)
+                        .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
 
                 long fuel_quantity_1 = 58_932L;
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 1L, 5),
                                 GT_Utility.getIntegratedCircuit(1))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_1))
+                        .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(infinity.getCatalystAmount(2)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(infinity.getResidueAmount(2)),
                                 Materials.Infinity.getMolten(64L * 144L))
-                        .duration(base_time).eut(102_400_000).metadata(COIL_HEAT, hypogen_heat)
+                        .duration(infinity.getDuration(2)).eut(infinity.getEUt(2)).metadata(COIL_HEAT, hypogen_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long fuel_quantity_2 = 26_244L;
@@ -702,11 +725,12 @@ public class DTPFRecipes implements Runnable {
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 2L, 5),
                                 GT_Utility.getIntegratedCircuit(4))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_2))
+                        .fluidInputs(MaterialsUEVplus.ExcitedDTEC.getFluid(infinity.getCatalystAmount(3)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(infinity.getResidueAmount(3)),
                                 Materials.Infinity.getMolten(128L * 144L))
-                        .duration(base_time / 2).eut(204_800_000).metadata(COIL_HEAT, eternal_heat)
+                        .duration(infinity.getDuration(3)).eut(infinity.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long fuel_quantity_6 = 11_373L;
@@ -714,11 +738,12 @@ public class DTPFRecipes implements Runnable {
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 4L, 5),
                                 GT_Utility.getIntegratedCircuit(4))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTSC.getFluid(fuel_quantity_6))
+                        .fluidInputs(MaterialsUEVplus.ExcitedDTSC.getFluid(infinity.getCatalystAmount(4)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_6 * 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue
+                                        .getFluid(infinity.getResidueAmount(4)),
                                 Materials.Infinity.getMolten(256L * 144L))
-                        .duration(base_time / 4).eut(409_600_000).metadata(COIL_HEAT, eternal_heat)
+                        .duration(infinity.getDuration(4)).eut(infinity.getEUt(4)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
             }
 
@@ -736,14 +761,15 @@ public class DTPFRecipes implements Runnable {
 
             // LuV Superconductor
             {
+
                 long base_quantity = 8190L;
                 long tier_up_multiplier = 2L;
 
-                int base_time = 1260;
+                DTPFCalculator baseLuV = new DTPFCalculator().setBaseParallel(base_quantity).setHighestCatalystTier(3)
+                        .calculateGenericEBFBasedRecipe(
+                                Materials.Tetraindiumditindibariumtitaniumheptacoppertetrakaidekaoxid);
 
                 long tier_1_quantity = 144L * base_quantity;
-                long fuel_quantity_1 = 9295L;
-                long energy_1 = 14_277_120L;
                 GT_Values.RA.stdBuilder().itemInputs(GT_Utility.getIntegratedCircuit(6))
                         .fluidInputs(
                                 Materials.Indium.getMolten(4L * tier_1_quantity / 30),
@@ -752,16 +778,15 @@ public class DTPFRecipes implements Runnable {
                                 Materials.Titanium.getMolten(tier_1_quantity / 30),
                                 Materials.Copper.getMolten(7L * tier_1_quantity / 30),
                                 Materials.Oxygen.getPlasma(14_000L / 32 * tier_1_quantity / 30 / 144),
-                                MaterialsUEVplus.ExcitedDTCC.getFluid(fuel_quantity_1))
+                                MaterialsUEVplus.ExcitedDTCC.getFluid(baseLuV.getCatalystAmount(0)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 8),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseLuV.getResidueAmount(0)),
                                 Materials.Tetraindiumditindibariumtitaniumheptacoppertetrakaidekaoxid
                                         .getMolten(tier_1_quantity))
-                        .duration(base_time).eut(energy_1).metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
+                        .duration(baseLuV.getDuration(0)).eut(baseLuV.getEUt(0)).metadata(COIL_HEAT, awakened_heat)
+                        .addTo(plasmaForgeRecipes);
 
                 long tier_2_quantity = 144L * base_quantity * tier_up_multiplier;
-                long fuel_quantity_2 = 3637L;
-                long energy_2 = energy_1 * 2;
                 GT_Values.RA.stdBuilder().itemInputs(GT_Utility.getIntegratedCircuit(6))
                         .fluidInputs(
                                 Materials.Indium.getMolten(4L * tier_2_quantity / 30),
@@ -770,17 +795,15 @@ public class DTPFRecipes implements Runnable {
                                 Materials.Titanium.getMolten(tier_2_quantity / 30),
                                 Materials.Copper.getMolten(7L * tier_2_quantity / 30),
                                 Materials.Oxygen.getPlasma(14_000L / 32 * tier_2_quantity / 30 / 144),
-                                MaterialsUEVplus.ExcitedDTPC.getFluid(fuel_quantity_2))
+                                MaterialsUEVplus.ExcitedDTPC.getFluid(baseLuV.getCatalystAmount(1)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2 / 4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseLuV.getResidueAmount(1)),
                                 Materials.Tetraindiumditindibariumtitaniumheptacoppertetrakaidekaoxid
                                         .getMolten(tier_2_quantity))
-                        .duration(base_time / 2).eut(energy_2).metadata(COIL_HEAT, infinity_heat)
+                        .duration(baseLuV.getDuration(1)).eut(baseLuV.getEUt(1)).metadata(COIL_HEAT, infinity_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_3_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
-                long fuel_quantity_3 = 1570L;
-                long energy_3 = energy_2 * 2;
                 GT_Values.RA.stdBuilder().itemInputs(GT_Utility.getIntegratedCircuit(6))
                         .fluidInputs(
                                 Materials.Indium.getMolten(4L * tier_3_quantity / 30),
@@ -789,20 +812,18 @@ public class DTPFRecipes implements Runnable {
                                 Materials.Titanium.getMolten(tier_3_quantity / 30),
                                 Materials.Copper.getMolten(7L * tier_3_quantity / 30),
                                 Materials.Oxygen.getPlasma(14_000L / 32 * tier_3_quantity / 30 / 144),
-                                MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_3))
+                                MaterialsUEVplus.ExcitedDTRC.getFluid(baseLuV.getCatalystAmount(2)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseLuV.getResidueAmount(2)),
                                 Materials.Tetraindiumditindibariumtitaniumheptacoppertetrakaidekaoxid
                                         .getMolten(tier_3_quantity))
-                        .duration(base_time / 4).eut(energy_3).metadata(COIL_HEAT, hypogen_heat)
+                        .duration(baseLuV.getDuration(2)).eut(baseLuV.getEUt(2)).metadata(COIL_HEAT, hypogen_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_4_quantity = 144L * base_quantity
                         * tier_up_multiplier
                         * tier_up_multiplier
                         * tier_up_multiplier;
-                long fuel_quantity_4 = 662L;
-                long energy_4 = energy_3 * 2;
                 GT_Values.RA.stdBuilder().itemInputs(GT_Utility.getIntegratedCircuit(6))
                         .fluidInputs(
                                 Materials.Indium.getMolten(4L * tier_4_quantity / 30),
@@ -811,86 +832,81 @@ public class DTPFRecipes implements Runnable {
                                 Materials.Titanium.getMolten(tier_4_quantity / 30),
                                 Materials.Copper.getMolten(7L * tier_4_quantity / 30),
                                 Materials.Oxygen.getPlasma(14_000L / 32 * tier_4_quantity / 30 / 144),
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_4))
+                                MaterialsUEVplus.ExcitedDTEC.getFluid(baseLuV.getCatalystAmount(3)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseLuV.getResidueAmount(3)),
                                 Materials.Tetraindiumditindibariumtitaniumheptacoppertetrakaidekaoxid
                                         .getMolten(tier_4_quantity))
-                        .duration(base_time / 8).eut(energy_4).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseLuV.getDuration(3)).eut(baseLuV.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
             }
 
             // ZPM Superconductor
             {
+
                 long base_quantity = 4095L;
                 long tier_up_multiplier = 2L;
 
-                int base_time = 1440;
+                DTPFCalculator baseZPM = new DTPFCalculator().setBaseParallel(base_quantity).setHighestCatalystTier(3)
+                        .calculateGenericEBFBasedRecipe(Materials.Tetranaquadahdiindiumhexaplatiumosminid);
 
                 long tier_1_quantity = 144L * base_quantity;
-                long fuel_quantity_1 = 12740L;
-                long energy_1 = 17_122_560L;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Palladium.getMolten(6L * tier_1_quantity / 13),
                                 Materials.Indium.getMolten(2L * tier_1_quantity / 13),
                                 Materials.Osmium.getMolten(tier_1_quantity / 13),
                                 Materials.Naquadah.getMolten(4L * tier_1_quantity / 13),
-                                MaterialsUEVplus.ExcitedDTCC.getFluid(fuel_quantity_1))
+                                MaterialsUEVplus.ExcitedDTCC.getFluid(baseZPM.getCatalystAmount(0)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 8),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseZPM.getResidueAmount(0)),
                                 Materials.Tetranaquadahdiindiumhexaplatiumosminid.getMolten(tier_1_quantity))
-                        .duration(base_time).eut(energy_1).metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
+                        .duration(baseZPM.getDuration(0)).eut(baseZPM.getEUt(0)).metadata(COIL_HEAT, awakened_heat)
+                        .addTo(plasmaForgeRecipes);
 
                 long tier_2_quantity = 144L * base_quantity * tier_up_multiplier;
-                long fuel_quantity_2 = 4985L;
-                long energy_2 = energy_1 * 2;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Palladium.getMolten(6L * tier_2_quantity / 13),
                                 Materials.Indium.getMolten(2L * tier_2_quantity / 13),
                                 Materials.Osmium.getMolten(tier_2_quantity / 13),
                                 Materials.Naquadah.getMolten(4L * tier_2_quantity / 13),
-                                MaterialsUEVplus.ExcitedDTPC.getFluid(fuel_quantity_2))
+                                MaterialsUEVplus.ExcitedDTPC.getFluid(baseZPM.getCatalystAmount(1)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2 / 4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseZPM.getResidueAmount(1)),
                                 Materials.Tetranaquadahdiindiumhexaplatiumosminid.getMolten(tier_2_quantity))
-                        .duration(base_time / 2).eut(energy_2).metadata(COIL_HEAT, infinity_heat)
+                        .duration(baseZPM.getDuration(1)).eut(baseZPM.getEUt(1)).metadata(COIL_HEAT, infinity_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_3_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
-                long fuel_quantity_3 = 2151L;
-                long energy_3 = energy_2 * 2;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Palladium.getMolten(6L * tier_3_quantity / 13),
                                 Materials.Indium.getMolten(2L * tier_3_quantity / 13),
                                 Materials.Osmium.getMolten(tier_3_quantity / 13),
                                 Materials.Naquadah.getMolten(4L * tier_3_quantity / 13),
-                                MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_3))
+                                MaterialsUEVplus.ExcitedDTRC.getFluid(baseZPM.getCatalystAmount(2)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseZPM.getResidueAmount(2)),
                                 Materials.Tetranaquadahdiindiumhexaplatiumosminid.getMolten(tier_3_quantity))
-                        .duration(base_time / 4).eut(energy_3).metadata(COIL_HEAT, hypogen_heat)
+                        .duration(baseZPM.getDuration(2)).eut(baseZPM.getEUt(2)).metadata(COIL_HEAT, hypogen_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_4_quantity = 144L * base_quantity
                         * tier_up_multiplier
                         * tier_up_multiplier
                         * tier_up_multiplier;
-                long fuel_quantity_4 = 908L;
-                long energy_4 = energy_3 * 2;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Palladium.getMolten(6L * tier_4_quantity / 13),
                                 Materials.Indium.getMolten(2L * tier_4_quantity / 13),
                                 Materials.Osmium.getMolten(tier_4_quantity / 13),
                                 Materials.Naquadah.getMolten(4L * tier_4_quantity / 13),
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_4))
+                                MaterialsUEVplus.ExcitedDTEC.getFluid(baseZPM.getCatalystAmount(3)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseZPM.getResidueAmount(3)),
                                 Materials.Tetranaquadahdiindiumhexaplatiumosminid.getMolten(tier_4_quantity))
-                        .duration(base_time / 8).eut(energy_4).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseZPM.getDuration(3)).eut(baseZPM.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
             }
 
@@ -900,69 +916,66 @@ public class DTPFRecipes implements Runnable {
                 long base_quantity = 2043L;
                 long tier_up_multiplier = 2L;
 
-                int base_time = 5040;
+                DTPFCalculator baseUV = new DTPFCalculator().setBaseParallel(base_quantity).setHighestCatalystTier(3)
+                        .calculateGenericEBFBasedRecipe(Materials.Longasssuperconductornameforuvwire);
 
                 long tier_1_quantity = 144L * base_quantity;
-                long fuel_quantity_1 = 2491L;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Samarium.getMolten(tier_1_quantity / 9),
                                 Materials.Europium.getMolten(tier_1_quantity / 9),
                                 Materials.Osmiridium.getMolten(3L * tier_1_quantity / 9),
                                 Materials.Naquadria.getMolten(4L * tier_1_quantity / 9),
-                                MaterialsUEVplus.ExcitedDTCC.getFluid(fuel_quantity_1))
+                                MaterialsUEVplus.ExcitedDTCC.getFluid(baseUV.getCatalystAmount(0)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 8),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUV.getResidueAmount(0)),
                                 Materials.Longasssuperconductornameforuvwire.getMolten(tier_1_quantity))
-                        .duration(base_time).eut(14_345_265).metadata(COIL_HEAT, awakened_heat)
+                        .duration(baseUV.getDuration(0)).eut(baseUV.getEUt(0)).metadata(COIL_HEAT, awakened_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_2_quantity = 144L * base_quantity * tier_up_multiplier;
-                long fuel_quantity_2 = 1354L;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Samarium.getMolten(tier_2_quantity / 9),
                                 Materials.Europium.getMolten(tier_2_quantity / 9),
                                 Materials.Osmiridium.getMolten(3L * tier_2_quantity / 9),
                                 Materials.Naquadria.getMolten(4L * tier_2_quantity / 9),
-                                MaterialsUEVplus.ExcitedDTPC.getFluid(fuel_quantity_2))
+                                MaterialsUEVplus.ExcitedDTPC.getFluid(baseUV.getCatalystAmount(1)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2 / 4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUV.getResidueAmount(1)),
                                 Materials.Longasssuperconductornameforuvwire.getMolten(tier_2_quantity))
-                        .duration(base_time / 2).eut(28_690_530).metadata(COIL_HEAT, infinity_heat)
+                        .duration(baseUV.getDuration(1)).eut(baseUV.getEUt(1)).metadata(COIL_HEAT, infinity_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_3_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
-                long fuel_quantity_3 = 671L;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Samarium.getMolten(tier_3_quantity / 9),
                                 Materials.Europium.getMolten(tier_3_quantity / 9),
                                 Materials.Osmiridium.getMolten(3L * tier_3_quantity / 9),
                                 Materials.Naquadria.getMolten(4L * tier_3_quantity / 9),
-                                MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_3))
+                                MaterialsUEVplus.ExcitedDTRC.getFluid(baseUV.getCatalystAmount(2)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUV.getResidueAmount(2)),
                                 Materials.Longasssuperconductornameforuvwire.getMolten(tier_3_quantity))
-                        .duration(base_time / 4).eut(57_381_060).metadata(COIL_HEAT, hypogen_heat)
+                        .duration(baseUV.getDuration(2)).eut(baseUV.getEUt(2)).metadata(COIL_HEAT, hypogen_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_4_quantity = 144L * base_quantity
                         * tier_up_multiplier
                         * tier_up_multiplier
                         * tier_up_multiplier;
-                long fuel_quantity_4 = 303L;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Samarium.getMolten(tier_4_quantity / 9),
                                 Materials.Europium.getMolten(tier_4_quantity / 9),
                                 Materials.Osmiridium.getMolten(3L * tier_4_quantity / 9),
                                 Materials.Naquadria.getMolten(4L * tier_4_quantity / 9),
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_4))
+                                MaterialsUEVplus.ExcitedDTEC.getFluid(baseUV.getCatalystAmount(3)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUV.getResidueAmount(3)),
                                 Materials.Longasssuperconductornameforuvwire.getMolten(tier_4_quantity))
-                        .duration(base_time / 8).eut(114_762_120).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseUV.getDuration(3)).eut(baseUV.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
             }
 
@@ -972,66 +985,64 @@ public class DTPFRecipes implements Runnable {
                 long base_quantity = 1008L;
                 long tier_up_multiplier = 2L;
 
-                int base_time = 3150;
+                DTPFCalculator baseUHV = new DTPFCalculator().setBaseParallel(base_quantity).setLowestCatalystTier(1)
+                        .setHighestCatalystTier(4)
+                        .calculateGenericEBFBasedRecipe(Materials.Longasssuperconductornameforuhvwire);
 
                 long tier_1_quantity = 144L * base_quantity;
-                long fuel_quantity_1 = 44_384L;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Draconium.getMolten(6L * tier_1_quantity / 24),
                                 Materials.Americium.getMolten(6L * tier_1_quantity / 24),
                                 Materials.CosmicNeutronium.getMolten(7L * tier_1_quantity / 24),
                                 Materials.Tritanium.getMolten(5L * tier_1_quantity / 24),
-                                MaterialsUEVplus.ExcitedDTPC.getFluid(fuel_quantity_1))
+                                MaterialsUEVplus.ExcitedDTPC.getFluid(baseUHV.getCatalystAmount(1)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 4),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUHV.getResidueAmount(1)),
                                 Materials.Longasssuperconductornameforuhvwire.getMolten(tier_1_quantity))
-                        .duration(base_time).eut(62_717_952).metadata(COIL_HEAT, infinity_heat)
+                        .duration(baseUHV.getDuration(1)).eut(baseUHV.getEUt(1)).metadata(COIL_HEAT, infinity_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_2_quantity = 144L * base_quantity * tier_up_multiplier;
-                long fuel_quantity_2 = 19_806L;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Draconium.getMolten(6L * tier_2_quantity / 24),
                                 Materials.Americium.getMolten(6L * tier_2_quantity / 24),
                                 Materials.CosmicNeutronium.getMolten(7L * tier_2_quantity / 24),
                                 Materials.Tritanium.getMolten(5L * tier_2_quantity / 24),
-                                MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_2))
+                                MaterialsUEVplus.ExcitedDTRC.getFluid(baseUHV.getCatalystAmount(2)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUHV.getResidueAmount(2)),
                                 Materials.Longasssuperconductornameforuhvwire.getMolten(tier_2_quantity))
-                        .duration(base_time / 2).eut(125_435_904).metadata(COIL_HEAT, hypogen_heat)
+                        .duration(baseUHV.getDuration(2)).eut(baseUHV.getEUt(2)).metadata(COIL_HEAT, hypogen_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_3_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
-                long fuel_quantity_3 = 8_654L;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Draconium.getMolten(6L * tier_3_quantity / 24),
                                 Materials.Americium.getMolten(6L * tier_3_quantity / 24),
                                 Materials.CosmicNeutronium.getMolten(7L * tier_3_quantity / 24),
                                 Materials.Tritanium.getMolten(5L * tier_3_quantity / 24),
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_3))
+                                MaterialsUEVplus.ExcitedDTEC.getFluid(baseUHV.getCatalystAmount(3)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUHV.getResidueAmount(3)),
                                 Materials.Longasssuperconductornameforuhvwire.getMolten(tier_3_quantity))
-                        .duration(base_time / 4).eut(250_871_808).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseUHV.getDuration(3)).eut(baseUHV.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_4_quantity = 144L * base_quantity * (long) Math.pow(tier_up_multiplier, 3);
-                long fuel_quantity_4 = 4_389L;
                 GT_Values.RA.stdBuilder()
                         .fluidInputs(
                                 Materials.Draconium.getMolten(6L * tier_4_quantity / 24),
                                 Materials.Americium.getMolten(6L * tier_4_quantity / 24),
                                 Materials.CosmicNeutronium.getMolten(7L * tier_4_quantity / 24),
                                 Materials.Tritanium.getMolten(5L * tier_4_quantity / 24),
-                                MaterialsUEVplus.ExcitedDTSC.getFluid(fuel_quantity_4))
+                                MaterialsUEVplus.ExcitedDTSC.getFluid(baseUHV.getCatalystAmount(4)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_4 * 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUHV.getResidueAmount(4)),
                                 Materials.Longasssuperconductornameforuhvwire.getMolten(tier_4_quantity))
-                        .duration(base_time / 8).eut(501_743_616).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseUHV.getDuration(4)).eut(baseUHV.getEUt(4)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
             }
 
@@ -1042,10 +1053,10 @@ public class DTPFRecipes implements Runnable {
                 long base_quantity = 504L;
                 long tier_up_multiplier = 2L;
 
-                int base_time = 7431;
+                DTPFCalculator baseUEV = new DTPFCalculator().setBaseParallel(base_quantity).setLowestCatalystTier(2)
+                        .setHighestCatalystTier(4).calculateGenericEBFBasedRecipe(Materials.SuperconductorUEVBase);
 
                 long tier_1_quantity = 144L * base_quantity;
-                long fuel_quantity_1 = 40_477;
 
                 GT_Values.RA.stdBuilder().fluidInputs(
                         new FluidStack(FluidRegistry.getFluid("molten.advancednitinol"), (int) tier_1_quantity / 12),
@@ -1053,15 +1064,14 @@ public class DTPFRecipes implements Runnable {
                         Materials.DraconiumAwakened.getMolten(5L * tier_1_quantity / 12),
                         Materials.Infinity.getMolten(5L * tier_1_quantity / 12),
                         Materials.Iron.getPlasma(tier_1_quantity / 12),
-                        MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_1))
+                        MaterialsUEVplus.ExcitedDTRC.getFluid(baseUEV.getCatalystAmount(2)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUEV.getResidueAmount(2)),
                                 Materials.SuperconductorUEVBase.getMolten(tier_1_quantity))
-                        .duration(base_time / 2).eut(195_457_244).metadata(COIL_HEAT, hypogen_heat)
+                        .duration(baseUEV.getDuration(2)).eut(baseUEV.getEUt(2)).metadata(COIL_HEAT, hypogen_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_2_quantity = 144L * base_quantity * tier_up_multiplier;
-                long fuel_quantity_2 = 18_274;
 
                 GT_Values.RA.stdBuilder().fluidInputs(
                         new FluidStack(FluidRegistry.getFluid("molten.advancednitinol"), (int) tier_2_quantity / 12),
@@ -1069,15 +1079,14 @@ public class DTPFRecipes implements Runnable {
                         Materials.DraconiumAwakened.getMolten(5L * tier_2_quantity / 12),
                         Materials.Infinity.getMolten(5L * tier_2_quantity / 12),
                         Materials.Iron.getPlasma(tier_2_quantity / 12),
-                        MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_2))
+                        MaterialsUEVplus.ExcitedDTEC.getFluid(baseUEV.getCatalystAmount(3)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUEV.getResidueAmount(3)),
                                 Materials.SuperconductorUEVBase.getMolten(tier_2_quantity))
-                        .duration(base_time / 4).eut(390_914_488).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseUEV.getDuration(3)).eut(baseUEV.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_3_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
-                long fuel_quantity_3 = 7_981;
 
                 GT_Values.RA.stdBuilder().fluidInputs(
                         new FluidStack(FluidRegistry.getFluid("molten.advancednitinol"), (int) tier_3_quantity / 12),
@@ -1085,25 +1094,24 @@ public class DTPFRecipes implements Runnable {
                         Materials.DraconiumAwakened.getMolten(5L * tier_3_quantity / 12),
                         Materials.Infinity.getMolten(5L * tier_3_quantity / 12),
                         Materials.Iron.getPlasma(tier_3_quantity / 12),
-                        MaterialsUEVplus.ExcitedDTSC.getFluid(fuel_quantity_3))
+                        MaterialsUEVplus.ExcitedDTSC.getFluid(baseUEV.getCatalystAmount(4)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3 * 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUEV.getResidueAmount(4)),
                                 Materials.SuperconductorUEVBase.getMolten(tier_3_quantity))
-                        .duration(base_time / 8).eut(781_828_976).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseUEV.getDuration(4)).eut(baseUEV.getEUt(4)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
             }
 
             // UIV Superconductors.
-
-            if (GTPlusPlus.isModLoaded()) {
+            {
 
                 long base_quantity = 250L;
                 long tier_up_multiplier = 2L;
 
-                int base_time = 7431;
+                DTPFCalculator baseUIV = new DTPFCalculator().setBaseParallel(base_quantity).setLowestCatalystTier(2)
+                        .setHighestCatalystTier(4).calculateGenericEBFBasedRecipe(Materials.SuperconductorUIVBase);
 
                 long tier_1_quantity = 144L * base_quantity;
-                long fuel_quantity_1 = 77_448;
 
                 GT_Values.RA.stdBuilder().fluidInputs(
                         GT_CoreModSupport.RadoxPolymer.getMolten(4L * tier_1_quantity / 25),
@@ -1111,15 +1119,14 @@ public class DTPFRecipes implements Runnable {
                         new FluidStack(FluidRegistry.getFluid("molten.rhugnor"), (int) tier_1_quantity * 6 / 25),
                         new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), (int) tier_1_quantity * 5 / 25),
                         Materials.Bismuth.getPlasma(tier_1_quantity / 25),
-                        MaterialsUEVplus.ExcitedDTRC.getFluid(fuel_quantity_1))
+                        MaterialsUEVplus.ExcitedDTRC.getFluid(baseUIV.getCatalystAmount(2)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1 / 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUIV.getResidueAmount(2)),
                                 Materials.SuperconductorUIVBase.getMolten(tier_1_quantity))
-                        .duration(base_time / 2).eut(374_265_584).metadata(COIL_HEAT, hypogen_heat)
+                        .duration(baseUIV.getDuration(2)).eut(baseUIV.getEUt(2)).metadata(COIL_HEAT, hypogen_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_2_quantity = 144L * base_quantity * tier_up_multiplier;
-                long fuel_quantity_2 = 34_992;
 
                 GT_Values.RA.stdBuilder().fluidInputs(
                         GT_CoreModSupport.RadoxPolymer.getMolten(4L * tier_2_quantity / 25),
@@ -1127,15 +1134,14 @@ public class DTPFRecipes implements Runnable {
                         new FluidStack(FluidRegistry.getFluid("molten.rhugnor"), (int) tier_2_quantity * 6 / 25),
                         new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), (int) tier_2_quantity * 5 / 25),
                         Materials.Bismuth.getPlasma(tier_2_quantity / 25),
-                        MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_2))
+                        MaterialsUEVplus.ExcitedDTEC.getFluid(baseUIV.getCatalystAmount(3)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUIV.getResidueAmount(3)),
                                 Materials.SuperconductorUIVBase.getMolten(tier_2_quantity))
-                        .duration(base_time / 4).eut(748_531_167).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseUIV.getDuration(3)).eut(baseUIV.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_3_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
-                long fuel_quantity_3 = 15_282;
 
                 GT_Values.RA.stdBuilder().fluidInputs(
                         GT_CoreModSupport.RadoxPolymer.getMolten(4L * tier_3_quantity / 25),
@@ -1143,25 +1149,24 @@ public class DTPFRecipes implements Runnable {
                         new FluidStack(FluidRegistry.getFluid("molten.rhugnor"), (int) tier_3_quantity * 6 / 25),
                         new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), (int) tier_3_quantity * 5 / 25),
                         Materials.Bismuth.getPlasma(tier_3_quantity / 25),
-                        MaterialsUEVplus.ExcitedDTSC.getFluid(fuel_quantity_3))
+                        MaterialsUEVplus.ExcitedDTSC.getFluid(baseUIV.getCatalystAmount(4)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_3 * 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUIV.getResidueAmount(4)),
                                 Materials.SuperconductorUIVBase.getMolten(tier_3_quantity))
-                        .duration(base_time / 8).eut(1_497_062_335).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseUIV.getDuration(4)).eut(baseUIV.getEUt(4)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
             }
 
             // UMV Superconductors.
-
-            if (GoodGenerator.isModLoaded()) {
+            {
 
                 long base_quantity = 243L;
-                long tier_up_multiplier = 4L;
+                long tier_up_multiplier = 2L;
 
-                int base_time = 3715;
+                DTPFCalculator baseUMV = new DTPFCalculator().setBaseParallel(base_quantity).setLowestCatalystTier(3)
+                        .setHighestCatalystTier(4).calculateGenericEBFBasedRecipe(Materials.SuperconductorUMVBase);
 
                 long tier_1_quantity = 144L * base_quantity;
-                long fuel_quantity_1 = 65_536;
                 GT_Values.RA.stdBuilder().fluidInputs(
                         MaterialsUEVplus.SpaceTime.getMolten(6L * tier_1_quantity / 27),
                         new FluidStack(FluidRegistry.getFluid("molten.orundum"), (int) tier_1_quantity * 3 / 27),
@@ -1169,15 +1174,14 @@ public class DTPFRecipes implements Runnable {
                         new FluidStack(FluidRegistry.getFluid("molten.titansteel"), (int) tier_1_quantity * 5 / 27),
                         new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), (int) tier_1_quantity * 2 / 27),
                         Materials.Oxygen.getPlasma(tier_1_quantity / 27),
-                        MaterialsUEVplus.ExcitedDTEC.getFluid(fuel_quantity_1))
+                        MaterialsUEVplus.ExcitedDTEC.getFluid(baseUMV.getCatalystAmount(3)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_1),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUMV.getResidueAmount(3)),
                                 Materials.SuperconductorUMVBase.getMolten(tier_1_quantity))
-                        .duration(base_time).eut(1_455_144_621).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseUMV.getDuration(3)).eut(baseUMV.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
 
                 long tier_2_quantity = 144L * base_quantity * tier_up_multiplier;
-                long fuel_quantity_2 = 59_416;
 
                 GT_Values.RA.stdBuilder().fluidInputs(
                         MaterialsUEVplus.SpaceTime.getMolten(6L * tier_2_quantity / 27),
@@ -1186,11 +1190,11 @@ public class DTPFRecipes implements Runnable {
                         new FluidStack(FluidRegistry.getFluid("molten.titansteel"), (int) tier_2_quantity * 5 / 27),
                         new FluidStack(FluidRegistry.getFluid("molten.dragonblood"), (int) tier_2_quantity * 2 / 27),
                         Materials.Oxygen.getPlasma(tier_2_quantity / 27),
-                        MaterialsUEVplus.ExcitedDTSC.getFluid(fuel_quantity_2))
+                        MaterialsUEVplus.ExcitedDTSC.getFluid(baseUMV.getCatalystAmount(4)))
                         .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(fuel_quantity_2 * 2),
+                                MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(baseUMV.getResidueAmount(4)),
                                 Materials.SuperconductorUMVBase.getMolten(tier_2_quantity))
-                        .duration(base_time).eut(1_455_144_621).metadata(COIL_HEAT, eternal_heat)
+                        .duration(baseUMV.getDuration(4)).eut(baseUMV.getEUt(4)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
             }
         }

--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -527,18 +527,17 @@ public class DTPFRecipes implements Runnable {
             // Astral titanium ebf
             long total_EU_per_astral_ingot_ebf = 22_118_400_000L;
             // Astral titanium freezer
-            long total_EU_per_astral_ingot_freezer = 1_639_710_720;
+            long total_EU_per_astral_ingot_freezer = 1_639_710_720L;
             // 2 astral titanium blocks per 320 quantum ingots
             float astral_ingots_per_quantum_ingot = 18 / 320f;
             // Based on quantum abs including coil discount
             long recipe_time_per_quantum_ingot = (long) (600 * 20 / 10 * 0.9);
+            long total_EUt = (long) (total_EU_per_quantum_ingot + astral_ingots_per_quantum_ingot
+                    * (total_EU_per_astral_dust + total_EU_per_astral_ingot_ebf + total_EU_per_astral_ingot_freezer))
+                    / recipe_time_per_quantum_ingot;
             DTPFCalculator quantum = new DTPFCalculator().setBaseParallel(320).setLowestCatalystTier(3)
-                    .setHighestCatalystTier(4).calculateNonEBFRecipe(
-                            total_EU_per_quantum_ingot + (long) (astral_ingots_per_quantum_ingot
-                                    * (total_EU_per_astral_dust + total_EU_per_astral_ingot_ebf
-                                            + total_EU_per_astral_ingot_freezer))
-                                    / recipe_time_per_quantum_ingot,
-                            recipe_time_per_quantum_ingot);
+                    .setHighestCatalystTier(4).setEUtDivisor(1.12f)
+                    .calculateNonEBFRecipe(total_EUt, recipe_time_per_quantum_ingot);
             GT_Values.RA.stdBuilder().itemInputs(
                     CI.getEnergyCore(9, 0),
                     BlockList.Quantinum.getIS(2),
@@ -634,7 +633,7 @@ public class DTPFRecipes implements Runnable {
 
                 DTPFCalculator infinity_bee = new DTPFCalculator().setBaseParallel(base_quantity)
                         .setLowestCatalystTier(2).setHighestCatalystTier(4).setCatalystDiscount(15)
-                        .setProcessingTimeDiscount(50).setEUtMultiplier(2).calculateNonEBFRecipe(32_000_000, base_time);
+                        .setProcessingTimeDiscount(50).setEUtDivisor(2).calculateNonEBFRecipe(32_000_000, base_time);
 
                 // Bee comb catalyst recipes for infinity
 
@@ -693,7 +692,7 @@ public class DTPFRecipes implements Runnable {
                 // normal recipes
 
                 DTPFCalculator infinity = new DTPFCalculator().setBaseParallel(base_quantity).setLowestCatalystTier(2)
-                        .setHighestCatalystTier(4).setEUtMultiplier(2).calculateNonEBFRecipe(32_000_000, base_time);
+                        .setHighestCatalystTier(4).setEUtDivisor(2).calculateNonEBFRecipe(32_000_000, base_time);
 
                 GT_Values.RA.stdBuilder()
                         .itemInputs(

--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -58,7 +58,7 @@ public class DTPFRecipes implements Runnable {
                 long tier_up_multiplier = 2L;
 
                 DTPFCalculator neutronium = new DTPFCalculator().setBaseParallel(base_quantity)
-                        .setCustomEBFinputItem(CustomItemList.RawNeutronium.get(1L)).setHighestCatalystTier(3)
+                        .setCustomEBFinputItem(CustomItemList.RawNeutronium.get(1L))
                         .calculateGenericEBFBasedRecipe(Materials.Neutronium);
 
                 long tier_1_quantity = 144L * base_quantity;
@@ -124,7 +124,7 @@ public class DTPFRecipes implements Runnable {
                 long tier_up_multiplier = 2L;
 
                 DTPFCalculator cosmic_neutronium_bee = new DTPFCalculator().setBaseParallel(base_quantity)
-                        .setHighestCatalystTier(3).setCatalystDiscount(15).setProcessingTimeDiscount(50)
+                        .setCatalystDiscount(15).setProcessingTimeDiscount(50)
                         .calculateGenericEBFBasedRecipe(Materials.CosmicNeutronium);
 
                 int base_time = 4200;
@@ -200,7 +200,7 @@ public class DTPFRecipes implements Runnable {
                 // normal ones
 
                 DTPFCalculator cosmic_neutronium = new DTPFCalculator().setBaseParallel(base_quantity)
-                        .setHighestCatalystTier(3).calculateGenericEBFBasedRecipe(Materials.CosmicNeutronium);
+                        .calculateGenericEBFBasedRecipe(Materials.CosmicNeutronium);
 
                 GT_Values.RA.stdBuilder().itemInputs(GT_Utility.getIntegratedCircuit(4))
                         .fluidInputs(
@@ -263,7 +263,7 @@ public class DTPFRecipes implements Runnable {
                 long tier_up_multiplier = 2L;
 
                 DTPFCalculator bedrockium = new DTPFCalculator().setBaseParallel(base_quantity)
-                        .setHighestCatalystTier(3).calculateGenericEBFBasedRecipe(Materials.Bedrockium);
+                        .calculateGenericEBFBasedRecipe(Materials.Bedrockium);
 
                 long tier_1_quantity = 144L * base_quantity;
 
@@ -378,7 +378,7 @@ public class DTPFRecipes implements Runnable {
                 long tier_up_multiplier = 2L;
 
                 DTPFCalculator chromatic_glass = new DTPFCalculator().setBaseParallel(base_quantity)
-                        .setHighestCatalystTier(3).calculateNonEBFRecipe(1_966_080, 6_000);
+                        .calculateNonEBFRecipe(1_966_080, 6_000);
 
                 long tier_1_quantity = 144L * base_quantity;
 
@@ -764,7 +764,7 @@ public class DTPFRecipes implements Runnable {
                 long base_quantity = 8190L;
                 long tier_up_multiplier = 2L;
 
-                DTPFCalculator baseLuV = new DTPFCalculator().setBaseParallel(base_quantity).setHighestCatalystTier(3)
+                DTPFCalculator baseLuV = new DTPFCalculator().setBaseParallel(base_quantity)
                         .calculateGenericEBFBasedRecipe(
                                 Materials.Tetraindiumditindibariumtitaniumheptacoppertetrakaidekaoxid);
 
@@ -846,7 +846,7 @@ public class DTPFRecipes implements Runnable {
                 long base_quantity = 4095L;
                 long tier_up_multiplier = 2L;
 
-                DTPFCalculator baseZPM = new DTPFCalculator().setBaseParallel(base_quantity).setHighestCatalystTier(3)
+                DTPFCalculator baseZPM = new DTPFCalculator().setBaseParallel(base_quantity)
                         .calculateGenericEBFBasedRecipe(Materials.Tetranaquadahdiindiumhexaplatiumosminid);
 
                 long tier_1_quantity = 144L * base_quantity;
@@ -915,7 +915,7 @@ public class DTPFRecipes implements Runnable {
                 long base_quantity = 2043L;
                 long tier_up_multiplier = 2L;
 
-                DTPFCalculator baseUV = new DTPFCalculator().setBaseParallel(base_quantity).setHighestCatalystTier(3)
+                DTPFCalculator baseUV = new DTPFCalculator().setBaseParallel(base_quantity)
                         .calculateGenericEBFBasedRecipe(Materials.Longasssuperconductornameforuvwire);
 
                 long tier_1_quantity = 144L * base_quantity;

--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -49,8 +49,6 @@ public class DTPFRecipes implements Runnable {
             // ------------------------------------- Plasma Forge ---------------------------------------
             // ------------------------------------------------------------------------------------------
 
-            // See https://docs.google.com/spreadsheets/d/1_n2HSFyzfNzkJHYBPFu3HTZvkh69GBi5LXw2c9FyG9o/edit?usp=sharing
-            // for details on plasma forge maths.
             {
                 // Neutronium Smelting.
 

--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -48,6 +48,7 @@ import com.dreammaster.gthandler.GT_CoreModSupport;
 import com.dreammaster.gthandler.GT_CustomLoader;
 import com.dreammaster.gthandler.GT_Loader_CasingNH;
 import com.dreammaster.gthandler.GT_Loader_ItemPipes;
+import com.dreammaster.gthandler.recipes.DTPFRecipes;
 import com.dreammaster.item.CustomPatterns;
 import com.dreammaster.item.ItemList;
 import com.dreammaster.item.WoodenBrickForm;
@@ -495,6 +496,7 @@ public class MainRegistry {
     public void CompleteLoad(FMLLoadCompleteEvent event) {
         RecipeRemover.run();
         ScriptLoader.run();
+        new DTPFRecipes().run();
         if (BartWorks.isModLoaded()) {
             BW_RadHatchMaterial.runRadHatchAdder();
         }


### PR DESCRIPTION
As the title suggests, this PR adds a calculator to help with the creation of dtpf recipes. 
Until now one had to use a complex spreadsheet without much documentation to determine the parameters for each recipe, which wasnt great for maintainability.
The DTPF calculator replaces that by implementing all the necessary math into a documented and consistent tool in code.

Recipes for materials can be either generated directly based on their ebf and vacuum freezer recipes or based on a manual input of recipe voltage and duration (useful for materials that dont have ebf & vacuum freezer recipes, like chromatic glass).

This has the side effect of a large portion of dtpf recipes changing, as now both the ebf gas changes that happened a year ago have been taken into account by the calculator and typos/mistakes in the original spreadsheet have been fixed.