### PR TITLE
Remove map recipe from crafting and recipe removal logic

### DIFF
--- a/src/main/java/com/dreammaster/recipes/RecipeRemover.java
+++ b/src/main/java/com/dreammaster/recipes/RecipeRemover.java
@@ -1813,7 +1813,6 @@ public class RecipeRemover {
         removeRecipeByOutputDelayed(getModItem(Minecraft.ID, "painting", 1, 0, missing));
         removeRecipeByOutputDelayed(getModItem(Minecraft.ID, "flint_and_steel", 1, 0, missing));
         removeRecipeByOutputDelayed(getModItem(Minecraft.ID, "dragon_egg", 1, 0, missing));
-        removeRecipeByOutputDelayed(getModItem(Minecraft.ID, "map", 1, 0, missing));
         removeRecipeByOutputDelayed(getModItem(Minecraft.ID, "wooden_door", 1, 0, missing));
         removeRecipeByOutputDelayed(getModItem(Minecraft.ID, "iron_door", 1, 0, missing));
         removeRecipeByOutputDelayed(getModItem(Minecraft.ID, "skull", 1, 1, missing));

--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -4278,17 +4278,6 @@ public class ScriptMinecraft implements IScriptLoader {
                 null,
                 "craftingToolScrewdriver",
                 null);
-        addShapedRecipe(
-                getModItem(Minecraft.ID, "map", 1, 0, missing),
-                "paperEmpty",
-                "paperEmpty",
-                "paperEmpty",
-                "paperEmpty",
-                getModItem(Minecraft.ID, "compass", 1, 0, missing),
-                "paperEmpty",
-                "paperEmpty",
-                "paperEmpty",
-                "paperEmpty");
         addShapelessRecipe(
                 getModItem(Minecraft.ID, "dye", 3, 15, missing),
                 getModItem(Minecraft.ID, "bone", 1, 0, missing),


### PR DESCRIPTION
Original code was removing all map recipes but only adding back the base one. This resulted in only the base zoom map being available and prevented things such as the navigation module for Open Computers from being able to be aware of a larger area.

Please let me know if more information is required.