### PR TITLE
add missing ismodloaded checks for forestry

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.84:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.49.87:dev")
     api("com.github.GTNewHorizons:Yamcl:0.6.0:dev")
     api("com.github.GTNewHorizons:Baubles:1.0.4:dev")
 
@@ -21,7 +21,7 @@ dependencies {
     compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.26:deobf") { transitive = false }
     compileOnly("com.github.GTNewHorizons:amunra:0.6.0:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Galacticraft:3.2.4-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.10:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.12:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.4.6-GTNH:dev")
 
     runtimeOnlyNonPublishable rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")

--- a/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
@@ -90,12 +90,6 @@ public class CentrifugeRecipes implements Runnable {
                 .fluidOutputs(Materials.Water.getFluid(500L)).duration(30 * SECONDS).eut(TierEU.RECIPE_MV)
                 .addTo(centrifugeRecipes);
 
-        GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(Forestry.ID, "beeCombs", 1L, 9))
-                .itemOutputs(
-                        GTModHandler.getModItem(Forestry.ID, "beeswax", 1L, 0),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iridium, 1L))
-                .outputChances(10000, 11).duration(15 * SECONDS).eut(TierEU.RECIPE_IV).addTo(centrifugeRecipes);
-
         GTValues.RA.stdBuilder().itemInputs(new ItemStack(Items.fire_charge, 1, 0))
                 .itemOutputs(
                         new ItemStack(Items.blaze_powder, 1, 0),
@@ -594,19 +588,6 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Electrum, 1L))
                 .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(centrifugeRecipes);
 
-        GTValues.RA.stdBuilder()
-                .itemInputs(GTUtility.getIntegratedCircuit(2), GTBees.combs.getStackForType(CombType.INDIUM, 8))
-                .fluidInputs(GGMaterial.thoriumBasedLiquidFuelDepleted.getFluidOrGas(1000))
-                .itemOutputs(
-                        WerkstoffLoader.Thorium232.get(OrePrefixes.dust, 64),
-                        WerkstoffLoader.Thorium232.get(OrePrefixes.dust, 16),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Praseodymium, 64),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Praseodymium, 32),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Boron, 2),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 12))
-                .outputChances(10000, 8000, 10000, 8000, 3000, 5000).duration(1 * MINUTES + 15 * SECONDS)
-                .eut(TierEU.RECIPE_EV / 2).addTo(centrifugeRecipes);
-
         GTValues.RA.stdBuilder().itemInputs(ItemList.Cell_Air.get(5L))
                 .itemOutputs(Materials.Oxygen.getCells(1), ItemList.Cell_Empty.get(4L))
                 .fluidOutputs(Materials.Nitrogen.getGas(3900L)).duration(1 * MINUTES + 20 * SECONDS).eut(8)
@@ -672,6 +653,24 @@ public class CentrifugeRecipes implements Runnable {
                     .fluidOutputs(Materials.FierySteel.getFluid(10L)).duration(12 * TICKS).eut(TierEU.RECIPE_HV)
                     .addTo(centrifugeRecipes);
         }
-
+        if (Forestry.isModLoaded()) {
+            GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(Forestry.ID, "beeCombs", 1L, 9))
+                    .itemOutputs(
+                            GTModHandler.getModItem(Forestry.ID, "beeswax", 1L, 0),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iridium, 1L))
+                    .outputChances(10000, 11).duration(15 * SECONDS).eut(TierEU.RECIPE_IV).addTo(centrifugeRecipes);
+            GTValues.RA.stdBuilder()
+                    .itemInputs(GTUtility.getIntegratedCircuit(2), GTBees.combs.getStackForType(CombType.INDIUM, 8))
+                    .fluidInputs(GGMaterial.thoriumBasedLiquidFuelDepleted.getFluidOrGas(1000))
+                    .itemOutputs(
+                            WerkstoffLoader.Thorium232.get(OrePrefixes.dust, 64),
+                            WerkstoffLoader.Thorium232.get(OrePrefixes.dust, 16),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Praseodymium, 64),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Praseodymium, 32),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Boron, 2),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 12))
+                    .outputChances(10000, 8000, 10000, 8000, 3000, 5000).duration(1 * MINUTES + 15 * SECONDS)
+                    .eut(TierEU.RECIPE_EV / 2).addTo(centrifugeRecipes);
+        }
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
@@ -2,6 +2,7 @@ package com.dreammaster.gthandler.recipes;
 
 import static goodgenerator.items.GGMaterial.indiumPhosphate;
 import static gregtech.api.enums.Mods.DraconicEvolution;
