### PR TITLE
Buff compressor casings

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -733,22 +733,22 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
 
         // Electric Compressor Casing
         GTModHandler.addCraftingRecipe(
-                ItemList.Compressor_Casing.get(1),
+                ItemList.Compressor_Casing.get(2),
                 bits,
                 new Object[] { "PhP", "PFP", "PwP", 'P', GGMaterial.incoloy903.get(OrePrefixes.plate), 'F',
-                        GGMaterial.incoloy903.get(OrePrefixes.block) });
+                        OrePrefixes.frameGt.get(Materials.Titanium) });
 
         // Compression Pipe Casing
         GTModHandler.addCraftingRecipe(
                 ItemList.Compressor_Pipe_Casing.get(1),
                 bits,
                 new Object[] { "PQP", "QFQ", "PQP", 'P', GGMaterial.incoloy903.get(OrePrefixes.plate), 'Q',
-                        GGMaterial.incoloy903.get(OrePrefixes.pipeMedium), 'F',
-                        GGMaterial.incoloy903.get(OrePrefixes.gearGt) });
+                        GGMaterial.incoloy903.get(OrePrefixes.pipeSmall), 'F',
+                        OrePrefixes.gearGt.get(Materials.Titanium) });
 
         // Neutronium Stabilization Casing
         GTModHandler.addCraftingRecipe(
-                ItemList.Neutronium_Stable_Casing.get(2),
+                ItemList.Neutronium_Stable_Casing.get(4),
                 bits,
                 new Object[] { "PQP", "QFQ", "PQP", 'P',
                         GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.NaquadahAlloy, 1), 'Q',

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -733,10 +733,10 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
 
         // Electric Compressor Casing
         GTModHandler.addCraftingRecipe(
-                ItemList.Compressor_Casing.get(2),
+                ItemList.Compressor_Casing.get(1),
                 bits,
-                new Object[] { "PhP", "PFP", "PwP", 'P', GGMaterial.incoloy903.get(OrePrefixes.plate), 'F',
-                        OrePrefixes.frameGt.get(Materials.Titanium) });
+                new Object[] { "PhP", "SFS", "PwP", 'P', GGMaterial.incoloy903.get(OrePrefixes.plate), 'F',
+                        OrePrefixes.frameGt.get(Materials.Titanium), 'S', OrePrefixes.plate.get(Materials.Steel) });
 
         // Compression Pipe Casing
         GTModHandler.addCraftingRecipe(

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2339,9 +2339,10 @@ public class AssemblerRecipes implements Runnable {
         // Electric Compressor Casing
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GGMaterial.incoloy903.get(OrePrefixes.plate, 6),
+                        GGMaterial.incoloy903.get(OrePrefixes.plate, 4),
+                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 2),
                         GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Titanium, 1))
-                .itemOutputs(ItemList.Compressor_Casing.get(2)).duration(2 * SECONDS + 10 * TICKS).eut(16)
+                .itemOutputs(ItemList.Compressor_Casing.get(1)).duration(2 * SECONDS + 10 * TICKS).eut(16)
                 .addTo(assemblerRecipes);
 
         // Compression Pipe Casing

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2287,7 +2287,7 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.NaquadahAlloy, 4),
                         ItemList.Casing_MAX.get(1),
                         GTUtility.getIntegratedCircuit(16))
-                .itemOutputs(ItemList.Neutronium_Stable_Casing.get(2)).duration(2 * SECONDS + 10 * TICKS).eut(16)
+                .itemOutputs(ItemList.Neutronium_Stable_Casing.get(4)).duration(2 * SECONDS + 10 * TICKS).eut(16)
                 .addTo(assemblerRecipes);
 
         // Neutronium Compressor conversion
@@ -2340,16 +2340,16 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GGMaterial.incoloy903.get(OrePrefixes.plate, 6),
-                        GGMaterial.incoloy903.get(OrePrefixes.block, 1))
-                .itemOutputs(ItemList.Compressor_Casing.get(1)).duration(2 * SECONDS + 10 * TICKS).eut(16)
+                        GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Titanium, 1))
+                .itemOutputs(ItemList.Compressor_Casing.get(2)).duration(2 * SECONDS + 10 * TICKS).eut(16)
                 .addTo(assemblerRecipes);
 
         // Compression Pipe Casing
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GGMaterial.incoloy903.get(OrePrefixes.plate, 4),
-                        GGMaterial.incoloy903.get(OrePrefixes.gearGt, 1),
-                        GGMaterial.incoloy903.get(OrePrefixes.pipeMedium, 4))
+                        GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Titanium, 1),
+                        GGMaterial.incoloy903.get(OrePrefixes.pipeSmall, 4))
                 .itemOutputs(ItemList.Compressor_Pipe_Casing.get(1)).duration(2 * SECONDS + 10 * TICKS).eut(16)
                 .addTo(assemblerRecipes);
 


### PR DESCRIPTION
Related to https://github.com/GTNewHorizons/GT5-Unofficial/pull/3261

Again, hoping I can push this through since it's pretty egregious and related to beta feedback 🙏 

Reduces the incoloy-903 cost of the compressor casings by a lot, replacing some with titanium. Frankly, this multi is still very expensive at its tier. It was way way too much before and that's my fault for not really thinking about the EV cost when I was making these recipes.

Also made the stabilization casings for neutronium compressors give 4 (from 2) per recipe, since their cost is very high in field generators and the multi is already much more expensive than its original singleblock.

![image](https://github.com/user-attachments/assets/586fd090-d286-4e1d-9bfb-79624b55b393)
![image](https://github.com/user-attachments/assets/5d617eb0-5be4-4a9a-bf44-1b2180eb6b3a)
![image](https://github.com/user-attachments/assets/ae239645-f877-4b7d-bbbc-8300dfb0a3ce)