### PR TITLE
More EFR recipe work

### DIFF
--- a/src/main/java/com/dreammaster/recipes/RecipeRemover.java
+++ b/src/main/java/com/dreammaster/recipes/RecipeRemover.java
@@ -3257,6 +3257,13 @@ public class RecipeRemover {
                 new Object[] { getModItem(Natura.ID, "barleyFood", 1, 6, missing),
                         getModItem(Natura.ID, "barleyFood", 1, 6, missing) },
                 new Object[0]);
+        removeRecipeShapedDelayed(
+                getModItem(Minecraft.ID, "leather", 1, 0, missing),
+                new Object[] { getModItem(EtFuturumRequiem.ID, "rabbit_hide", 1, 0, missing),
+                        getModItem(EtFuturumRequiem.ID, "rabbit_hide", 1, 0, missing) },
+                new Object[] { getModItem(EtFuturumRequiem.ID, "rabbit_hide", 1, 0, missing),
+                        getModItem(EtFuturumRequiem.ID, "rabbit_hide", 1, 0, missing) },
+                new Object[0]);
         removeRecipeShapedDelayed(getModItem(OpenBlocks.ID, "paintBrush", 1, 0, missing));
         removeRecipeShapedDelayed(getModItem(OpenBlocks.ID, "goldenEye", 1, wildcard, missing));
         removeRecipeShapedDelayed(getModItem(Railcraft.ID, "cart.energy.batbox", 1, 0, missing));

--- a/src/main/java/com/dreammaster/scripts/ScriptEFR.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEFR.java
@@ -3,6 +3,7 @@ package com.dreammaster.scripts;
 import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.Minecraft;
