### PR TITLE
Change shadow steel recipe to be similar to the HV steel recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BlastFurnaceRecipes.java
@@ -965,11 +965,10 @@ public class BlastFurnaceRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.ShadowIron, 1L),
-                        GTUtility.getIntegratedCircuit(11))
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.ShadowIron, 4L),
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Carbon, 1L))
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.ShadowSteel, 1L))
-                .fluidInputs(Materials.Oxygen.getGas(1000L)).duration(25 * SECONDS).eut(TierEU.RECIPE_MV)
-                .metadata(COIL_HEAT, 1100).addTo(blastFurnaceRecipes);
+                .duration(10 * SECONDS).eut(TierEU.RECIPE_EV).metadata(COIL_HEAT, 2000).addTo(blastFurnaceRecipes);
 
         GTValues.RA.stdBuilder()
                 .itemInputs(

--- a/src/main/java/com/dreammaster/gthandler/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BlastFurnaceRecipes.java
@@ -967,7 +967,7 @@ public class BlastFurnaceRecipes implements Runnable {
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.ShadowIron, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Carbon, 1L))
-                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.ShadowSteel, 1L))
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.ShadowSteel, 4L))
                 .duration(10 * SECONDS).eut(TierEU.RECIPE_EV).metadata(COIL_HEAT, 2000).addTo(blastFurnaceRecipes);
 
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17784

While shadow steel does not conflict with shadow iron ingot, this is the only recipe which makes another item while fluids are stocked, so you either have to manually remove oxygen from MBFs, dedicating a MBF without oxygen, or autocrafting the gasses for it.

This changes the recipe to follow the carbon way of making steel for shadow steel, 4 shadow iron and 1 carbon makes 4 shadow steel
![image](https://github.com/user-attachments/assets/414f7508-7d9c-48cf-ba21-8d94d7b65a57)
This PR does increase the voltage and coil requirement for it, but since shadow iron is a T5+ ore, this shouldn't affect anything