### PR TITLE
Buff T8 waterline cost (again)

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -1381,7 +1381,7 @@ public class AssemblingLineRecipes implements Runnable {
                             GTOreDictUnificator.get(OrePrefixes.plate, Materials.Ledox, 32),
                             GTOreDictUnificator.get(OrePrefixes.plate, Materials.CallistoIce, 32),
                             GTOreDictUnificator.get(OrePrefixes.plate, Materials.EnrichedHolmium, 32),
-                            ItemList.Field_Generator_UEV.get(1),
+                            ItemList.Field_Generator_UHV.get(1),
                             new Object[] { OrePrefixes.circuit.get(Materials.UEV), 8 },
                             new Object[] { OrePrefixes.circuit.get(Materials.UIV), 4 },
                             GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Infinity, 32))


### PR DESCRIPTION
The tier 8 waterline multiblock has proven itself to still be way too expensive, so this final buff removes the UEV field generator cost from the most used casing and replaces it with a UHV field generator instead to cut down on infinity.