### PR TITLE
Improve forbidden isModLoaded and getModItem scripts

### DIFF
--- a/.github/workflows/test-forbidden-getmoditems.yml
+++ b/.github/workflows/test-forbidden-getmoditems.yml
@@ -15,5 +15,5 @@ jobs:
       - name: Detect forbidden getModItem calls
         shell: bash
         run: |
-          ! grep -E -r 'getModItem\("(bartworks|galacticgreg|ggfab|GoodGenerator|gregtech|gtnhlanth|miscutils|kekztech|kubatech|tectech|gtneioreplugin|dreamcraft)"' src/main/java
           ! grep -E -r 'getModItem\(.*(BartWorks|GalactiGreg|GGFab|GoodGenerator|GregTech|GTNHLanthanides|GTPlusPlus|KekzTech|KubaTech|TecTech|NEIOrePlugin|NewHorizonsCoreMod)\.ID' src/main/java
+          ! grep -E -r 'getModItem\(".*", .*)' src/main/java

--- a/.github/workflows/test-forbidden-getmoditems.yml
+++ b/.github/workflows/test-forbidden-getmoditems.yml
@@ -15,4 +15,5 @@ jobs:
       - name: Detect forbidden getModItem calls
         shell: bash
         run: |
-          ! grep -E -r 'getModItem\(("(bartworks|galacticgreg|ggfab|GoodGenerator|gregtech|gtnhlanth|miscutils|kekztech|kubatech|tectech|gtneioreplugin|dreamcraft)"|.*(BartWorks|GalactiGreg|GGFab|GoodGenerator|GregTech|GTNHLanthanides|GTPlusPlus|KekzTech|KubaTech|TecTech|NEIOrePlugin|NewHorizonsCoreMod)\.ID)' src/main/java
+          ! grep -E -r 'getModItem\("(bartworks|galacticgreg|ggfab|GoodGenerator|gregtech|gtnhlanth|miscutils|kekztech|kubatech|tectech|gtneioreplugin|dreamcraft)"' src/main/java
+          ! grep -E -r 'getModItem\(.*(BartWorks|GalactiGreg|GGFab|GoodGenerator|GregTech|GTNHLanthanides|GTPlusPlus|KekzTech|KubaTech|TecTech|NEIOrePlugin|NewHorizonsCoreMod)\.ID' src/main/java

--- a/.github/workflows/test-forbidden-ismodloaded.yml
+++ b/.github/workflows/test-forbidden-ismodloaded.yml
@@ -16,3 +16,6 @@ jobs:
         shell: bash
         run: |
           ! grep -E -r '(BartWorks|GalactiGreg|GGFab|GoodGenerator|GTNHLanthanides|GregTech|GTPlusPlus|KekzTech|KubaTech|TecTech|NEIOrePlugin|NewHorizonsCoreMod)\.isModLoaded' src/main/java
+          ! grep -E -r 'isModLoaded\(".*")' src/main/java
+          ! grep -E -r '@(Optional.|)Method\(modid = ".*")' src/main/java
+          ! grep -E -r '@(Optional.|)Interface\(.*modid = ".*".*)' src/main/java

--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -1,6 +1,7 @@
 package com.dreammaster.main;
 
 import static gregtech.api.enums.Dyes.MACHINE_METAL;
+import static gregtech.api.enums.Mods.AmazingTrophies;
 import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.BloodMagic;
 import static gregtech.api.enums.Mods.DetravScannerMod;
@@ -79,7 +80,6 @@ import com.dreammaster.witchery.WitcheryPlugin;
 
 import bartworks.system.material.WerkstoffLoader;
 import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
