### PR TITLE
Rework endgame nether star processing

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -90,10 +90,6 @@ public class CompressorRecipes implements Runnable {
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.WroughtIron, 1L))
                 .duration(15 * SECONDS).eut(2).addTo(compressorRecipes);
 
-        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 9))
-                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.block, Materials.NetherStar, 1)).duration(15 * SECONDS)
-                .eut(TierEU.RECIPE_UV).addTo(compressorRecipes);
-
         GTValues.RA.stdBuilder().itemInputs(WerkstoffMaterialPool.Gangue.get(OrePrefixes.dust, 9))
                 .itemOutputs((WerkstoffMaterialPool.Gangue.get(OrePrefixes.block, 1))).duration(10 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(compressorRecipes);

--- a/src/main/java/com/dreammaster/gthandler/recipes/ImplosionCompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ImplosionCompressorRecipes.java
@@ -1,5 +1,6 @@
 package com.dreammaster.gthandler.recipes;
 
+import static bartworks.API.recipe.BartWorksRecipeMaps.electricImplosionCompressorRecipes;
 import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.DraconicEvolution;
 import static gregtech.api.enums.Mods.ExtraUtilities;
@@ -352,5 +353,10 @@ public class ImplosionCompressorRecipes implements Runnable {
                     .duration(20 * TICKS).eut(TierEU.RECIPE_LV).metadata(ADDITIVE_AMOUNT, 2).addTo(implosionRecipes);
 
         }
+
+        // Nether Star Dust -> Gem EIC recipe
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 4))
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.gem, Materials.NetherStar, 3)).duration(25)
+                .eut(TierEU.RECIPE_UEV).addTo(electricImplosionCompressorRecipes);
     }
 }


### PR DESCRIPTION
Rework agreed upon with @GDCloudstrike 

Due to changes to the compressor in 2.7, as well as the addition of Superdense Plates which strain the compressor much more (and, as a result, the Electric Implosion Compressor much less since singularities were also moved), we decided it would be a good idea to no longer have a Dust -> Block recipe for Nether Star Block, instead having a Dust -> Gem Electric Implosion Compressor recipe, and then doing the normal Gem -> Block compressor recipe.

Duration + EU/t are chosen based on the former recipe:
15s @ UV for 1 Block (9 Gems worth of Dust) -> 3.75s at UEV -> 1.25s at UEV for 3 Gems, so the total time is unchanged, but the process is moved to another machine and standardized more. Additionally, this does slightly increase the cost of Nether Stars for Nether Star Block from Dust, but I think this is a fair nerf for the improved process in the EIC.