### PR TITLE
Downtiers advanced fluid storage housings

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -4202,7 +4202,7 @@ public class AssemblerRecipes implements Runnable {
             GT_Values.RA.stdBuilder()
                     .itemInputs(
                             GT_OreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 1L),
-                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Neutronium, 2L),
+                            GT_ModHandler.getModItem(GTPlusPlus.ID, "itemPlateNitinol60", 2L),
                             GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 1L),
                             GT_OreDictUnificator.get(OrePrefixes.screw, Materials.CertusQuartz, 2L),
                             GT_Utility.getIntegratedCircuit(3))
@@ -4222,7 +4222,7 @@ public class AssemblerRecipes implements Runnable {
             GT_Values.RA.stdBuilder()
                     .itemInputs(
                             GT_OreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L),
-                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Infinity, 2L),
+                            GT_ModHandler.getModItem(GTPlusPlus.ID, "itemPlateZeron100", 2L),
                             GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 1L),
                             GT_OreDictUnificator.get(OrePrefixes.screw, Materials.CertusQuartz, 2L),
                             GT_Utility.getIntegratedCircuit(3))

--- a/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
@@ -172,6 +172,9 @@ public class ScriptAE2FC implements IScriptLoader {
         ItemStack[] components = new ItemStack[] { COMPONENT_1, COMPONENT_4, COMPONENT_16, COMPONENT_64, COMPONENT_256,
                 COMPONENT_1024, COMPONENT_4096, COMPONENT_16384 };
 
+        final ItemStack nitinolPlate = GT_ModHandler.getModItem(GTPlusPlus.ID, "itemPlateNitinol60", 2L);
+        final ItemStack zeronPlate = GT_ModHandler.getModItem(GTPlusPlus.ID, "itemPlateZeron100", 2L);
+
         // AE2FC_FLUID_STORAGE_HOUSING
         GT_ModHandler.addCraftingRecipe(
                 AE2FC_FLUID_STORAGE_HOUSING,
@@ -243,12 +246,12 @@ public class ScriptAE2FC implements IScriptLoader {
                 AE2FC_ADVANCED_FLUID_STORAGE_HOUSING,
                 RecipeBits.BUFFERED | RecipeBits.DELETE_ALL_OTHER_SHAPED_RECIPES,
                 new Object[] { "hCW", "S-S", "WAd", 'C', "plateCertusQuartz", 'W', "screwCertusQuartz", 'S',
-                        "plateNeutronium", 'A', "plateStainlessSteel" });
+                        nitinolPlate, 'A', "plateStainlessSteel" });
         GT_ModHandler.addCraftingRecipe(
                 AE2FC_ADVANCED_FLUID_STORAGE_HOUSING,
                 RecipeBits.BUFFERED,
                 new Object[] { "dCW", "S-S", "WAh", 'C', "plateCertusQuartz", 'W', "screwCertusQuartz", 'S',
-                        "plateNeutronium", 'A', "plateStainlessSteel" });
+                        nitinolPlate, 'A', "plateStainlessSteel" });
         for (Map.Entry<ItemStack, ItemStack> entry : new HashMap<ItemStack, ItemStack>() {
 
             {
@@ -262,12 +265,12 @@ public class ScriptAE2FC implements IScriptLoader {
                     entry.getKey(),
                     RecipeBits.BUFFERED | RecipeBits.DELETE_ALL_OTHER_SHAPED_RECIPES,
                     new Object[] { "hCW", "SKS", "WAd", 'C', "plateCertusQuartz", 'W', "screwCertusQuartz", 'S',
-                            "plateNeutronium", 'A', "plateStainlessSteel", 'K', entry.getValue() });
+                            nitinolPlate, 'A', "plateStainlessSteel", 'K', entry.getValue() });
             GT_ModHandler.addCraftingRecipe(
                     entry.getKey(),
                     RecipeBits.BUFFERED,
                     new Object[] { "dCW", "SKS", "WAh", 'C', "plateCertusQuartz", 'W', "screwCertusQuartz", 'S',
-                            "plateNeutronium", 'A', "plateStainlessSteel", 'K', entry.getValue() });
+                            nitinolPlate, 'A', "plateStainlessSteel", 'K', entry.getValue() });
             addShapelessRecipe(entry.getKey(), AE2FC_ADVANCED_FLUID_STORAGE_HOUSING, entry.getValue());
         }
 