@@ -510,7 +510,7 @@ public class MainRegistry {
         BW_RadHatchMaterial.runRadHatchAdder();
 
         if (Thaumcraft.isModLoaded()) TCLoader.checkRecipeProblems();
-        if (Loader.isModLoaded("amazingtrophies") && BloodMagic.isModLoaded()
+        if (AmazingTrophies.isModLoaded() && BloodMagic.isModLoaded()
                 && Avaritia.isModLoaded()
                 && SGCraft.isModLoaded()
                 && TinkerConstruct.isModLoaded()) {

--- a/src/main/java/com/dreammaster/modcustomdrops/CustomDropsHandler.java
+++ b/src/main/java/com/dreammaster/modcustomdrops/CustomDropsHandler.java
@@ -41,10 +41,11 @@ import eu.usrv.yamcore.auxiliary.ItemDescriptor;
 import eu.usrv.yamcore.auxiliary.LogHelper;
 import eu.usrv.yamcore.auxiliary.PlayerChatHelper;
 import eu.usrv.yamcore.persisteddata.PersistedDataBase;
+import gregtech.api.enums.Mods;
 import io.netty.buffer.ByteBuf;
 import thaumcraft.common.lib.FakeThaumcraftPlayer;
 
-@Optional.Interface(iface = "com.kuba6000.mobsinfo.api.IMobExtraInfoProvider", modid = "mobsinfo")
+@Optional.Interface(iface = "com.kuba6000.mobsinfo.api.IMobExtraInfoProvider", modid = Mods.Names.MOBS_INFO)
 public class CustomDropsHandler implements IMobExtraInfoProvider {
 
     private LogHelper _mLogger = MainRegistry.Logger;
@@ -220,7 +221,7 @@ public class CustomDropsHandler implements IMobExtraInfoProvider {
         }
     }
 
-    @Optional.Method(modid = "mobsinfo")
+    @Optional.Method(modid = Mods.Names.MOBS_INFO)
     @Override
     public void provideExtraDropsInformation(@NotNull String entityString, @NotNull ArrayList<MobDrop> drops,
             @NotNull MobRecipe recipe) {

--- a/src/main/java/com/dreammaster/scripts/ScriptAmunRa.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAmunRa.java
@@ -51,6 +51,7 @@ import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.MaterialsKevlar;
+import gregtech.api.enums.Mods;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTRecipeConstants;
@@ -503,7 +504,7 @@ public class ScriptAmunRa implements IScriptLoader {
                 .eut(TierEU.RECIPE_UEV).addTo(GTRecipeConstants.AssemblyLine);
     }
 
-    @Optional.Method(modid = "GalacticraftAmunRa")
+    @Optional.Method(modid = Mods.Names.GALACTICRAFT_AMUN_RA)
     private static void setMothershipRecipe() {
         final HashMap<Object, Integer> recipe = new HashMap<>();
 

--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -51,6 +51,7 @@ import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.Mods;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.recipe.RecipeCategories;
@@ -61,7 +62,6 @@ import gregtech.api.util.GTUtility;
 import micdoodle8.mods.galacticraft.api.GalacticraftRegistry;
 import micdoodle8.mods.galacticraft.api.recipe.SpaceStationRecipe;
 import micdoodle8.mods.galacticraft.api.world.SpaceStationType;
-import micdoodle8.mods.galacticraft.core.Constants;
 import micdoodle8.mods.galacticraft.core.blocks.GCBlocks;
 import micdoodle8.mods.galacticraft.core.items.GCItems;
 import micdoodle8.mods.galacticraft.core.nei.BuggyRecipeHandler;
@@ -2817,7 +2817,7 @@ public class ScriptGalacticraft implements IScriptLoader {
                 .eut(TierEU.RECIPE_HV).addTo(mixerRecipes);
     }
 
-    @Optional.Method(modid = "GalacticraftCore")
+    @Optional.Method(modid = Mods.Names.GALACTICRAFT_CORE)
     private static void spaceStationRecipes() {
         final HashMap<Object, Integer> inputMap = new HashMap<>();
         inputMap.put(new ItemStack(GCBlocks.basicBlock, 1, 4), 231);
@@ -2828,7 +2828,7 @@ public class ScriptGalacticraft implements IScriptLoader {
                 new SpaceStationType(ConfigManagerCore.idDimensionOverworldOrbit, 0, new SpaceStationRecipe(inputMap)));
     }
 
-    @Optional.Method(modid = "GalacticraftCore")
+    @Optional.Method(modid = Mods.Names.GALACTICRAFT_CORE)
     private static void buggyRecipes() {
         HashMap<Integer, ItemStack> input = new HashMap<>();
         HashMap<Integer, ItemStack> input2;
@@ -2880,7 +2880,7 @@ public class ScriptGalacticraft implements IScriptLoader {
             input3.put(
                     3,
                     new PositionedStack(
-                            getModItem(Constants.MOD_ID_GALAXYSPACE, "item.RocketControlComputer", 1, 100),
+                            getModItem(GalaxySpace.ID, "item.RocketControlComputer", 1, 100),
                             62 - x,
                             73 - y));
         }
@@ -2993,15 +2993,15 @@ public class ScriptGalacticraft implements IScriptLoader {
                 new PositionedStack(new ItemStack(GCItems.buggy, 1, 3), 143 - x, 64 - y));
     }
 
-    @Optional.Method(modid = "GalacticraftCore")
+    @Optional.Method(modid = Mods.Names.GALACTICRAFT_CORE)
     private static void cargoRecipes() {
         HashMap<Integer, ItemStack> input = new HashMap<>();
         HashMap<Integer, ItemStack> input2;
         input.put(1, new ItemStack(GCItems.basicItem, 1, 14));
         if (GalaxySpace.isModLoaded()) {
-            input.put(2, getModItem(Constants.MOD_ID_GALAXYSPACE, "item.RocketControlComputer", 1, 101));
+            input.put(2, getModItem(GalaxySpace.ID, "item.RocketControlComputer", 1, 101));
             for (int i = 3; i <= 5; i++) {
-                input.put(i, getModItem(Constants.MOD_ID_GALAXYSPACE, "item.ModuleSmallFuelCanister", 1));
+                input.put(i, getModItem(GalaxySpace.ID, "item.ModuleSmallFuelCanister", 1));
             }
         }
         input.put(7, new ItemStack(GCItems.partNoseCone));
@@ -3033,22 +3033,22 @@ public class ScriptGalacticraft implements IScriptLoader {
         if (GalaxySpace.isModLoaded()) {
             input3.add(
                     new PositionedStack(
-                            getModItem(Constants.MOD_ID_GALAXYSPACE, "item.RocketControlComputer", 1, 101),
+                            getModItem(GalaxySpace.ID, "item.RocketControlComputer", 1, 101),
                             134 - x,
                             28 - y));
             input3.add(
                     new PositionedStack(
-                            getModItem(Constants.MOD_ID_GALAXYSPACE, "item.ModuleSmallFuelCanister", 1),
+                            getModItem(GalaxySpace.ID, "item.ModuleSmallFuelCanister", 1),
                             116 - x,
                             19 - y));
             input3.add(
                     new PositionedStack(
-                            getModItem(Constants.MOD_ID_GALAXYSPACE, "item.ModuleSmallFuelCanister", 1),
+                            getModItem(GalaxySpace.ID, "item.ModuleSmallFuelCanister", 1),
                             152 - x,
                             19 - y));
             input3.add(
                     new PositionedStack(
-                            getModItem(Constants.MOD_ID_GALAXYSPACE, "item.ModuleSmallFuelCanister", 1),
+                            getModItem(GalaxySpace.ID, "item.ModuleSmallFuelCanister", 1),
                             116 - x,
                             37 - y));
         }
@@ -3084,7 +3084,7 @@ public class ScriptGalacticraft implements IScriptLoader {
                 new PositionedStack(new ItemStack(MarsItems.spaceship, 1, 13), 134 - x, 73 - y));
     }
 
-    @Optional.Method(modid = "GalacticraftCore")
+    @Optional.Method(modid = Mods.Names.GALACTICRAFT_CORE)
     private static void astroMinerRecipes() {
         final HashMap<Integer, ItemStack> input = new HashMap<>();
         for (int i = 1; i <= 8; i++) {
@@ -3099,7 +3099,7 @@ public class ScriptGalacticraft implements IScriptLoader {
             input.put(i, new ItemStack(AsteroidsItems.orionDrive));
         }
         if (GalaxySpace.isModLoaded()) {
-            input.put(18, getModItem(Constants.MOD_ID_GALAXYSPACE, "item.RocketControlComputer", 1, 102));
+            input.put(18, getModItem(GalaxySpace.ID, "item.RocketControlComputer", 1, 102));
         }
         input.put(19, new ItemStack(GCItems.basicItem, 1, 14));
         input.put(20, new ItemStack(GCItems.basicItem, 1, 14));
@@ -3110,8 +3110,8 @@ public class ScriptGalacticraft implements IScriptLoader {
         input.put(25, RecipeUtil.getChestItemStack(1, 1));
         input.put(26, new ItemStack(AsteroidsItems.basicItem, 1, 8));
         input.put(27, new ItemStack(AsteroidBlocks.beamReceiver));
-        input.put(28, getModItem(Constants.MOD_ID_GREGTECH, "gt.metaitem.01", 1, 32603));
-        input.put(29, getModItem(Constants.MOD_ID_GREGTECH, "gt.metaitem.01", 1, 32603));
+        input.put(28, ItemList.Electric_Motor_EV.get(1));
+        input.put(29, ItemList.Electric_Motor_EV.get(1));
         GalacticraftRegistry
                 .addAstroMinerRecipe(new NasaWorkbenchRecipe(new ItemStack(AsteroidsItems.astroMiner, 1, 0), input));
 
@@ -3141,7 +3141,7 @@ public class ScriptGalacticraft implements IScriptLoader {
         if (GalaxySpace.isModLoaded()) {
             input3.add(
                     new PositionedStack(
-                            getModItem(Constants.MOD_ID_GALAXYSPACE, "item.RocketControlComputer", 1, 102),
+                            getModItem(GalaxySpace.ID, "item.RocketControlComputer", 1, 102),
                             62 - x,
                             37 - y));
         }
@@ -3154,10 +3154,8 @@ public class ScriptGalacticraft implements IScriptLoader {
         input3.add(new PositionedStack(RecipeUtil.getChestItemStack(1, 1), 98 - x, 55 - y));
         input3.add(new PositionedStack(new ItemStack(AsteroidsItems.basicItem, 1, 8), 44 - x, 73 - y));
         input3.add(new PositionedStack(new ItemStack(AsteroidBlocks.beamReceiver), 62 - x, 73 - y));
-        input3.add(
-                new PositionedStack(getModItem(Constants.MOD_ID_GREGTECH, "gt.metaitem.01", 1, 32603), 80 - x, 73 - y));
-        input3.add(
-                new PositionedStack(getModItem(Constants.MOD_ID_GREGTECH, "gt.metaitem.01", 1, 32603), 98 - x, 73 - y));
+        input3.add(new PositionedStack(ItemList.Electric_Motor_EV.get(1), 80 - x, 73 - y));
+        input3.add(new PositionedStack(ItemList.Electric_Motor_EV.get(1), 98 - x, 73 - y));
         instance.registerAstroMinerRecipe(
                 input3,
                 new PositionedStack(new ItemStack(AsteroidsItems.astroMiner), 143 - x, 55 - y));

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
@@ -9,6 +9,7 @@ import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.TaintedMagic;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.ThaumicEnergistics;
+import static gregtech.api.enums.Mods.ThaumicInsurgence;
 import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.recipe.RecipeMaps.circuitAssemblerRecipes;
@@ -89,7 +90,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         final ItemStack CalcProcessor = getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 23, missing);
         final ItemStack EngProcessor = getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 24, missing);
 
-        final ItemStack InfusionIntercepter = getModItem("thaumicinsurgence", "infusionIntercepter", 1, 0);
+        final ItemStack InfusionIntercepter = getModItem(ThaumicInsurgence.ID, "infusionIntercepter", 1, 0);
 
         final ItemStack ZPMEmitter = ItemList.Emitter_ZPM.get(1);
         final ItemStack ZPMSensor = ItemList.Sensor_ZPM.get(1);

--- a/src/main/java/com/dreammaster/scripts/ScriptZZClientOnly.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptZZClientOnly.java
@@ -29,6 +29,7 @@ import forestry.factory.recipes.CarpenterRecipe;
 import gregtech.GTMod;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Mods;
 import gregtech.api.util.GTRecipe;
 import gregtech.api.util.GTUtility;
 
@@ -51,7 +52,7 @@ public class ScriptZZClientOnly implements IScriptLoader {
     Object[] stamps = null;
     ArrayList<GTRecipe> coins = new ArrayList<>();
 
-    @Optional.Method(modid = "Forestry")
+    @Optional.Method(modid = Mods.Names.FORESTRY)
     void stamps(boolean enabled) {
         if (stamps == null) {
             stamps = new CarpenterRecipe[] {


### PR DESCRIPTION
Similar to https://github.com/GTNewHorizons/GT5-Unofficial/pull/4208

Draft because it relies on a mod being added to the GT mods enum, which is added in #4208 (actions are run based on the scripts in master, so the tests pass in the PR. However once this merges, there will be a failure [here](https://github.com/GTNewHorizons/NewHorizonsCoreMod/blob/fb2f0037f9a8d2648e654a9f37f56096a47bbdcf/src/main/java/com/dreammaster/main/MainRegistry.java#L513))