### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/dreamcraft/lang/en_US.lang
+++ b/src/main/resources/assets/dreamcraft/lang/en_US.lang
@@ -224,6 +224,7 @@ item.LeadNickelPlate.name=Compressed Lead-Nickel Plate
 item.LeadOriharukonPlate.name=Compressed Lead-Oriharukon Plate
 item.EnvironmentalCircuit.name=Environmental Circuit
 item.GeneticCircuit.name=Genetic Circuit
+item.Cast.name=Cast
 item.BowFletchingCast.name=Bow Fletching Cast
 item.Cast.BowFletchingCast.name=Bow Fletching Cast
 item.BowStringCast.name=Bow String Cast
@@ -288,6 +289,7 @@ itemGroup.tabDreamCraftSpace=GT New Horizons: GC-GS Space
 itemGroup.tabDreamCraftSolar=GT New Horizons: Solar Components
 itemGroup.tabDreamCraftBars_Casings=GT New Horizons: Bars and Casings
 itemGroup.tabDreamGregTechAdditions=GT New Horizons: New GT Tiles and Casings
+item.OvenGlove.name=Glove
 item.OvenGlove_0_0.name=Pizza Glove (Left hand)
 item.OvenGlove_0_1.name=Cake Glove (Left hand)
 item.OvenGlove_0_2.name=Lava Glove (Left hand)
@@ -1753,3 +1755,5 @@ dreamcraft.welcome.click_discord=Click to open discord!
 
 dreamcraft.pausemenu.bug=Report a Bug
 dreamcraft.pausemenu.wiki=Open the Wiki
+
+gt.blockcasingsNH.name=Air Filter Turbine Casing

--- a/src/main/resources/assets/dreamcraft/lang/en_US.lang
+++ b/src/main/resources/assets/dreamcraft/lang/en_US.lang
@@ -1755,5 +1755,3 @@ dreamcraft.welcome.click_discord=Click to open discord!
 
 dreamcraft.pausemenu.bug=Report a Bug
 dreamcraft.pausemenu.wiki=Open the Wiki
-
-gt.blockcasingsNH.name=Air Filter Turbine Casing


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.