+import static gregtech.api.enums.Mods.PamsHarvestCraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
@@ -84,5 +85,22 @@ public class ScriptEFR implements IScriptLoader {
                         GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 2L))
                 .itemOutputs(getModItem(EtFuturumRequiem.ID, "barrel", 1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
                 .addTo(assemblerRecipes);
+
+        GTModHandler.addCraftingRecipe(
+                getModItem(EtFuturumRequiem.ID, "lantern", 1, 0, missing),
+                bits,
+                new Object[] { "IGI", "PCP", "III", 'I', "plateIron", 'G', "dustGlowstone", 'P', "paneGlassColorless",
+                        'C', getModItem(PamsHarvestCraft.ID, "pamcandleDeco1", 1, 0, missing) });
+
+        GTModHandler.addCraftingRecipe(
+                getModItem(EtFuturumRequiem.ID, "blast_furnace", 1, 0, missing),
+                bits,
+                new Object[] { "PPP", "PFP", "SSS", 'S', getModItem(Minecraft.ID, "stone", 1, 0, missing), 'F',
+                        getModItem(Minecraft.ID, "furnace", 1, 0, missing), 'P', "plateIron" });
+        GTModHandler.addCraftingRecipe(
+                getModItem(Minecraft.ID, "leather", 1, 0, missing),
+                bits,
+                new Object[] { "SSS", "HHH", "SSS", 'S', getModItem(Minecraft.ID, "string", 1, 0, missing), 'H',
+                        getModItem(EtFuturumRequiem.ID, "rabbit_hide", 1, 0, missing) });
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptEFR.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEFR.java
@@ -4,14 +4,21 @@ import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
+import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
+import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 
 import java.util.Arrays;
 import java.util.List;
 
 import com.dreammaster.recipes.CustomItem;
 
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTModHandler;
+import gregtech.api.util.GTOreDictUnificator;
 
 public class ScriptEFR implements IScriptLoader {
 
@@ -65,5 +72,17 @@ public class ScriptEFR implements IScriptLoader {
                     createItemStack(Thaumcraft.ID, "blockWoodenDevice", 1, 8, "{color:" + i + "b}", missing),
                     GTModHandler.getModItem(EtFuturumRequiem.ID, "banner", 1L, i));
         }
+
+        GTModHandler.addCraftingRecipe(
+                getModItem(EtFuturumRequiem.ID, "barrel", 1, 0, missing),
+                bits,
+                new Object[] { "hPs", "PCP", " P ", 'P', GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1L),
+                        'C', "chestWood" });
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(Minecraft.ID, "chest", 1L),
+                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 2L))
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "barrel", 1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
+                .addTo(assemblerRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptEFR.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEFR.java
@@ -92,11 +92,15 @@ public class ScriptEFR implements IScriptLoader {
                 new Object[] { "IGI", "PCP", "III", 'I', "plateIron", 'G', "dustGlowstone", 'P', "paneGlassColorless",
                         'C', getModItem(PamsHarvestCraft.ID, "pamcandleDeco1", 1, 0, missing) });
 
+        GTModHandler.addSmeltingRecipe(
+                getModItem(Minecraft.ID, "stone", 1, 0, missing),
+                getModItem(EtFuturumRequiem.ID, "smooth_stone", 1, 0, missing));
+
         GTModHandler.addCraftingRecipe(
                 getModItem(EtFuturumRequiem.ID, "blast_furnace", 1, 0, missing),
                 bits,
-                new Object[] { "PPP", "PFP", "SSS", 'S', getModItem(Minecraft.ID, "stone", 1, 0, missing), 'F',
-                        getModItem(Minecraft.ID, "furnace", 1, 0, missing), 'P', "plateIron" });
+                new Object[] { "PPP", "PFP", "SSS", 'S', getModItem(EtFuturumRequiem.ID, "smooth_stone", 1, 0, missing),
+                        'F', getModItem(Minecraft.ID, "furnace", 1, 0, missing), 'P', "plateIron" });
         GTModHandler.addCraftingRecipe(
                 getModItem(Minecraft.ID, "leather", 1, 0, missing),
                 bits,

--- a/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
@@ -689,17 +689,6 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 getModItem(ExtraUtilities.ID, "unstableingot", 1, 0, missing),
                 getModItem(ExtraUtilities.ID, "unstableingot", 1, 2, missing));
         addShapedRecipe(
-                getModItem(ExtraUtilities.ID, "chestFull", 1, 0, missing),
-                "craftingToolHardHammer",
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1L),
-                "craftingToolSaw",
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1L),
-                "chestWood",
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1L),
-                null,
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1L),
-                null);
-        addShapedRecipe(
                 getModItem(ExtraUtilities.ID, "chestMini", 1, 0, missing),
                 "craftingToolHardHammer",
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1L),
@@ -1189,12 +1178,6 @@ public class ScriptExtraUtilities implements IScriptLoader {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Obsidian, 4L))
                 .itemOutputs(getModItem(ExtraUtilities.ID, "decorativeBlock2", 1, 11, missing)).duration(20 * SECONDS)
                 .eut(30).addTo(assemblerRecipes);
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(Minecraft.ID, "chest", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 2L))
-                .itemOutputs(getModItem(ExtraUtilities.ID, "chestFull", 1, 0, missing)).duration(5 * SECONDS).eut(30)
-                .addTo(assemblerRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "flint", 1, 0, missing),


### PR DESCRIPTION
- replaces recipe for slightly larger chest from XU with the EFR barrel. functionally identical but just all around nicer.
- add recipe for EFR lantern similar to existing bibliocraft lantern recipe.
- adjust rabbit hide to leather recipe to work exactly like imp leather.
- add recipe for EFR blast furnace with plates instead of ingots.

![image](https://github.com/user-attachments/assets/05c6c8ee-2b15-442e-81b5-feca503764e6)
![image](https://github.com/user-attachments/assets/809fbb50-8857-4579-a682-f50a95f9093d)
![image](https://github.com/user-attachments/assets/6ea56e57-99e6-40b1-9c14-122f8f37c6d9)
![image](https://github.com/user-attachments/assets/c93fe914-6d06-423f-83ad-d77cb7c40e95)