@@ -275,13 +278,13 @@ public class ScriptAE2FC implements IScriptLoader {
         GT_ModHandler.addCraftingRecipe(
                 AE2FC_ADVANCED_MULTI_FLUID_STORAGE_HOUSING,
                 RecipeBits.BUFFERED | RecipeBits.DELETE_ALL_OTHER_SHAPED_RECIPES,
-                new Object[] { "hCW", "S-S", "WAd", 'C', "plateCertusQuartz", 'W', "screwCertusQuartz", 'S',
-                        "plateInfinity", 'A', "plateTungstenSteel" });
+                new Object[] { "hCW", "S-S", "WAd", 'C', "plateCertusQuartz", 'W', "screwCertusQuartz", 'S', zeronPlate,
+                        'A', "plateTungstenSteel" });
         GT_ModHandler.addCraftingRecipe(
                 AE2FC_ADVANCED_MULTI_FLUID_STORAGE_HOUSING,
                 RecipeBits.BUFFERED,
-                new Object[] { "dCW", "S-S", "WAh", 'C', "plateCertusQuartz", 'W', "screwCertusQuartz", 'S',
-                        "plateInfinity", 'A', "plateTungstenSteel" });
+                new Object[] { "dCW", "S-S", "WAh", 'C', "plateCertusQuartz", 'W', "screwCertusQuartz", 'S', zeronPlate,
+                        'A', "plateTungstenSteel" });
         for (Map.Entry<ItemStack, ItemStack> entry : new HashMap<ItemStack, ItemStack>() {
 
             {
@@ -295,12 +298,12 @@ public class ScriptAE2FC implements IScriptLoader {
                     entry.getKey(),
                     RecipeBits.BUFFERED | RecipeBits.DELETE_ALL_OTHER_SHAPED_RECIPES,
                     new Object[] { "hCW", "SKS", "WAd", 'C', "plateCertusQuartz", 'W', "screwCertusQuartz", 'S',
-                            "plateInfinity", 'A', "plateTungstenSteel", 'K', entry.getValue() });
+                            zeronPlate, 'A', "plateTungstenSteel", 'K', entry.getValue() });
             GT_ModHandler.addCraftingRecipe(
                     entry.getKey(),
                     RecipeBits.BUFFERED,
                     new Object[] { "dCW", "SKS", "WAh", 'C', "plateCertusQuartz", 'W', "screwCertusQuartz", 'S',
-                            "plateInfinity", 'A', "plateTungstenSteel", 'K', entry.getValue() });
+                            zeronPlate, 'A', "plateTungstenSteel", 'K', entry.getValue() });
             addShapelessRecipe(entry.getKey(), AE2FC_ADVANCED_MULTI_FLUID_STORAGE_HOUSING, entry.getValue());
         }
 


### PR DESCRIPTION
Currently, the AE2FC advanced fluid storage housing items require Neutronium for the single fluid type, and Infinity for the multi-fluid type. This creates a situation where the player can make storage components for higher-capacity fluid disks fairly early, but can't actually put them in ME Drives and ME Chests due to the stringent housing requirements. Additionally, with the ME output hatch change, these storage components can be employed to buffer fluid up to their capacity in an ME output hatch as early as EV. Combined with a smaller disk with a sticky card somewhere else in the network, this allows the components to be used (after a fashion) without incurring the cost of the housing.

In light of this, I've authored this PR. It changes the recipes for these items to use GT++ alloys. I chose GT++ alloys because they are very strictly tiered, due to the Alloy Blast Smelter not allowing two hatches nor having a mega version until UHV. 

Single fluid housing: 2 Neutronium plates -> 2 Nitinol-60 plates (IV)
Multi-fluid housing: 2 Infinity plates -> 2 Zeron-100 plates (LuV)

This follows the trend of fluid housings generally being more expensive than item housings, as well as protecting the tiering assertions of single vs multi fluid housings (multi-fluid housings should be higher tier than singles.)

The hope here is that this will allow players to use these higher-tier disks without having to engage in circuitous buffering with an ME output hatch. 