### PR TITLE
Remove gtcrate recipes from scripts

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
@@ -1030,11 +1030,6 @@ public class ScriptIndustrialCraft implements IScriptLoader {
                 null,
                 null);
         addShapedRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Iridium, 16L),
-                GT_OreDictUnificator.get(OrePrefixes.crateGtPlate, Materials.Iridium, 1L),
-                "craftingToolCrowbar",
-                null);
-        addShapedRecipe(
                 GT_OreDictUnificator.get(OrePrefixes.toolHeadAxe, Materials.Iridium, 1L),
                 "plateIridium",
                 "ingotIridium",
@@ -1127,11 +1122,6 @@ public class ScriptIndustrialCraft implements IScriptLoader {
                 "craftingToolFile",
                 "plateIridium",
                 "craftingToolHardHammer");
-        addShapedRecipe(
-                GT_OreDictUnificator.get(OrePrefixes.ingot, Materials.Iridium, 16L),
-                GT_OreDictUnificator.get(OrePrefixes.crateGtIngot, Materials.Iridium, 1L),
-                "craftingToolCrowbar",
-                null);
         addShapedRecipe(
                 getModItem(IndustrialCraft2.ID, "itemWeedingTrowel", 1, 0, missing),
                 "screwSteel",

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -5078,10 +5078,6 @@ public class ScriptMinecraft implements IScriptLoader {
                 "craftingToolScrewdriver",
                 "stickWood");
         addShapedRecipe(
-                getModItem(Minecraft.ID, "nether_star", 16, 0, missing),
-                GT_OreDictUnificator.get(OrePrefixes.crateGtGem, Materials.NetherStar, 1L),
-                "craftingToolCrowbar");
-        addShapedRecipe(
                 getModItem(Minecraft.ID, "mossy_cobblestone", 1, 0, missing),
                 getModItem(BiomesOPlenty.ID, "moss", 1, 0, missing),
                 getModItem(BiomesOPlenty.ID, "moss", 1, 0, missing),


### PR DESCRIPTION
follow up to https://github.com/GTNewHorizons/GT5-Unofficial/pull/2687 so that coremod works again.