### PR TITLE
Add lsc casing to lsc assembler recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2425,7 +2425,8 @@ public class AssemblerRecipes implements Runnable {
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.battery, Materials.EV, 4),
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.LuV, 2),
-                        ItemList.Circuit_Chip_PIC.get(2))
+                        ItemList.Circuit_Chip_PIC.get(2),
+                        new ItemStack(kekztech.common.Blocks.lscLapotronicEnergyUnit, 1, 0))
                 .itemOutputs(TileEntities.lsc.getStackForm(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
 


### PR DESCRIPTION
Adds previously missing lsc casing to the lsc recipe, previously allowing for a slightly cheaper assembler recipe for no reason.