### PR TITLE
RC Firestone for LV Age

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptRailcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptRailcraft.java
@@ -16,6 +16,7 @@ import static gregtech.api.enums.Mods.StevesCarts2;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.recipe.RecipeMaps.alloySmelterRecipes;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
+import static gregtech.api.recipe.RecipeMaps.blastFurnaceRecipes;
 import static gregtech.api.recipe.RecipeMaps.cutterRecipes;
 import static gregtech.api.recipe.RecipeMaps.hammerRecipes;
 import static gregtech.api.recipe.RecipeMaps.laserEngraverRecipes;
@@ -2047,22 +2048,6 @@ public class ScriptRailcraft implements IScriptLoader {
                 .eut(TierEU.RECIPE_LV).addTo(alloySmelterRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(Railcraft.ID, "firestone.cut", 1, 0, missing),
-                        getModItem(Minecraft.ID, "redstone_block", 2, 0, missing),
-                        GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(getModItem(Railcraft.ID, "firestone.refined", 1, 5000, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("lava", 576)).duration(10 * SECONDS).eut(TierEU.RECIPE_HV)
-                .addTo(assemblerRecipes);
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(Railcraft.ID, "firestone.cracked", 1, wildcard, missing),
-                        getModItem(Minecraft.ID, "redstone_block", 2, 0, missing),
-                        GTUtility.getIntegratedCircuit(1))
-                .itemOutputs(getModItem(Railcraft.ID, "firestone.refined", 1, 5000, missing))
-                .fluidInputs(FluidRegistry.getFluidStack("lava", 576)).duration(10 * SECONDS).eut(TierEU.RECIPE_HV)
-                .addTo(assemblerRecipes);
-        GTValues.RA.stdBuilder()
-                .itemInputs(
                         getModItem(Minecraft.ID, "minecart", 1, 0, missing),
                         getModItem(Minecraft.ID, "crafting_table", 1, 0, missing),
                         GTUtility.getIntegratedCircuit(1))
@@ -2131,6 +2116,24 @@ public class ScriptRailcraft implements IScriptLoader {
                         GTUtility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Railcraft.ID, "tool.surveyor", 1, 0, missing)).duration(15 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(Railcraft.ID, "firestone.cut", 1, 0, missing),
+                        getModItem(Minecraft.ID, "redstone_block", 16, 0, missing),
+                        GTUtility.getIntegratedCircuit(1))
+                .itemOutputs(getModItem(Railcraft.ID, "firestone.refined", 1, 5000, missing))
+                .fluidInputs(FluidRegistry.getFluidStack("lava", 16000)).duration(10 * MINUTES).eut(TierEU.RECIPE_MV)
+                .specialValue(1200).addTo(blastFurnaceRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(Railcraft.ID, "firestone.cracked", 1, 0, missing),
+                        getModItem(Minecraft.ID, "redstone_block", 16, 0, missing),
+                        GTUtility.getIntegratedCircuit(1))
+                .itemOutputs(getModItem(Railcraft.ID, "firestone.refined", 1, 5000, missing))
+                .fluidInputs(FluidRegistry.getFluidStack("lava", 8000)).duration(5 * MINUTES).eut(TierEU.RECIPE_MV)
+                .specialValue(1200).addTo(blastFurnaceRecipes);
+
         GTValues.RA.stdBuilder().itemInputs(getModItem(Railcraft.ID, "cube", 1, 8, missing))
                 .itemOutputs(getModItem(Railcraft.ID, "slab", 4, 38, missing))
                 .fluidInputs(FluidRegistry.getFluidStack("water", 4)).duration(10 * SECONDS).eut(TierEU.RECIPE_LV)
@@ -2158,8 +2161,15 @@ public class ScriptRailcraft implements IScriptLoader {
                 .itemInputs(
                         GTUtility.copyAmount(0L, GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 1L)),
                         getModItem(Railcraft.ID, "firestone.raw", 1, 0, missing))
+                .itemOutputs(getModItem(Railcraft.ID, "firestone.cut", 1, 0, missing)).duration(8 * MINUTES)
+                .eut(TierEU.RECIPE_LV).addTo(laserEngraverRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        GTUtility.copyAmount(0L, GTOreDictUnificator.get(OrePrefixes.lens, Materials.Firestone, 1L)),
+                        getModItem(Railcraft.ID, "firestone.raw", 1, 0, missing))
                 .itemOutputs(getModItem(Railcraft.ID, "firestone.cut", 1, 0, missing)).duration(2 * MINUTES)
-                .eut(TierEU.RECIPE_HV).addTo(laserEngraverRecipes);
+                .eut(TierEU.RECIPE_LV).addTo(laserEngraverRecipes);
 
         TCHelper.removeArcaneRecipe(getModItem(Railcraft.ID, "tool.crowbar.magic", 1, 0, missing));
         TCHelper.removeArcaneRecipe(getModItem(Railcraft.ID, "tool.crowbar.void", 1, 0, missing));


### PR DESCRIPTION
(cherry picked from commit 2169c37c883ecacd2674222c71234cd599835f84)
After some discussion with Gleese

Quest changes
- https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/19116

Make Firestone be LV available to used as RC Boiler fuel in the "Steam Multiblock Age"
**old**
![image](https://github.com/user-attachments/assets/1e1d04aa-b82b-4be5-b74f-a94bfaa13665)
**new**
![image](https://github.com/user-attachments/assets/8541e9d7-94e5-442d-a504-91a70d4addc2)
**old**
![image](https://github.com/user-attachments/assets/31a8fc8a-a979-4caf-9c51-f3a6c5136273)
**new**
![image](https://github.com/user-attachments/assets/43eaecb4-da09-4617-a604-32de9ffaa7eb)
also use other varaint of firestone gem
![image](https://github.com/user-attachments/assets/a7be5121-89d0-49b2-a9c0-37ac073345b3)



