### PR TITLE
remove ic2 valuable ore compat, ic2 miner, and ic2 scanners

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
@@ -925,7 +925,7 @@ public class ScriptExtraUtilities implements IScriptLoader {
                         'g',
                         getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 11, missing),
                         'h',
-                        getModItem(IndustrialCraft2.ID, "blockMachine2", 1, 11, missing),
+                        ItemList.OreDrill2.get(1L),
                         'i',
                         getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 11, missing)));
         EnderConstructorRecipesHandler.registerRecipe(

--- a/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
@@ -709,28 +709,6 @@ public class ScriptIndustrialCraft implements IScriptLoader {
                 "batteryAdvanced",
                 "itemCasingAnyIron");
         addShapedRecipe(
-                getModItem(IndustrialCraft2.ID, "itemScanner", 1, 0, missing),
-                "itemCasingGold",
-                "plateStainlessSteel",
-                "itemCasingGold",
-                "circuitAdvanced",
-                CustomItemList.Display.get(1L),
-                "circuitAdvanced",
-                "cableGt01Gold",
-                "batteryAdvanced",
-                "cableGt01Gold");
-        addShapedRecipe(
-                getModItem(IndustrialCraft2.ID, "itemScannerAdv", 1, 0, missing),
-                "itemCasingTitanium",
-                getModItem(IndustrialCraft2.ID, "itemScanner", 1, wildcard, missing),
-                "itemCasingTitanium",
-                "circuitData",
-                CustomItemList.Display.get(1L),
-                "circuitData",
-                "cableGt01Nichrome",
-                "batteryData",
-                "cableGt01Nichrome");
-        addShapedRecipe(
                 getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 3, missing),
                 "cableGt01AnyCopper",
                 "itemCasingSteel",
@@ -873,17 +851,6 @@ public class ScriptIndustrialCraft implements IScriptLoader {
                 "itemCasingSteel",
                 "circuitBasic",
                 "itemCasingSteel");
-        addShapedRecipe(
-                getModItem(IndustrialCraft2.ID, "blockMachine2", 1, 11, missing),
-                "circuitElite",
-                getModItem(IndustrialCraft2.ID, "blockElectric", 1, 2, missing),
-                "circuitElite",
-                ItemList.Electric_Motor_IV.get(1L),
-                getModItem(IndustrialCraft2.ID, "blockMachine", 1, 12, missing),
-                ItemList.Electric_Motor_IV.get(1L),
-                ItemList.Robot_Arm_IV.get(1L),
-                getModItem(IndustrialCraft2.ID, "blockMachine2", 1, 0, missing),
-                ItemList.Robot_Arm_IV.get(1L));
         addShapedRecipe(
                 getModItem(IndustrialCraft2.ID, "blockMachine2", 1, 1, missing),
                 getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 0, missing),


### PR DESCRIPTION
nhcoremod part of https://github.com/GTNewHorizons/GT5-Unofficial/pull/3785

This part removes the recipes. It also changes the recipe for the enderquarry from the ic2 advminer to the T2 GT multiblock drill, which are similarly tiered, though the main cost and tiering of the recipe is elsewhere anyway so this does not change balance.