### PR TITLE
Fix artificial universe cell recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -349,7 +349,7 @@ public class SpaceAssemblerRecipes implements Runnable {
                                 ItemList.Field_Generator_UXV.get(1L),
                                 filledUMVCell,
                                 new ItemStack(TTCasingsContainer.SpacetimeCompressionFieldGenerators, 4, 8),
-                                GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UXV, 4),
+                                MaterialsUEVplus.MagMatter.getNanite(4),
                                 MaterialsUEVplus.Eternity.getNanite(4))
                         .fluidInputs(MaterialsUEVplus.Eternity.getMolten(36864))
                         .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemExtremeStorageCell.Universe", 1))
@@ -381,7 +381,7 @@ public class SpaceAssemblerRecipes implements Runnable {
                                 new ItemStack(Loaders.yottaFluidTankCell, 2, 9),
                                 new ItemStack(tfftStorageField, 2, 10),
                                 new ItemStack(TTCasingsContainer.SpacetimeCompressionFieldGenerators, 4, 8),
-                                GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UXV, 4),
+                                MaterialsUEVplus.MagMatter.getNanite(4),
                                 MaterialsUEVplus.Eternity.getNanite(4))
                         .fluidInputs(MaterialsUEVplus.Eternity.getMolten(36864))
                         .itemOutputs(getModItem(AE2FluidCraft.ID, "fluid_storage.Universe", 1)).specialValue(3)

--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -341,9 +341,15 @@ public class SpaceAssemblerRecipes implements Runnable {
                     filledUMVCell.setTagCompound(euNBT);
                 }
 
+                ItemStack item_singularity = getModItem(
+                        AppliedEnergistics2.ID,
+                        "item.ItemExtremeStorageCell.Singularity",
+                        1);
+                item_singularity.setTagCompound(new NBTTagCompound());
+
                 GTValues.RA.stdBuilder()
                         .itemInputs(
-                                getModItem(AppliedEnergistics2.ID, "item.ItemExtremeStorageCell.Singularity", 1),
+                                item_singularity,
                                 GTOreDictUnificator
                                         .get(OrePrefixes.plateDense, MaterialsUEVplus.TranscendentMetal, 64L),
                                 ItemList.Field_Generator_UXV.get(1L),
@@ -385,8 +391,7 @@ public class SpaceAssemblerRecipes implements Runnable {
                                 MaterialsUEVplus.Eternity.getNanite(4))
                         .fluidInputs(MaterialsUEVplus.Eternity.getMolten(36864))
                         .itemOutputs(getModItem(AE2FluidCraft.ID, "fluid_storage.Universe", 1)).specialValue(3)
-                        .nbtSensitive().duration(1 * MINUTES).eut(TierEU.RECIPE_UXV)
-                        .addTo(IGRecipeMaps.spaceAssemblerRecipes);
+                        .duration(1 * MINUTES).eut(TierEU.RECIPE_UXV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
 
                 // ME Fluid Digital Singularity Storage Cell
                 GTValues.RA.stdBuilder()


### PR DESCRIPTION
Since recipes can only either be nbt sensitive or oredicted and not both, the artificial universe cell recipe ran into issues. This PR fixes that by swapping the oredicted circuits with magmatter nanites to remove the oredict requirement.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18466