### PR TITLE
Add Iron Tank Minecarts and unify Tank Cart recipes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.227:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.234:dev")
     api("com.github.GTNewHorizons:Yamcl:0.7.0:dev")
     api("com.github.GTNewHorizons:Baubles:1.0.4:dev")
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,6 +9,8 @@ dependencies {
 
     compileOnly("com.github.GTNewHorizons:AkashicTome:1.2.2:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Avaritia:1.62:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Irontanks:1.4.0:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:IronTankMinecarts:1.0.2:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:twilightforest:2.7.5:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:GTNH-Intergalactic:1.5.39:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Mantle:0.5.0:dev") { transitive = false }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:AkashicTome:1.2.2:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Avaritia:1.62:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Irontanks:1.4.0:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:IronTankMinecarts:1.0.2:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:IronTankMinecarts:1.0.3:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:twilightforest:2.7.5:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:GTNH-Intergalactic:1.5.39:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Mantle:0.5.0:dev") { transitive = false }

--- a/src/main/java/com/dreammaster/recipes/RecipeRemover.java
+++ b/src/main/java/com/dreammaster/recipes/RecipeRemover.java
@@ -38,6 +38,7 @@ import static gregtech.api.enums.Mods.GraviSuiteNEO;
 import static gregtech.api.enums.Mods.HardcoreEnderExpansion;
 import static gregtech.api.enums.Mods.IC2NuclearControl;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
+import static gregtech.api.enums.Mods.IronTanksMinecarts;
 import static gregtech.api.enums.Mods.MCFrames;
 import static gregtech.api.enums.Mods.MagicBees;
 import static gregtech.api.enums.Mods.MalisisDoors;
@@ -86,6 +87,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
@@ -3292,6 +3294,15 @@ public class RecipeRemover {
         removeRecipeShapedDelayed(getModItem(Railcraft.ID, "tool.magnifying.glass", 1, 0, missing));
         removeRecipeShapedDelayed(getModItem(Railcraft.ID, "tool.signal.tuner", 1, 0, missing));
         removeRecipeShapedDelayed(getModItem(Railcraft.ID, "tool.surveyor", 1, 0, missing));
+        removeRecipeShapedDelayed(getModItem(IronTanksMinecarts.ID, "minecart_tank_iron", 1, 0, missing));
+        removeRecipeShapedDelayed(getModItem(IronTanksMinecarts.ID, "minecart_tank_gold", 1, 0, missing));
+        removeRecipeShapedDelayed(getModItem(IronTanksMinecarts.ID, "minecart_tank_steel", 1, 0, missing));
+        removeRecipeShapedDelayed(getModItem(IronTanksMinecarts.ID, "minecart_tank_copper", 1, 0, missing));
+        removeRecipeShapedDelayed(getModItem(IronTanksMinecarts.ID, "minecart_tank_diamond", 1, 0, missing));
+        removeRecipeShapedDelayed(getModItem(IronTanksMinecarts.ID, "minecart_tank_aluminium", 1, 0, missing));
+        removeRecipeShapedDelayed(getModItem(IronTanksMinecarts.ID, "minecart_tank_stainlesssteel", 1, 0, missing));
+        removeRecipeShapedDelayed(getModItem(IronTanksMinecarts.ID, "minecart_tank_titanium", 1, 0, missing));
+        removeRecipeShapedDelayed(getModItem(IronTanksMinecarts.ID, "minecart_tank_tungstensteel", 1, 0, missing));
         removeRecipeShapedDelayed(
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
                 new Object[] { getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 0, missing) },

--- a/src/main/java/com/dreammaster/scripts/ScriptIronTankMinecarts.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIronTankMinecarts.java
@@ -1,0 +1,65 @@
+package com.dreammaster.scripts;
+
+import static gregtech.api.enums.Mods.IronTanks;
+import static gregtech.api.enums.Mods.IronTanksMinecarts;
+import static gregtech.api.enums.Mods.Minecraft;
+import static gregtech.api.enums.Mods.Railcraft;
+import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
+import static gregtech.api.util.GTModHandler.getModItem;
+import static gregtech.api.util.GTRecipeBuilder.SECONDS;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
+import com.indemnity83.irontank.reference.TankType;
+
+import gregtech.api.enums.GTValues;
+import gregtech.api.util.GTUtility;
+
+public class ScriptIronTankMinecarts implements IScriptLoader {
+
+    @Override
+    public String getScriptName() {
+        return "Iron Tank Minecarts";
+    }
+
+    @Override
+    public List<String> getDependencies() {
+        return Arrays.asList(Railcraft.ID, IronTanks.ID);
+    }
+
+    @Override
+    public void loadRecipes() {
+        for (TankType type : TankType.values()) {
+            if (type == TankType.GLASS || type == TankType.OBSIDIAN) {
+                continue;
+            }
+            ItemStack tank = getModItem(IronTanks.ID, type.name, 1, 1, missing);
+            ItemStack cart = getModItem(
+                    IronTanksMinecarts.ID,
+                    "minecart_tank_" + secondderivative.irontankminecarts.IronTankMinecarts.tankTypeName(type),
+                    1,
+                    0,
+                    missing);
+            addShapedRecipe(
+                    cart,
+                    "craftingToolHardHammer",
+                    tank,
+                    "craftingToolWrench",
+                    null,
+                    getModItem(Minecraft.ID, "minecart", 1, 0, missing),
+                    null,
+                    null,
+                    "craftingToolScrewdriver",
+                    null);
+            GTValues.RA.stdBuilder()
+                    .itemInputs(
+                            getModItem(Minecraft.ID, "minecart", 1, 0, missing),
+                            tank,
+                            GTUtility.getIntegratedCircuit(1))
+                    .itemOutputs(cart).duration(5 * SECONDS).eut(16).addTo(assemblerRecipes);
+        }
+    }
+}

--- a/src/main/java/com/dreammaster/scripts/ScriptLoader.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptLoader.java
@@ -81,6 +81,7 @@ public class ScriptLoader {
                         new ScriptIndustrialCraft(),
                         new ScriptIronChests(),
                         new ScriptIronChestsMinecarts(),
+                        new ScriptIronTankMinecarts(),
                         new ScriptJABBA(),
                         new ScriptLogisticPipes(),
                         new ScriptMagicBees(),

--- a/src/main/java/com/dreammaster/scripts/ScriptRailcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptRailcraft.java
@@ -3,6 +3,7 @@ package com.dreammaster.scripts;
 import static com.dreammaster.main.MainRegistry.Module_CustomFuels;
 import static gregtech.api.enums.Mods.Backpack;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
+import static gregtech.api.enums.Mods.BuildCraftFactory;
 import static gregtech.api.enums.Mods.EnderIO;
 import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.ForgeMicroblocks;
@@ -64,6 +65,7 @@ public class ScriptRailcraft implements IScriptLoader {
     @Override
     public List<String> getDependencies() {
         return Arrays.asList(
+                BuildCraftFactory.ID,
                 Railcraft.ID,
                 Thaumcraft.ID,
                 Backpack.ID,
@@ -1004,7 +1006,7 @@ public class ScriptRailcraft implements IScriptLoader {
         addShapedRecipe(
                 getModItem(Railcraft.ID, "cart.tank", 1, 0, missing),
                 "craftingToolHardHammer",
-                getModItem(Railcraft.ID, "machine.beta", 1, 1, missing),
+                getModItem(BuildCraftFactory.ID, "tankBlock", 1, 1, missing),
                 "craftingToolWrench",
                 null,
                 getModItem(Minecraft.ID, "minecart", 1, 0, missing),
@@ -2070,7 +2072,7 @@ public class ScriptRailcraft implements IScriptLoader {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         getModItem(Minecraft.ID, "minecart", 1, 0, missing),
-                        getModItem(Railcraft.ID, "machine.beta", 1, 1, missing),
+                        getModItem(BuildCraftFactory.ID, "tankBlock", 1, 1, missing),
                         GTUtility.getIntegratedCircuit(1))
                 .itemOutputs(getModItem(Railcraft.ID, "cart.tank", 1, 0, missing)).duration(5 * SECONDS).eut(16)
                 .addTo(assemblerRecipes);


### PR DESCRIPTION
Add the Iron Tank Minecarts mod scripts.

The RC tank cart is now built with a BC Factory Tank

this patch needs a GT5 release with [this PR](https://github.com/GTNewHorizons/GT5-Unofficial/pull/4182)