### PR TITLE
Add recipes to pre-apply storage components to ME hatches

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -1,6 +1,8 @@
 package com.dreammaster.gthandler;
 
+import static gregtech.api.enums.Mods.AE2FluidCraft;
 import static gregtech.api.enums.Mods.AdventureBackpack;
+import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.BartWorks;
 import static gregtech.api.enums.Mods.BuildCraftFactory;
 import static gregtech.api.enums.Mods.Chisel;
@@ -28,6 +30,7 @@ import java.util.function.Consumer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 
 import com.dreammaster.main.NHItems;
 import com.dreammaster.mantle.MantleManualRecipeRegistry;
@@ -1856,6 +1859,68 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
             GT_ModHandler.addCraftingRecipe(
                     GT_ModHandler.getModItem(TinkerConstruct.ID, "Clay Cast", 1, 3),
                     new Object[] { "  C", "W  ", "   ", 'W', ToolDictNames.craftingToolKnife, 'C', aBlankClayCast });
+        }
+
+        // Add storage component recipes to pre-apply cache upgrades
+
+        final ItemStack COMPONENT_1 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 35);
+        final ItemStack COMPONENT_4 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 36);
+        final ItemStack COMPONENT_16 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 37);
+        final ItemStack COMPONENT_64 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 38);
+        final ItemStack COMPONENT_256 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 57);
+        final ItemStack COMPONENT_1024 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 58);
+        final ItemStack COMPONENT_4096 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 59);
+        final ItemStack COMPONENT_16384 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 60);
+        final ItemStack FLUIDCOMPONENT_1 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 0);
+        final ItemStack FLUIDCOMPONENT_4 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 1);
+        final ItemStack FLUIDCOMPONENT_16 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 2);
+        final ItemStack FLUIDCOMPONENT_64 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 3);
+        final ItemStack FLUIDCOMPONENT_256 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 4);
+        final ItemStack FLUIDCOMPONENT_1024 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 5);
+        final ItemStack FLUIDCOMPONENT_4096 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 6);
+        final ItemStack FLUIDCOMPONENT_16384 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 7);
+
+        ItemStack[] itemComponents = new ItemStack[] { COMPONENT_1, COMPONENT_4, COMPONENT_16, COMPONENT_64,
+                COMPONENT_256, COMPONENT_1024, COMPONENT_4096, COMPONENT_16384 };
+        ItemStack[] fluidComponents = new ItemStack[] { FLUIDCOMPONENT_1, FLUIDCOMPONENT_4, FLUIDCOMPONENT_16,
+                FLUIDCOMPONENT_64, FLUIDCOMPONENT_256, FLUIDCOMPONENT_1024, FLUIDCOMPONENT_4096, FLUIDCOMPONENT_16384 };
+        long[] capacities = { 8192, 32768, 131072, 524288, 2097152, 8388608, 33554432, 134217728 };
+
+        for (int i = 0; i <= 7; i++) {
+            ItemStack modifiedHatch = ItemList.Hatch_Output_ME.get(1L);
+            NBTTagCompound hatchNBT = modifiedHatch.getTagCompound();
+            if (hatchNBT != null) {
+                hatchNBT.setLong("baseCapacity", capacities[i]);
+            } else {
+                hatchNBT = new NBTTagCompound();
+                hatchNBT.setLong("baseCapacity", capacities[i] * 256);
+                modifiedHatch.setTagCompound(hatchNBT);
+            }
+
+            ItemStack modifiedBus = ItemList.Hatch_Output_Bus_ME.get(1L);
+            NBTTagCompound busNBT = modifiedBus.getTagCompound();
+            if (busNBT != null) {
+                busNBT.setLong("baseCapacity", capacities[i]);
+            } else {
+                busNBT = new NBTTagCompound();
+                busNBT.setLong("baseCapacity", capacities[i]);
+                modifiedBus.setTagCompound(busNBT);
+            }
+
+            GT_ModHandler.addShapelessCraftingRecipe(
+                    modifiedHatch,
+                    new Object[] { ItemList.Hatch_Output_ME.get(1L), fluidComponents[i] });
+            GT_ModHandler.addShapelessCraftingRecipe(
+                    modifiedBus,
+                    new Object[] { ItemList.Hatch_Output_Bus_ME.get(1L), itemComponents[i] });
         }
     }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -3877,68 +3876,6 @@ public class AssemblerRecipes implements Runnable {
                         GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(ItemList.Hatch_Output_ME.get(1)).duration(15 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
-
-        // Add storage component recipes to pre-apply cache upgrades
-
-        final ItemStack COMPONENT_1 = GT_ModHandler
-                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 35);
-        final ItemStack COMPONENT_4 = GT_ModHandler
-                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 36);
-        final ItemStack COMPONENT_16 = GT_ModHandler
-                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 37);
-        final ItemStack COMPONENT_64 = GT_ModHandler
-                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 38);
-        final ItemStack COMPONENT_256 = GT_ModHandler
-                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 57);
-        final ItemStack COMPONENT_1024 = GT_ModHandler
-                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 58);
-        final ItemStack COMPONENT_4096 = GT_ModHandler
-                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 59);
-        final ItemStack COMPONENT_16384 = GT_ModHandler
-                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 60);
-        final ItemStack FLUIDCOMPONENT_1 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 0);
-        final ItemStack FLUIDCOMPONENT_4 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 1);
-        final ItemStack FLUIDCOMPONENT_16 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 2);
-        final ItemStack FLUIDCOMPONENT_64 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 3);
-        final ItemStack FLUIDCOMPONENT_256 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 4);
-        final ItemStack FLUIDCOMPONENT_1024 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 5);
-        final ItemStack FLUIDCOMPONENT_4096 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 6);
-        final ItemStack FLUIDCOMPONENT_16384 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 7);
-
-        ItemStack[] itemComponents = new ItemStack[] { COMPONENT_1, COMPONENT_4, COMPONENT_16, COMPONENT_64,
-                COMPONENT_256, COMPONENT_1024, COMPONENT_4096, COMPONENT_16384 };
-        ItemStack[] fluidComponents = new ItemStack[] { FLUIDCOMPONENT_1, FLUIDCOMPONENT_4, FLUIDCOMPONENT_16,
-                FLUIDCOMPONENT_64, FLUIDCOMPONENT_256, FLUIDCOMPONENT_1024, FLUIDCOMPONENT_4096, FLUIDCOMPONENT_16384 };
-        long[] capacities = { 8192, 32768, 131072, 524288, 2097152, 8388608, 33554432, 134217728 };
-
-        for (int i = 0; i <= 7; i++) {
-            ItemStack modifiedHatch = ItemList.Hatch_Output_ME.get(1L);
-            NBTTagCompound hatchNBT = modifiedHatch.getTagCompound();
-            if (hatchNBT != null) {
-                hatchNBT.setLong("baseCapacity", capacities[i]);
-            } else {
-                hatchNBT = new NBTTagCompound();
-                hatchNBT.setLong("baseCapacity", capacities[i] * 256);
-                modifiedHatch.setTagCompound(hatchNBT);
-            }
-
-            ItemStack modifiedBus = ItemList.Hatch_Output_Bus_ME.get(1L);
-            NBTTagCompound busNBT = modifiedBus.getTagCompound();
-            if (busNBT != null) {
-                busNBT.setLong("baseCapacity", capacities[i]);
-            } else {
-                busNBT = new NBTTagCompound();
-                busNBT.setLong("baseCapacity", capacities[i]);
-                modifiedBus.setTagCompound(busNBT);
-            }
-
-            GT_ModHandler.addShapelessCraftingRecipe(
-                    modifiedHatch,
-                    new Object[] { ItemList.Hatch_Output_ME.get(1L), fluidComponents[i] });
-            GT_ModHandler.addShapelessCraftingRecipe(
-                    modifiedBus,
-                    new Object[] { ItemList.Hatch_Output_Bus_ME.get(1L), itemComponents[i] });
-        }
 
         // Stocking Input Bus (ME)
         GT_Values.RA.stdBuilder()

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -3876,6 +3877,68 @@ public class AssemblerRecipes implements Runnable {
                         GT_Utility.getIntegratedCircuit(1))
                 .itemOutputs(ItemList.Hatch_Output_ME.get(1)).duration(15 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
+
+        // Add storage component recipes to pre-apply cache upgrades
+
+        final ItemStack COMPONENT_1 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 35);
+        final ItemStack COMPONENT_4 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 36);
+        final ItemStack COMPONENT_16 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 37);
+        final ItemStack COMPONENT_64 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 38);
+        final ItemStack COMPONENT_256 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 57);
+        final ItemStack COMPONENT_1024 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 58);
+        final ItemStack COMPONENT_4096 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 59);
+        final ItemStack COMPONENT_16384 = GT_ModHandler
+                .getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1L, 60);
+        final ItemStack FLUIDCOMPONENT_1 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 0);
+        final ItemStack FLUIDCOMPONENT_4 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 1);
+        final ItemStack FLUIDCOMPONENT_16 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 2);
+        final ItemStack FLUIDCOMPONENT_64 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 3);
+        final ItemStack FLUIDCOMPONENT_256 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 4);
+        final ItemStack FLUIDCOMPONENT_1024 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 5);
+        final ItemStack FLUIDCOMPONENT_4096 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 6);
+        final ItemStack FLUIDCOMPONENT_16384 = GT_ModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 1, 7);
+
+        ItemStack[] itemComponents = new ItemStack[] { COMPONENT_1, COMPONENT_4, COMPONENT_16, COMPONENT_64,
+                COMPONENT_256, COMPONENT_1024, COMPONENT_4096, COMPONENT_16384 };
+        ItemStack[] fluidComponents = new ItemStack[] { FLUIDCOMPONENT_1, FLUIDCOMPONENT_4, FLUIDCOMPONENT_16,
+                FLUIDCOMPONENT_64, FLUIDCOMPONENT_256, FLUIDCOMPONENT_1024, FLUIDCOMPONENT_4096, FLUIDCOMPONENT_16384 };
+        long[] capacities = { 8192, 32768, 131072, 524288, 2097152, 8388608, 33554432, 134217728 };
+
+        for (int i = 0; i <= 7; i++) {
+            ItemStack modifiedHatch = ItemList.Hatch_Output_ME.get(1L);
+            NBTTagCompound hatchNBT = modifiedHatch.getTagCompound();
+            if (hatchNBT != null) {
+                hatchNBT.setLong("baseCapacity", capacities[i]);
+            } else {
+                hatchNBT = new NBTTagCompound();
+                hatchNBT.setLong("baseCapacity", capacities[i] * 256);
+                modifiedHatch.setTagCompound(hatchNBT);
+            }
+
+            ItemStack modifiedBus = ItemList.Hatch_Output_Bus_ME.get(1L);
+            NBTTagCompound busNBT = modifiedBus.getTagCompound();
+            if (busNBT != null) {
+                busNBT.setLong("baseCapacity", capacities[i]);
+            } else {
+                busNBT = new NBTTagCompound();
+                busNBT.setLong("baseCapacity", capacities[i]);
+                modifiedBus.setTagCompound(busNBT);
+            }
+
+            GT_ModHandler.addShapelessCraftingRecipe(
+                    modifiedHatch,
+                    new Object[] { ItemList.Hatch_Output_ME.get(1L), fluidComponents[i] });
+            GT_ModHandler.addShapelessCraftingRecipe(
+                    modifiedBus,
+                    new Object[] { ItemList.Hatch_Output_Bus_ME.get(1L), itemComponents[i] });
+        }
 
         // Stocking Input Bus (ME)
         GT_Values.RA.stdBuilder()


### PR DESCRIPTION
Adds shapeless recipes to craft the ME output bus and hatch with AE storage components to change the base cache size. Requires https://github.com/GTNewHorizons/GT5-Unofficial/pull/2718 to actually do anything useful.

![image](https://github.com/user-attachments/assets/05f78724-b063-4c5f-b8b8-019d440e0625)

![image](https://github.com/user-attachments/assets/a75c73a3-fb45-410d-a165-87a7e235633f)
