### PR TITLE
Added recipes in oreder to get currently unobtainable foods

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
@@ -8,7 +8,6 @@ import static gregtech.api.enums.Mods.DraconicEvolution;
 import static gregtech.api.enums.Mods.EnderIO;
 import static gregtech.api.enums.Mods.ExtraTrees;
 import static gregtech.api.enums.Mods.Genetics;
-import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.KubaTech;
 import static gregtech.api.enums.Mods.Natura;
@@ -1215,7 +1214,7 @@ public class MixerRecipes implements Runnable {
                     .itemOutputs(
                             new ItemStack(Items.glass_bottle, 2, 0),
                             new ItemStack(Items.bucket, 1, 0),
-                            GTModHandler.getModItem(GregTech.ID, "gt.metaitem.01", 1L, 32404))
+                            ItemList.ThermosCan_Empty.get(1L))
                     .fluidInputs(
                             FluidRegistry.getFluidStack("potion.diablosauce", 7500),
                             FluidRegistry.getFluidStack("potion.piratebrew", 2500),

--- a/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
@@ -1200,18 +1200,15 @@ public class MixerRecipes implements Runnable {
                             MaterialsUEVplus.ExcitedDTEC.getFluid(128000))
                     .duration(3 * SECONDS).eut(TierEU.RECIPE_UIV).addTo(mixerNonCellRecipes);
         }
