### PR TITLE
fix NPE in TCLoader

### DIFF
--- a/src/main/java/com/dreammaster/thaumcraft/TCLoader.java
+++ b/src/main/java/com/dreammaster/thaumcraft/TCLoader.java
@@ -56,13 +56,19 @@ public class TCLoader {
                 if (researchName == null || (!(output instanceof ItemStack) && !(output instanceof String))) continue;
                 String outputString;
                 if (output instanceof ItemStack) {
-                    Item i = ((ItemStack) output).getItem();
+                    Item item = ((ItemStack) output).getItem();
+                    if (item == null) continue;
                     GameRegistry.UniqueIdentifier ui;
-                    if (i instanceof ItemBlock) ui = GameRegistry.findUniqueIdentifierFor(Block.getBlockFromItem(i));
-                    else ui = GameRegistry.findUniqueIdentifierFor(i);
-                    outputString = (ui != null ? ui.toString() : Item.getIdFromItem(i)) + ":"
+                    if (item instanceof ItemBlock) {
+                        ui = GameRegistry.findUniqueIdentifierFor(Block.getBlockFromItem(item));
+                    } else {
+                        ui = GameRegistry.findUniqueIdentifierFor(item);
+                    }
+                    outputString = (ui != null ? ui.toString() : Item.getIdFromItem(item)) + ":"
                             + ((ItemStack) output).getItemDamage();
-                } else outputString = (String) output;
+                } else {
+                    outputString = (String) output;
+                }
                 if (!availableResearches.contains(researchName)) {
                     MainRegistry.Logger.warn(
                             "WARNING!! Thaumcraft recipe for " + outputString


### PR DESCRIPTION
```
java.lang.NullPointerException: Cannot invoke "net.minecraft.item.Item.getDamage(net.minecraft.item.ItemStack)" because the return value of "net.minecraft.item.ItemStack.func_77973_b()" is null
	at Launch//net.minecraft.item.ItemStack.func_77960_j(ItemStack.java:217)
	at Launch//com.dreammaster.thaumcraft.TCLoader.checkRecipeProblems(TCLoader.java:64)
	at Launch//com.dreammaster.main.MainRegistry.CompleteLoad(MainRegistry.java:517)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at Launch//cpw.mods.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:532)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at System//com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at System//com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at System//com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at System//com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at System//com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at Launch//cpw.mods.fml.common.LoadController.sendEventToModContainer(LoadController.java:212)
	at Launch//cpw.mods.fml.common.LoadController.propogateStateMessage(LoadController.java:190)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at System//com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at System//com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at System//com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at System//com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at System//com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at Launch//cpw.mods.fml.common.LoadController.distributeStateMessage(LoadController.java:119)
	at Launch//cpw.mods.fml.common.Loader.initializeMods(Loader.java:745)
	at Launch//cpw.mods.fml.client.FMLClientHandler.finishMinecraftLoading(FMLClientHandler.java:311)
	at Launch//net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:552)
	at Launch//net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:878)
	at Launch//net.minecraft.client.main.Main.main(SourceFile:148)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at System//net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
	at System//net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
	at System//net.minecraft.launchwrapper.Launch.main(Launch.java:60)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at System//org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:243)
	at System//org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:278)
	at System//org.multimc.EntryPoint.listen(EntryPoint.java:143)
	at System//org.multimc.EntryPoint.main(EntryPoint.java:34)
```