### PR TITLE
Don't allow railcraft crowbars in crafting

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
@@ -266,15 +266,6 @@ public class GT_Loader_OreDictionary extends gregtech.loaders.preload.LoaderGTOr
 
         GTOreDictUnificator
                 .registerOre("craftingToolShears", GTModHandler.getModItem(Railcraft.ID, "tool.steel.shears", 1L, 0));
-        GTOreDictUnificator
-                .registerOre("craftingToolCrowbar", GTModHandler.getModItem(Railcraft.ID, "tool.crowbar", 1L, 0));
-        GTOreDictUnificator.registerOre(
-                "craftingToolCrowbar",
-                GTModHandler.getModItem(Railcraft.ID, "tool.crowbar.reinforced", 1L, 0));
-        GTOreDictUnificator
-                .registerOre("craftingToolCrowbar", GTModHandler.getModItem(Railcraft.ID, "tool.crowbar.magic", 1L, 0));
-        GTOreDictUnificator
-                .registerOre("craftingToolCrowbar", GTModHandler.getModItem(Railcraft.ID, "tool.crowbar.void", 1L, 0));
 
         GTOreDictUnificator.registerOre(
                 OrePrefixes.block,


### PR DESCRIPTION
Remove the oredict which allows railcraft crowbars in place of gt ones in crafts (the only meaningful one being maintenance hatch). This served only to confuse people, as this only works with full durability crowbars and consumes them entirely (leading players to often ask why the craft is not working). There is no reason to allow this broken interaction.