+import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.Gendustry;
 import static gregtech.api.enums.Mods.Genetics;
 import static gregtech.api.enums.Mods.HardcoreEnderExpansion;
@@ -577,34 +578,36 @@ public class ChemicalReactorRecipes implements Runnable {
                 .fluidInputs(Materials.Water.getFluid(16000L)).fluidOutputs(Materials.Hydrogen.getGas(48000L))
                 .duration(20 * SECONDS).eut(TierEU.RECIPE_HV).addTo(multiblockChemicalReactorRecipes);
 
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 36L),
-                        GTBees.combs.getStackForType(CombType.INDIUM, 4),
-                        GTUtility.getIntegratedCircuit(3))
-                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 3L))
-                .fluidInputs(new FluidStack(ItemList.sIndiumConcentrate, 72000))
-                .fluidOutputs(new FluidStack(ItemList.sLeadZincSolution, 72000)).duration(22 * SECONDS + 10 * TICKS)
-                .eut(TierEU.RECIPE_HV).addTo(multiblockChemicalReactorRecipes);
+        if (Forestry.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                    .itemInputs(
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 36L),
+                            GTBees.combs.getStackForType(CombType.INDIUM, 4),
+                            GTUtility.getIntegratedCircuit(3))
+                    .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 3L))
+                    .fluidInputs(new FluidStack(ItemList.sIndiumConcentrate, 72000))
+                    .fluidOutputs(new FluidStack(ItemList.sLeadZincSolution, 72000)).duration(22 * SECONDS + 10 * TICKS)
+                    .eut(TierEU.RECIPE_HV).addTo(multiblockChemicalReactorRecipes);
 
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        indiumPhosphate.get(OrePrefixes.dust, 12),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Calcium, 3),
-                        GTBees.combs.getStackForType(CombType.INDIUM, 8),
-                        GTUtility.getIntegratedCircuit(2))
-                .itemOutputs(
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 6),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.TricalciumPhosphate, 5))
-                .duration(1 * SECONDS).eut(TierEU.RECIPE_LV).addTo(multiblockChemicalReactorRecipes);
+            GTValues.RA.stdBuilder()
+                    .itemInputs(
+                            indiumPhosphate.get(OrePrefixes.dust, 12),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Calcium, 3),
+                            GTBees.combs.getStackForType(CombType.INDIUM, 8),
+                            GTUtility.getIntegratedCircuit(2))
+                    .itemOutputs(
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 6),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.TricalciumPhosphate, 5))
+                    .duration(1 * SECONDS).eut(TierEU.RECIPE_LV).addTo(multiblockChemicalReactorRecipes);
 
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Indium, 4),
-                        GTBees.combs.getStackForType(CombType.INDIUM, 16))
-                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Indium, 12))
-                .fluidInputs(Materials.PhthalicAcid.getFluid(2688)).duration(14 * SECONDS + 8 * TICKS)
-                .eut(TierEU.RECIPE_IV).addTo(UniversalChemical);
+            GTValues.RA.stdBuilder()
+                    .itemInputs(
+                            GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Indium, 4),
+                            GTBees.combs.getStackForType(CombType.INDIUM, 16))
+                    .itemOutputs(GTOreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Indium, 12))
+                    .fluidInputs(Materials.PhthalicAcid.getFluid(2688)).duration(14 * SECONDS + 8 * TICKS)
+                    .eut(TierEU.RECIPE_IV).addTo(UniversalChemical);
+        }
     }
 
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -131,70 +131,73 @@ public class DTPFRecipes implements Runnable {
                 long tier_1_quantity = 144L * base_quantity;
                 // Bee Recipes
 
-                GTValues.RA.stdBuilder()
-                        .itemInputs(
-                                GTBees.combs.getStackForType(CombType.COSMICNEUTRONIUM),
-                                GTUtility.getIntegratedCircuit(1))
-                        .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTCC.getFluid(cosmic_neutronium_bee.getCatalystAmount(0)),
-                                Materials.Copper.getMolten(tier_1_quantity))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue
-                                        .getFluid(cosmic_neutronium_bee.getResidueAmount(0)),
-                                Materials.CosmicNeutronium.getMolten(tier_1_quantity))
-                        .duration(cosmic_neutronium_bee.getDuration(0)).eut(cosmic_neutronium_bee.getEUt(0))
-                        .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
+                if (Forestry.isModLoaded()) {
 
-                long tier_2_bee_quantity = 144L * base_quantity * tier_up_multiplier;
+                    GTValues.RA.stdBuilder()
+                            .itemInputs(
+                                    GTBees.combs.getStackForType(CombType.COSMICNEUTRONIUM),
+                                    GTUtility.getIntegratedCircuit(1))
+                            .fluidInputs(
+                                    MaterialsUEVplus.ExcitedDTCC.getFluid(cosmic_neutronium_bee.getCatalystAmount(0)),
+                                    Materials.Copper.getMolten(tier_1_quantity))
+                            .fluidOutputs(
+                                    MaterialsUEVplus.DimensionallyTranscendentResidue
+                                            .getFluid(cosmic_neutronium_bee.getResidueAmount(0)),
+                                    Materials.CosmicNeutronium.getMolten(tier_1_quantity))
+                            .duration(cosmic_neutronium_bee.getDuration(0)).eut(cosmic_neutronium_bee.getEUt(0))
+                            .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
 
-                GTValues.RA.stdBuilder()
-                        .itemInputs(
-                                GTBees.combs.getStackForType(CombType.COSMICNEUTRONIUM),
-                                GTUtility.getIntegratedCircuit(1))
-                        .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTPC.getFluid(cosmic_neutronium_bee.getCatalystAmount(1)),
-                                Materials.Copper.getMolten(tier_2_bee_quantity))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue
-                                        .getFluid(cosmic_neutronium_bee.getResidueAmount(1)),
-                                Materials.CosmicNeutronium.getMolten(tier_2_bee_quantity))
-                        .duration(cosmic_neutronium_bee.getDuration(1)).eut(cosmic_neutronium_bee.getEUt(1))
-                        .metadata(COIL_HEAT, infinity_heat).addTo(plasmaForgeRecipes);
+                    long tier_2_bee_quantity = 144L * base_quantity * tier_up_multiplier;
 
