### PR TITLE
Final recipes for waterline

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2114,6 +2114,61 @@ public class AssemblerRecipes implements Runnable {
                 .itemOutputs(ItemList.BlockPlasmaHeatingCasing.get(1)).eut(TierEU.RECIPE_ZPM).duration(10 * SECONDS)
                 .addTo(assemblerRecipes);
 
+        // Ph sensor hatch
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Casing_LuV.get(1),
+                        ItemList.Cover_ActivityDetector.get(1),
+                        ItemList.Cover_Screen.get(1),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.NaquadahAlloy, 4),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.LuV, 1),
+                        ItemList.Sensor_LuV.get(1),
+                        ItemList.Emitter_LuV.get(1),
+                        GT_Utility.getIntegratedCircuit(1))
+                .fluidInputs(Materials.SolderingAlloy.getMolten(8 * 144)).itemOutputs(ItemList.Hatch_pHSensor.get(1))
+                .eut(TierEU.RECIPE_LuV).duration(10 * SECONDS).addTo(assemblerRecipes);
+
+        // Lens housing
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Hatch_Input_Bus_UV.get(1),
+                        GT_OreDictUnificator.get(OrePrefixes.ring, Materials.Neutronium, 4),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Draconium, 4),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.SuperconductorUHV, 1),
+                        GT_Utility.getIntegratedCircuit(1))
+                .fluidInputs(Materials.SolderingAlloy.getMolten(8 * 144)).itemOutputs(ItemList.Hatch_LensHousing.get(1))
+                .eut(TierEU.RECIPE_ZPM).duration(10 * SECONDS).addTo(assemblerRecipes);
+
+        // lens indicator hatch
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Casing_UV.get(1),
+                        ItemList.Cover_ActivityDetector.get(1),
+                        ItemList.Cover_Screen.get(1),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Neutronium, 4),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.SuperconductorUHV, 1),
+                        ItemList.Sensor_UV.get(1),
+                        ItemList.Emitter_UV.get(1),
+                        GT_Utility.getIntegratedCircuit(1))
+                .fluidInputs(Materials.SolderingAlloy.getMolten(8 * 144))
+                .itemOutputs(ItemList.Hatch_LensIndicator.get(1)).eut(TierEU.RECIPE_ZPM).duration(10 * SECONDS)
+                .addTo(assemblerRecipes);
+
+        // degasser control hatch
+        GT_Values.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Casing_UV.get(1),
+                        ItemList.Cover_ActivityDetector.get(1),
+                        ItemList.Cover_Screen.get(1),
+                        GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Infinity, 4),
+                        GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.UHV, 1),
+                        ItemList.Sensor_UHV.get(1),
+                        ItemList.Emitter_UHV.get(1),
+                        GT_Utility.getIntegratedCircuit(1))
+                .fluidInputs(Materials.SolderingAlloy.getMolten(8 * 144))
+                .itemOutputs(ItemList.Hatch_DegasifierControl.get(1)).eut(TierEU.RECIPE_UHV).duration(10 * SECONDS)
+                .addTo(assemblerRecipes);
+
         if (HardcoreEnderExpansion.isModLoaded()) {
             // Biome Compass
             GT_Values.RA.stdBuilder()

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -40,6 +40,7 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
 import gregtech.api.util.GT_OreDictUnificator;
+import gtPlusPlus.core.material.Particle;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 
 public class AssemblingLineRecipes implements Runnable {
@@ -981,6 +982,105 @@ public class AssemblingLineRecipes implements Runnable {
                             Materials.Lubricant.getFluid(128000))
                     .itemOutputs(ItemList.Machine_Multi_PurificationUnitDegasifier.get(1)).duration(60 * SECONDS)
                     .eut(TierEU.RECIPE_UEV).addTo(AssemblyLine);
+
+            GT_Values.RA.stdBuilder().metadata(RESEARCH_ITEM, Materials.Grade7PurifiedWater.getCells(1))
+                    .metadata(RESEARCH_TIME, 1 * HOURS)
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Infinity, 16),
+                            ItemList.BlockQuarkContainmentCasing.get(8),
+                            ItemList.BlockQuarkReleaseChamber.get(8),
+                            com.github.technus.tectech.thing.CustomItemList.eM_energyMulti64_UEV.get(1),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Infinity, 16),
+                            GT_OreDictUnificator.get(OrePrefixes.rotor, Materials.Infinity, 8),
+                            GT_OreDictUnificator.get(OrePrefixes.rotor, Materials.CosmicNeutronium, 8),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CosmicNeutronium, 16),
+                            ItemList.Electric_Motor_UEV.get(8),
+                            ItemList.Electric_Pump_UEV.get(8),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.UHV, 16),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.UEV, 8),
+                            GT_OreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Infinity, 64))
+                    .fluidInputs(
+                            Materials.SuperconductorUHV.getMolten(64 * 144),
+                            Materials.Infinity.getMolten(64 * 144),
+                            new FluidStack(solderUEV, 64 * 144),
+                            Materials.Lubricant.getFluid(128000))
+                    .itemOutputs(ItemList.Machine_Multi_PurificationUnitParticleExtractor.get(1)).duration(60 * SECONDS)
+                    .eut(TierEU.RECIPE_UIV).addTo(AssemblyLine);
+
+            // Quark exclusion casing
+            GT_Values.RA.stdBuilder().metadata(RESEARCH_ITEM, Particle.getBaseParticle(Particle.STRANGE))
+                    .metadata(RESEARCH_TIME, 1 * HOURS)
+                    .itemInputs(
+                            GT_OreDictUnificator
+                                    .get(OrePrefixes.frameGt, Materials.Longasssuperconductornameforuhvwire, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Ledox, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.CallistoIce, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.EnrichedHolmium, 4),
+                            GT_OreDictUnificator
+                                    .get(OrePrefixes.plate, Materials.Longasssuperconductornameforuhvwire, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Ledox, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CallistoIce, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.EnrichedHolmium, 4),
+                            ItemList.Field_Generator_UEV.get(1),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.UEV, 2),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.UIV, 1),
+                            GT_OreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Infinity, 4))
+                    .fluidInputs(
+                            Materials.Longasssuperconductornameforuhvwire.getMolten(8 * 144),
+                            Materials.Ledox.getMolten(8 * 144),
+                            Materials.CallistoIce.getMolten(8 * 144),
+                            MaterialsUEVplus.ExcitedDTRC.getFluid(1000L))
+                    .itemOutputs(ItemList.BlockQuarkContainmentCasing.get(1)).duration(60 * SECONDS)
+                    .eut(TierEU.RECIPE_UIV).addTo(AssemblyLine);
+
+            // Femtometer-calibrated particle beam casing
+            GT_Values.RA.stdBuilder().metadata(RESEARCH_ITEM, Particle.getBaseParticle(Particle.CHARM))
+                    .metadata(RESEARCH_TIME, 1 * HOURS)
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.CosmicNeutronium, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Infinity, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Tritanium, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Neutronium, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.CosmicNeutronium, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Infinity, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Tritanium, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.plate, Materials.Neutronium, 4),
+                            ItemList.Field_Generator_UEV.get(1),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.UEV, 2),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.UIV, 1),
+                            GT_OreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Infinity, 4))
+                    .fluidInputs(
+                            Materials.Infinity.getMolten(8 * 144),
+                            Materials.Tritanium.getMolten(8 * 144),
+                            new FluidStack(solderUEV, 8 * 144),
+                            MaterialsUEVplus.ExcitedDTRC.getFluid(1000L))
+                    .itemOutputs(ItemList.BlockQuarkReleaseChamber.get(1)).duration(60 * SECONDS).eut(TierEU.RECIPE_UIV)
+                    .addTo(AssemblyLine);
+
+            // Particle beam guidance pipe casing
+            GT_Values.RA.stdBuilder().metadata(RESEARCH_ITEM, Particle.getBaseParticle(Particle.BOTTOM))
+                    .metadata(RESEARCH_TIME, 1 * HOURS)
+                    .itemInputs(
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.CosmicNeutronium, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Naquadria, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.NaquadahAlloy, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.Bedrockium, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Infinity, 16),
+                            GT_OreDictUnificator.get(OrePrefixes.foil, Materials.CosmicNeutronium, 16),
+                            GT_OreDictUnificator
+                                    .get(OrePrefixes.foil, Materials.Longasssuperconductornameforuhvwire, 16),
+                            GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Draconium, 16),
+                            ItemList.Field_Generator_UEV.get(1),
+                            ItemList.Tesseract.get(1),
+                            GT_OreDictUnificator.get(OrePrefixes.circuit, Materials.UEV, 4),
+                            GT_OreDictUnificator.get(OrePrefixes.pipeQuadruple, Materials.Infinity, 4))
+                    .fluidInputs(
+                            Materials.Infinity.getMolten(8 * 144),
+                            Materials.Tritanium.getMolten(8 * 144),
+                            new FluidStack(solderUEV, 8 * 144),
+                            MaterialsUEVplus.ExcitedDTRC.getFluid(1000L))
+                    .itemOutputs(ItemList.BlockQuarkPipe.get(1)).duration(60 * SECONDS).eut(TierEU.RECIPE_UIV)
+                    .addTo(AssemblyLine);
         }
 
         // Piko Circuit

