### PR TITLE
Fix artificial universe cell

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -341,15 +341,9 @@ public class SpaceAssemblerRecipes implements Runnable {
                     filledUMVCell.setTagCompound(euNBT);
                 }
 
-                ItemStack item_singularity = getModItem(
-                        AppliedEnergistics2.ID,
-                        "item.ItemExtremeStorageCell.Singularity",
-                        1);
-                item_singularity.setTagCompound(new NBTTagCompound());
-
                 GTValues.RA.stdBuilder()
                         .itemInputs(
-                                item_singularity,
+                                getModItem(AppliedEnergistics2.ID, "item.ItemExtremeStorageCell.Singularity", 1),
                                 GTOreDictUnificator
                                         .get(OrePrefixes.plateDense, MaterialsUEVplus.TranscendentMetal, 64L),
                                 ItemList.Field_Generator_UXV.get(1L),


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18682

The issue was caused by ae cells having an empty nbt tag when cheated in from nei, which the recipe was based on. 
Crafted ones do not have this tag which broke the recipe.