### PR TITLE
update irontanks and iron tank minecarts dependency

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,8 +9,8 @@ dependencies {
 
     compileOnly("com.github.GTNewHorizons:AkashicTome:1.2.2:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Avaritia:1.62:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Irontanks:1.4.0:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:IronTankMinecarts:1.0.3:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Irontanks:1.4.1:dev") { transitive = false }
+    compileOnly("secondderivative.irontankminecarts:IronTankMinecarts:1.0.5:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:twilightforest:2.7.5:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:GTNH-Intergalactic:1.5.39:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Mantle:0.5.0:dev") { transitive = false }

--- a/src/main/java/com/dreammaster/scripts/ScriptIronTankMinecarts.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIronTankMinecarts.java
@@ -27,7 +27,7 @@ public class ScriptIronTankMinecarts implements IScriptLoader {
 
     @Override
     public List<String> getDependencies() {
-        return Arrays.asList(Railcraft.ID, IronTanks.ID);
+        return Arrays.asList(Railcraft.ID, IronTanks.ID, IronTankMinecarts.ID);
     }
 
     @Override

--- a/src/main/java/com/dreammaster/scripts/ScriptIronTankMinecarts.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIronTankMinecarts.java
@@ -27,7 +27,7 @@ public class ScriptIronTankMinecarts implements IScriptLoader {
 
     @Override
     public List<String> getDependencies() {
-        return Arrays.asList(Railcraft.ID, IronTanks.ID, IronTanksMinecarts.ID);
+        return Arrays.asList(Railcraft.ID, IronTanks.ID, IronTankMinecarts.ID);
     }
 
     @Override

--- a/src/main/java/com/dreammaster/scripts/ScriptIronTankMinecarts.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIronTankMinecarts.java
@@ -27,7 +27,7 @@ public class ScriptIronTankMinecarts implements IScriptLoader {
 
     @Override
     public List<String> getDependencies() {
-        return Arrays.asList(Railcraft.ID, IronTanks.ID, IronTankMinecarts.ID);
+        return Arrays.asList(Railcraft.ID, IronTanks.ID, IronTanksMinecarts.ID);
     }
 
     @Override


### PR DESCRIPTION
moving back to the old maven group in 1.0.5 and doing this early so scripts etc keep working smoothly for further updates