### PR TITLE
Add recipes to pre-add planet block to EOH controller

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,6 +4,7 @@ dependencies {
     api("com.github.GTNewHorizons:GT5-Unofficial:5.09.48.113:dev")
     api("com.github.GTNewHorizons:Yamcl:0.6.0:dev")
     api("com.github.GTNewHorizons:Baubles:1.0.4:dev")
+    implementation('com.github.GTNewHorizons:GTNEIOrePlugin:1.3.2:dev') { transitive = false }
 
     compileOnly("com.github.GTNewHorizons:AkashicTome:1.1.4:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Avaritia:1.51:dev") { transitive = false }

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -55,6 +55,8 @@ import gregtech.api.util.GT_OreDictUnificator;
 import gregtech.api.util.GT_Utility;
 import gregtech.common.GT_Proxy;
 import ic2.core.Ic2Items;
+import pers.gwyog.gtneioreplugin.plugin.block.ModBlocks;
+import pers.gwyog.gtneioreplugin.util.DimensionHelper;
 
 public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_CraftingRecipeLoader implements Runnable {
 
@@ -1970,6 +1972,23 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.GT_Crafti
                     modifiedBus,
                     new Object[] { ItemList.Hatch_Output_Bus_ME.get(1L), itemComponents[i] });
         }
+
+        // Pre-add planet block to EOH controller
+        for (String dimAbbreviation : DimensionHelper.DimNameDisplayed) {
+            ItemStack dimDisplay = new ItemStack(ModBlocks.getBlock(dimAbbreviation));
+            ItemStack EOHController = com.github.technus.tectech.thing.CustomItemList.Machine_Multi_EyeOfHarmony
+                    .get(1L);
+            ItemStack NBTController = EOHController.copy();
+            NBTTagCompound nbt = new NBTTagCompound();
+            nbt.setString("planetBlock", dimAbbreviation);
+            NBTController.setTagCompound(nbt);
+            GT_ModHandler.addShapelessCraftingRecipe(NBTController, new Object[] { EOHController, dimDisplay });
+        }
+
+        // Transform EOH controller back to non-NBT one
+        GT_ModHandler.addShapelessCraftingRecipe(
+                com.github.technus.tectech.thing.CustomItemList.Machine_Multi_EyeOfHarmony.get(1L),
+                new Object[] { com.github.technus.tectech.thing.CustomItemList.Machine_Multi_EyeOfHarmony.get(1L) });
     }
 
     private Consumer<Recipe> shapelessUnremovableGtRecipes() {


### PR DESCRIPTION
Requires https://github.com/GTNewHorizons/GT5-Unofficial/pull/2792
Adds shapeless recipes to craft EOH controller with planet block. A planet block will be added to controller slot when placing the controller.