### PR TITLE
fix grapple recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -14,6 +14,7 @@ import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.NewHorizonsCoreMod;
 import static gregtech.api.enums.Mods.PamsHarvestCraft;
 import static gregtech.api.enums.Mods.ProjectRedIllumination;
+import static gregtech.api.enums.Mods.TinkersGregworks;
 import static gregtech.api.recipe.RecipeMaps.arcFurnaceRecipes;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.recipe.RecipeMaps.blastFurnaceRecipes;
@@ -1095,11 +1096,17 @@ public class ScriptGalacticraft implements IScriptLoader {
                 getModItem(GalacticraftMars.ID, "item.grapple", 1, 0, missing),
                 null,
                 null,
-                "toolHeadArrowMeteoricSteel",
+                createItemStack(
+                        TinkersGregworks.ID,
+                        "tGregToolPartArrowHead",
+                        1,
+                        1573,
+                        "{material:\"MeteoricSteel\"}",
+                        missing),
                 CustomItemList.MeteoricIronString.get(1L),
                 CustomItemList.MeteoricIronString.get(1L),
                 CustomItemList.MeteoricIronString.get(1L),
-                "ringMeteoricSteel",
+                "springMeteoricSteel",
                 null,
                 null);
         addShapedRecipe(


### PR DESCRIPTION
the toolHeadArrow was removed so this recipe was broken. now uses the corresponding tinker arrow head. (and a spring because thats how it works :P )

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17018