-                long tier_3_bee_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
+                    GTValues.RA.stdBuilder()
+                            .itemInputs(
+                                    GTBees.combs.getStackForType(CombType.COSMICNEUTRONIUM),
+                                    GTUtility.getIntegratedCircuit(1))
+                            .fluidInputs(
+                                    MaterialsUEVplus.ExcitedDTPC.getFluid(cosmic_neutronium_bee.getCatalystAmount(1)),
+                                    Materials.Copper.getMolten(tier_2_bee_quantity))
+                            .fluidOutputs(
+                                    MaterialsUEVplus.DimensionallyTranscendentResidue
+                                            .getFluid(cosmic_neutronium_bee.getResidueAmount(1)),
+                                    Materials.CosmicNeutronium.getMolten(tier_2_bee_quantity))
+                            .duration(cosmic_neutronium_bee.getDuration(1)).eut(cosmic_neutronium_bee.getEUt(1))
+                            .metadata(COIL_HEAT, infinity_heat).addTo(plasmaForgeRecipes);
 
-                GTValues.RA.stdBuilder()
-                        .itemInputs(
-                                GTBees.combs.getStackForType(CombType.COSMICNEUTRONIUM),
-                                GTUtility.getIntegratedCircuit(1))
-                        .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTRC.getFluid(cosmic_neutronium_bee.getCatalystAmount(2)),
-                                Materials.Copper.getMolten(tier_3_bee_quantity))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue
-                                        .getFluid(cosmic_neutronium_bee.getResidueAmount(2)),
-                                Materials.CosmicNeutronium.getMolten(tier_3_bee_quantity))
-                        .duration(cosmic_neutronium_bee.getDuration(2)).eut(cosmic_neutronium_bee.getEUt(2))
-                        .metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
+                    long tier_3_bee_quantity = 144L * base_quantity * tier_up_multiplier * tier_up_multiplier;
 