-        if (KubaTech.isModLoaded() && EnderIO.isModLoaded()
-                && BiomesOPlenty.isModLoaded()
-                && Witchery.isModLoaded()
-                && GregTech.isModLoaded()) {
+        if (KubaTech.isModLoaded() && EnderIO.isModLoaded() && BiomesOPlenty.isModLoaded() && Witchery.isModLoaded()) {
             GTValues.RA.stdBuilder()
                     .itemInputs(
-                            GTModHandler.getModItem(KubaTech.ID, "kubaitems", 1L, 14),
-                            GTModHandler.getModItem(KubaTech.ID, "kubaitems", 1L, 16),
-                            GTModHandler.getModItem(KubaTech.ID, "kubaitems", 1L, 17),
-                            GTModHandler.getModItem(KubaTech.ID, "kubaitems", 1L, 19),
+                            kubatech.api.enums.ItemList.EarlGrayTea.get(1),
+                            kubatech.api.enums.ItemList.LemonTea.get(1),
+                            kubatech.api.enums.ItemList.MilkTea.get(1),
+                            kubatech.api.enums.ItemList.PeppermintTea.get(1),
                             GTModHandler.getModItem(EnderIO.ID, "bucketVapor_of_levity", 1L),
-                            GTModHandler.getModItem(GregTech.ID, "gt.metaitem.02", 1L, 32009),
+                            ItemList.ThermosCan_Ice_Tea.get(1L),
                             GTModHandler.getModItem(BiomesOPlenty.ID, "food", 1L, 10),
                             GTModHandler.getModItem(Witchery.ID, "potion", 1L),
                             GTModHandler.getModItem(Witchery.ID, "ingredient", 1L, 40))

--- a/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
@@ -9,7 +9,6 @@ import static gregtech.api.enums.Mods.EnderIO;
 import static gregtech.api.enums.Mods.ExtraTrees;
 import static gregtech.api.enums.Mods.Genetics;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
-import static gregtech.api.enums.Mods.KubaTech;
 import static gregtech.api.enums.Mods.Natura;
 import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.PamsHarvestCraft;
@@ -1199,7 +1198,7 @@ public class MixerRecipes implements Runnable {
                             MaterialsUEVplus.ExcitedDTEC.getFluid(128000))
                     .duration(3 * SECONDS).eut(TierEU.RECIPE_UIV).addTo(mixerNonCellRecipes);
         }
-        if (KubaTech.isModLoaded() && EnderIO.isModLoaded() && BiomesOPlenty.isModLoaded() && Witchery.isModLoaded()) {
+        if (EnderIO.isModLoaded() && BiomesOPlenty.isModLoaded() && Witchery.isModLoaded()) {
             GTValues.RA.stdBuilder()
                     .itemInputs(
                             kubatech.api.enums.ItemList.EarlGrayTea.get(1),

--- a/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
@@ -8,7 +8,9 @@ import static gregtech.api.enums.Mods.DraconicEvolution;
 import static gregtech.api.enums.Mods.EnderIO;
 import static gregtech.api.enums.Mods.ExtraTrees;
 import static gregtech.api.enums.Mods.Genetics;
+import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
+import static gregtech.api.enums.Mods.KubaTech;
 import static gregtech.api.enums.Mods.Natura;
 import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.PamsHarvestCraft;
@@ -1197,6 +1199,37 @@ public class MixerRecipes implements Runnable {
                             GGMaterial.naquadahBasedFuelMkV.getFluidOrGas(1000),
                             MaterialsUEVplus.ExcitedDTEC.getFluid(128000))
                     .duration(3 * SECONDS).eut(TierEU.RECIPE_UIV).addTo(mixerNonCellRecipes);
+        }
+        if (KubaTech.isModLoaded() && EnderIO.isModLoaded()
+                && BiomesOPlenty.isModLoaded()
+                && Witchery.isModLoaded()
+                && GregTech.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                    .itemInputs(
+                            GTModHandler.getModItem(KubaTech.ID, "kubaitems", 1L, 14),
+                            GTModHandler.getModItem(KubaTech.ID, "kubaitems", 1L, 16),
+                            GTModHandler.getModItem(KubaTech.ID, "kubaitems", 1L, 17),
+                            GTModHandler.getModItem(KubaTech.ID, "kubaitems", 1L, 19),
+                            GTModHandler.getModItem(EnderIO.ID, "bucketVapor_of_levity", 1L),
+                            GTModHandler.getModItem(GregTech.ID, "gt.metaitem.02", 1L, 32009),
+                            GTModHandler.getModItem(BiomesOPlenty.ID, "food", 1L, 10),
+                            GTModHandler.getModItem(Witchery.ID, "potion", 1L),
+                            GTModHandler.getModItem(Witchery.ID, "ingredient", 1L, 40))
+                    .itemOutputs(
+                            new ItemStack(Items.glass_bottle, 2, 0),
+                            new ItemStack(Items.bucket, 1, 0),
+                            GTModHandler.getModItem(GregTech.ID, "gt.metaitem.01", 1L, 32404))
+                    .fluidInputs(
+                            FluidRegistry.getFluidStack("potion.diablosauce", 7500),
+                            FluidRegistry.getFluidStack("potion.piratebrew", 2500),
+                            FluidRegistry.getFluidStack("potion.jagi", 2500),
+                            FluidRegistry.getFluidStack("potion.alcopops", 2500),
+                            FluidRegistry.getFluidStack("potion.goldencider", 2500),
+                            FluidRegistry.getFluidStack("potion.chocolatemilk", 7500))
+                    .fluidOutputs(
+                            FluidRegistry.getFluidStack("potion.diablosauce.strong", 12000),
+                            FluidRegistry.getFluidStack("potion.mundane", 22000))
+                    .duration(200 * SECONDS).eut(TierEU.RECIPE_ZPM).addTo(mixerNonCellRecipes);
         }
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptBiomesOPlenty.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiomesOPlenty.java
@@ -2,11 +2,14 @@ package com.dreammaster.scripts;
 
 import static com.dreammaster.main.MainRegistry.Module_CustomFuels;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
+import static gregtech.api.enums.Mods.Botany;
 import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.GTPlusPlus;
+import static gregtech.api.enums.Mods.HardcoreEnderExpansion;
 import static gregtech.api.enums.Mods.IguanaTweaksTinkerConstruct;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.PamsHarvestCraft;
+import static gregtech.api.enums.Mods.RandomThings;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.recipe.RecipeMaps.centrifugeRecipes;
 import static gregtech.api.recipe.RecipeMaps.extractorRecipes;
@@ -14,6 +17,7 @@ import static gregtech.api.recipe.RecipeMaps.fluidCannerRecipes;
 import static gregtech.api.recipe.RecipeMaps.fluidExtractionRecipes;
 import static gregtech.api.recipe.RecipeMaps.fluidSolidifierRecipes;
 import static gregtech.api.recipe.RecipeMaps.maceratorRecipes;
+import static gregtech.api.recipe.RecipeMaps.mixerRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
@@ -29,6 +33,7 @@ import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
@@ -283,6 +288,24 @@ public class ScriptBiomesOPlenty implements IScriptLoader {
                         GTOreDictUnificator.get(OrePrefixes.dustSmall, Materials.Gypsum, 1L),
                         GTOreDictUnificator.get(OrePrefixes.dustSmall, Materials.Calcite, 1L))
                 .outputChances(10000, 7500, 2500, 2500).duration(10 * SECONDS).eut(8).addTo(maceratorRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(HardcoreEnderExpansion.ID, "end_powder", 8L),
+                        getModItem(RandomThings.ID, "ingredient", 1L, 6))
+                .itemOutputs(GTModHandler.getModItem(BiomesOPlenty.ID, "misc", 1L, 4))
+                .fluidInputs(FluidRegistry.getFluidStack("endergoo", 1000)).duration(15 * SECONDS).eut(TierEU.RECIPE_HV)
+                .addTo(mixerRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Salt, 1L),
+                        getModItem(PamsHarvestCraft.ID, "seaweedItem", 32L),
+                        getModItem(Botany.ID, "misc", 1L, 7))
+                .itemOutputs(GTModHandler.getModItem(BiomesOPlenty.ID, "coral1", 32L, 11))
+                .fluidInputs(FluidRegistry.getFluidStack("weedex9000", 100)).duration(15 * SECONDS)
+                .eut(TierEU.RECIPE_MV).addTo(mixerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "jarEmpty", 1L))
+                .itemOutputs(getModItem(BiomesOPlenty.ID, "jarFilled", 1L)).fluidInputs(Materials.Honey.getFluid(1000L))
+                .duration(2 * SECONDS).eut(1).addTo(fluidCannerRecipes);
 
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptExtraTrees.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraTrees.java
@@ -7476,5 +7476,27 @@ public class ScriptExtraTrees implements IScriptLoader {
                 "stickWood",
                 getModItem(Minecraft.ID, "planks", 1, 5, missing),
                 "stickWood");
+        addShapedRecipe(
+                createItemStack(ExtraTrees.ID, "food", 1, 23, "{meta:23}", missing),
+                "dustSugar",
+                getModItem(Minecraft.ID, "sand", 1, 1, missing),
+                "dustSugar",
+                getModItem(Minecraft.ID, "sand", 1, 1, missing),
+                "cropPear",
+                getModItem(Minecraft.ID, "sand", 1, 1, missing),
+                "dustSugar",
+                getModItem(Minecraft.ID, "sand", 1, 1, missing),
+                "dustSugar");
+        addShapedRecipe(
+                createItemStack(ExtraTrees.ID, "food", 1, 40, "{meta:40}", missing),
+                "dustLazurite",
+                "gemChippedOlivine",
+                "dustLapis",
+                "dustSugar",
+                getModItem(Forestry.ID, "fruits", 1, 6, missing),
+                "gemChippedOlivine",
+                "dustSodalite",
+                "dustSugar",
+                "dustLazurite");
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicExploration.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicExploration.java
@@ -2,7 +2,9 @@ package com.dreammaster.scripts;
 
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.ExtraUtilities;
+import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.Minecraft;
+import static gregtech.api.enums.Mods.Natura;
 import static gregtech.api.enums.Mods.PamsHarvestCraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.ThaumicExploration;
@@ -1888,6 +1890,23 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         TCHelper.findInfusionRecipe(getModItem(ThaumicExploration.ID, "talismanFood", 1, 0, missing))));
         TCHelper.addResearchPrereq("THINKTANK", "BraincureGTNH", false);
         ThaumcraftApi.addWarpToResearch("THINKTANK", 2);
