### PR TITLE
Add recipes for Item Holder Covers

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2642,6 +2642,35 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.LuV, 1))
                 .itemOutputs(ItemList.Casing_Assembler.get(1)).duration(10 * SECONDS).eut(TierEU.RECIPE_LV)
                 .addTo(assemblerRecipes);
+
+        if (IronChests.isModLoaded()) {
+            for (FluidStack fluid : new FluidStack[] { Materials.SolderingAlloy.getMolten(L / 2),
+                    Materials.Tin.getMolten(L), Materials.Lead.getMolten(L * 2), }) {
+                GTValues.RA.stdBuilder()
+                        .itemInputs(
+                                new ItemStack(Blocks.chest),
+                                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 1),
+                                GTUtility.getIntegratedCircuit(1))
+                        .fluidInputs(fluid.copy()).itemOutputs(ItemList.Cover_Chest_Basic.get(1)).duration(40 * SECONDS)
+                        .eut(16).addTo(assemblerRecipes);
+
+                GTValues.RA.stdBuilder()
+                        .itemInputs(
+                                getModItem(IronChests.ID, "BlockIronChest", 1, 3),
+                                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1),
+                                GTUtility.getIntegratedCircuit(1))
+                        .fluidInputs(fluid.copy()).itemOutputs(ItemList.Cover_Chest_Good.get(1)).duration(40 * SECONDS)
+                        .eut(16).addTo(assemblerRecipes);
+
+                GTValues.RA.stdBuilder()
+                        .itemInputs(
+                                getModItem(IronChests.ID, "BlockIronChest", 1, 0),
+                                GTOreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 1),
+                                GTUtility.getIntegratedCircuit(1))
+                        .fluidInputs(fluid.copy()).itemOutputs(ItemList.Cover_Chest_Advanced.get(1))
+                        .duration(40 * SECONDS).eut(16).addTo(assemblerRecipes);
+            }
+        }
     }
 
     private void makeElectricMachinePartRecipes() {


### PR DESCRIPTION
Adds recipes for the Item Holder covers added here: https://github.com/GTNewHorizons/GT5-Unofficial/pull/2593.

Follows the format:
`Tiered Chest (from Input/Output Bus recipe) + Tiered Plate + C1 + Tiered Fluid (from other cover recipes), 40s @ 16 EU/t (both from other cover recipes)`

I decided not to have the assembler recipes be tiered, and instead all LV, but I could go either way on this so I'm open to opinions.

I'm marking this as a bugfix PR since these covers were added in this dev cycle, and recipes were just forgotten about for a while, so I think this should definitely go into 2.7.