-                long tier_4_bee_quantity = 144L * base_quantity
-                        * tier_up_multiplier
-                        * tier_up_multiplier
-                        * tier_up_multiplier;
+                    GTValues.RA.stdBuilder()
+                            .itemInputs(
+                                    GTBees.combs.getStackForType(CombType.COSMICNEUTRONIUM),
+                                    GTUtility.getIntegratedCircuit(1))
+                            .fluidInputs(
+                                    MaterialsUEVplus.ExcitedDTRC.getFluid(cosmic_neutronium_bee.getCatalystAmount(2)),
+                                    Materials.Copper.getMolten(tier_3_bee_quantity))
+                            .fluidOutputs(
+                                    MaterialsUEVplus.DimensionallyTranscendentResidue
+                                            .getFluid(cosmic_neutronium_bee.getResidueAmount(2)),
+                                    Materials.CosmicNeutronium.getMolten(tier_3_bee_quantity))
+                            .duration(cosmic_neutronium_bee.getDuration(2)).eut(cosmic_neutronium_bee.getEUt(2))
+                            .metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
 
-                GTValues.RA.stdBuilder()
-                        .itemInputs(
-                                GTBees.combs.getStackForType(CombType.COSMICNEUTRONIUM),
-                                GTUtility.getIntegratedCircuit(1))
-                        .fluidInputs(
-                                MaterialsUEVplus.ExcitedDTEC.getFluid(cosmic_neutronium_bee.getCatalystAmount(3)),
-                                Materials.Copper.getMolten(tier_4_bee_quantity))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue
-                                        .getFluid(cosmic_neutronium_bee.getResidueAmount(3)),
-                                Materials.CosmicNeutronium.getMolten(tier_4_bee_quantity))
-                        .duration(cosmic_neutronium_bee.getDuration(3)).eut(cosmic_neutronium_bee.getEUt(3))
-                        .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
+                    long tier_4_bee_quantity = 144L * base_quantity
+                            * tier_up_multiplier
+                            * tier_up_multiplier
+                            * tier_up_multiplier;
+
+                    GTValues.RA.stdBuilder()
+                            .itemInputs(
+                                    GTBees.combs.getStackForType(CombType.COSMICNEUTRONIUM),
+                                    GTUtility.getIntegratedCircuit(1))
+                            .fluidInputs(
+                                    MaterialsUEVplus.ExcitedDTEC.getFluid(cosmic_neutronium_bee.getCatalystAmount(3)),
+                                    Materials.Copper.getMolten(tier_4_bee_quantity))
+                            .fluidOutputs(
+                                    MaterialsUEVplus.DimensionallyTranscendentResidue
+                                            .getFluid(cosmic_neutronium_bee.getResidueAmount(3)),
+                                    Materials.CosmicNeutronium.getMolten(tier_4_bee_quantity))
+                            .duration(cosmic_neutronium_bee.getDuration(3)).eut(cosmic_neutronium_bee.getEUt(3))
+                            .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
+                }
 
                 // normal ones
 
