### PR TITLE
Nerf glass loop 

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/FluidExtractorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/FluidExtractorRecipes.java
@@ -6,7 +6,6 @@ import static gregtech.api.recipe.RecipeMaps.fluidExtractionRecipes;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 
-import gregtech.api.recipe.RecipeCategories;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -16,6 +15,7 @@ import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.TierEU;
+import gregtech.api.recipe.RecipeCategories;
 import gregtech.api.util.GTModHandler;
 
 public class FluidExtractorRecipes implements Runnable {
@@ -71,13 +71,11 @@ public class FluidExtractorRecipes implements Runnable {
 
             GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(TinkerConstruct.ID, "GlassBlock", 1L, 0))
                     .fluidOutputs(Materials.Glass.getMolten(144L)).duration(24 * TICKS).eut(54)
-                    .recipeCategory(RecipeCategories.fluidExtractorRecycling)
-                    .addTo(fluidExtractionRecipes);
+                    .recipeCategory(RecipeCategories.fluidExtractorRecycling).addTo(fluidExtractionRecipes);
 
             GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(TinkerConstruct.ID, "GlassPane", 1L, 0))
                     .fluidOutputs(Materials.Glass.getMolten(54L)).duration(9 * TICKS).eut(54)
-                    .recipeCategory(RecipeCategories.fluidExtractorRecycling)
-                    .addTo(fluidExtractionRecipes);
+                    .recipeCategory(RecipeCategories.fluidExtractorRecycling).addTo(fluidExtractionRecipes);
 
         }
     }

--- a/src/main/java/com/dreammaster/gthandler/recipes/FluidExtractorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/FluidExtractorRecipes.java
@@ -6,6 +6,7 @@ import static gregtech.api.recipe.RecipeMaps.fluidExtractionRecipes;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 
+import gregtech.api.recipe.RecipeCategories;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -66,6 +67,16 @@ public class FluidExtractorRecipes implements Runnable {
 
             GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(TinkerConstruct.ID, "materials", 1L, 36))
                     .fluidOutputs(new FluidStack(FluidRegistry.getFluid("glue"), 144)).duration(5 * SECONDS).eut(16)
+                    .addTo(fluidExtractionRecipes);
+
+            GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(TinkerConstruct.ID, "GlassBlock", 1L, 0))
+                    .fluidOutputs(Materials.Glass.getMolten(144L)).duration(30 * TICKS).eut(54)
+                    .recipeCategory(RecipeCategories.fluidExtractorRecycling)
+                    .addTo(fluidExtractionRecipes);
+
+            GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(TinkerConstruct.ID, "GlassPane", 1L, 0))
+                    .fluidOutputs(Materials.Glass.getMolten(54L)).duration(9 * TICKS).eut(54)
+                    .recipeCategory(RecipeCategories.fluidExtractorRecycling)
                     .addTo(fluidExtractionRecipes);
 
         }

--- a/src/main/java/com/dreammaster/gthandler/recipes/FluidExtractorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/FluidExtractorRecipes.java
@@ -70,7 +70,7 @@ public class FluidExtractorRecipes implements Runnable {
                     .addTo(fluidExtractionRecipes);
 
             GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(TinkerConstruct.ID, "GlassBlock", 1L, 0))
-                    .fluidOutputs(Materials.Glass.getMolten(144L)).duration(30 * TICKS).eut(54)
+                    .fluidOutputs(Materials.Glass.getMolten(144L)).duration(24 * TICKS).eut(54)
                     .recipeCategory(RecipeCategories.fluidExtractorRecycling)
                     .addTo(fluidExtractionRecipes);
 

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -29,7 +29,6 @@ import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.recipe.RecipeMaps.alloySmelterRecipes;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
-import static gregtech.api.recipe.RecipeMaps.blastFurnaceRecipes;
 import static gregtech.api.recipe.RecipeMaps.cutterRecipes;
 import static gregtech.api.recipe.RecipeMaps.extractorRecipes;
 import static gregtech.api.recipe.RecipeMaps.fluidExtractionRecipes;

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -2167,18 +2167,6 @@ public class ScriptMinecraft implements IScriptLoader {
                         GTUtility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Minecraft.ID, "saddle", 1, 0, missing)).duration(5 * SECONDS).eut(24)
                 .addTo(assemblerRecipes);
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(TinkerConstruct.ID, "GlassBlock", 1, 0, missing),
-                        GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(getModItem(Minecraft.ID, "glass", 1, 0, missing)).duration(5 * SECONDS)
-                .eut(TierEU.RECIPE_MV).specialValue(1000).addTo(blastFurnaceRecipes);
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                        GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(getModItem(Minecraft.ID, "glass_pane", 1, 0, missing)).duration(5 * SECONDS)
-                .eut(TierEU.RECIPE_MV).specialValue(1000).addTo(blastFurnaceRecipes);
         GTValues.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "wooden_pressure_plate", 1, 0, missing))
                 .itemOutputs(getModItem(Minecraft.ID, "wooden_button", 2, 0, missing))
                 .fluidInputs(Materials.Water.getFluid(4)).duration(2 * SECONDS + 10 * TICKS).eut(4)


### PR DESCRIPTION
This PR removes the clear glass -> regular glass ebf recipes, since they were allowing for a godforge leveling cheese due to there also existing glass -> clear glass ebf recipes, forming a closed ebf loop.
Instead, there now are fluid extractor recipes for both clear glass panes and blocks with equal stats to those of regular glass.
![image](https://github.com/user-attachments/assets/84d06db7-6a8b-4d62-b8ad-e67a4e9adf77)
