### PR TITLE
Fix glass dupe using aurora

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -1710,14 +1710,30 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
         }
 
         if (ZTones.isModLoaded()) {
+            // for recycling
             GTModHandler.addCraftingRecipe(
                     GTModHandler.getModItem(ZTones.ID, "stoneTile", 8L, 0),
-                    bits,
+                    GTModHandler.RecipeBits.REVERSIBLE,
+                    new Object[] { " S ", "STS", " S ", 'S', new ItemStack(Blocks.stone_slab, 1), 'T',
+                            new ItemStack(Blocks.stone, 1) });
+            GTModHandler.removeRecipeByOutput(GTModHandler.getModItem(ZTones.ID, "stoneTile", 8L, 0));
+            // actual
+            GTModHandler.addCraftingRecipe(
+                    GTModHandler.getModItem(ZTones.ID, "stoneTile", 8L, 0),
+                    bits4,
                     new Object[] { "SSS", "STS", "SSS", 'S', new ItemStack(Blocks.stone_slab, 1), 'T',
                             new ItemStack(Blocks.stone, 1) });
+            // for recycling
             GTModHandler.addCraftingRecipe(
                     GTModHandler.getModItem(ZTones.ID, "auroraBlock", 8L, 0),
-                    bits,
+                    GTModHandler.RecipeBits.REVERSIBLE,
+                    new Object[] { " G ", "GDG", " G ", 'G', new ItemStack(Blocks.glass, 1), 'D',
+                            new ItemStack(Items.dye, 1, GTValues.W) });
+            GTModHandler.removeRecipeByOutput(GTModHandler.getModItem(ZTones.ID, "auroraBlock", 8L, 0));
+            // actual
+            GTModHandler.addCraftingRecipe(
+                    GTModHandler.getModItem(ZTones.ID, "auroraBlock", 8L, 0),
+                    bits4,
                     new Object[] { "GGG", "GDG", "GGG", 'G', new ItemStack(Blocks.glass, 1), 'D',
                             new ItemStack(Items.dye, 1, GTValues.W) });
             GTModHandler.addCraftingRecipe(


### PR DESCRIPTION
Fixes a glass duplication bug with Ztones' Aurora block.

8 Glass -> 8 Aurora in the crafting table, 4 Glass -> 8 Aurora in the assembler, but the recycling recipes (macerator / fluid extractor) converted 1 Aurora -> 1 Glass. This is now halfed to match the assembler ratio.

Also fixes the same duplication bug with Ztones' Ztone Tile.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10070 and partially closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17127