### PR TITLE
Remove railcraft oredict

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
@@ -309,10 +309,6 @@ public class GT_Loader_OreDictionary extends gregtech.loaders.preload.LoaderGTOr
 
         GTOreDictUnificator
                 .registerOre("craftingToolShears", GTModHandler.getModItem(Railcraft.ID, "tool.steel.shears", 1L, 0));
-        GTOreDictUnificator.registerOre(
-                OrePrefixes.plate,
-                Materials.Lead,
-                GTModHandler.getModItem(Railcraft.ID, "part.plate", 1L, 4));
         GTOreDictUnificator
                 .registerOre("craftingToolCrowbar", GTModHandler.getModItem(Railcraft.ID, "tool.crowbar", 1L, 0));
         GTOreDictUnificator.registerOre(


### PR DESCRIPTION
Railcraft items were removed but not their oredict entries, which caused "object "part.plate" with mod id "Railcraft" has returned null because the item was not found in the game registry" to be thrown in the log.