### PR TITLE
Streamline smeltery melting recipes

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptCoreMod.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptCoreMod.java
@@ -41,6 +41,7 @@ import static gregtech.api.util.GTRecipeBuilder.TICKS;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -50,6 +51,7 @@ import com.dreammaster.gthandler.CustomItemList;
 import com.dreammaster.item.CustomPatterns;
 import com.dreammaster.item.NHItemList;
 import com.dreammaster.main.NHItems;
+import com.dreammaster.tinkersConstruct.TConstructHelper;
 
 import cpw.mods.fml.common.registry.GameRegistry;
 import forestry.api.recipes.RecipeManagers;
@@ -63,7 +65,6 @@ import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import tconstruct.library.TConstructRegistry;
-import tconstruct.library.crafting.Smeltery;
 
 public class ScriptCoreMod implements IScriptLoader {
 
@@ -584,385 +585,73 @@ public class ScriptCoreMod implements IScriptLoader {
 
         GTModHandler
                 .addSmeltingRecipe(CustomItemList.UnfiredCokeOvenBrick.get(1L), CustomItemList.CokeOvenBrick.get(1L));
-
-        Smeltery.addMelting(
-                NHItemList.ShapeBolt.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeHoeHead.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeGear.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapePlate.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormAnvil.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormPlate.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormLeggings.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormBaguette.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormGear.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormRotor.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeBottle.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeRotor.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeTurbineBlade.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeSmallGear.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormBoots.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeLargePipe.getIS(),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormSmallGear.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormCasing.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeWire.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormChestplate.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeShovelHead.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormBread.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeIngot.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormIngot.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeFileHead.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeRod.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeHugePipe.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeSwordBlade.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeRing.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeCasing.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormNuggets.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeSmallPipe.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormName.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeHammerHead.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeTinyPipe.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormCylinder.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormBottle.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeAxeHead.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeSawBlade.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormBlock.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeCell.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormArrowHead.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeBoat.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormCoinage.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormBall.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeBlock.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormHelmet.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapePickaxeHead.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormBuns.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.ShapeNormalPipe.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                CustomItemList.MarshmallowFormMold.get(1L),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormStick.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormStickLong.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormScrew.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormRing.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormBolt.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormRound.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormTurbineBlade.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormPipeTiny.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormPipeSmall.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormPipeMedium.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormPipeLarge.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                NHItemList.MoldFormPipeHuge.getIS(1),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
+        TConstructHelper
+                .getMeltingAdder(GameRegistry.findBlock("TConstruct", "MetalBlock"), 7, 500, "aluminumbrass.molten", 72)
+                .add(
+                        Stream.of(
+                                NHItemList.ShapeBolt,
+                                NHItemList.ShapeHoeHead,
+                                NHItemList.ShapeGear,
+                                NHItemList.ShapePlate,
+                                NHItemList.MoldFormAnvil,
+                                NHItemList.MoldFormPlate,
+                                NHItemList.MoldFormLeggings,
+                                NHItemList.MoldFormBaguette,
+                                NHItemList.MoldFormGear,
+                                NHItemList.MoldFormRotor,
+                                NHItemList.ShapeBottle,
+                                NHItemList.ShapeRotor,
+                                NHItemList.ShapeTurbineBlade,
+                                NHItemList.ShapeSmallGear,
+                                NHItemList.MoldFormBoots,
+                                NHItemList.ShapeLargePipe,
+                                NHItemList.MoldFormSmallGear,
+                                NHItemList.MoldFormCasing,
+                                NHItemList.ShapeWire,
+                                NHItemList.MoldFormChestplate,
+                                NHItemList.ShapeShovelHead,
+                                NHItemList.MoldFormBread,
+                                NHItemList.ShapeIngot,
+                                NHItemList.MoldFormIngot,
+                                NHItemList.ShapeFileHead,
+                                NHItemList.ShapeRod,
+                                NHItemList.ShapeHugePipe,
+                                NHItemList.ShapeSwordBlade,
+                                NHItemList.ShapeRing,
+                                NHItemList.ShapeCasing,
+                                NHItemList.MoldFormNuggets,
+                                NHItemList.ShapeSmallPipe,
+                                NHItemList.MoldFormName,
+                                NHItemList.ShapeHammerHead,
+                                NHItemList.ShapeTinyPipe,
+                                NHItemList.MoldFormCylinder,
+                                NHItemList.MoldFormBottle,
+                                NHItemList.ShapeAxeHead,
+                                NHItemList.ShapeSawBlade,
+                                NHItemList.MoldFormBlock,
+                                NHItemList.ShapeCell,
+                                NHItemList.MoldFormArrowHead,
+                                NHItemList.ShapeBoat,
+                                NHItemList.MoldFormCoinage,
+                                NHItemList.MoldFormBall,
+                                NHItemList.ShapeBlock,
+                                NHItemList.MoldFormHelmet,
+                                NHItemList.ShapePickaxeHead,
+                                NHItemList.MoldFormBuns,
+                                NHItemList.ShapeNormalPipe,
+                                NHItemList.MoldFormStick,
+                                NHItemList.MoldFormStickLong,
+                                NHItemList.MoldFormScrew,
+                                NHItemList.MoldFormRing,
+                                NHItemList.MoldFormBolt,
+                                NHItemList.MoldFormRound,
+                                NHItemList.MoldFormTurbineBlade,
+                                NHItemList.MoldFormPipeTiny,
+                                NHItemList.MoldFormPipeSmall,
+                                NHItemList.MoldFormPipeMedium,
+                                NHItemList.MoldFormPipeLarge,
+                                NHItemList.MoldFormPipeHuge).map(NHItemList::getIS))
+                .add(CustomItemList.MarshmallowFormMold.get(1L));
 
         GTValues.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "machine.alpha", 1, 7, missing))
                 .itemOutputs(CustomItemList.CokeOvenBrick.get(4L)).duration(15 * SECONDS).eut(2)

--- a/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
@@ -1958,42 +1958,27 @@ public class ScriptTinkersConstruct implements IScriptLoader {
         TConstructHelper.removeMeltingRecipe(getModItem(ExtraUtilities.ID, "cobblestone_compressed", 1, 14, missing));
         TConstructHelper.removeMeltingRecipe(getModItem(ExtraUtilities.ID, "cobblestone_compressed", 1, 15, missing));
         TConstructHelper.removeBasinRecipe(getModItem(IndustrialCraft2.ID, "blockMetal", 1, 5, missing));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockmachines"),
-                1585,
-                500,
-                FluidRegistry.getFluidStack("aluminum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Aluminium, 1),
-                GameRegistry.findBlock("gregtech", "gt.blockmachines"),
-                1585,
-                500,
-                FluidRegistry.getFluidStack("aluminum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.dustTiny, Materials.Aluminium, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockmachines"),
-                1585,
-                500,
-                FluidRegistry.getFluidStack("aluminum.molten", 16));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.dustSmall, Materials.Aluminium, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockmachines"),
-                1585,
-                500,
-                FluidRegistry.getFluidStack("aluminum.molten", 36));
+        TConstructHelper
+                .getMeltingAdder(
+                        GameRegistry.findBlock("gregtech", "gt.blockmachines"),
+                        1585,
+                        500,
+                        "aluminum.molten",
+                        144)
+                .add(
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Aluminium, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Aluminium, 1))
+                .withAmount(16)
+                .add(
+                        GTOreDictUnificator.get(OrePrefixes.dustTiny, Materials.Aluminium, 1L),
+                        getModItem(TinkerConstruct.ID, "oreBerries", 1, 4, missing))
+                .withAmount(36).add(GTOreDictUnificator.get(OrePrefixes.dustSmall, Materials.Aluminium, 1L));
         Smeltery.addMelting(
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Glass, 1L),
                 GameRegistry.findBlock("minecraft", "sand"),
                 0,
                 800,
                 FluidRegistry.getFluidStack("glass.molten", 1000));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "oreBerries", 1, 4, missing),
