### PR TITLE
Add Roquesite indium boost

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
@@ -1,5 +1,6 @@
 package com.dreammaster.gthandler.recipes;
 
+import static bartworks.system.material.WerkstoffLoader.Roquesit;
 import static goodgenerator.items.GGMaterial.indiumPhosphate;
 import static gregtech.api.enums.Mods.DraconicEvolution;
 import static gregtech.api.enums.Mods.Forestry;
@@ -607,6 +608,15 @@ public class ChemicalReactorRecipes implements Runnable {
                     .itemOutputs(GTOreDictUnificator.get(OrePrefixes.crushedPurified, Materials.Indium, 12))
                     .fluidInputs(Materials.PhthalicAcid.getFluid(2688)).duration(14 * SECONDS + 8 * TICKS)
                     .eut(TierEU.RECIPE_IV).addTo(UniversalChemical);
+
+            GTValues.RA.stdBuilder()
+                    .itemInputs(Roquesit.get(OrePrefixes.dust, 4), GTBees.combs.getStackForType(CombType.INDIUM, 4))
+                    .itemOutputs(
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Copper, 1),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Indium, 3),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Sulfur, 2))
+                    .fluidInputs(Materials.PhthalicAcid.getFluid(90)).duration(3 * SECONDS + 4 * TICKS)
+                    .eut(TierEU.RECIPE_HV).addTo(multiblockChemicalReactorRecipes);
         }
     }
 


### PR DESCRIPTION
Adds the missing indium boost from https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/967

![image](https://github.com/user-attachments/assets/cb0405e3-2aa3-4bb2-8cc9-b5c121c5a6a2)

Adds it to lcr instead of electrolyzer since electrolyzer would need circuit and would make the indium comb recipe multiblock only, but if that's preferred, I could change it.

Regular roquesite processing:
![image](https://github.com/user-attachments/assets/43fa7692-b244-4ae9-8754-1ab72bc25b39)