### PR TITLE
readd iron ore gravel recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/MaceratorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MaceratorRecipes.java
@@ -139,6 +139,10 @@ public class MaceratorRecipes implements Runnable {
                             GTOreDictUnificator.get(OrePrefixes.dust, Materials.Bauxite, 1L))
                     .outputChances(10000, 1000).duration(20 * SECONDS).eut(2).addTo(maceratorRecipes);
 
+            GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(TinkerConstruct.ID, "GravelOre", 1L, 0))
+                    .itemOutputs(GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Iron, 2L))
+                    .duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);
+
             GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 12))
                     .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 1L))
                     .outputChances(10000).duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);


### PR DESCRIPTION
was accidentally removed when ic2 recipes were moved.

also doesn't autogen for some reason and never has but the debug for that was accidentally(?) removed as well, so who knows.

also of course the block shouldnt even generate but thats not a bug anyone has figured out so far. XD

fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17610