@@ -632,59 +635,59 @@ public class DTPFRecipes implements Runnable {
                         .setProcessingTimeDiscount(50).setEUtDivisor(2).calculateNonEBFRecipe(32_000_000, base_time);
 
                 // Bee comb catalyst recipes for infinity
+                if (Forestry.isModLoaded()) {
+                    GTValues.RA.stdBuilder()
+                            .itemInputs(
+                                    GTModHandler.getModItem(Avaritia.ID, "Resource", 4L, 5),
+                                    GTBees.combs.getStackForType(CombType.INFINITY),
+                                    GTUtility.getIntegratedCircuit(3))
+                            .fluidInputs(MaterialsUEVplus.ExcitedDTSC.getFluid(infinity_bee.getCatalystAmount(4)))
+                            .fluidOutputs(
+                                    MaterialsUEVplus.DimensionallyTranscendentResidue
+                                            .getFluid(infinity_bee.getResidueAmount(4)),
+                                    Materials.Infinity.getMolten(256L * 144L))
+                            .duration(infinity_bee.getDuration(4)).eut(infinity_bee.getEUt(4))
+                            .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
 
-                GTValues.RA.stdBuilder()
-                        .itemInputs(
-                                GTModHandler.getModItem(Avaritia.ID, "Resource", 4L, 5),
-                                GTBees.combs.getStackForType(CombType.INFINITY),
-                                GTUtility.getIntegratedCircuit(3))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTSC.getFluid(infinity_bee.getCatalystAmount(4)))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue
-                                        .getFluid(infinity_bee.getResidueAmount(4)),
-                                Materials.Infinity.getMolten(256L * 144L))
-                        .duration(infinity_bee.getDuration(4)).eut(infinity_bee.getEUt(4))
-                        .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
+                    GTValues.RA.stdBuilder()
+                            .itemInputs(
+                                    GTModHandler.getModItem(Avaritia.ID, "Resource", 2L, 5),
+                                    GTBees.combs.getStackForType(CombType.INFINITY),
+                                    GTUtility.getIntegratedCircuit(3))
+                            .fluidInputs(MaterialsUEVplus.ExcitedDTEC.getFluid(infinity_bee.getCatalystAmount(3)))
+                            .fluidOutputs(
+                                    MaterialsUEVplus.DimensionallyTranscendentResidue
+                                            .getFluid(infinity_bee.getResidueAmount(3)),
+                                    Materials.Infinity.getMolten(128L * 144L))
+                            .duration(infinity_bee.getDuration(3)).eut(infinity_bee.getEUt(3))
+                            .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
 
-                GTValues.RA.stdBuilder()
-                        .itemInputs(
-                                GTModHandler.getModItem(Avaritia.ID, "Resource", 2L, 5),
-                                GTBees.combs.getStackForType(CombType.INFINITY),
-                                GTUtility.getIntegratedCircuit(3))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTEC.getFluid(infinity_bee.getCatalystAmount(3)))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue
-                                        .getFluid(infinity_bee.getResidueAmount(3)),
-                                Materials.Infinity.getMolten(128L * 144L))
-                        .duration(infinity_bee.getDuration(3)).eut(infinity_bee.getEUt(3))
-                        .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
+                    GTValues.RA.stdBuilder()
+                            .itemInputs(
+                                    GTModHandler.getModItem(Avaritia.ID, "Resource", 1L, 5),
+                                    GTBees.combs.getStackForType(CombType.INFINITY),
+                                    GTUtility.getIntegratedCircuit(2))
+                            .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(infinity_bee.getCatalystAmount(2)))
+                            .fluidOutputs(
+                                    MaterialsUEVplus.DimensionallyTranscendentResidue
+                                            .getFluid(infinity_bee.getResidueAmount(2)),
+                                    Materials.Infinity.getMolten(64L * 144L))
+                            .duration(infinity_bee.getDuration(2)).eut(infinity_bee.getEUt(2))
+                            .metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
 
-                GTValues.RA.stdBuilder()
-                        .itemInputs(
-                                GTModHandler.getModItem(Avaritia.ID, "Resource", 1L, 5),
-                                GTBees.combs.getStackForType(CombType.INFINITY),
-                                GTUtility.getIntegratedCircuit(2))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(infinity_bee.getCatalystAmount(2)))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue
-                                        .getFluid(infinity_bee.getResidueAmount(2)),
-                                Materials.Infinity.getMolten(64L * 144L))
-                        .duration(infinity_bee.getDuration(2)).eut(infinity_bee.getEUt(2))
-                        .metadata(COIL_HEAT, hypogen_heat).addTo(plasmaForgeRecipes);
-
-                GTValues.RA.stdBuilder()
-                        .itemInputs(
-                                GTModHandler.getModItem(Avaritia.ID, "Resource", 1L, 5),
-                                GTBees.combs.getStackForType(CombType.INFINITY),
-                                GTUtility.getIntegratedCircuit(3))
-                        .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(infinity_bee.getCatalystAmount(2) / 64))
-                        .fluidOutputs(
-                                MaterialsUEVplus.DimensionallyTranscendentResidue
-                                        .getFluid(infinity_bee.getResidueAmount(2) / 64),
-                                Materials.Infinity.getMolten(144L))
-                        .duration(infinity_bee.getDuration(2) / 128).eut(infinity_bee.getEUt(2) / 64)
-                        .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
-
+                    GTValues.RA.stdBuilder()
+                            .itemInputs(
+                                    GTModHandler.getModItem(Avaritia.ID, "Resource", 1L, 5),
+                                    GTBees.combs.getStackForType(CombType.INFINITY),
+                                    GTUtility.getIntegratedCircuit(3))
+                            .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(infinity_bee.getCatalystAmount(2) / 64))
+                            .fluidOutputs(
+                                    MaterialsUEVplus.DimensionallyTranscendentResidue
+                                            .getFluid(infinity_bee.getResidueAmount(2) / 64),
+                                    Materials.Infinity.getMolten(144L))
+                            .duration(infinity_bee.getDuration(2) / 128).eut(infinity_bee.getEUt(2) / 64)
+                            .metadata(COIL_HEAT, awakened_heat).addTo(plasmaForgeRecipes);
+                }
                 // normal recipes
 
                 DTPFCalculator infinity = new DTPFCalculator().setBaseParallel(base_quantity).setLowestCatalystTier(2)

