### PR TITLE
fix 2 Coolant Cells in same Slot for LuV Solenoid

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -1447,7 +1447,8 @@ public class AssemblingLineRecipes implements Runnable {
                             GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.NiobiumTitanium, 1L),
                             WerkstoffMaterialPool.MuMetal.get(OrePrefixes.stickLong, 8),
                             GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.HSSS, 2L),
-                            ItemList.Reactor_Coolant_Sp_3.get(2),
+                            ItemList.Reactor_Coolant_Sp_3.get(1),
+                            ItemList.Reactor_Coolant_Sp_3.get(1),
                             ItemList.Electric_Pump_LuV.get(1))
                     .fluidInputs(new FluidStack(solderIndalloy, (int) (L * 4)))
                     .itemOutputs(ItemList.Superconducting_Magnet_Solenoid_LuV.get(1)).duration(20 * SECONDS)


### PR DESCRIPTION
made a mistake when changing the Coolant cells from 1080 to 540 here: https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1107
changes it to 2 different slots instead of 2 in one slot
![image](https://github.com/user-attachments/assets/f93a40fe-2704-4b83-88b3-3202433f83ab)
