### PR TITLE
Downtier wireless data hatches to UEV

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -296,19 +296,19 @@ public class AssemblingLineRecipes implements Runnable {
                         DATApipe.get(64),
                         // Internet card
                         GTModHandler.getModItem(OpenComputers.ID, "item", 1L, 44),
-                        // Dense infinity plate
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Infinity, 64),
-                        // Shirabon foil
-                        GTOreDictUnificator.get("foilShirabon", 64),
-                        // Quantum circuit
-                        new Object[] { OrePrefixes.circuit.get(Materials.UXV), 1L },
-                        // Energized tesseract
-                        ItemList.EnergisedTesseract.get(1) },
-                new FluidStack[] { new FluidStack(solderUEV, 1296), MaterialsUEVplus.ExcitedDTEC.getFluid(500L) },
+                        // Superdense neutronium plate
+                        GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.Neutronium, 4),
+                        // infinity foil
+                        GTOreDictUnificator.get(OrePrefixes.foil, Materials.Infinity, 64),
+                        // UIV circuit
+                        new Object[] { OrePrefixes.circuit.get(Materials.UIV), 2L },
+                        // UEV emitter
+                        ItemList.Sensor_UEV.get(1) },
+                new FluidStack[] { new FluidStack(solderUEV, 1296) },
                 // Wireless assembly line slave connector
                 dataInAss_Wireless_Hatch.get(1),
                 30 * SECONDS,
-                (int) TierEU.RECIPE_UMV);
+                (int) TierEU.RECIPE_UEV);
 
         // Wireless data bank master connector
         TTRecipeAdder.addResearchableAssemblylineRecipe(
@@ -327,19 +327,19 @@ public class AssemblingLineRecipes implements Runnable {
                         DATApipe.get(64),
                         // Internet card
                         GTModHandler.getModItem(OpenComputers.ID, "item", 1L, 44),
-                        // Dense infinity plate
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Infinity, 64),
-                        // Shirabon foil
-                        GTOreDictUnificator.get("foilShirabon", 64),
-                        // Quantum circuit
-                        new Object[] { OrePrefixes.circuit.get(Materials.UXV), 1L },
-                        // Energized tesseract
-                        ItemList.EnergisedTesseract.get(1) },
-                new FluidStack[] { new FluidStack(solderUEV, 1296), MaterialsUEVplus.ExcitedDTEC.getFluid(500L) },
+                        // Superdense neutronium plate
+                        GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.Neutronium, 4),
+                        // infinity foil
+                        GTOreDictUnificator.get(OrePrefixes.foil, Materials.Infinity, 64),
+                        // UIV circuit
+                        new Object[] { OrePrefixes.circuit.get(Materials.UIV), 2L },
+                        // UEV emitter
+                        ItemList.Emitter_UEV.get(1) },
+                new FluidStack[] { new FluidStack(solderUEV, 1296) },
                 // Wireless data bank master connector
                 dataOutAss_Wireless_Hatch.get(1),
                 30 * SECONDS,
-                (int) TierEU.RECIPE_UMV);
+                (int) TierEU.RECIPE_UEV);
 
         if (GalaxySpace.isModLoaded()) {
             // Dyson Swarm Module


### PR DESCRIPTION
Wireless data currently has the same gating wireless computation, which is gated behind eternal DTPF, primarily because of dyson, but data doesn't have the same issue.
This downtiers the wireless data hatches to UEV, to help the assembly line scaling, for example crafting the DTPF, which usually makes the players setup a dozen of assembly lines.

![image](https://github.com/user-attachments/assets/0e28759f-852a-4589-98f0-574227ab229d)
![image](https://github.com/user-attachments/assets/f3af444d-fe7d-46c7-b77b-43a6be16b1c0)
