### PR TITLE
Meteor miner recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -1,5 +1,6 @@
 package com.dreammaster.gthandler;
 
+import static bartworks.common.loaders.ItemRegistry.bw_realglas;
 import static gregtech.api.enums.Mods.AE2FluidCraft;
 import static gregtech.api.enums.Mods.AdventureBackpack;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
@@ -831,6 +832,24 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
                 new Object[] { "PQP", "QFQ", "PQP", 'P', OrePrefixes.plate.get(Materials.BlackPlutonium), 'Q',
                         OrePrefixes.pipeMedium.get(Materials.BlackPlutonium), 'F',
                         OrePrefixes.frameGt.get(Materials.BlackPlutonium) });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.MeteorMiner.get(1L),
+                bits,
+                new Object[] { "ABA", "CDC", "ECE", 'A', OrePrefixes.circuit.get(Materials.LuV), 'B',
+                        tectech.thing.CustomItemList.eM_dynamoTunnel1_LuV, 'C', ItemList.Casing_Coil_Superconductor,
+                        'D', ItemList.OreDrill3, 'E', ItemList.LuV_Coil });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Laser_Beacon.get(1L),
+                bits,
+                new Object[] { "AAA", "BCB", "DED", 'A', new ItemStack(bw_realglas, 1, 3), 'B',
+                        new ItemStack(
+                                ItemRegistry.TecTechPipeEnergyLowPower.getItem(),
+                                1,
+                                ItemRegistry.TecTechPipeEnergyLowPower.getItemDamage()),
+                        'C', OrePrefixes.lens.get(Materials.NetherStar), 'D', OrePrefixes.circuit.get(Materials.LuV),
+                        'E', ItemList.Casing_Coil_Superconductor });
 
         // BM raw orbs
         GTModHandler.addCraftingRecipe(

--- a/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
@@ -32,6 +32,7 @@ import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.core.material.MaterialsElements;
+import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 
 public class CircuitAssemblerRecipes implements Runnable {
 
@@ -1579,6 +1580,25 @@ public class CircuitAssemblerRecipes implements Runnable {
                         .fluidInputs(tMat.getMolten(144L * tMultiplier / 2L)).duration(12 * SECONDS + 10 * TICKS)
                         .eut(TierEU.RECIPE_HV).addTo(circuitAssemblerRecipes);
 
+                // Meteor Miner Schematic 1
+                GTValues.RA.stdBuilder()
+                        .itemInputs(
+                                ItemList.Circuit_Board_Wetware.get(32L),
+                                GregtechItemList.Laser_Lens_Special.get(1L),
+                                com.dreammaster.item.ItemList.LaserEmitter.getIS(4),
+                                ItemList.Tool_DataOrb.get(1L))
+                        .itemOutputs(ItemList.MeteorMinerSchematic1.get(1)).requiresCleanRoom().requiresLowGravity()
+                        .duration(1 * MINUTES).eut(TierEU.RECIPE_UV).addTo(circuitAssemblerRecipes);
+
+                // Meteor Miner Schematic 2
+                GTValues.RA.stdBuilder()
+                        .itemInputs(
+                                ItemList.Circuit_Board_Bio.get(32L),
+                                GregtechItemList.Laser_Lens_Special.get(1L),
+                                ItemList.MeteorMinerSchematic1.get(1L),
+                                ItemList.Tool_DataOrb.get(1L))
+                        .itemOutputs(ItemList.MeteorMinerSchematic2.get(1)).requiresCleanRoom().requiresLowGravity()
+                        .duration(1 * MINUTES).eut(TierEU.RECIPE_UV).addTo(circuitAssemblerRecipes);
             }
 
         }

--- a/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
@@ -262,6 +262,24 @@ public class LaserEngraverRecipes implements Runnable {
                 .eut(TierEU.RECIPE_UIV).fluidOutputs(MaterialsUEVplus.Antimatter.getFluid(1L)).requiresCleanRoom()
                 .addTo(laserEngraverRecipes);
 
+        // Meteor Miner Schematic 1
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        CustomItemList.SchematicsTier6.get(0),
+                        GTOreDictUnificator.get(OrePrefixes.circuit.get(Materials.ZPM), 1L))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.indalloy140", 1440))
+                .itemOutputs(ItemList.MeteorMinerSchematic1.get(1)).duration(1 * MINUTES).eut(TierEU.RECIPE_LuV)
+                .requiresCleanRoom().addTo(laserEngraverRecipes);
+
+        // Meteor Miner Schematic 2
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        CustomItemList.SchematicsTier7.get(0),
+                        GTOreDictUnificator.get(OrePrefixes.circuit.get(Materials.UV), 1L))
+                .fluidInputs(FluidRegistry.getFluidStack("molten.indalloy140", 1440))
+                .itemOutputs(ItemList.MeteorMinerSchematic2.get(1)).duration(1 * MINUTES + 30 * SECONDS)
+                .eut(TierEU.RECIPE_ZPM).requiresCleanRoom().addTo(laserEngraverRecipes);
+
         if (OpenComputers.isModLoaded()) {
             // floppys w NBT
             makeFloppy("OpenOS (Operating System)", "openos", 2, 1);


### PR DESCRIPTION
I added the recipes for the meteor miner schematics as asked by DreamMaster:
T1 Schematic -> T6 Rocket Schematic Chip + ZPM circuit + Indalloy
T2 schematic -> T7 Rocket Schematic Chip + UV circuit + Indalloy
Both are Engraving recipes

For rocketless recipes:
T1 Schematic -> 32 Wetware Circuit Board + Quantum Anomaly + 4 Laser Emitter + Data Orb
T2 Schematic -> 32 Bio Circuit Board + Quantum Anomaly + T1 Schematic + Data Orb
Both are UV recipes in the circuit assembler

The build will fail since there's no schematic in current GT5 stable version
* https://github.com/GTNewHorizons/GT5-Unofficial/pull/3116