### PR TITLE
Buff Crystalline Fluid Conduit Recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptEnderIO.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEnderIO.java
@@ -1641,7 +1641,7 @@ public class ScriptEnderIO implements IScriptLoader {
                         GTOreDictUnificator.get(OrePrefixes.pipeMedium, Materials.Polytetrafluoroethylene, 1L),
                         GTOreDictUnificator.get(OrePrefixes.plate, Materials.CrystallineAlloy, 1L))
                 .itemOutputs(getModItem(EnderIO.ID, "itemLiquidConduit", 1, 3, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("molten.epoxid", 144)).duration(5 * SECONDS).eut(960)
+                .fluidInputs(FluidRegistry.getFluidStack("molten.plastic", 144)).duration(5 * SECONDS).eut(960)
                 .addTo(assemblerRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(


### PR DESCRIPTION
It's just objectively not worth crafting vs adding a bit of pink slime and diamond for the crystalline one. Right now it needs a PTFE pipe, crystalline plate, and 1 ingot of epoxid. One tier down is a tiny PTFE pipe, vibrant plate, and 1 ingot of plastic, and one tier up is a PTFE pipe, pink crystalline plate, and 1 ingot of PTFE. Changes the epoxid to be plastic. It is weaker than the pink crystalline one by half stats, so should be cheaper (thus plastic over PTFE), and I see absolutely 0 reason to nerf any of the higher tier conduits.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19077