### PR TITLE
fix ichorium block infusion recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
@@ -2864,7 +2864,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("infernus"), 24)
                         .add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("superbia"), 16)
                         .add(Aspect.getAspect("terra"), 8),
-                BlockList.MysteriousCrystal.getIS(),
+                BlockList.Mytryl.getIS(),
                 new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
                         getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
                         getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),


### PR DESCRIPTION
The material was accidentally changed from mytryl to mysterious crystal (higher tier) by a getmoditem-refactor. This is the fix. back to the 2.6.1 and prior recipe.

![image](https://github.com/user-attachments/assets/9001be02-89b5-48f1-9275-e5d3d522a33d)
