### PR TITLE
fix a few recipe conflicts

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2587,7 +2587,7 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Steel, 1),
                         GTOreDictUnificator.get(OrePrefixes.stick, Materials.Steel, 4),
                         GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 4),
-                        GTUtility.getIntegratedCircuit(3))
+                        GTUtility.getIntegratedCircuit(13))
                 .itemOutputs(ItemList.Casing_Firebox_Steel.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
                 .addTo(assemblerRecipes);
 
@@ -2596,7 +2596,7 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Titanium, 1),
                         GTOreDictUnificator.get(OrePrefixes.stick, Materials.Titanium, 4),
                         GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 4),
-                        GTUtility.getIntegratedCircuit(3))
+                        GTUtility.getIntegratedCircuit(13))
                 .itemOutputs(ItemList.Casing_Firebox_Titanium.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
                 .addTo(assemblerRecipes);
 
@@ -2605,7 +2605,7 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.TungstenSteel, 1),
                         GTOreDictUnificator.get(OrePrefixes.stick, Materials.TungstenSteel, 4),
                         GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 4),
-                        GTUtility.getIntegratedCircuit(3))
+                        GTUtility.getIntegratedCircuit(13))
                 .itemOutputs(ItemList.Casing_Firebox_TungstenSteel.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
                 .addTo(assemblerRecipes);
 


### PR DESCRIPTION
fix proper recipe conflicts for firebox assembler recipes and bars.

fixes part of https://discord.com/channels/181078474394566657/522098956491030558/1315089195945033771

found with the nei custom diagram and checked with it afterwards.