### PR TITLE
Move Digital Singularities from Dire table to Space Asssembler

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -444,8 +444,6 @@ public class SpaceAssemblerRecipes implements Runnable {
                                     new ItemStack[] { getModItem(EternalSingularity.ID, "eternal_singularity", 1),
                                             getModItem(ThaumicEnergistics.ID, "storage.component", 12, 8),
                                             getModItem(Thaumcraft.ID, "blockEssentiaReservoir", 8, 0),
-                                            getModItem(AE2FluidCraft.ID, "fluid_part", 8, 7),
-                                            ItemList.Quantum_Tank_IV.get(8L),
                                             GTOreDictUnificator.get(OrePrefixes.block, Materials.Infinity, 4L),
                                             getModItem(Avaritia.ID, "Resource", 4, 5),
                                             GTOreDictUnificator

--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -2,6 +2,8 @@ package com.dreammaster.gthandler.recipes;
 
 import static gregtech.api.enums.Mods.AE2FluidCraft;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
+import static gregtech.api.enums.Mods.Avaritia;
+import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.GTNHIntergalactic;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.OpenComputers;
@@ -383,6 +385,22 @@ public class SpaceAssemblerRecipes implements Runnable {
                         (int) TierEU.RECIPE_UXV,
                         null,
                         null);
+
+                // Digital Singularity ME Storage Cell
+                IG_RecipeAdder.addSpaceAssemblerRecipe(
+                        new ItemStack[] { getModItem(EternalSingularity.ID, "eternal_singularity", 1),
+                                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 12, 60),
+                                ItemList.Quantum_Chest_IV.get(8L),
+                                GTOreDictUnificator.get(OrePrefixes.block, Materials.Infinity, 4L),
+                                getModItem(Avaritia.ID, "Resource", 4, 5),
+                                GTOreDictUnificator.get(OrePrefixes.block, Materials.CosmicNeutronium, 12L) },
+                        new FluidStack[] { new FluidStack(solderUEV, 2304) },
+                        getModItem(AppliedEnergistics2.ID, "item.ItemExtremeStorageCell.Singularity", 1),
+                        1,
+                        10 * SECONDS,
+                        (int) TierEU.RECIPE_UHV,
+                        null,
+                        null);
             }
             if (AE2FluidCraft.isModLoaded()) {
                 // Artificial Fluid Universe Cell
@@ -398,6 +416,22 @@ public class SpaceAssemblerRecipes implements Runnable {
                         3,
                         1 * MINUTES,
                         (int) TierEU.RECIPE_UXV,
+                        null,
+                        null);
+
+                // ME Fluid Digital Singularity Storage Cell
+                IG_RecipeAdder.addSpaceAssemblerRecipe(
+                        new ItemStack[] { getModItem(EternalSingularity.ID, "eternal_singularity", 1),
+                                new ItemStack(Loaders.yottaFluidTankCell, 4, 6),
+                                getModItem(AE2FluidCraft.ID, "fluid_part", 8, 7), ItemList.Quantum_Tank_IV.get(8L),
+                                GTOreDictUnificator.get(OrePrefixes.block, Materials.Infinity, 4L),
+                                getModItem(Avaritia.ID, "Resource", 4, 5),
+                                GTOreDictUnificator.get(OrePrefixes.block, Materials.CosmicNeutronium, 12L) },
+                        new FluidStack[] { new FluidStack(solderUEV, 2304) },
+                        getModItem(AE2FluidCraft.ID, "fluid_storage.singularity", 1, 0),
+                        1,
+                        10 * SECONDS,
+                        (int) TierEU.RECIPE_UHV,
                         null,
                         null);
             }

--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -8,6 +8,8 @@ import static gregtech.api.enums.Mods.GTNHIntergalactic;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.SuperSolarPanels;
+import static gregtech.api.enums.Mods.Thaumcraft;
+import static gregtech.api.enums.Mods.ThaumicEnergistics;
 import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
@@ -434,6 +436,28 @@ public class SpaceAssemblerRecipes implements Runnable {
                         (int) TierEU.RECIPE_UHV,
                         null,
                         null);
+
+                // ME Essentia Digital Singularity Storage Cell
+                if (ThaumicEnergistics.isModLoaded()) {
+                    IG_RecipeAdder
+                            .addSpaceAssemblerRecipe(
+                                    new ItemStack[] { getModItem(EternalSingularity.ID, "eternal_singularity", 1),
+                                            getModItem(ThaumicEnergistics.ID, "storage.component", 12, 8),
+                                            getModItem(Thaumcraft.ID, "blockEssentiaReservoir", 8, 0),
+                                            getModItem(AE2FluidCraft.ID, "fluid_part", 8, 7),
+                                            ItemList.Quantum_Tank_IV.get(8L),
+                                            GTOreDictUnificator.get(OrePrefixes.block, Materials.Infinity, 4L),
+                                            getModItem(Avaritia.ID, "Resource", 4, 5),
+                                            GTOreDictUnificator
+                                                    .get(OrePrefixes.block, Materials.CosmicNeutronium, 12L) },
+                                    new FluidStack[] { new FluidStack(solderUEV, 2304) },
+                                    getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 10),
+                                    1,
+                                    10 * SECONDS,
+                                    (int) TierEU.RECIPE_UHV,
+                                    null,
+                                    null);
+                }
             }
         }
     }

