### PR TITLE
Fix off-by-one error in chunk randomization

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/multiAirFilter/GT_MetaTileEntity_AirFilterBase.java
+++ b/src/main/java/com/dreammaster/gthandler/multiAirFilter/GT_MetaTileEntity_AirFilterBase.java
@@ -398,7 +398,7 @@ public abstract class GT_MetaTileEntity_AirFilterBase
                 // pick the chunk randomly
                 ChunkCoordinates pollutedChunk;
                 if (pollutedChunkList.size() > 1) {
-                    pollutedChunk = pollutedChunkList.get(MainRegistry.Rnd.nextInt(pollutedChunkList.size() - 1));
+                    pollutedChunk = pollutedChunkList.get(MainRegistry.Rnd.nextInt(pollutedChunkList.size()));
                     pollutedChunk.removePollution(pollutionCleaningRatePerSecond);
                 } else if (pollutedChunkList.size() == 1) { // no random on only one element
                     pollutedChunk = pollutedChunkList.get(0);


### PR DESCRIPTION
Random.nextInt(int) is already exclusive on the upper end, so the -1 actually causes precisely one chunk to be ignored.