### PR TITLE
Retier CRIB, proxy, adv stocking hatch

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1716,12 +1716,6 @@ public class AssemblerRecipes implements Runnable {
                 .fluidInputs(Materials.Polybenzimidazole.getMolten(2304L)).duration(30 * SECONDS).eut(TierEU.RECIPE_UIV)
                 .addTo(assemblerRecipes);
 
-        // crafting input slave
-        GTValues.RA.stdBuilder()
-                .itemInputs(ItemList.Hatch_CraftingInput_Bus_ME_ItemOnly.get(1L), ItemList.Sensor_UV.get(1L))
-                .itemOutputs(ItemList.Hatch_CraftingInput_Bus_Slave.get(1)).duration(10 * SECONDS)
-                .eut(TierEU.RECIPE_LuV).addTo(assemblerRecipes);
-
         // Gear Box Casings
         GTValues.RA.stdBuilder()
                 .itemInputs(

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -2,7 +2,6 @@ package com.dreammaster.gthandler.recipes;
 
 import static bartworks.system.material.WerkstoffLoader.Californium;
 import static gregtech.api.enums.GTValues.L;
-import static gregtech.api.enums.Mods.AE2FluidCraft;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.Computronics;
@@ -15,7 +14,6 @@ import static gregtech.api.enums.Mods.SGCraft;
 import static gregtech.api.enums.Mods.SuperSolarPanels;
 import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.HOURS;
-import static gregtech.api.util.GTRecipeBuilder.INGOTS;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
@@ -199,29 +197,6 @@ public class AssemblingLineRecipes implements Runnable {
                 .fluidInputs(new FluidStack(solderIndalloy, 288), FluidRegistry.getFluidStack("lubricant", 500))
                 .itemOutputs(ItemList.Hatch_Input_Bus_ME_Advanced.get(1L)).eut(TierEU.RECIPE_LuV).duration(15 * SECONDS)
                 .addTo(AssemblyLine);
-
-        TTRecipeAdder.addResearchableAssemblylineRecipe(
-                ItemList.Hatch_CraftingInput_Bus_ME_ItemOnly.get(1L),
-                2000 * 60 * 8,
-                2000,
-                3000000,
-                2,
-                new ItemStack[] { ItemList.Hatch_Input_Bus_ME.get(1L), ItemList.Hatch_Input_Multi_2x2_UEV.get(1L),
-                        // 16384k storage component
-                        GTModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 8, 60),
-                        // 16384k fluid storage component
-                        GTModHandler.getModItem(AE2FluidCraft.ID, "fluid_part", 8, 7),
-                        // ME Controller
-                        GTModHandler.getModItem(AppliedEnergistics2.ID, "tile.BlockController", 1, WILDCARD),
-                        // Dual Interface
-                        GTModHandler.getModItem(AE2FluidCraft.ID, "part_fluid_interface", 1, WILDCARD),
-                        // Pattern capacity card
-                        GTModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 3, 54) },
-                new FluidStack[] { FluidRegistry.getFluidStack("molten.spacetime", 16 * INGOTS),
-                        FluidRegistry.getFluidStack("molten.mutatedlivingsolder", 2000), },
-                ItemList.Hatch_CraftingInput_Bus_ME.get(1L),
-                30 * SECONDS,
-                (int) TierEU.RECIPE_UIV);
 
         // Cloud Computation Client Hatch
         TTRecipeAdder.addResearchableAssemblylineRecipe(

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -986,10 +986,10 @@ public class AssemblingLineRecipes implements Runnable {
                     (int) TierEU.RECIPE_UMV);
         }
 
-        GTValues.RA.stdBuilder().metadata(RESEARCH_ITEM, ItemList.Hatch_Input_Bus_ME_Advanced.get(1L))
-                .metadata(SCANNING, new Scanning(1 * MINUTES + 40 * SECONDS, TierEU.RECIPE_EV))
-                .itemInputs(
-                        ItemList.Hatch_Input_Bus_ME_Advanced.get(1L),
+        GTValues.RA.stdBuilder()
+                .metadata(RESEARCH_ITEM, GTModHandler.getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1L))
+                .metadata(SCANNING, new Scanning(1 * MINUTES + 40 * SECONDS, TierEU.RECIPE_EV)).itemInputs(
+                        ItemList.Hatch_Input_Bus_ME.get(1L),
                         // 4096k Me Storage Component
                         GTModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 59),
                         // ME Controller

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -988,7 +988,8 @@ public class AssemblingLineRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
                 .metadata(RESEARCH_ITEM, GTModHandler.getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1L))
-                .metadata(SCANNING, new Scanning(1 * MINUTES + 40 * SECONDS, TierEU.RECIPE_EV)).itemInputs(
+                .metadata(SCANNING, new Scanning(1 * MINUTES + 40 * SECONDS, TierEU.RECIPE_EV))
+                .itemInputs(
                         ItemList.Hatch_Input_Bus_ME.get(1L),
                         // 4096k Me Storage Component
                         GTModHandler.getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 59),

--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -329,8 +329,8 @@ public class SpaceAssemblerRecipes implements Runnable {
                                 // Hyper-Acceleration Card
                                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4L, 56))
                         .fluidInputs(new FluidStack(solderUEV, 2304))