--- a/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
@@ -2,7 +2,6 @@ package com.dreammaster.scripts;
 
 import static gregtech.api.enums.Mods.AE2FluidCraft;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
-import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.GTPlusPlus;
 import static gregtech.api.enums.Mods.GoodGenerator;
@@ -719,32 +718,6 @@ public class ScriptAE2FC implements IScriptLoader {
                 COMPONENT_16384,
                 'e',
                 AE2FC_ADVANCED_FLUID_STORAGE_HOUSING);
-        // ME Digital Singularity
-        ExtremeCraftingManager.getInstance().addExtremeShapedOreRecipe(
-                AE2FC_SINGULARITY_CELL,
-                "----a----",
-                "---aba---",
-                "--ecdce--",
-                "-acdgdca-",
-                "abdgfgdba",
-                "-acdgdca-",
-                "--ecdce--",
-                "---aba---",
-                "----a----",
-                'a',
-                "blockCosmicNeutronium",
-                'b',
-                getModItem(Avaritia.ID, "Resource", 1, 5),
-                'c',
-                ItemList.Quantum_Tank_IV.get(1L),
-                'd',
-                COMPONENT_16384,
-                'e',
-                "blockInfinity",
-                'f',
-                getModItem(EternalSingularity.ID, "eternal_singularity", 1),
-                'g',
-                T7_YOT);
 
         // level maintainer
         addShapedRecipe(

--- a/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
@@ -472,31 +472,6 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
                 'e',
                 AE2_ADVANCED_HOUSING);
 
-        // ME Digital Singularity
-        ExtremeCraftingManager.getInstance().addExtremeShapedOreRecipe(
-                getModItem(AppliedEnergistics2.ID, "item.ItemExtremeStorageCell.Singularity", 1),
-                "----a----",
-                "---aba---",
-                "--ecdce--",
-                "-acdddca-",
-                "abddfddba",
-                "-acdddca-",
-                "--ecdce--",
-                "---aba---",
-                "----a----",
-                'a',
-                "blockCosmicNeutronium",
-                'b',
-                getModItem(Avaritia.ID, "Resource", 1, 5),
-                'c',
-                ItemList.Quantum_Chest_IV.get(1L),
-                'd',
-                components[3],
-                'e',
-                "blockInfinity",
-                'f',
-                getModItem(EternalSingularity.ID, "eternal_singularity", 1));
-
         // ME Singularity crafting storage
         ExtremeCraftingManager.getInstance().addExtremeShapedOreRecipe(
                 getModItem(AppliedEnergistics2.ID, "tile.BlockSingularityCraftingStorage", 1),

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
@@ -2,7 +2,6 @@ package com.dreammaster.scripts;
 
 import static gregtech.api.enums.Mods.AE2Stuff;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
-import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.BartWorks;
 import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.Gadomancy;
@@ -1381,30 +1380,6 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 EssentialComponent16384K,
                 'e',
                 getModItem(ThaumicEnergistics.ID, "storage.casing", 1, 0, missing));
-        // ME Digital Singularity
-        ExtremeCraftingManager.getInstance().addExtremeShapedOreRecipe(
-                getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 10, missing),
-                "----a----",
-                "---aba---",
-                "--ecdce--",
-                "-acdddca-",
-                "abddfddba",
-                "-acdddca-",
-                "--ecdce--",
-                "---aba---",
-                "----a----",
-                'a',
-                "blockCosmicNeutronium",
-                'b',
-                getModItem(Avaritia.ID, "Resource", 1, 5),
-                'c',
-                getModItem(Thaumcraft.ID, "blockEssentiaReservoir", 1, 0, missing),
-                'd',
-                EssentialComponent16384K,
-                'e',
-                "blockInfinity",
-                'f',
-                getModItem(EternalSingularity.ID, "eternal_singularity", 1));
 
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
@@ -110,7 +110,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 getModItem(Gadomancy.ID, "BlockEssentiaCompressor", 1) };
 
         // ItemStacks for in/out
-        ItemStack SingularityDrive = getModItem(EternalSingularity.ID, "eternal_singularity", 1);
+        ItemStack DigitalSingularity = getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 10);
         // Creative Essentia Cell
         ItemStack CEC = EssentialCellCreative;
 
@@ -120,7 +120,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 10,
                 new AspectList().add(Aspect.AIR, 2000).add(Aspect.FIRE, 2000).add(Aspect.ORDER, 2000)
                         .add(Aspect.ENTROPY, 2000).add(Aspect.EARTH, 2000).add(Aspect.WATER, 2000),
-                SingularityDrive,
+                DigitalSingularity,
                 CECInfusionItems);
 
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
Moves the digital singularity recipe to space assembler to reduce the strain from dire tables and to make it more consistent to Artificial Universe.
![image](https://github.com/user-attachments/assets/5aeb0125-2c97-4c2e-8f08-73b18d5db0fb)
![image](https://github.com/user-attachments/assets/058be701-99ef-45f3-b835-705781834dbf)
![image](https://github.com/user-attachments/assets/abc861cd-cba0-46f6-bb04-9ebfbc6772dc)

