### PR TITLE
Adds conversion recipes to busses and hatches

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -2148,6 +2148,315 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
         GTModHandler.addShapelessCraftingRecipe(
                 tectech.thing.CustomItemList.Machine_Multi_EyeOfHarmony.get(1L),
                 new Object[] { tectech.thing.CustomItemList.Machine_Multi_EyeOfHarmony.get(1L) });
+
+        // Bus and Hatch Conversion
+        // Input bus to Output bus
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_Bus_ULV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_Bus_ULV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_Bus_LV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_Bus_LV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_Bus_MV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_Bus_MV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_Bus_HV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_Bus_HV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_Bus_EV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_Bus_EV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_Bus_IV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_Bus_IV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_Bus_LuV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_Bus_LuV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_Bus_ZPM.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_Bus_ZPM, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_Bus_UV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_Bus_UV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_Bus_MAX.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_Bus_MAX, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        // Output bus to Input bus
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_Bus_ULV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_Bus_ULV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_Bus_LV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_Bus_LV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_Bus_MV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_Bus_MV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_Bus_HV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_Bus_HV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_Bus_EV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_Bus_EV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_Bus_IV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_Bus_IV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_Bus_LuV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_Bus_LuV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_Bus_ZPM.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_Bus_ZPM, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_Bus_UV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_Bus_UV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_Bus_MAX.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_Bus_MAX, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        // Input hatch to Output Hatch
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_ULV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_ULV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_LV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_LV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_MV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_MV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_HV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_HV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_EV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_EV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_IV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_IV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_LuV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_LuV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_ZPM.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_ZPM, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_UV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_UV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_UHV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_UHV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_UEV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_UEV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_UIV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_UIV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_UMV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_UMV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_UXV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_UXV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Output_MAX.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Input_MAX, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        // Output hatch to Input Hatch
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_ULV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_ULV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_LV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_LV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_MV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_MV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_HV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_HV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_EV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_EV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_IV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_IV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_LuV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_LuV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_ZPM.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_ZPM, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_UV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_UV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_UHV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_UHV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_UEV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_UEV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_UIV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_UIV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_UMV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_UMV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_UXV.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_UXV, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
+
+        GTModHandler.addCraftingRecipe(
+                ItemList.Hatch_Input_MAX.get(1),
+                bits,
+                new Object[] { " S ", " B ", "   ", 'B', ItemList.Hatch_Output_MAX, 'S',
+                        ToolDictNames.craftingToolScrewdriver, });
     }
 
     private Consumer<Recipe> shapelessUnremovableGtRecipes() {


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/8273

In early game especially, players might do the mistake of making an output hatch even though they wanted an input hatch for their first ebf, but currently there is no way to convert the busses or hatches to the other counterpart.

This adds screwdriver recipes to freely convert output <-> input

![java_1kjM608rGB](https://github.com/user-attachments/assets/7a1b1653-66d3-406c-ac99-b0c9e98b160d)
![java_L2CM1kyPVZ](https://github.com/user-attachments/assets/f1ba6ed5-2c91-4f4b-b388-ab20a92a41b0)
