### PR TITLE
fix: migrate module recipe from forming press to assembler

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
@@ -431,7 +431,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                         getModItem(BuildCraftSilicon.ID, "redstoneChipset", 1, 2, missing),
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 2, 28, missing))
                 .itemOutputs(getModItem(LogisticsPipes.ID, "item.itemModule", 4, 502, missing)).duration(30 * SECONDS)
-                .eut(TierEU.RECIPE_LV).addTo(formingPressRecipes);
+                .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
 
         // Creative Tab Based ItemSink module
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c80d4c11-782e-4ad4-a87e-1c4f48fd7b9a)
Previously recipe was made for forming press, which is supposed to be LV tier. But since it requires 3 ingredients, its craft requires HV version. This commit transfers Active Supplier Module recipe from Forming Press to Assembler to allow its craft on LV tier.

The module itself is very simple, so old recipe was my mistake