--- a/src/main/java/com/dreammaster/gthandler/recipes/VacuumFurnaceRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/VacuumFurnaceRecipes.java
@@ -1,5 +1,6 @@
 package com.dreammaster.gthandler.recipes;
 
+import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeConstants.COIL_HEAT;
 import static gtPlusPlus.api.recipe.GTPPRecipeMaps.vacuumFurnaceRecipes;
@@ -23,41 +24,43 @@ public class VacuumFurnaceRecipes implements Runnable {
     @Override
     public void run() {
 
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        GTUtility.getIntegratedCircuit(12),
-                        GTBees.combs.getStackForType(CombType.INDIUM, 64),
-                        GTBees.combs.getStackForType(CombType.INDIUM, 64),
-                        GTBees.combs.getStackForType(CombType.INDIUM, 64),
-                        GTBees.combs.getStackForType(CombType.INDIUM, 64))
-                .itemOutputs(
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 64L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 64L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 52L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iron, 64L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iron, 56L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 64L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 64L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 64L),
-                        MaterialsElements.getInstance().GERMANIUM.getDust(15))
-                .fluidInputs(FluidUtils.getFluidStack(SphaleriteFlotationFroth, 4000))
-                .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-                .eut((int) TierEU.RECIPE_LuV).metadata(COIL_HEAT, 5500).duration(2 * MINUTES)
-                .addTo(vacuumFurnaceRecipes);
+        if (Forestry.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                    .itemInputs(
+                            GTUtility.getIntegratedCircuit(12),
+                            GTBees.combs.getStackForType(CombType.INDIUM, 64),
+                            GTBees.combs.getStackForType(CombType.INDIUM, 64),
+                            GTBees.combs.getStackForType(CombType.INDIUM, 64),
+                            GTBees.combs.getStackForType(CombType.INDIUM, 64))
+                    .itemOutputs(
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 64L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 64L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Zinc, 52L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iron, 64L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iron, 56L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 64L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 64L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 64L),
+                            MaterialsElements.getInstance().GERMANIUM.getDust(15))
+                    .fluidInputs(FluidUtils.getFluidStack(SphaleriteFlotationFroth, 4000))
+                    .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
+                    .eut((int) TierEU.RECIPE_LuV).metadata(COIL_HEAT, 5500).duration(2 * MINUTES)
+                    .addTo(vacuumFurnaceRecipes);
 
-        GTValues.RA.stdBuilder()
-                .itemInputs(GTUtility.getIntegratedCircuit(13), GTBees.combs.getStackForType(CombType.INDIUM, 40))
-                .itemOutputs(
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 64L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 64L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 52L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iron, 64L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iron, 56L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Cadmium, 50L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 30L))
-                .fluidInputs(FluidUtils.getFluidStack(ChalcopyriteFlotationFroth, 4000))
-                .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
-                .eut((int) TierEU.RECIPE_IV).metadata(COIL_HEAT, 4500).duration(2 * MINUTES)
-                .addTo(vacuumFurnaceRecipes);
+            GTValues.RA.stdBuilder()
+                    .itemInputs(GTUtility.getIntegratedCircuit(13), GTBees.combs.getStackForType(CombType.INDIUM, 40))
+                    .itemOutputs(
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 64L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 64L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 52L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iron, 64L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Iron, 56L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Cadmium, 50L),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 30L))
+                    .fluidInputs(FluidUtils.getFluidStack(ChalcopyriteFlotationFroth, 4000))
+                    .fluidOutputs(FluidUtils.getFluidStack(AgriculturalChem.RedMud, 2000), FluidUtils.getWater(2000))
+                    .eut((int) TierEU.RECIPE_IV).metadata(COIL_HEAT, 4500).duration(2 * MINUTES)
+                    .addTo(vacuumFurnaceRecipes);
+        }
     }
 }

