### PR TITLE
added preconfigured storage buses

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.50.77:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.50.78:dev")
     api("com.github.GTNewHorizons:Yamcl:0.6.0:dev")
     api("com.github.GTNewHorizons:Baubles:1.0.4:dev")
 

--- a/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
@@ -448,10 +448,7 @@ public class ScriptAE2FC implements IScriptLoader {
                     .itemOutputs(preconfiguredStorageBus).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                     .addTo(circuitAssemblerRecipes);
 
-            addShapelessRecipe(
-                    preconfiguredStorageBus,
-                    AE2FC_FLUID_STORAGE_BUS,
-                    GTUtility.getIntegratedCircuit(i));
+            addShapelessRecipe(preconfiguredStorageBus, AE2FC_FLUID_STORAGE_BUS, GTUtility.getIntegratedCircuit(i));
         }
 
         // Big Long But: Components in Circuit Assembler

--- a/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
@@ -436,6 +437,17 @@ public class ScriptAE2FC implements IScriptLoader {
                 .itemInputs(AE2_STORAGE_BUS, GTOreDictUnificator.get(OrePrefixes.plate, Materials.Lapis, 3))
                 .itemOutputs(AE2FC_FLUID_STORAGE_BUS).duration(15 * SECONDS).eut(TierEU.RECIPE_MV)
                 .addTo(assemblerRecipes);
+
+        // preconfigurated priorities for storage buses
+        ItemStack preconfiguredStorageBus = AE2FC_FLUID_STORAGE_BUS.copy();
+        for (int i = 1; i < 25; i++) {
+            NBTTagCompound tag = new NBTTagCompound();
+            tag.setInteger("priority", i);
+            preconfiguredStorageBus.setTagCompound(tag);
+            GTValues.RA.stdBuilder().itemInputs(AE2FC_FLUID_STORAGE_BUS, GTUtility.getIntegratedCircuit(i))
+                    .itemOutputs(preconfiguredStorageBus).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                    .addTo(assemblerRecipes);
+        }
 
         // Big Long But: Components in Circuit Assembler
         // 1k ME Storage Component

--- a/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
@@ -446,7 +446,12 @@ public class ScriptAE2FC implements IScriptLoader {
             preconfiguredStorageBus.setTagCompound(tag);
             GTValues.RA.stdBuilder().itemInputs(AE2FC_FLUID_STORAGE_BUS, GTUtility.getIntegratedCircuit(i))
                     .itemOutputs(preconfiguredStorageBus).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
-                    .addTo(assemblerRecipes);
+                    .addTo(circuitAssemblerRecipes);
+
+            addShapelessRecipe(
+                    preconfiguredStorageBus,
+                    AE2FC_FLUID_STORAGE_BUS,
+                    GTUtility.getIntegratedCircuit(i));
         }
 
         // Big Long But: Components in Circuit Assembler

--- a/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
@@ -101,7 +101,12 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
             preconfiguredStorageBus.setTagCompound(tag);
             GTValues.RA.stdBuilder().itemInputs(storageBus, GTUtility.getIntegratedCircuit(i))
                     .itemOutputs(preconfiguredStorageBus).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
-                    .addTo(assemblerRecipes);
+                    .addTo(circuitAssemblerRecipes);
+
+            addShapelessRecipe(
+                    preconfiguredStorageBus,
+                    storageBus,
+                    GTUtility.getIntegratedCircuit(i));
         }
         // Hyper-Acceleration Card
         addShapelessRecipe(

--- a/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
@@ -90,7 +91,18 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
         ItemStack[] FluixSmartCableColor = new ItemStack[16];
         ItemStack[] FluixDenseSmartCableColor = new ItemStack[16];
         ItemStack[] FluixGlassCableColor = new ItemStack[16];
+        final ItemStack storageBus = getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 220, missing);
 
+        // preconfigurated priorities for storage buses
+        ItemStack preconfiguredStorageBus = storageBus.copy();
+        for (int i = 1; i < 25; i++) {
+            NBTTagCompound tag = new NBTTagCompound();
+            tag.setInteger("priority", i);
+            preconfiguredStorageBus.setTagCompound(tag);
+            GTValues.RA.stdBuilder().itemInputs(storageBus, GTUtility.getIntegratedCircuit(i))
+                    .itemOutputs(preconfiguredStorageBus).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
+                    .addTo(assemblerRecipes);
+        }
         // Hyper-Acceleration Card
         addShapelessRecipe(
                 SuperSpeedCard,
@@ -1411,7 +1423,7 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L));
         // ME storage bus
         addShapedRecipe(
-                getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 220, missing),
+                storageBus,
                 "craftingToolScrewdriver",
                 "chestWood",
                 "craftingToolHardHammer",
@@ -1911,8 +1923,7 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
                         getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 440, missing),
                         GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 2),
                         ItemList.Electric_Piston_LV.get(1L))
-                .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemMultiPart", 1, 220, missing))
-                .duration(10 * SECONDS).eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
+                .itemOutputs(storageBus).duration(10 * SECONDS).eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1),

--- a/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
@@ -103,10 +103,7 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
                     .itemOutputs(preconfiguredStorageBus).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                     .addTo(circuitAssemblerRecipes);
 
-            addShapelessRecipe(
-                    preconfiguredStorageBus,
-                    storageBus,
-                    GTUtility.getIntegratedCircuit(i));
+            addShapelessRecipe(preconfiguredStorageBus, storageBus, GTUtility.getIntegratedCircuit(i));
         }
         // Hyper-Acceleration Card
         addShapelessRecipe(


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17821
requires https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/615 and https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/615

Add recipes for preconfigured storage and fluid storage buses, from priority 1 to priority 24.

![image](https://github.com/user-attachments/assets/4e625e00-cfdd-4e72-bfba-f12c121d8e18)
(tooltips added with CustomTooltips)