### PR TITLE
Fix array out of bounds crash in DebugHandler

### DIFF
--- a/src/main/java/com/dreammaster/main/DebugHandler.java
+++ b/src/main/java/com/dreammaster/main/DebugHandler.java
@@ -13,7 +13,12 @@ public final class DebugHandler {
     public void onDrawDebug(RenderGameOverlayEvent.Text event) {
         if (Minecraft.getMinecraft().gameSettings.showDebugInfo) {
             if (MainRegistry.CoreConfig.ModDebugVersionDisplay_Enabled) {
-                event.left.add(1, String.format("%s %s", Refstrings.NAME, Refstrings.MODPACKPACK_VERSION));
+                final String text = String.format("%s %s", Refstrings.NAME, Refstrings.MODPACKPACK_VERSION);
+                if (event.left.isEmpty()) {
+                    event.left.add(text);
+                } else {
+                    event.left.add(1, text);
+                }
             }
         }
     }


### PR DESCRIPTION
If a mod cancels the `RenderGameOverlayEvent.Pre` for `type == DEBUG`, the lists `event.left` and `event.right` will be empty, therefore we need to check the sizes before adding to a specific index.

```
java.lang.IndexOutOfBoundsException: Index: 1, Size: 0
    at java.util.ArrayList.rangeCheckForAdd(ArrayList.java:756)
    at java.util.ArrayList.add(ArrayList.java:481)
    at com.dreammaster.main.DebugHandler.onDrawDebug(DebugHandler.java:16)
    at cpw.mods.fml.common.eventhandler.ASMEventHandler_1336_DebugHandler_onDrawDebug_Text.invoke(.dynamic)
    at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
    at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
    at net.minecraftforge.client.GuiIngameForge.renderHUDText(GuiIngameForge.java:699)
    at net.minecraftforge.client.GuiIngameForge.renderGameOverlay(GuiIngameForge.java:155)
    at com.gtnewhorizons.angelica.hudcaching.HUDCaching.renderCachedHud(HUDCaching.java:130)
    at net.minecraft.client.renderer.EntityRenderer.redirect$zfh000$angelica$renderCachedHUD(EntityRenderer.java:4068)
    at net.minecraft.client.renderer.EntityRenderer.updateCameraAndRender(EntityRenderer.java:1038)
    at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1001)
    at net.minecraft.client.Minecraft.run(Minecraft.java:5110)
    at net.minecraft.client.main.Main.main(SourceFile:148)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:568)
    at net.minecraft.launchwrapper.Launch.rfb$realLaunch(Launch.java:250)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:35)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:60)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:568)
    at com.gtnewhorizons.retrofuturabootstrap.Main.main(Main.java:207)
    at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:100)
    at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129)
    at org.prismlauncher.EntryPoint.main(EntryPoint.java:70)
```