--- a/src/main/java/com/dreammaster/recipes/RecipeRemover.java
+++ b/src/main/java/com/dreammaster/recipes/RecipeRemover.java
@@ -1168,13 +1168,6 @@ public class RecipeRemover {
         removeRecipeByOutputDelayed(getModItem(Forestry.ID, "fences", 1, wildcard, missing));
         removeRecipeByOutputDelayed(getModItem(Forestry.ID, "cart.beehouse", 1, wildcard, missing));
         removeRecipeByOutputDelayed(GregtechItemList.GT4_Thermal_Boiler.get(1));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameAccelerated));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameMutagenic));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameBusy));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameDecay));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameSlow));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameStalilize));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameArborist));
         removeRecipeByOutputDelayed(new ItemStack(ModItems.itemPersonalCloakingDevice));
         removeRecipeByOutputDelayed(ItemList.Electric_Motor_UHV.get(1L));
         removeRecipeByOutputDelayed(ItemList.Electric_Pump_UHV.get(1L));

--- a/src/main/java/com/dreammaster/recipes/RecipeRemover.java
+++ b/src/main/java/com/dreammaster/recipes/RecipeRemover.java
@@ -107,7 +107,6 @@ import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.block.ModBlocks;
 import gtPlusPlus.core.item.ModItems;
-import gtPlusPlus.xmod.forestry.bees.items.FRItemRegistry;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 
 public class RecipeRemover {

--- a/src/main/java/com/dreammaster/recipes/RecipeRemover.java
+++ b/src/main/java/com/dreammaster/recipes/RecipeRemover.java
@@ -1168,13 +1168,15 @@ public class RecipeRemover {
         removeRecipeByOutputDelayed(getModItem(Forestry.ID, "fences", 1, wildcard, missing));
         removeRecipeByOutputDelayed(getModItem(Forestry.ID, "cart.beehouse", 1, wildcard, missing));
         removeRecipeByOutputDelayed(GregtechItemList.GT4_Thermal_Boiler.get(1));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameAccelerated));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameMutagenic));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameBusy));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameDecay));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameSlow));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameStalilize));
-        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameArborist));
+        if (Forestry.isModLoaded()) {
+            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameAccelerated));
+            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameMutagenic));
+            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameBusy));
+            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameDecay));
+            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameSlow));
+            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameStalilize));
+            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameArborist));
+        }
         removeRecipeByOutputDelayed(new ItemStack(ModItems.itemPersonalCloakingDevice));
         removeRecipeByOutputDelayed(ItemList.Electric_Motor_UHV.get(1L));
         removeRecipeByOutputDelayed(ItemList.Electric_Pump_UHV.get(1L));

--- a/src/main/java/com/dreammaster/recipes/RecipeRemover.java
+++ b/src/main/java/com/dreammaster/recipes/RecipeRemover.java
@@ -1168,15 +1168,13 @@ public class RecipeRemover {
         removeRecipeByOutputDelayed(getModItem(Forestry.ID, "fences", 1, wildcard, missing));
         removeRecipeByOutputDelayed(getModItem(Forestry.ID, "cart.beehouse", 1, wildcard, missing));
         removeRecipeByOutputDelayed(GregtechItemList.GT4_Thermal_Boiler.get(1));
-        if (Forestry.isModLoaded()) {
-            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameAccelerated));
-            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameMutagenic));
-            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameBusy));
-            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameDecay));
-            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameSlow));
-            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameStalilize));
-            removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameArborist));
-        }
+        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameAccelerated));
+        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameMutagenic));
+        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameBusy));
+        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameDecay));
+        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameSlow));
+        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameStalilize));
+        removeRecipeByOutputDelayed(new ItemStack(FRItemRegistry.hiveFrameArborist));
         removeRecipeByOutputDelayed(new ItemStack(ModItems.itemPersonalCloakingDevice));
         removeRecipeByOutputDelayed(ItemList.Electric_Motor_UHV.get(1L));
         removeRecipeByOutputDelayed(ItemList.Electric_Pump_UHV.get(1L));

