### PR TITLE
Add assembler recipes for some new items used in stargate

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2600,6 +2600,48 @@ public class AssemblerRecipes implements Runnable {
                         GTUtility.getIntegratedCircuit(3))
                 .itemOutputs(ItemList.Casing_Firebox_TungstenSteel.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
                 .addTo(assemblerRecipes);
+
+        // Alloy Blast Smelter
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Machine_IV_AlloySmelter.get(1),
+                        MaterialsAlloy.ZIRCONIUM_CARBIDE.getPlate(2),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt04, Materials.Tungsten, 2),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.IV, 2))
+                .itemOutputs(GregtechItemList.Industrial_AlloyBlastSmelter.get(1)).duration(1 * SECONDS)
+                .eut(TierEU.RECIPE_EV).addTo(assemblerRecipes);
+
+        // IV Alloy Smelter
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Hull_IV.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.TPV, 4),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Platinum, 2),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.IV, 2))
+                .itemOutputs(ItemList.Machine_IV_AlloySmelter.get(1)).duration(1 * SECONDS).eut(TierEU.RECIPE_EV)
+                .addTo(assemblerRecipes);
+
+        // LuV World Accelerator
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Electric_Motor_LuV.get(2),
+                        ItemList.Electric_Pump_LuV.get(1),
+                        ItemList.Conveyor_Module_LuV.get(1),
+                        ItemList.Robot_Arm_LuV.get(2),
+                        ItemList.Electric_Piston_LuV.get(2),
+                        ItemList.Hull_LuV.get(1))
+                .itemOutputs(ItemList.AcceleratorUV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(assemblerRecipes);
+
+        // Assembler Machine Casing
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.TungstenSteel, 1),
+                        ItemList.Electric_Motor_IV.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.ZPM, 6),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.LuV, 1))
+                .itemOutputs(ItemList.Casing_Assembler.get(1)).duration(10 * SECONDS).eut(TierEU.RECIPE_LV)
+                .addTo(assemblerRecipes);
     }
 
     private void makeElectricMachinePartRecipes() {

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2554,6 +2554,52 @@ public class AssemblerRecipes implements Runnable {
                 .fluidInputs(Materials.SolderingAlloy.getMolten(L * 2))
                 .itemOutputs(ItemList.Superconducting_Magnet_Solenoid_IV.get(1)).duration(10 * SECONDS)
                 .eut(TierEU.RECIPE_IV).addTo(assemblerRecipes);
+
+        // EV Battery Buffer (16 Slots)
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Hull_EV.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt16, Materials.Aluminium, 4),
+                        new ItemStack(Blocks.chest))
+                .itemOutputs(ItemList.Battery_Buffer_4by4_EV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_MV)
+                .addTo(assemblerRecipes);
+
+        // Firebox Casings
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Bronze, 1),
+                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.Bronze, 4),
+                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Bronze, 4),
+                        GTUtility.getIntegratedCircuit(3))
+                .itemOutputs(ItemList.Casing_Firebox_Bronze.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
+                .addTo(assemblerRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Steel, 1),
+                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.Steel, 4),
+                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 4),
+                        GTUtility.getIntegratedCircuit(3))
+                .itemOutputs(ItemList.Casing_Firebox_Steel.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
+                .addTo(assemblerRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Titanium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.Titanium, 4),
+                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4),
+                        GTUtility.getIntegratedCircuit(3))
+                .itemOutputs(ItemList.Casing_Firebox_Titanium.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
+                .addTo(assemblerRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.TungstenSteel, 1),
+                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.TungstenSteel, 4),
+                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 4),
+                        GTUtility.getIntegratedCircuit(3))
+                .itemOutputs(ItemList.Casing_Firebox_TungstenSteel.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
+                .addTo(assemblerRecipes);
     }
 
     private void makeElectricMachinePartRecipes() {

--- a/src/main/java/com/dreammaster/scripts/ScriptEnderIO.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEnderIO.java
@@ -1820,5 +1820,53 @@ public class ScriptEnderIO implements IScriptLoader {
                         getModItem(EnderIO.ID, "itemMaterial", 1, 17, missing))
                 .outputChances(10000, 1000, 100, 10).duration(15 * SECONDS).eut(480).addTo(maceratorRecipes);
 
+        // Vibrant Capacitor Bank
+        ItemStack vibrantCapacitor = createItemStack(
+                EnderIO.ID,
+                "blockCapBank",
+                1,
+                3,
+                "{type:\"VIBRANT\",storedEnergyRF:0}",
+                missing);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(EnderIO.ID, "itemMachinePart", 1, 0, missing),
+                        getModItem(EnderIO.ID, "itemMaterial", 2, 6, missing),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.HV, 1),
+                        getModItem(EnderIO.ID, "itemBasicCapacitor", 4, 2, missing),
+                        ItemList.BatteryHull_EV_Full.get(1))
+                .itemOutputs(vibrantCapacitor.copy()).duration(5 * SECONDS).eut(TierEU.RECIPE_MV)
+                .addTo(assemblerRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(EnderIO.ID, "itemMachinePart", 1, 0, missing),
+                        getModItem(EnderIO.ID, "itemMaterial", 2, 6, missing),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.HV, 1),
+                        getModItem(EnderIO.ID, "itemBasicCapacitor", 4, 9, missing),
+                        ItemList.BatteryHull_EV_Full.get(1))
+                .itemOutputs(vibrantCapacitor.copy()).duration(5 * SECONDS).eut(TierEU.RECIPE_MV)
+                .addTo(assemblerRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(EnderIO.ID, "itemMachinePart", 1, 0, missing),
+                        getModItem(EnderIO.ID, "itemMaterial", 2, 6, missing),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.HV, 1),
+                        getModItem(EnderIO.ID, "itemBasicCapacitor", 4, 2, missing),
+                        GregtechItemList.Battery_RE_EV_Lithium.get(1))
+                .itemOutputs(vibrantCapacitor.copy()).duration(5 * SECONDS).eut(TierEU.RECIPE_MV)
+                .addTo(assemblerRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(EnderIO.ID, "itemMachinePart", 1, 0, missing),
+                        getModItem(EnderIO.ID, "itemMaterial", 2, 6, missing),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.HV, 1),
+                        getModItem(EnderIO.ID, "itemBasicCapacitor", 4, 9, missing),
+                        GregtechItemList.Battery_RE_EV_Lithium.get(1))
+                .itemOutputs(vibrantCapacitor.copy()).duration(5 * SECONDS).eut(TierEU.RECIPE_MV)
+                .addTo(assemblerRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -1765,6 +1765,15 @@ public class ScriptGalacticraft implements IScriptLoader {
                         getModItem(GalacticraftMars.ID, "tile.walkway", 1, 0, missing))
                 .itemOutputs(getModItem(GalacticraftMars.ID, "tile.walkwayWire", 1, 0, missing)).duration(1 * SECONDS)
                 .eut(120).addTo(assemblerRecipes);
+
+        // Oxygen Vent
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(GalacticraftCore.ID, "item.basicItem", 4, 7, missing),
+                        getModItem(GalacticraftCore.ID, "item.basicItem", 1, 9, missing),
+                        new ItemStack(Blocks.iron_bars, 4))
+                .itemOutputs(getModItem(GalacticraftCore.ID, "item.airVent", 1, 0, missing)).duration(1 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
     }
 
     private void blastFurnaceRecipes() {


### PR DESCRIPTION
Adds assembler recipes for:
- Galacticraft Oxygen Vent
- EnderIO Vibrant Capacitor Bank
- EV Battery Buffer (16 Slots)
- Bronze/Steel/Titanium/Tungstensteel Firebox Casings
- Alloy Blast Smelter controller
- IV Alloy Smelter
- LuV World Accelerator
- Assembler Machine Casing

These items are all things used at larger scale than previously due to the stargate recipe changes, or in the case of a few, desperately needed assembler recipes previously