--- a/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
@@ -18,6 +18,7 @@ import com.dreammaster.gthandler.GT_CustomLoader;
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.MaterialsUEVplus;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GT_ModHandler;
@@ -108,6 +109,12 @@ public class FluidSolidifierRecipes implements Runnable {
         GT_Values.RA.stdBuilder().itemInputs(ItemList.GlassUVResistant.get(1))
                 .fluidInputs(Materials.Infinity.getMolten(144))
                 .itemOutputs(ItemList.GlassOmniPurposeInfinityFused.get(1)).eut(TierEU.RECIPE_UEV).duration(5 * SECONDS)
+                .addTo(fluidSolidifierRecipes);
+
+        // Non photonic matter exclusion glass
+        GT_Values.RA.stdBuilder().itemInputs(ItemList.GlassOmniPurposeInfinityFused.get(1))
+                .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(1000L))
+                .itemOutputs(ItemList.GlassQuarkContainment.get(1)).eut(TierEU.RECIPE_UEV).duration(5 * SECONDS)
                 .addTo(fluidSolidifierRecipes);
 
         if (TinkerConstruct.isModLoaded()) {


### PR DESCRIPTION
Adds all missing recipes for waterline hatches and T8 casings.

![image](https://github.com/user-attachments/assets/75b362a7-3599-4b49-b40d-c2765958a91c)
*pH Sensor Hatch*

![image](https://github.com/user-attachments/assets/003fdc6d-40eb-4dc0-bf00-27ce9e612f85)
*Lens Housing*

![image](https://github.com/user-attachments/assets/866c693b-c2f5-4c7d-b412-a786f4acd276)
*Lens Indicator Hatch*

![image](https://github.com/user-attachments/assets/c09d636c-c12c-4931-8a65-7c62c511c2ea)
*Degasser Control Hatch*

![image](https://github.com/user-attachments/assets/fa7eb297-511b-49c9-9d3b-2197544e6046)
*Absolute Baryonic Perfection Purification Unit (screenshot missing molten superconductor base UHV)*

![image](https://github.com/user-attachments/assets/8fab92fa-4e94-47d1-aca5-71b2f8631a4c)
*Quark Exclusion Casing*

![image](https://github.com/user-attachments/assets/3675e591-78fd-42d3-8e55-ca319872013b)
*Femtometer-Calibrated Particle Beam Casing*

![image](https://github.com/user-attachments/assets/616becc7-2f6b-4b35-a3e5-cc71c32e9bb5)
*Particle Beam Guidance Casing*

![image](https://github.com/user-attachments/assets/6815dd9d-b488-43b0-9af7-ad2acddc4374)
*Non-Photonic Matter Exclusion Glass*

