### PR TITLE
Move radox to GT5u

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.38:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.40:dev")
     api("com.github.GTNewHorizons:Yamcl:0.6.0:dev")
     api("com.github.GTNewHorizons:Baubles:1.0.4:dev")
 
@@ -22,7 +22,6 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:amunra:0.6.0:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Galacticraft:3.2.1-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.7:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:DetravScannerMod:1.8.1:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.4.5-GTNH:dev")
 
     runtimeOnlyNonPublishable rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")

--- a/src/main/java/com/dreammaster/bartworksHandler/BacteriaRegistry.java
+++ b/src/main/java/com/dreammaster/bartworksHandler/BacteriaRegistry.java
@@ -34,7 +34,6 @@ import net.minecraftforge.oredict.OreDictionary;
 
 import com.dreammaster.fluids.FluidList;
 import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.gthandler.GT_CoreModSupport;
 import com.github.bartimaeusnek.bartworks.common.loaders.BioItemList;
 import com.github.bartimaeusnek.bartworks.util.BioCulture;
 import com.github.bartimaeusnek.bartworks.util.BioDNA;
@@ -186,7 +185,7 @@ public class BacteriaRegistry {
 
     private void runAdditionalFuelRecipes() {
         // XenoxRecycleRecipe
-        GT_Values.RA.stdBuilder().itemOutputs(Ash.getDust(1)).fluidInputs(DelutedXenoxene.getFluid(1000))
+        GT_Values.RA.stdBuilder().itemOutputs(Ash.getDust(1)).fluidInputs(Materials.DilutedXenoxene.getFluid(1000))
                 .fluidOutputs(Xenoxene.getFluid(250), RadoxLight.getGas(300)).duration(30 * SECONDS)
                 .eut(TierEU.RECIPE_UV).addTo(distillationTowerRecipes);
 
@@ -214,10 +213,11 @@ public class BacteriaRegistry {
                 .itemInputs(
                         GT_ModHandler.getModItem(GalaxySpace.ID, "barnardaClog", 64L),
                         GT_Utility.getIntegratedCircuit(24))
-                .itemOutputs(Ash.getDust(8)).fluidInputs(Xenoxene.getFluid(1000)).fluidOutputs(RawRadox.getFluid(1000))
-                .duration(3 * MINUTES).eut(TierEU.RECIPE_UV).addTo(pyrolyseRecipes);
+                .itemOutputs(Ash.getDust(8)).fluidInputs(Materials.Xenoxene.getFluid(1000))
+                .fluidOutputs(Materials.RawRadox.getFluid(1000)).duration(3 * MINUTES).eut(TierEU.RECIPE_UV)
+                .addTo(pyrolyseRecipes);
 
-        GT_Values.RA.stdBuilder().itemOutputs(Ash.getDust(5)).fluidInputs(RawRadox.getFluid(5000))
+        GT_Values.RA.stdBuilder().itemOutputs(Ash.getDust(5)).fluidInputs(Materials.RawRadox.getFluid(5000))
                 .fluidOutputs(
                         OilHeavy.getFluid(600),
                         Oil.getFluid(300),
@@ -227,7 +227,7 @@ public class BacteriaRegistry {
                         FermentedBiomass.getFluid(50),
                         RadoxSuperHeavy.getFluid(100),
                         RadoxHeavy.getFluid(150),
-                        DelutedXenoxene.getFluid(50),
+                        DilutedXenoxene.getFluid(50),
                         RadoxLight.getGas(300),
                         RadoxSuperLight.getGas(500))
                 .duration(40 * SECONDS).eut(TierEU.RECIPE_UHV).addTo(distillationTowerRecipes);
@@ -255,8 +255,8 @@ public class BacteriaRegistry {
 
         GT_Values.RA.stdBuilder().itemInputs(GT_Utility.getIntegratedCircuit(2))
                 .fluidInputs(RadoxGas.getGas(2160), Oxygen.getPlasma(7500L), Titanium.getPlasma(100L))
-                .fluidOutputs(GT_CoreModSupport.RadoxPolymer.getMolten(720L)).duration(30 * SECONDS)
-                .eut(TierEU.RECIPE_UV).addTo(multiblockChemicalReactorRecipes);
+                .fluidOutputs(Materials.RadoxPolymer.getMolten(720L)).duration(30 * SECONDS).eut(TierEU.RECIPE_UV)
+                .addTo(multiblockChemicalReactorRecipes);
 
         GT_Values.RA.stdBuilder().itemInputs(GT_OreDictUnificator.get(OrePrefixes.cell, RadoxPolymer, 1L))
                 .itemOutputs(GT_OreDictUnificator.get(OrePrefixes.cellMolten, RadoxPolymer, 1L)).duration(30 * SECONDS)

--- a/src/main/java/com/dreammaster/gthandler/CoreMod_PCBFactory_MaterialLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/CoreMod_PCBFactory_MaterialLoader.java
@@ -1,10 +1,11 @@
 package com.dreammaster.gthandler;
 
+import gregtech.api.enums.Materials;
 import gregtech.api.util.GT_PCBFactoryManager;
 
 public class CoreMod_PCBFactory_MaterialLoader {
 
     public static void init() {
-        GT_PCBFactoryManager.addPlasticTier(GT_CoreModSupport.RadoxPolymer, 8);
+        GT_PCBFactoryManager.addPlasticTier(Materials.RadoxPolymer, 8);
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/GT_CoreModSupport.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CoreModSupport.java
@@ -1,67 +1,9 @@
 package com.dreammaster.gthandler;
 
-import java.util.Arrays;
-
-import gregtech.api.enums.Dyes;
-import gregtech.api.enums.MaterialBuilder;
 import gregtech.api.enums.Materials;
-import gregtech.api.enums.TC_Aspects;
-import gregtech.api.enums.TextureSet;
 import gregtech.api.interfaces.IMaterialHandler;
-import gregtech.api.objects.MaterialStack;
 
 public class GT_CoreModSupport implements IMaterialHandler {
-
-    public static Materials RawRadox = new MaterialBuilder(-1, TextureSet.SET_DULL, "Raw Radox").setRGB(80, 30, 80)
-            .addFluid().constructMaterial();
-    public static Materials RadoxSuperLight = new MaterialBuilder(-1, TextureSet.SET_DULL, "Super Light Radox")
-            .setRGB(155, 0, 155).addGas().constructMaterial();
-    public static Materials RadoxLight = new MaterialBuilder(-1, TextureSet.SET_DULL, "Light Radox").setRGB(140, 0, 140)
-            .addGas().constructMaterial();
-    public static Materials RadoxHeavy = new MaterialBuilder(-1, TextureSet.SET_DULL, "Heavy Radox").setRGB(115, 0, 115)
-            .addFluid().constructMaterial();
-    public static Materials RadoxSuperHeavy = new MaterialBuilder(-1, TextureSet.SET_DULL, "Super Heavy Radox")
-            .setRGB(100, 0, 100).addFluid().constructMaterial();
-    public static Materials Xenoxene = new MaterialBuilder(-1, TextureSet.SET_DULL, "Xenoxene").setRGB(133, 130, 128)
-            .addFluid().constructMaterial();
-    public static Materials DelutedXenoxene = new MaterialBuilder(-1, TextureSet.SET_DULL, "Diluted Xenoxene")
-            .setRGB(206, 200, 196).addFluid().constructMaterial();
-    public static Materials RadoxCracked = new MaterialBuilder(-1, TextureSet.SET_DULL, "Cracked Radox")
-            .setRGB(180, 130, 180).addGas().constructMaterial();
-    public static Materials RadoxGas = new MaterialBuilder(-1, TextureSet.SET_DULL, "Radox Gas").setRGB(255, 130, 255)
-            .addGas().constructMaterial();
-    public static Materials RadoxPolymer = new Materials(
-            979, // Material ID was choosen randomly
-            TextureSet.SET_DULL,
-            8.0F,
-            346,
-            3,
-            1 | 2 | 16,
-            133,
-            0,
-            128,
-            0,
-            "RadoxPoly",
-            "Radox Polymer",
-            0,
-            0,
-            6203,
-            0,
-            true,
-            false,
-            1,
-            1,
-            1,
-            Dyes.dyePurple,
-            0,
-            Arrays.asList(
-                    new MaterialStack(Materials.Carbon, 14),
-                    new MaterialStack(Materials.Osmium, 11),
-                    new MaterialStack(Materials.Oxygen, 7),
-                    new MaterialStack(Materials.Silver, 3),
-                    new MaterialStack(Materials.CallistoIce, 1)),
-            Arrays.asList(new TC_Aspects.TC_AspectStack(TC_Aspects.HUMANUS, 2))).setHasCorrespondingGas(true)
-                    .setGasTemperature(12406);
 
     public GT_CoreModSupport() {
         Materials.add(this);

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
@@ -1198,10 +1198,10 @@ public class GT_Loader_Machines {
 
         for (int aTier = 10; aTier < 15; aTier++) {
             GT_Values.RA.stdBuilder().itemInputs(flInputs[aTier - 10]).itemOutputs(inHatches[aTier - 10])
-                    .fluidInputs(GT_CoreModSupport.RadoxPolymer.getMolten((long) (2.25 * Math.pow(2, (aTier - 9)))))
+                    .fluidInputs(Materials.RadoxPolymer.getMolten((long) (2.25 * Math.pow(2, (aTier - 9)))))
                     .duration(24 * SECONDS).eut((int) (30 * Math.pow(4, (aTier - 1)))).addTo(assemblerRecipes);
             GT_Values.RA.stdBuilder().itemInputs(flInputs2[aTier - 10]).itemOutputs(outHatches[aTier - 10])
-                    .fluidInputs(GT_CoreModSupport.RadoxPolymer.getMolten((long) (2.25 * Math.pow(2, (aTier - 9)))))
+                    .fluidInputs(Materials.RadoxPolymer.getMolten((long) (2.25 * Math.pow(2, (aTier - 9)))))
                     .duration(24 * SECONDS).eut((int) (30 * Math.pow(4, (aTier - 1)))).addTo(assemblerRecipes);
         }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1,7 +1,6 @@
 package com.dreammaster.gthandler.recipes;
 
 import static com.dreammaster.bartworksHandler.BartWorksMaterials.getBartWorksMaterialByIGNName;
-import static com.dreammaster.gthandler.GT_CoreModSupport.Xenoxene;
 import static gregtech.api.enums.GT_Values.W;
 import static gregtech.api.enums.Mods.*;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
@@ -30,7 +29,6 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.gthandler.GT_CoreModSupport;
 import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
 import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
 import common.TileEntities;
@@ -2387,8 +2385,8 @@ public class AssemblerRecipes implements Runnable {
                             GT_OreDictUnificator.get(OrePrefixes.foil, Materials.CosmicNeutronium, 2),
                             (GT_ModHandler.getModItem(GTPlusPlus.ID, "itemFineWireChromaticGlass", 2)))
                     .itemOutputs(com.github.technus.tectech.thing.CustomItemList.DATApipe.get(64))
-                    .fluidInputs(GT_CoreModSupport.RadoxPolymer.getMolten(144L)).duration(10 * SECONDS)
-                    .eut(TierEU.RECIPE_UV).addTo(assemblerRecipes);
+                    .fluidInputs(Materials.RadoxPolymer.getMolten(144L)).duration(10 * SECONDS).eut(TierEU.RECIPE_UV)
+                    .addTo(assemblerRecipes);
         }
         // Fusion Coil Block
         GT_Values.RA.stdBuilder()
@@ -3595,8 +3593,9 @@ public class AssemblerRecipes implements Runnable {
                                 .get(OrePrefixes.foil, Materials.Tetranaquadahdiindiumhexaplatiumosminid, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorLuV, 1L),
                         GT_Utility.getIntegratedCircuit(9))
-                .itemOutputs(ItemList.Circuit_Parts_ResistorXSMD.get(32L)).fluidInputs(Xenoxene.getFluid(144L))
-                .duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM).addTo(assemblerRecipes);
+                .itemOutputs(ItemList.Circuit_Parts_ResistorXSMD.get(32L))
+                .fluidInputs(Materials.Xenoxene.getFluid(144L)).duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM)
+                .addTo(assemblerRecipes);
         // Transistor
 
         GT_Values.RA.stdBuilder()
@@ -3607,8 +3606,9 @@ public class AssemblerRecipes implements Runnable {
                                 .get(OrePrefixes.foil, Materials.Tetranaquadahdiindiumhexaplatiumosminid, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorLuV, 1L),
                         GT_Utility.getIntegratedCircuit(9))
-                .itemOutputs(ItemList.Circuit_Parts_TransistorXSMD.get(32L)).fluidInputs(Xenoxene.getFluid(144L))
-                .duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM).addTo(assemblerRecipes);
+                .itemOutputs(ItemList.Circuit_Parts_TransistorXSMD.get(32L))
+                .fluidInputs((Materials.Xenoxene.getFluid(144L))).duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM)
+                .addTo(assemblerRecipes);
         // Capacitor
 
         GT_Values.RA.stdBuilder()
@@ -3619,8 +3619,9 @@ public class AssemblerRecipes implements Runnable {
                                 .get(OrePrefixes.foil, Materials.Tetranaquadahdiindiumhexaplatiumosminid, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorLuV, 1L),
                         GT_Utility.getIntegratedCircuit(9))
-                .itemOutputs(ItemList.Circuit_Parts_CapacitorXSMD.get(32L)).fluidInputs(Xenoxene.getFluid(144L))
-                .duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM).addTo(assemblerRecipes);
+                .itemOutputs(ItemList.Circuit_Parts_CapacitorXSMD.get(32L))
+                .fluidInputs((Materials.Xenoxene.getFluid(144L))).duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM)
+                .addTo(assemblerRecipes);
         // Diode
 
         GT_Values.RA.stdBuilder()
@@ -3631,7 +3632,7 @@ public class AssemblerRecipes implements Runnable {
                                 .get(OrePrefixes.foil, Materials.Tetranaquadahdiindiumhexaplatiumosminid, 1L),
                         GT_OreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorLuV, 1L),
                         GT_Utility.getIntegratedCircuit(9))
-                .itemOutputs(ItemList.Circuit_Parts_DiodeXSMD.get(64L)).fluidInputs(Xenoxene.getFluid(144L))
+                .itemOutputs(ItemList.Circuit_Parts_DiodeXSMD.get(64L)).fluidInputs((Materials.Xenoxene.getFluid(144L)))
                 .duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM).addTo(assemblerRecipes);
         // Inductor
 
@@ -3641,8 +3642,9 @@ public class AssemblerRecipes implements Runnable {
                         GT_ModHandler.getModItem(BartWorks.ID, "gt.bwMetaGeneratedfoil", 1L, 10102),
                         GT_OreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorLuV, 1L),
                         GT_Utility.getIntegratedCircuit(9))
