### PR TITLE
Fix UEV+ casing and hull recycling recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -104,23 +104,48 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
         // UEV, UIV, UMV, UXV casings
         GTModHandler.addCraftingRecipe(
                 CustomItemList.Casing_UEV.get(1L),
-                GTModHandler.RecipeBits.BUFFERED | GTModHandler.RecipeBits.NOT_REMOVABLE,
+                bits,
                 new Object[] { "PPP", "PwP", "PPP", 'P', OrePrefixes.plate.get(Materials.Bedrockium) });
         GTModHandler.addCraftingRecipe(
                 CustomItemList.Casing_UIV.get(1L),
-                GTModHandler.RecipeBits.BUFFERED | GTModHandler.RecipeBits.NOT_REMOVABLE,
+                bits,
                 new Object[] { "PPP", "PwP", "PPP", 'P', OrePrefixes.plate.get(Materials.BlackPlutonium) });
         GTModHandler.addCraftingRecipe(
                 CustomItemList.Casing_UMV.get(1L),
-                GTModHandler.RecipeBits.BUFFERED | GTModHandler.RecipeBits.NOT_REMOVABLE,
+                bits,
                 new Object[] { "PPP", "PwP", "PPP", 'P', OrePrefixes.plate.get(MaterialsUEVplus.SpaceTime) });
 
         GTModHandler.addCraftingRecipe(
                 CustomItemList.Casing_UXV.get(1L),
-                GTModHandler.RecipeBits.BUFFERED | GTModHandler.RecipeBits.NOT_REMOVABLE,
+                bits,
                 new Object[] { "PSP", "SwS", "PSP", 'P',
                         OrePrefixes.plate.get(MaterialsUEVplus.MagnetohydrodynamicallyConstrainedStarMatter), 'S',
                         OrePrefixes.plate.get(MaterialsUEVplus.MagMatter) });
+
+        // Hull recycling placed here after the casing recipes for proper item data
+        GTOreDictUnificator.addItemDataFromInputs(
+                ItemList.Hull_UEV.get(1L),
+                CustomItemList.Casing_UEV.get(1L),
+                OrePrefixes.cableGt08.get(Materials.Draconium),
+                OrePrefixes.cableGt08.get(Materials.Draconium));
+
+        GTOreDictUnificator.addItemDataFromInputs(
+                ItemList.Hull_UIV.get(1L),
+                CustomItemList.Casing_UIV.get(1L),
+                OrePrefixes.cableGt08.get(Materials.NetherStar),
+                OrePrefixes.cableGt08.get(Materials.NetherStar));
+
+        GTOreDictUnificator.addItemDataFromInputs(
+                ItemList.Hull_UMV.get(1L),
+                CustomItemList.Casing_UMV.get(1L),
+                OrePrefixes.wireGt12.get(Materials.Quantium),
+                OrePrefixes.wireGt12.get(Materials.Quantium));
+
+        GTOreDictUnificator.addItemDataFromInputs(
+                ItemList.Hull_UXV.get(1L),
+                CustomItemList.Casing_UXV.get(1L),
+                OrePrefixes.wireGt16.get(Materials.BlackPlutonium),
+                OrePrefixes.wireGt16.get(Materials.BlackPlutonium));
 
         // Mine and Blade Battlegear remove recipes NBT?
         Object[] o = new Object[0];

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
@@ -83,7 +83,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Hull_UEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BUFFERED | GTModHandler.RecipeBits.NOT_REMOVABLE,
                 new Object[] { "PHP", "WMW", 'M', CustomItemList.Casing_UEV, 'W',
                         OrePrefixes.cableGt08.get(Materials.Draconium), 'H',
                         OrePrefixes.plate.get(Materials.Bedrockium), 'P',
@@ -91,7 +91,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Hull_UIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BUFFERED | GTModHandler.RecipeBits.NOT_REMOVABLE,
                 new Object[] { "PHP", "WMW", 'M', CustomItemList.Casing_UIV, 'W',
                         OrePrefixes.cableGt08.get(Materials.NetherStar), 'H',
                         OrePrefixes.plate.get(Materials.BlackPlutonium), 'P',


### PR DESCRIPTION
- UEV+ casings did not have reversible bit set.
- UEV and UIV hulls had reversible set on their crafting table recipes (wrong) but since the casings had no data, they did not cause a dupe. Had the casings been set, you could dupe materials this way.
- Adds recycling data for UEV+ hulls the proper way