-                        .itemOutputs(ItemList.Hatch_Input_ME_Advanced.get(1)).specialValue(1).duration(15 * SECONDS)
-                        .eut(TierEU.RECIPE_UHV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
+                        .itemOutputs(ItemList.Hatch_Input_ME_Advanced.get(1)).metadata(IGRecipeMaps.MODULE_TIER, 1)
+                        .duration(15 * SECONDS).eut(TierEU.RECIPE_UHV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
 
                 // Crafting Input Buffer (ME)
                 GTValues.RA.stdBuilder()
@@ -348,8 +348,8 @@ public class SpaceAssemblerRecipes implements Runnable {
                                 // Pattern capacity card
                                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 3, 54))
                         .fluidInputs(new FluidStack(solderUEV, 2304), Materials.Grade7PurifiedWater.getFluid(4000))
-                        .itemOutputs(ItemList.Hatch_CraftingInput_Bus_ME.get(1)).specialValue(1).duration(15 * SECONDS)
-                        .eut(TierEU.RECIPE_UHV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
+                        .itemOutputs(ItemList.Hatch_CraftingInput_Bus_ME.get(1)).metadata(IGRecipeMaps.MODULE_TIER, 1)
+                        .duration(15 * SECONDS).eut(TierEU.RECIPE_UHV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
 
                 if (AE2Stuff.isModLoaded()) {
                     // Crafting Input Proxy
@@ -368,8 +368,9 @@ public class SpaceAssemblerRecipes implements Runnable {
                             .fluidInputs(
                                     new FluidStack(solderUEV, 2304),
                                     MaterialsUEVplus.DimensionallyShiftedSuperfluid.getFluid(4000))
-                            .itemOutputs(ItemList.Hatch_CraftingInput_Bus_Slave.get(1)).specialValue(2)
-                            .duration(15 * SECONDS).eut(TierEU.RECIPE_UIV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
+                            .itemOutputs(ItemList.Hatch_CraftingInput_Bus_Slave.get(1))
+                            .metadata(IGRecipeMaps.MODULE_TIER, 2).duration(15 * SECONDS).eut(TierEU.RECIPE_UIV)
+                            .addTo(IGRecipeMaps.spaceAssemblerRecipes);
                 }
             }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -335,7 +335,7 @@ public class SpaceAssemblerRecipes implements Runnable {
                 // Crafting Input Buffer (ME)
                 GTValues.RA.stdBuilder()
                         .itemInputs(
-                                ItemList.Hatch_Input_Bus_ME_Advanced.get(1),
+                                ItemList.Hatch_CraftingInput_Bus_ME_ItemOnly.get(1),
                                 ItemList.Hatch_Input_Multi_2x2_UEV.get(1),
                                 // 16384k storage component
                                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 8, 60),

--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -1,6 +1,7 @@
 package com.dreammaster.gthandler.recipes;
 
 import static gregtech.api.enums.Mods.AE2FluidCraft;
+import static gregtech.api.enums.Mods.AE2Stuff;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.EternalSingularity;
@@ -13,6 +14,7 @@ import static gregtech.api.enums.Mods.ThaumicEnergistics;
 import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
+import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
 import static kekztech.common.Blocks.tfftStorageField;
 
 import net.minecraft.item.ItemStack;
@@ -281,21 +283,6 @@ public class SpaceAssemblerRecipes implements Runnable {
                         .fluidInputs(new FluidStack(solderUEV, 1152))
                         .itemOutputs(ItemList.Optically_Compatible_Memory.get(32)).metadata(IGRecipeMaps.MODULE_TIER, 2)
                         .duration(20 * SECONDS).eut(TierEU.RECIPE_UIV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
-
-                // Advanced Stocking Input Hatch (ME)
-                GTValues.RA.stdBuilder()
-                        .itemInputs(
-                                ItemList.Hatch_Input_Multi_2x2_UEV.get(4L),
-                                getModItem(AE2FluidCraft.ID, "fluid_interface", 1L),
-                                ItemList.Optically_Compatible_Memory.get(2),
-                                ItemList.Electric_Pump_UEV.get(1L),
-                                // 16384k Me Fluid Storage Component
-                                getModItem(AE2FluidCraft.ID, "fluid_part", 4, 7),
-                                // Hyper-Acceleration Card
-                                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4L, 56))
-                        .fluidInputs(new FluidStack(solderUEV, 2304))
-                        .itemOutputs(ItemList.Hatch_Input_ME_Advanced.get(1)).metadata(IGRecipeMaps.MODULE_TIER, 1)
-                        .duration(15 * SECONDS).eut(TierEU.RECIPE_UHV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
             }
 
             if (OpenComputers.isModLoaded()) {
@@ -329,6 +316,61 @@ public class SpaceAssemblerRecipes implements Runnable {
                         .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockPatternOptimizationMatrix", 1))
                         .metadata(IGRecipeMaps.MODULE_TIER, 1).duration(5 * MINUTES).eut(TierEU.RECIPE_UHV)
                         .addTo(IGRecipeMaps.spaceAssemblerRecipes);
+
+                // Advanced Stocking Input Hatch (ME)
+                GTValues.RA.stdBuilder()
+                        .itemInputs(
+                                ItemList.Hatch_Input_Multi_2x2_UHV.get(4L),
+                                getModItem(AE2FluidCraft.ID, "fluid_interface", 1L),
+                                ItemList.Circuit_Chip_BioCPU.get(1),
+                                ItemList.Electric_Pump_UHV.get(1L),
+                                // 16384k Me Fluid Storage Component
+                                getModItem(AE2FluidCraft.ID, "fluid_part", 4, 7),
+                                // Hyper-Acceleration Card
+                                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4L, 56))
+                        .fluidInputs(new FluidStack(solderUEV, 2304))
+                        .itemOutputs(ItemList.Hatch_Input_ME_Advanced.get(1)).specialValue(1).duration(15 * SECONDS)
+                        .eut(TierEU.RECIPE_UHV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
+
+                // Crafting Input Buffer (ME)
+                GTValues.RA.stdBuilder()
+                        .itemInputs(
+                                ItemList.Hatch_Input_Bus_ME_Advanced.get(1),
+                                ItemList.Hatch_Input_Multi_2x2_UEV.get(1),
+                                // 16384k storage component
+                                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 8, 60),
+                                // 16384k Me Fluid Storage Component
+                                getModItem(AE2FluidCraft.ID, "fluid_part", 8, 7),
+                                // ME Controller
+                                getModItem(AppliedEnergistics2.ID, "tile.BlockController", 1, WILDCARD),
+                                // Dual Interface
+                                getModItem(AE2FluidCraft.ID, "part_fluid_interface", 1, WILDCARD),
+                                // Pattern capacity card
+                                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 3, 54))
+                        .fluidInputs(new FluidStack(solderUEV, 2304), Materials.Grade7PurifiedWater.getFluid(4000))
+                        .itemOutputs(ItemList.Hatch_CraftingInput_Bus_ME.get(1)).specialValue(1).duration(15 * SECONDS)
+                        .eut(TierEU.RECIPE_UHV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
+
+                if (AE2Stuff.isModLoaded()) {
+                    // Crafting Input Proxy
+                    GTValues.RA.stdBuilder().itemInputs(
+                            ItemList.Hatch_CraftingInput_Bus_ME.get(1),
+                            // 64 Core Co-Processing Unit
+                            getModItem(AppliedEnergistics2.ID, "tile.BlockAdvancedCraftingUnit", 1, 0),
+                            // 16384k storage component
+                            getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 8, 60),
+                            // 16384k Me Fluid Storage Component
+                            getModItem(AE2FluidCraft.ID, "fluid_part", 8, 7),
+                            // Wireless Connector
+                            getModItem(AE2Stuff.ID, "Wireless", 2, 0),
+                            ItemList.Sensor_UEV.get(1),
+                            ItemList.EnergisedTesseract.get(1))
+                            .fluidInputs(
+                                    new FluidStack(solderUEV, 2304),
+                                    MaterialsUEVplus.DimensionallyShiftedSuperfluid.getFluid(4000))
+                            .itemOutputs(ItemList.Hatch_CraftingInput_Bus_Slave.get(1)).specialValue(2)
+                            .duration(15 * SECONDS).eut(TierEU.RECIPE_UIV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
+                }
             }
 
             if (AppliedEnergistics2.isModLoaded()) {


### PR DESCRIPTION
Retiers Crafting Input Buffer, Crafting Input Proxy, and Advanced Stocking Input Hatch as discussed in https://discord.com/channels/181078474394566657/1326201379265449995.

Moves all parts to Space Assembler as well, since late game (UHV+) AE2 parts always go in space assembler now, these recipes were just old and now is a good time to move them.

Advanced Stocking Input Hatch: UEV -> UHV
Crafting Input Buffer: UIV -> UEV
Crafting Input Proxy: UV -> UIV

GT5u PR changing the casing textures on these parts to the new tiers: https://github.com/GTNewHorizons/GT5-Unofficial/pull/3766

|                     **Part**                     | **Old** | **New** |
|:------------------------------------------------:|:-------:|:-------:|
| **Advanced Stocking Input Hatch** _(UEV -> UHV)_ |    ![image](https://github.com/user-attachments/assets/948bd030-02e8-4a90-a665-662ea4a123b5)     |     ![image](https://github.com/user-attachments/assets/54c43d17-4f49-46dd-98b1-1f1a22e997a6)    |
| **Crafting Input Buffer** _(UIV -> UEV)_         |     ![image](https://github.com/user-attachments/assets/5175c8cb-00fe-44cf-a910-ef77edaf543e)    |    ![image](https://github.com/user-attachments/assets/aee639bb-8fc2-4fa1-9497-2c53fc76f72a)     |
| **Crafting Input Proxy** _(UV -> UIV)_           |     ![image](https://github.com/user-attachments/assets/41ab829f-ef11-4761-86d4-42c0279914eb)    |    ![image](https://github.com/user-attachments/assets/d5b93bed-eabe-49c5-ac7f-c4eaf78cd238)     |