### PR TITLE
Add fallback string for close window dialog

### DIFF
--- a/src/main/java/com/dreammaster/mixin/mixins/early/MixinMinecraft_ConfirmExit.java
+++ b/src/main/java/com/dreammaster/mixin/mixins/early/MixinMinecraft_ConfirmExit.java
@@ -7,7 +7,7 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.I18n;
+import net.minecraft.util.StatCollector;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -48,7 +48,12 @@ public class MixinMinecraft_ConfirmExit {
                 final ImageIcon imageIcon = resource == null ? null : new ImageIcon(resource);
                 final int result = JOptionPane.showConfirmDialog(
                         frame,
-                        I18n.format("dreamcraft.gui.quitmessage"),
+                        // When FML encounters an error, the only way to close the window is through the close button,
+                        // which will show this message, unfortunately at this point, no localisations will have been
+                        // loaded, so we add a hardcoded fallback message here.
+                        StatCollector.canTranslate("dreamcraft.gui.quitmessage")
+                                ? StatCollector.translateToLocal("dreamcraft.gui.quitmessage")
+                                : "Are you sure you want to exit the game?",
                         Refstrings.NAME,
                         JOptionPane.YES_NO_OPTION,
                         JOptionPane.QUESTION_MESSAGE,

--- a/src/main/resources/assets/dreamcraft/lang/en_US.lang
+++ b/src/main/resources/assets/dreamcraft/lang/en_US.lang
@@ -1739,7 +1739,7 @@ item.tconstruct.manual.weaponry.part_materials=\n\nValid Shaft Materials:\n* Sti
 item.tconstruct.manual.weaponry.bolts=\n\nBolts:\nCrafting bolts is a delicate process. First you need a core in the form of a tool rod.\nTake this tool rod to a smeltery and put it into a Casting Table. Pour some metal onto it to coat the tip with a more damaging material.\nAfter this process, add a fletching and your bolts are ready to be used.\n\nSince the bolts consist of a harder core and tip they carry more weight than regular arrows, making them perfect to fight armored targets.
 
 dreamcraft.mobsinfocompat.limitedropcount=Drops only %s times per person
-dreamcraft.gui.quitmessage=Are you sure you want to exit the game ?
+dreamcraft.gui.quitmessage=Are you sure you want to exit the game?
 
 dreamcraft.welcome.welcome=Welcome to Gregtech: New Horizons
 dreamcraft.welcome.questbook=The Quest Book has a shortcut key, check your keybindings.


### PR DESCRIPTION
When FML encounters an error, the only way to quit the game is through the close button. This will show a "are you sure" dialog. Unfortunately, the dialog will show no message as locales have not been loaded yet at this stage. This adds a fallback message in English (same locale as the FML error).

Fixes the following:
![GTNH close window bug](https://github.com/user-attachments/assets/72d8bc7b-7eb6-4d49-b4a1-17a474e9eb84)