-                .itemOutputs(ItemList.Circuit_Parts_InductorXSMD.get(32L)).fluidInputs(Xenoxene.getFluid(144L))
-                .duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM).addTo(assemblerRecipes);
+                .itemOutputs(ItemList.Circuit_Parts_InductorXSMD.get(32L))
+                .fluidInputs((Materials.Xenoxene.getFluid(144L))).duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM)
+                .addTo(assemblerRecipes);
 
     }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -34,7 +34,6 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.gthandler.GT_CoreModSupport;
 import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
 import com.github.technus.tectech.recipe.TT_recipeAdder;
 
@@ -467,7 +466,7 @@ public class AssemblingLineRecipes implements Runnable {
                                 CustomItemList.MicaInsulatorFoil.get(64), CustomItemList.MicaInsulatorFoil.get(64),
                                 CustomItemList.MicaInsulatorFoil.get(64), CustomItemList.MicaInsulatorFoil.get(64),
                                 CustomItemList.MicaInsulatorFoil.get(64) },
-                        new FluidStack[] { GT_CoreModSupport.RadoxPolymer.getMolten(3_456),
+                        new FluidStack[] { Materials.RadoxPolymer.getMolten(3_456),
                                 Materials.SuperCoolant.getFluid(16_000), new FluidStack(solderUEV, 11_520),
                                 Materials.UUMatter.getFluid(8_000) },
                         GT_ModHandler.getModItem(GalaxySpace.ID, "dysonswarmparts", 4, 6),
@@ -486,7 +485,7 @@ public class AssemblingLineRecipes implements Runnable {
                                 ItemList.Casing_Coil_AwakenedDraconium.get(4), CustomItemList.MicaInsulatorFoil.get(64),
                                 CustomItemList.MicaInsulatorFoil.get(64), CustomItemList.MicaInsulatorFoil.get(64),
                                 CustomItemList.MicaInsulatorFoil.get(64), CustomItemList.MicaInsulatorFoil.get(64) },
-                        new FluidStack[] { GT_CoreModSupport.RadoxPolymer.getMolten(3_240),
+                        new FluidStack[] { Materials.RadoxPolymer.getMolten(3_240),
                                 Materials.SuperCoolant.getFluid(16_000), new FluidStack(solderUEV, 11_520),
                                 Materials.UUMatter.getFluid(8_000) },
                         GT_ModHandler.getModItem(GalaxySpace.ID, "dysonswarmparts", 4, 7),
@@ -503,7 +502,7 @@ public class AssemblingLineRecipes implements Runnable {
                         new ItemStack[] { GT_OreDictUnificator.get(OrePrefixes.screw, Materials.CosmicNeutronium, 4),
                                 GT_OreDictUnificator.get(OrePrefixes.foil, Materials.Neutronium, 8),
                                 GT_OreDictUnificator.get(OrePrefixes.frameGt, Materials.SuperconductorUEVBase, 4), },
-                        new FluidStack[] { GT_CoreModSupport.RadoxPolymer.getMolten(144),
+                        new FluidStack[] { Materials.RadoxPolymer.getMolten(144),
                                 Materials.SuperCoolant.getFluid(16_000), new FluidStack(solderUEV, 11_520),
                                 Materials.UUMatter.getFluid(8_000) },
                         GT_ModHandler.getModItem(GalaxySpace.ID, "dysonswarmparts", 1, 8),

--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -14,7 +14,6 @@ import net.minecraftforge.fluids.FluidStack;
 import com.dreammaster.block.BlockList;
 import com.dreammaster.gthandler.CustomItemList;
 import com.dreammaster.gthandler.DTPFCalculator;
-import com.dreammaster.gthandler.GT_CoreModSupport;
 
 import goodgenerator.items.MyMaterial;
 import goodgenerator.util.ItemRefer;
@@ -1127,7 +1126,7 @@ public class DTPFRecipes implements Runnable {
                 long tier_1_quantity = 144L * base_quantity;
 
                 GT_Values.RA.stdBuilder().fluidInputs(
-                        GT_CoreModSupport.RadoxPolymer.getMolten(4L * tier_1_quantity / 25),
+                        Materials.RadoxPolymer.getMolten(4L * tier_1_quantity / 25),
                         MaterialsUEVplus.TranscendentMetal.getMolten(10L * tier_1_quantity / 25),
                         new FluidStack(FluidRegistry.getFluid("molten.rhugnor"), (int) tier_1_quantity * 6 / 25),
                         new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), (int) tier_1_quantity * 5 / 25),
@@ -1142,7 +1141,7 @@ public class DTPFRecipes implements Runnable {
                 long tier_2_quantity = 144L * base_quantity * tier_up_multiplier;
 
                 GT_Values.RA.stdBuilder().fluidInputs(
-                        GT_CoreModSupport.RadoxPolymer.getMolten(4L * tier_2_quantity / 25),
+                        Materials.RadoxPolymer.getMolten(4L * tier_2_quantity / 25),
                         MaterialsUEVplus.TranscendentMetal.getMolten(10L * tier_2_quantity / 25),
                         new FluidStack(FluidRegistry.getFluid("molten.rhugnor"), (int) tier_2_quantity * 6 / 25),
                         new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), (int) tier_2_quantity * 5 / 25),
@@ -1157,7 +1156,7 @@ public class DTPFRecipes implements Runnable {
                 long tier_3_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
 
                 GT_Values.RA.stdBuilder().fluidInputs(
-                        GT_CoreModSupport.RadoxPolymer.getMolten(4L * tier_3_quantity / 25),
+                        Materials.RadoxPolymer.getMolten(4L * tier_3_quantity / 25),
                         MaterialsUEVplus.TranscendentMetal.getMolten(10L * tier_3_quantity / 25),
                         new FluidStack(FluidRegistry.getFluid("molten.rhugnor"), (int) tier_3_quantity * 6 / 25),
                         new FluidStack(FluidRegistry.getFluid("molten.chromaticglass"), (int) tier_3_quantity * 5 / 25),

--- a/src/main/java/com/dreammaster/gthandler/recipes/LatheRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/LatheRecipes.java
@@ -6,7 +6,6 @@ import static gregtech.api.util.GT_RecipeBuilder.MINUTES;
 import static gregtech.api.util.GT_RecipeBuilder.SECONDS;
 
 import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.gthandler.GT_CoreModSupport;
 
 import gregtech.api.enums.GT_Values;
 import gregtech.api.enums.Materials;
@@ -24,7 +23,7 @@ public class LatheRecipes implements Runnable {
                 .itemOutputs(CustomItemList.ChromaticLens.get(1)).duration(60 * SECONDS).eut(TierEU.RECIPE_UHV)
                 .addTo(latheRecipes);
 
-        GT_Values.RA.stdBuilder().itemInputs(GT_CoreModSupport.RadoxPolymer.getPlates(1))
+        GT_Values.RA.stdBuilder().itemInputs(Materials.RadoxPolymer.getPlates(1))
                 .itemOutputs(CustomItemList.RadoxPolymerLens.get(1)).duration(1 * MINUTES + 30 * SECONDS)
                 .eut(TierEU.RECIPE_UEV).addTo(latheRecipes);
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
@@ -32,7 +32,6 @@ import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.gthandler.GT_CoreModSupport;
 
 import goodgenerator.items.MyMaterial;
 import gregtech.api.enums.GT_Values;
@@ -602,7 +601,7 @@ public class MixerRecipes implements Runnable {
 
         GT_Values.RA.stdBuilder()
                 .itemInputs(
-                        GT_OreDictUnificator.get(OrePrefixes.dust, GT_CoreModSupport.RadoxPolymer, 4L),
+                        GT_OreDictUnificator.get(OrePrefixes.dust, Materials.RadoxPolymer, 4L),
                         GT_OreDictUnificator.get(OrePrefixes.dust, MaterialsUEVplus.TranscendentMetal, 10L),
                         GT_ModHandler.getModItem(GTPlusPlus.ID, "itemDustRhugnor", 6L),
                         GT_ModHandler.getModItem(GTPlusPlus.ID, "itemDustChromaticGlass", 5L),

--- a/src/main/java/com/dreammaster/scripts/ScriptAmunRa.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAmunRa.java
@@ -37,7 +37,6 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
-import com.dreammaster.gthandler.GT_CoreModSupport;
 import com.github.technus.tectech.recipe.TT_recipeAdder;
 
 import cpw.mods.fml.common.Optional;
@@ -507,7 +506,7 @@ public class ScriptAmunRa implements IScriptLoader {
                         MaterialsKevlar.Kevlar.getPlates(7),
                         MaterialsKevlar.Kevlar.getPlates(7),
                         new Object[] { OrePrefixes.screw.get(Materials.Neutronium), 12 })
-                .fluidInputs(GT_CoreModSupport.RadoxPolymer.getMolten(4 * INGOTS))
+                .fluidInputs(Materials.RadoxPolymer.getMolten(4 * INGOTS))
                 .itemOutputs(com.dreammaster.item.ItemList.HeavyDutyAlloyIngotT9.getIS())
                 .metadata(GT_RecipeConstants.RESEARCH_ITEM, com.dreammaster.item.ItemList.HeavyDutyPlateTier8.getIS())
                 .metadata(GT_RecipeConstants.RESEARCH_TIME, 750 * SECONDS).duration(15 * SECONDS).eut(8000000)


### PR DESCRIPTION
Depends on https://github.com/GTNewHorizons/GT5-Unofficial/pull/3001 to access the radox materials in the GT5u `Materials` enum.