### PR TITLE
Color upgrade recipe change

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptNuclearControl.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNuclearControl.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import com.dreammaster.gthandler.CustomItemList;

--- a/src/main/java/com/dreammaster/scripts/ScriptNuclearControl.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNuclearControl.java
@@ -304,9 +304,9 @@ public class ScriptNuclearControl implements IScriptLoader {
 
         GTValues.RA.stdBuilder() // Color upgrade
                 .itemInputs(
-                        new ItemStack(Items.dye, 1, 1),
-                        new ItemStack(Items.dye, 1, 2),
-                        new ItemStack(Items.dye, 1, 4),
+                        ItemList.Color_01.get(1L),
+                        ItemList.Color_02.get(1L),
+                        ItemList.Color_04.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.HV, 1L))
                 .itemOutputs(getModItem(IC2NuclearControl.ID, "ItemUpgrade", 1, 1, missing)).duration(20 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);


### PR DESCRIPTION
Replacing vanilla dyes with dyes from GregTech

A long time ago when setting up the autocraft of things from Nuclear Control noticed that the color module has a recipe with vanilla dyes. I found its recipe in the code and wanted to change it to use a similar color from other mods, but did not find how to do it, so I specified the use of dyes from GregTech. Is it possible to specify the use of dyes from any mod?