### PR TITLE
Fix neutronium frame box research conflict

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -250,7 +250,7 @@ public class AssemblingLineRecipes implements Runnable {
                         (int) TierEU.RECIPE_UHV);
 
                 TT_recipeAdder.addResearchableAssemblylineRecipe(
-                        GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Neutronium, 1L),
+                        GT_OreDictUnificator.get(OrePrefixes.stickLong, Materials.Neutronium, 1L),
                         192_000,
                         512,
                         2_000_000,


### PR DESCRIPTION
The nt frame box is already used in space elevator research