### PR TITLE
Remove new Eternal Singularity recipe, fix other singularities

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/NeutroniumCompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/NeutroniumCompressorRecipes.java
@@ -16,7 +16,6 @@ import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gtnhlanth.common.register.WerkstoffMaterialPool.Gangue;
 
 import gregtech.api.enums.GTValues;
-import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.MaterialsUEVplus;
 import gregtech.api.enums.OrePrefixes;
@@ -394,12 +393,6 @@ public class NeutroniumCompressorRecipes implements Runnable {
             GTValues.RA.stdBuilder().fluidInputs(MaterialsUEVplus.SpaceTime.getMolten(72L))
                     .itemOutputs(getModItem(EternalSingularity.ID, "eternal_singularity", 1)).duration(100 * SECONDS)
                     .eut(TierEU.RECIPE_UMV).metadata(COMPRESSION_TIER, 2).addTo(neutroniumCompressorRecipes);
-
-            // Eternal Singularity Alternate Recipe
-            GTValues.RA.stdBuilder().fluidInputs(MaterialsUEVplus.Eternity.getMolten(72L * 8))
-                    .itemInputs(ItemList.Black_Hole_Opener.get(1))
-                    .itemOutputs(getModItem(EternalSingularity.ID, "eternal_singularity", 16)).duration(100 * SECONDS)
-                    .eut(TierEU.RECIPE_MAX).metadata(COMPRESSION_TIER, 2).addTo(neutroniumCompressorRecipes);
 
             // Iron Singularity
             GTValues.RA.stdBuilder().fluidInputs(Materials.Iron.getMolten(9455616L))

--- a/src/main/java/com/dreammaster/scripts/ScriptAvaritiaAddons.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAvaritiaAddons.java
@@ -14,7 +14,6 @@ import static gregtech.api.recipe.RecipeMaps.neutroniumCompressorRecipes;
 import static gregtech.api.recipe.RecipeMaps.plasmaArcFurnaceRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
-import static gregtech.api.util.GTRecipeConstants.COMPRESSION_TIER;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,6 +31,7 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.MaterialsUEVplus;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
+import gregtech.api.recipe.metadata.CompressionTierKey;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 
@@ -181,7 +181,7 @@ public class ScriptAvaritiaAddons implements IScriptLoader {
                     getModItem(UniversalSingularities.ID, "universal.general.singularity", 1L, 20))
                     .fluidInputs(MaterialsUEVplus.Mellion.getMolten(4 * 144L))
                     .itemOutputs(getModItem(EternalSingularity.ID, "combined_singularity", 1L, 2)).duration(1 * SECONDS)
-                    .eut(TierEU.RECIPE_UMV).metadata(COMPRESSION_TIER, 2).addTo(neutroniumCompressorRecipes);
+                    .eut(TierEU.RECIPE_UMV).metadata(CompressionTierKey.INSTANCE, 2).addTo(neutroniumCompressorRecipes);
 
             // Cryptic Singularity
             GTValues.RA.stdBuilder().itemInputs(
@@ -189,7 +189,7 @@ public class ScriptAvaritiaAddons implements IScriptLoader {
                     getModItem(Avaritia.ID, "Singularity", 1L, 0))
                     .fluidInputs(MaterialsUEVplus.Creon.getMolten(4 * 144L))
                     .itemOutputs(getModItem(EternalSingularity.ID, "combined_singularity", 1L, 4)).duration(1 * SECONDS)
-                    .eut(TierEU.RECIPE_UMV).metadata(COMPRESSION_TIER, 2).addTo(neutroniumCompressorRecipes);
+                    .eut(TierEU.RECIPE_UMV).metadata(CompressionTierKey.INSTANCE, 2).addTo(neutroniumCompressorRecipes);
         }
     }
 }


### PR DESCRIPTION
Removes the new Eternal Singularity recipe. This was a bit of an experiment and after more consideration we don't think this is needed.

Also fixes a visual issue with the Spaghettic and Cryptic Singularities not mentioning that they need black hole