+        ThaumcraftApi.addArcaneCraftingRecipe(
+                "TalismanfoodtGTNH",
+                getModItem(ThaumicExploration.ID, "taintBerry", 1, 0, missing),
+                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("aqua"), 20)
+                        .add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("terra"), 20)
+                        .add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("perditio"), 25),
+                "tft",
+                "gbg",
+                "ggg",
+                't',
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
+                'g',
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                'b',
+                getModItem(Natura.ID, "berry.nether", 1, missing),
+                'f',
+                getModItem(ForbiddenMagic.ID, "TaintFruit", 1, missing));
         TCHelper.orphanResearch("DREAMCATCHER");
         TCHelper.removeResearch("DREAMCATCHER");
         new ResearchItem(

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicHorizons.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicHorizons.java
@@ -1,8 +1,12 @@
 package com.dreammaster.scripts;
 
+import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.ThaumicHorizons;
+import static gregtech.api.recipe.RecipeMaps.compressorRecipes;
+import static gregtech.api.recipe.RecipeMaps.extractorRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
+import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 
 import java.util.Arrays;
 import java.util.List;
@@ -11,6 +15,7 @@ import net.minecraft.item.ItemStack;
 
 import com.dreammaster.thaumcraft.TCHelper;
 
+import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
 import gregtech.api.enums.OrePrefixes;
@@ -195,5 +200,11 @@ public class ScriptThaumicHorizons implements IScriptLoader {
         TCHelper.refreshResearchPages("transductionAmplifier");
         TCHelper.refreshResearchPages("vortexStabilizer");
         TCHelper.refreshResearchPages("recombinator");
+        GTValues.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "flesh", 2, missing))
+                .itemOutputs(getModItem(ThaumicHorizons.ID, "meatTH", 1, missing)).duration(15 * SECONDS).eut(2)
+                .addTo(compressorRecipes);
+        GTValues.RA.stdBuilder().itemInputs(getModItem(ThaumicHorizons.ID, "meatCookedTH", 1, missing))
+                .itemOutputs(getModItem(ThaumicHorizons.ID, "meatNuggetTH", 4, missing)).duration(15 * SECONDS).eut(2)
+                .addTo(extractorRecipes);
     }
 }


### PR DESCRIPTION
Related to https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17406

![image](https://github.com/user-attachments/assets/800b66b6-b1a2-46b7-a507-a465316cbaa4)
![image](https://github.com/user-attachments/assets/7e930441-459b-495f-9342-a0aed3bfbf0d)
![image](https://github.com/user-attachments/assets/0a3738ac-ffdc-4d8a-a314-8f38b046508b)
![image](https://github.com/user-attachments/assets/eeb0deb0-2b23-4386-a77a-886579d9189b)
![image](https://github.com/user-attachments/assets/a62314fa-0654-44c9-9004-335f51d54c27)
![image](https://github.com/user-attachments/assets/e883d594-eb54-4ffe-b3c9-ddfffea90c23)
![image](https://github.com/user-attachments/assets/9e6560bf-9845-4f41-886a-06bff653a65c)
The last recipe is a meme recipe using various brews, teas, and Jäggermesiter

and a QOL recipe for getting the honney jar, since the only way is to place honney in world and click it
![image](https://github.com/user-attachments/assets/d340e927-9a09-49d0-96f4-6f319533b7ba)
