### PR TITLE
Add new recipes to star fuel and dark matter

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -16,6 +16,7 @@ import com.dreammaster.gthandler.CustomItemList;
 import com.dreammaster.gthandler.DTPFCalculator;
 import com.dreammaster.gthandler.GT_CoreModSupport;
 
+import goodgenerator.items.MyMaterial;
 import goodgenerator.util.ItemRefer;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
@@ -704,7 +705,6 @@ public class DTPFRecipes implements Runnable {
                         .duration(infinity.getDuration(2) / 128).eut(infinity.getEUt(2) / 64)
                         .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
 
-                long fuel_quantity_1 = 58_932L;
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 1L, 5),
@@ -717,7 +717,6 @@ public class DTPFRecipes implements Runnable {
                         .duration(infinity.getDuration(2)).eut(infinity.getEUt(2)).metadata(COIL_HEAT, hypogen_heat)
                         .addTo(plasmaForgeRecipes);
 
-                long fuel_quantity_2 = 26_244L;
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 2L, 5),
@@ -730,7 +729,6 @@ public class DTPFRecipes implements Runnable {
                         .duration(infinity.getDuration(3)).eut(infinity.getEUt(3)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
 
-                long fuel_quantity_6 = 11_373L;
                 GT_Values.RA.stdBuilder()
                         .itemInputs(
                                 GT_ModHandler.getModItem(Avaritia.ID, "Resource", 4L, 5),
@@ -742,6 +740,24 @@ public class DTPFRecipes implements Runnable {
                                 Materials.Infinity.getMolten(256L * 144L))
                         .duration(infinity.getDuration(4)).eut(infinity.getEUt(4)).metadata(COIL_HEAT, eternal_heat)
                         .addTo(plasmaForgeRecipes);
+
+                if (GalacticraftAmunRa.isModLoaded()) {
+                    // Dark Matter
+                    GT_Values.RA.stdBuilder()
+                            .itemInputs(
+                                    GT_OreDictUnificator.get(OrePrefixes.block, MaterialsUEVplus.TranscendentMetal, 16),
+                                    GT_ModHandler.getModItem(Avaritia.ID, "Resource", 32L, 8),
+                                    GT_Utility.copyAmount(0, Particle.getBaseParticle(Particle.HIGGS_BOSON)))
+                            .fluidInputs(
+                                    MaterialsUEVplus.ExcitedDTEC.getFluid(1797693L),
+                                    Materials.CosmicNeutronium.getMolten(16384 * 144),
+                                    MyMaterial.tairitsu.getMolten(16384 * 144),
+                                    ELEMENT.STANDALONE.CELESTIAL_TUNGSTEN.getFluidStack(4096 * 144))
+                            .itemOutputs(GT_ModHandler.getModItem(GalacticraftAmunRa.ID, "tile.baseBlockRock", 1L, 14))
+                            .duration(80 * SECONDS)
+                            .fluidOutputs(MaterialsUEVplus.DimensionallyTranscendentResidue.getFluid(1797693L))
+                            .eut(TierEU.RECIPE_UMV).metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
+                }
             }
 
             // Quantum anomaly

--- a/src/main/java/com/dreammaster/gthandler/recipes/ExtractorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ExtractorRecipes.java
@@ -1,6 +1,7 @@
 package com.dreammaster.gthandler.recipes;
 
 import static gregtech.api.enums.Mods.BiomesOPlenty;
+import static gregtech.api.enums.Mods.GalacticraftAmunRa;
 import static gregtech.api.enums.Mods.GalaxySpace;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.Natura;
@@ -168,6 +169,13 @@ public class ExtractorRecipes implements Runnable {
                     .itemOutputs(new ItemStack(Items.glowstone_dust, 1, 0)).duration(15 * SECONDS).eut(2)
                     .addTo(extractorRecipes);
 
+        }
+
+        if (GalacticraftAmunRa.isModLoaded()) {
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(GT_ModHandler.getModItem(GalacticraftAmunRa.ID, "tile.baseBlockRock", 1L, 14))
+                    .itemOutputs(GT_ModHandler.getModItem(GalacticraftAmunRa.ID, "item.baseItem", 8L, 26))
+                    .duration(15 * SECONDS).eut(TierEU.RECIPE_UMV).addTo(extractorRecipes);
         }
 
     }

--- a/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
@@ -2,6 +2,7 @@ package com.dreammaster.gthandler.recipes;
 
 import static com.dreammaster.bartworksHandler.BartWorksMaterials.getBartWorksMaterialByIGNName;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
+import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.BartWorks;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.Chisel;
@@ -16,8 +17,10 @@ import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.PamsHarvestCraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.TinkerConstruct;
+import static gregtech.api.enums.Mods.UniversalSingularities;
 import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.recipe.RecipeMaps.mixerRecipes;
+import static gregtech.api.util.GT_ModHandler.getModItem;
 import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 import static gregtech.api.util.GT_RecipeBuilder.TICKS;
@@ -31,6 +34,7 @@ import net.minecraftforge.fluids.FluidStack;
 import com.dreammaster.gthandler.CustomItemList;
 import com.dreammaster.gthandler.GT_CoreModSupport;
 
+import goodgenerator.items.MyMaterial;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -1189,6 +1193,21 @@ public class MixerRecipes implements Runnable {
                         .itemOutputs(GT_ModHandler.getModItem(Chisel.ID, "hempcrete", 1L, meta)).duration(5 * SECONDS)
                         .eut(TierEU.RECIPE_LV).addTo(mixerRecipes);
             }
+        }
+
+        if (UniversalSingularities.isModLoaded() && Avaritia.isModLoaded()) {
+            // Star Fuel
+            GT_Values.RA.stdBuilder()
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.block, Materials.Neutronium, 64),
+                            GT_OreDictUnificator.get(OrePrefixes.block, Materials.CosmicNeutronium, 64L),
+                            // Diamond Singularity
+                            getModItem(UniversalSingularities.ID, "universal.vanilla.singularity", 1L, 2))
+                    .itemOutputs(GT_ModHandler.getModItem(Avaritia.ID, "Resource", 1L, 8))
+                    .fluidInputs(
+                            MyMaterial.naquadahBasedFuelMkV.getFluidOrGas(1000),
+                            MaterialsUEVplus.ExcitedDTEC.getFluid(128000))
+                    .duration(3 * SECONDS).eut(TierEU.RECIPE_UIV).addTo(mixerRecipes);
         }
     }
 }


### PR DESCRIPTION
This PR adds a new recipes to the avaritia star fuel item and amun ra dark matter, both of which are planned to be used in the upcoming godforge multiblock. Dark matter can be found naturally generating on the mehen belt, these recipes are optional ones for those who dont want to go search for it in world.
![image](https://github.com/user-attachments/assets/202c5c79-6efc-4f4e-b9cd-65156a86e0f8)
![image](https://github.com/user-attachments/assets/0a7a5b21-fa47-404e-bfe3-23959580494d)
![image](https://github.com/user-attachments/assets/474aa043-1fea-4492-b6c8-716cd1a262a1)
