### PR TITLE
Deprecate ic2 semifluid gen

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptEMT.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEMT.java
@@ -36,6 +36,7 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
+import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -2814,7 +2815,7 @@ public class ScriptEMT implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("permutatio"), 32)
                         .add(Aspect.getAspect("machina"), 16).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("metallum"), 32),
-                getModItem(IndustrialCraft2.ID, "blockGenerator", 1, 7, missing),
+                GregtechItemList.Generator_SemiFluid_LV.get(1),
                 new ItemStack[] { getModItem(Thaumcraft.ID, "FocusTrade", 1, 0, missing), ItemList.Emitter_MV.get(1L),
                         getModItem(Minecraft.ID, "hopper", 1, 0, missing), ItemList.Electric_Motor_MV.get(1L),
                         getModItem(IndustrialCraft2.ID, "blockElectric", 1, 7, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
@@ -1000,17 +1000,6 @@ public class ScriptIndustrialCraft implements IScriptLoader {
                 "rotorStainlessSteel",
                 "circuitAdvanced");
         addShapedRecipe(
-                getModItem(IndustrialCraft2.ID, "blockGenerator", 1, 7, missing),
-                "itemCasingSteel",
-                getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0, missing),
-                "itemCasingSteel",
-                GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.RedAlloy, 1L),
-                ItemList.Hull_LV.get(1L),
-                GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.RedAlloy, 1L),
-                "itemCasingSteel",
-                ItemList.Electric_Motor_LV.get(1L),
-                "itemCasingSteel");
-        addShapedRecipe(
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iridium, 1L),
                 "craftingToolHardHammer",
                 null,


### PR DESCRIPTION
makes in uncraftable and also replaces it in its one recipe usage.

Reason being that this is a gt pack and people just confuse it with the gt++ one constantly (as they search "semifluid" instead of "semi-fluid"/"semi fluid".

fixes https://discord.com/channels/181078474394566657/603348502637969419/1287196183185457252

new potentia gen recipe works:
![image](https://github.com/user-attachments/assets/59256cb3-5914-40c8-aaa5-6ed27b94f340)