--- a/src/main/java/com/dreammaster/scripts/ScriptGregtechPlusPlus.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGregtechPlusPlus.java
@@ -20,6 +20,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 
 import com.dreammaster.gthandler.CustomItemList;
 
+import cpw.mods.fml.common.Optional;
 import forestry.api.recipes.RecipeManagers;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
@@ -68,7 +69,7 @@ public class ScriptGregtechPlusPlus implements IScriptLoader {
                 getModItem(RemoteIO.ID, "tile.machine", 1, 1, missing),
                 ItemList.Machine_HV_Centrifuge.get(1L),
                 getModItem(RemoteIO.ID, "tile.machine", 1, 1, missing));
-        addShapelessRecipe(CustomItemList.CoinBeesI.get(16L), new ItemStack(FRItemRegistry.hiveFrameVoid));
+
         addShapedRecipe(
                 MaterialsAlloy.TUMBAGA.getRod(1),
                 "craftingToolFile",
@@ -191,6 +192,23 @@ public class ScriptGregtechPlusPlus implements IScriptLoader {
                 ItemList.Electric_Pump_MV.get(1L),
                 "circuitPrimitive");
 
+        // Shirabon and Eternity
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(EternalSingularity.ID, "combined_singularity", 1, 15, missing),
+                        ItemList.EnergisedTesseract.get(1),
+                        ItemUtils.getSimpleStack(GenericChem.TemporalHarmonyCatalyst, 0))
+                .itemOutputs(GTOreDictUnificator.get("dustShirabon", 64), ItemList.Timepiece.get(1))
+                .fluidInputs(MaterialsUEVplus.PrimordialMatter.getFluid(1152))
+                .fluidOutputs(MaterialsUEVplus.Eternity.getMolten(9216), MaterialsUEVplus.Time.getMolten(18432))
+                .metadata(QFT_FOCUS_TIER, 4).duration(20 * SECONDS).eut(TierEU.RECIPE_UMV)
+                .addTo(quantumForceTransformerRecipes);
+        addForestryRecipes();
+    }
+
+    @Optional.Method(modid = Mods.Names.FORESTRY)
+    private void addForestryRecipes() {
+        addShapelessRecipe(CustomItemList.CoinBeesI.get(16L), new ItemStack(FRItemRegistry.hiveFrameVoid));
         RecipeManagers.carpenterManager.addRecipe(
                 60,
                 FluidRegistry.getFluidStack("molten.redstone", 576),
@@ -373,17 +391,5 @@ public class ScriptGregtechPlusPlus implements IScriptLoader {
                 GTOreDictUnificator.get(OrePrefixes.stick, Materials.WoodSealed, 1L),
                 'i',
                 GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.WoodSealed, 1L));
-
-        // Shirabon and Eternity
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(EternalSingularity.ID, "combined_singularity", 1, 15, missing),
-                        ItemList.EnergisedTesseract.get(1),
-                        ItemUtils.getSimpleStack(GenericChem.TemporalHarmonyCatalyst, 0))
-                .itemOutputs(GTOreDictUnificator.get("dustShirabon", 64), ItemList.Timepiece.get(1))
-                .fluidInputs(MaterialsUEVplus.PrimordialMatter.getFluid(1152))
-                .fluidOutputs(MaterialsUEVplus.Eternity.getMolten(9216), MaterialsUEVplus.Time.getMolten(18432))
-                .metadata(QFT_FOCUS_TIER, 4).duration(20 * SECONDS).eut(TierEU.RECIPE_UMV)
-                .addTo(quantumForceTransformerRecipes);
     }
 }


### PR DESCRIPTION
a third follow up to https://github.com/GTNewHorizons/GT5-Unofficial/pull/3140 removing hidden forestry deps.

the gtpp reciperemovals are no longer needed due to https://github.com/GTNewHorizons/GT5-Unofficial/pull/3146