-                GameRegistry.findBlock("gregtech", "gt.blockmachines"),
-                1585,
-                500,
-                FluidRegistry.getFluidStack("aluminum.molten", 16));
         TConstructRegistry.getTableCasting().addCastingRecipe(
                 GTOreDictUnificator.get(OrePrefixes.nugget, Materials.Copper, 1L),
                 FluidRegistry.getFluidStack("copper.molten", 16),
@@ -2042,1320 +2027,253 @@ public class ScriptTinkersConstruct implements IScriptLoader {
                 getModItem(TinkerConstruct.ID, "metalPattern", 1, 0, missing),
                 false,
                 100);
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 0, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 1, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 2, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 3, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 4, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 5, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 6, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 7, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 8, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 9, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 10, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 11, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 12, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 13, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 14, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 15, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 16, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 17, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 18, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 19, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 20, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 21, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 22, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 25, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 26, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "metalPattern", 1, 27, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "Cast", 1, 0, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "Cast", 1, 1, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "Cast", 1, 2, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                getModItem(TinkerConstruct.ID, "Cast", 1, 3, missing),
-                GameRegistry.findBlock("TConstruct", "MetalBlock"),
-                7,
-                500,
-                FluidRegistry.getFluidStack("aluminumbrass.molten", 72));
-        Smeltery.addMelting(
-                new ItemStack(GregTechAPI.sBlockOres1, 1, 32),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Iron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Iron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Iron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.AnyIron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Iron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.BrownLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.BrownLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.BrownLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.BrownLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.BrownLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.BrownLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.YellowLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.YellowLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.YellowLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.YellowLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.YellowLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.YellowLimonite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.BandedIron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.BandedIron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.BandedIron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.BandedIron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.BandedIron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.BandedIron, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.GraniticMineralSand, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.GraniticMineralSand, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.GraniticMineralSand, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.GraniticMineralSand, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.GraniticMineralSand, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.GraniticMineralSand, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.Magnetite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Magnetite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Magnetite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                new ItemStack(GregTechAPI.sBlockOres1, 1, 28706),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Magnetite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Magnetite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.Pyrite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Pyrite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Pyrite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Pyrite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Pyrite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Pyrite, 1L),
-                GameRegistry.findBlock("minecraft", "iron_ore"),
-                0,
-                700,
-                FluidRegistry.getFluidStack("iron.molten", 144));
-        Smeltery.addMelting(
-                new ItemStack(GregTechAPI.sBlockOres1, 1, 35),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Copper, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Copper, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Copper, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Copper, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Copper, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                new ItemStack(GregTechAPI.sBlockOres1, 1, 871),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Malachite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Malachite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Malachite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Malachite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Malachite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.Tetrahedrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Tetrahedrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Tetrahedrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Tetrahedrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Tetrahedrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Tetrahedrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.Chalcopyrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Chalcopyrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Chalcopyrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Chalcopyrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Chalcopyrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Chalcopyrite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                3,
-                600,
-                FluidRegistry.getFluidStack("copper.molten", 144));
-        Smeltery.addMelting(
-                new ItemStack(GregTechAPI.sBlockOres1, 1, 57),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                400,
-                FluidRegistry.getFluidStack("tin.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Tin, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                400,
-                FluidRegistry.getFluidStack("tin.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Tin, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                400,
-                FluidRegistry.getFluidStack("tin.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Tin, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                400,
-                FluidRegistry.getFluidStack("tin.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Tin, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                400,
-                FluidRegistry.getFluidStack("tin.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Tin, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                400,
-                FluidRegistry.getFluidStack("tin.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.Cassiterite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Cassiterite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Cassiterite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Cassiterite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Cassiterite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Cassiterite, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                400,
-                FluidRegistry.getFluidStack("tin.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.CassiteriteSand, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.CassiteriteSand, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.CassiteriteSand, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.CassiteriteSand, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.CassiteriteSand, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.CassiteriteSand, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                4,
-                600,
-                FluidRegistry.getFluidStack("tin.molten", 288));
-        Smeltery.addMelting(
-                new ItemStack(GregTechAPI.sBlockOres1, 1, 86),
-                GameRegistry.findBlock("minecraft", "gold_ore"),
-                0,
-                600,
-                FluidRegistry.getFluidStack("gold.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Gold, 1L),
-                GameRegistry.findBlock("minecraft", "gold_ore"),
-                0,
-                600,
-                FluidRegistry.getFluidStack("gold.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Gold, 1L),
-                GameRegistry.findBlock("minecraft", "gold_ore"),
-                0,
-                600,
-                FluidRegistry.getFluidStack("gold.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Gold, 1L),
-                GameRegistry.findBlock("minecraft", "gold_ore"),
-                0,
-                600,
-                FluidRegistry.getFluidStack("gold.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Gold, 1L),
-                GameRegistry.findBlock("minecraft", "gold_ore"),
-                0,
-                600,
-                FluidRegistry.getFluidStack("gold.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Gold, 1L),
-                GameRegistry.findBlock("minecraft", "gold_ore"),
-                0,
-                600,
-                FluidRegistry.getFluidStack("gold.molten", 144));
-        Smeltery.addMelting(
-                new ItemStack(GregTechAPI.sBlockOres1, 1, 19),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                5,
-                400,
-                FluidRegistry.getFluidStack("aluminum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Aluminium, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                5,
-                400,
-                FluidRegistry.getFluidStack("aluminum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Aluminium, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                5,
-                400,
-                FluidRegistry.getFluidStack("aluminum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Aluminium, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                5,
-                400,
-                FluidRegistry.getFluidStack("aluminum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Aluminium, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                5,
-                400,
-                FluidRegistry.getFluidStack("aluminum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Aluminium, 1L),
-                GameRegistry.findBlock("TConstruct", "SearedBrick"),
-                5,
-                400,
-                FluidRegistry.getFluidStack("aluminum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.Nickel, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                34,
-                400,
-                FluidRegistry.getFluidStack("nickel.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Nickel, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                34,
-                400,
-                FluidRegistry.getFluidStack("nickel.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Nickel, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                34,
-                400,
-                FluidRegistry.getFluidStack("nickel.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Nickel, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                34,
-                400,
-                FluidRegistry.getFluidStack("nickel.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Nickel, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                34,
-                400,
-                FluidRegistry.getFluidStack("nickel.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Nickel, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                34,
-                400,
-                FluidRegistry.getFluidStack("nickel.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.Silver, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                54,
-                500,
-                FluidRegistry.getFluidStack("silver.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Silver, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                54,
-                500,
-                FluidRegistry.getFluidStack("silver.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Silver, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                54,
-                500,
-                FluidRegistry.getFluidStack("silver.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Silver, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                54,
-                500,
-                FluidRegistry.getFluidStack("silver.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Silver, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                54,
-                500,
-                FluidRegistry.getFluidStack("silver.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Silver, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                54,
-                500,
-                FluidRegistry.getFluidStack("silver.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ore, Materials.Platinum, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                85,
-                800,
-                FluidRegistry.getFluidStack("platinum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Platinum, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                85,
-                800,
-                FluidRegistry.getFluidStack("platinum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Platinum, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                85,
-                800,
-                FluidRegistry.getFluidStack("platinum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Platinum, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                85,
-                800,
-                FluidRegistry.getFluidStack("platinum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Platinum, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                85,
-                800,
-                FluidRegistry.getFluidStack("platinum.molten", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Platinum, 1L),
-                GameRegistry.findBlock("gregtech", "gt.blockores"),
-                85,
-                800,
-                FluidRegistry.getFluidStack("platinum.molten", 144));
-        Smeltery.addMelting(
-                new ItemStack(GregTechAPI.sBlockOres1, 1, 501),
-                GameRegistry.findBlock("minecraft", "emerald_ore"),
-                0,
-                800,
-                FluidRegistry.getFluidStack("emerald.liquid", 640));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Emerald, 1L),
-                GameRegistry.findBlock("minecraft", "emerald_ore"),
-                0,
-                800,
-                FluidRegistry.getFluidStack("emerald.liquid", 640));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Emerald, 1L),
-                GameRegistry.findBlock("minecraft", "emerald_ore"),
-                0,
-                800,
-                FluidRegistry.getFluidStack("emerald.liquid", 640));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Emerald, 1L),
-                GameRegistry.findBlock("minecraft", "emerald_ore"),
-                0,
-                800,
-                FluidRegistry.getFluidStack("emerald.liquid", 640));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Emerald, 1L),
-                GameRegistry.findBlock("minecraft", "emerald_ore"),
-                0,
-                800,
-                FluidRegistry.getFluidStack("emerald.liquid", 640));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Emerald, 1L),
-                GameRegistry.findBlock("minecraft", "emerald_ore"),
-                0,
-                800,
-                FluidRegistry.getFluidStack("emerald.liquid", 640));
-        Smeltery.addMelting(
+        TConstructHelper
+                .getMeltingAdder(GameRegistry.findBlock("TConstruct", "MetalBlock"), 7, 500, "aluminumbrass.molten", 72)
+                .add(
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 0, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 1, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 2, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 3, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 4, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 5, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 6, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 7, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 8, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 9, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 10, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 11, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 12, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 13, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 14, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 15, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 16, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 17, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 18, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 19, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 20, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 21, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 22, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 25, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 26, missing),
+                        getModItem(TinkerConstruct.ID, "metalPattern", 1, 27, missing),
+                        getModItem(TinkerConstruct.ID, "Cast", 1, 0, missing),
+                        getModItem(TinkerConstruct.ID, "Cast", 1, 1, missing),
+                        getModItem(TinkerConstruct.ID, "Cast", 1, 2, missing),
+                        getModItem(TinkerConstruct.ID, "Cast", 1, 3, missing));
+        TConstructHelper.getMeltingAdder(GameRegistry.findBlock("minecraft", "iron_ore"), 0, 700, "iron.molten", 144)
+                .add(
+                        new ItemStack(GregTechAPI.sBlockOres1, 1, 32),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Iron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Iron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Iron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.AnyIron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Iron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.BrownLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.BrownLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.BrownLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.BrownLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.BrownLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.BrownLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.YellowLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.YellowLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.YellowLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.YellowLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.YellowLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.YellowLimonite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.BandedIron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.BandedIron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.BandedIron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.BandedIron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.BandedIron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.BandedIron, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.GraniticMineralSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.GraniticMineralSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.GraniticMineralSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.GraniticMineralSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.GraniticMineralSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.GraniticMineralSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Magnetite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Magnetite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Magnetite, 1L),
+                        new ItemStack(GregTechAPI.sBlockOres1, 1, 28706),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Magnetite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Magnetite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Pyrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Pyrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Pyrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Pyrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Pyrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Pyrite, 1L));
+        TConstructHelper
+                .getMeltingAdder(GameRegistry.findBlock("TConstruct", "SearedBrick"), 3, 600, "copper.molten", 144).add(
+                        new ItemStack(GregTechAPI.sBlockOres1, 1, 35),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Copper, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Copper, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Copper, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Copper, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Copper, 1L),
+                        new ItemStack(GregTechAPI.sBlockOres1, 1, 871),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Malachite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Malachite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Malachite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Malachite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Malachite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Tetrahedrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Tetrahedrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Tetrahedrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Tetrahedrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Tetrahedrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Tetrahedrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Chalcopyrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Chalcopyrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Chalcopyrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Chalcopyrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Chalcopyrite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Chalcopyrite, 1L));
+        TConstructHelper.getMeltingAdder(GameRegistry.findBlock("TConstruct", "SearedBrick"), 4, 400, "tin.molten", 144)
+                .add(
+                        new ItemStack(GregTechAPI.sBlockOres1, 1, 57),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Tin, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Tin, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Tin, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Tin, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Tin, 1L));
+        TConstructHelper.getMeltingAdder(GameRegistry.findBlock("TConstruct", "SearedBrick"), 4, 600, "tin.molten", 288)
+                .add(
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Cassiterite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Cassiterite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Cassiterite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Cassiterite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Cassiterite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Cassiterite, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.CassiteriteSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.CassiteriteSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.CassiteriteSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.CassiteriteSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.CassiteriteSand, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.CassiteriteSand, 1L));
+        TConstructHelper.getMeltingAdder(GameRegistry.findBlock("minecraft", "gold_ore"), 0, 600, "gold.molten", 144)
+                .add(
+                        new ItemStack(GregTechAPI.sBlockOres1, 1, 86),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Gold, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Gold, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Gold, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Gold, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Gold, 1L));
+        TConstructHelper
+                .getMeltingAdder(GameRegistry.findBlock("TConstruct", "SearedBrick"), 5, 400, "aluminum.molten", 144)
+                .add(
+                        new ItemStack(GregTechAPI.sBlockOres1, 1, 19),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Aluminium, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Aluminium, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Aluminium, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Aluminium, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Aluminium, 1L));
+        TConstructHelper
+                .getMeltingAdder(GameRegistry.findBlock("gregtech", "gt.blockores"), 34, 400, "nickel.molten", 144).add(
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Nickel, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Nickel, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Nickel, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Nickel, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Nickel, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Nickel, 1L));
+        TConstructHelper
+                .getMeltingAdder(GameRegistry.findBlock("gregtech", "gt.blockores"), 54, 500, "silver.molten", 144).add(
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Silver, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Silver, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Silver, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Silver, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Silver, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Silver, 1L));
+        TConstructHelper
+                .getMeltingAdder(GameRegistry.findBlock("gregtech", "gt.blockores"), 85, 800, "platinum.molten", 144)
+                .add(
+                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Platinum, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Platinum, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Platinum, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Platinum, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Platinum, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Platinum, 1L));
+        TConstructHelper
+                .getMeltingAdder(GameRegistry.findBlock("minecraft", "emerald_ore"), 0, 800, "emerald.liquid", 640).add(
+                        new ItemStack(GregTechAPI.sBlockOres1, 1, 501),
+                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Emerald, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Emerald, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Emerald, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Emerald, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Emerald, 1L));
+        TConstructHelper.getMeltingAdder(GameRegistry.findBlock("IC2", "blockMetal"), 5, 800, "steel.molten", 576).add(
                 ItemList.Shape_Empty.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Plate.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Casing.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Gear.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Credit.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Bottle.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Ingot.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Ball.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Block.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Nugget.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Bun.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Bread.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Baguette.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Cylinder.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Anvil.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Name.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Arrow.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Gear_Small.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Rod.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Bolt.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Round.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Screw.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Ring.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Rod_Long.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Rotor.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Turbine_Blade.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Pipe_Tiny.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Pipe_Small.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Pipe_Medium.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Pipe_Large.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Mold_Pipe_Huge.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Plate.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Rod.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Bolt.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Ring.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Cell.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Ingot.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Wire.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Casing.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Pipe_Tiny.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Pipe_Small.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Pipe_Medium.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Pipe_Large.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Pipe_Huge.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Block.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Sword.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Pickaxe.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Shovel.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Axe.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Hoe.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Hammer.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_File.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Saw.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Gear.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Bottle.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Rotor.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Small_Gear.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 ItemList.Shape_Extruder_Turbine_Blade.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 NHItemList.ExtruderShapeBoat.getIS(1),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 CustomItemList.MarshmallowForm.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 CustomItemList.MoldChestplate.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 CustomItemList.MoldHelmet.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
                 CustomItemList.MoldLeggings.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
-                CustomItemList.MoldBoots.get(1L),
-                GameRegistry.findBlock("IC2", "blockMetal"),
-                5,
-                800,
-                FluidRegistry.getFluidStack("steel.molten", 576));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.dust, Materials.Rubber, 1L),
-                GameRegistry.findBlock("TConstruct", "GlueBlock"),
-                0,
-                250,
-                FluidRegistry.getFluidStack("glue", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Rubber, 1L),
-                GameRegistry.findBlock("TConstruct", "GlueBlock"),
-                0,
-                300,
-                FluidRegistry.getFluidStack("glue", 144));
-        Smeltery.addMelting(
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Rubber, 1L),
-                GameRegistry.findBlock("TConstruct", "GlueBlock"),
-                0,
-                350,
-                FluidRegistry.getFluidStack("glue", 144));
-        Smeltery.addMelting(
-                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 10, missing),
-                GameRegistry.findBlock("TConstruct", "GlueBlock"),
-                0,
-                400,
-                FluidRegistry.getFluidStack("glue", 576));
-        Smeltery.addMelting(
-                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 8, missing),
-                GameRegistry.findBlock("TConstruct", "GlueBlock"),
-                0,
-                200,
-                FluidRegistry.getFluidStack("glue", 288));
+                CustomItemList.MoldBoots.get(1L));
+        TConstructHelper.getMeltingAdder(GameRegistry.findBlock("TConstruct", "GlueBlock"), 0, 250, "glue", 144)
+                .add(
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Rubber, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Rubber, 1L),
+                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Rubber, 1L))
+                .withAmount(576).add(getModItem(ElectroMagicTools.ID, "EMTItems", 1, 10, missing)).withAmount(288)
+                .add(getModItem(ElectroMagicTools.ID, "EMTItems", 1, 8, missing));
         Smeltery.addMelting(
                 GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Cobalt, 1L),
                 GameRegistry.findBlock("TConstruct", "GravelOre"),
@@ -3392,18 +2310,10 @@ public class ScriptTinkersConstruct implements IScriptLoader {
                 getModItem(Minecraft.ID, "cobblestone", 1, 0, missing),
                 false,
                 245);
-        Smeltery.addMelting(
-                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
-                GameRegistry.findBlock("minecraft", "obsidian"),
-                0,
-                850,
-                FluidRegistry.getFluidStack("obsidian.molten", 288));
-        Smeltery.addMelting(
-                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                GameRegistry.findBlock("minecraft", "obsidian"),
-                0,
-                850,
-                FluidRegistry.getFluidStack("obsidian.molten", 288));
+        TConstructHelper
+                .getMeltingAdder(GameRegistry.findBlock("minecraft", "obsidian"), 0, 850, "obsidian.molten", 288).add(
+                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
+                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing));
         TConstructRegistry.getBasinCasting().addCastingRecipe(
                 getModItem(TinkerConstruct.ID, "MetalBlock", 1, 10, missing),
                 FluidRegistry.getFluidStack("ender", 2250),

--- a/src/main/java/com/dreammaster/tinkersConstruct/MeltingRecipeAdder.java
+++ b/src/main/java/com/dreammaster/tinkersConstruct/MeltingRecipeAdder.java
@@ -1,0 +1,52 @@
+package com.dreammaster.tinkersConstruct;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidRegistry;
+
+import tconstruct.library.crafting.Smeltery;
+
+public class MeltingRecipeAdder {
+
+    private final Consumer<ItemStack> addMelting;
+    private final Block renderBlock;
+    private final int renderBlockMeta;
+    private final int meltingTemperature;
+    private final String fluidName;
+
+    MeltingRecipeAdder(Block renderBlock, int renderBlockMeta, int meltingTemperature, String fluidName, int amount) {
+        this.renderBlock = renderBlock;
+        this.renderBlockMeta = renderBlockMeta;
+        this.meltingTemperature = meltingTemperature;
+        this.fluidName = fluidName;
+        addMelting = itemStack -> Smeltery.addMelting(
+                itemStack,
+                renderBlock,
+                renderBlockMeta,
+                meltingTemperature,
+                FluidRegistry.getFluidStack(fluidName, amount));
+    }
+
+    public MeltingRecipeAdder withAmount(int newAmount) {
+        return new MeltingRecipeAdder(renderBlock, renderBlockMeta, meltingTemperature, fluidName, newAmount);
+    }
+
+    public MeltingRecipeAdder add(ItemStack itemStack) {
+        addMelting.accept(itemStack);
+        return this;
+    }
+
+    public MeltingRecipeAdder add(Stream<ItemStack> itemStackStream) {
+        itemStackStream.forEach(addMelting);
+        return this;
+    }
+
+    public MeltingRecipeAdder add(ItemStack... itemStacks) {
+        add(Arrays.stream(itemStacks));
+        return this;
+    }
+}

--- a/src/main/java/com/dreammaster/tinkersConstruct/TConstructHelper.java
+++ b/src/main/java/com/dreammaster/tinkersConstruct/TConstructHelper.java
@@ -3,6 +3,7 @@ package com.dreammaster.tinkersConstruct;
 import java.lang.reflect.Field;
 import java.util.Map;
 
+import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -33,6 +34,11 @@ public class TConstructHelper {
         Smeltery.getSmeltingList().remove(wrap);
         Smeltery.getTemperatureList().remove(wrap);
         Smeltery.getRenderIndex().remove(wrap);
+    }
+
+    public static MeltingRecipeAdder getMeltingAdder(Block renderBlock, int renderBlockMeta, int meltingTemperature,
+            String fluidName, int amount) {
+        return new MeltingRecipeAdder(renderBlock, renderBlockMeta, meltingTemperature, fluidName, amount);
     }
 
     private static Map<Fluid, Integer[]> smelteryFuelList = null;


### PR DESCRIPTION
I'm going to be working in those files and the huge repetition annoyed me. Trying to lessen it somewhat.

Incidental changes: 
- redGranite cassiterite melted into half the amount as other versions of this ore for some reason, made it the same.
- For some reason rubber melted into glue at different temperatures. That didn't seem meaningful and worth keeping the extra calls so I unified it.

There should be no other functional changes. This should make my life easier when changing aluminium brass to brass as a casting material.