### PR TITLE
stop Luv solenoid being gated ZPM

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -1447,7 +1447,7 @@ public class AssemblingLineRecipes implements Runnable {
                             GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.NiobiumTitanium, 1L),
                             WerkstoffMaterialPool.MuMetal.get(OrePrefixes.stickLong, 8),
                             GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.HSSS, 2L),
-                            ItemList.Reactor_Coolant_Sp_6.get(1),
+                            ItemList.Reactor_Coolant_Sp_3.get(2),
                             ItemList.Electric_Pump_LuV.get(1))
                     .fluidInputs(new FluidStack(solderIndalloy, (int) (L * 4)))
                     .itemOutputs(ItemList.Superconducting_Magnet_Solenoid_LuV.get(1)).duration(20 * SECONDS)


### PR DESCRIPTION
as described in the issue, 1080k Sp Coolant needs Fluxed Elextrum, which needs Trinium Coils which needs ZPM Assembler in LuV
changed the 1 1080k Sp to 2 540k Sp Coolant Cells
![image](https://github.com/user-attachments/assets/f9e74cbd-f9a6-432b-ba4e-f755e301f228)
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18201
