### PR TITLE
Change alternate eternal singularity recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/NeutroniumCompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/NeutroniumCompressorRecipes.java
@@ -396,7 +396,7 @@ public class NeutroniumCompressorRecipes implements Runnable {
                     .eut(TierEU.RECIPE_UMV).metadata(COMPRESSION_TIER, 2).addTo(neutroniumCompressorRecipes);
 
             // Eternal Singularity Alternate Recipe
-            GTValues.RA.stdBuilder().fluidInputs(MaterialsUEVplus.SpaceTime.getMolten(72L * 64))
+            GTValues.RA.stdBuilder().fluidInputs(MaterialsUEVplus.Eternity.getMolten(72L * 32))
                     .itemInputs(ItemList.Black_Hole_Opener.get(1))
                     .itemOutputs(getModItem(EternalSingularity.ID, "eternal_singularity", 64)).duration(100 * SECONDS)
                     .eut(TierEU.RECIPE_MAX).metadata(COMPRESSION_TIER, 2).addTo(neutroniumCompressorRecipes);


### PR DESCRIPTION
The alternate eternal singularity recipe caused a collision. Changes the input to eternity instead of spacetime, both removing the collision and making it more of a "better recipe unlock"