### PR TITLE
Fix EV Battery Buffer 16-slot assembler recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -3098,7 +3098,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Hull_EV.get(1),
-                        GTOreDictUnificator.get(OrePrefixes.cableGt16, Materials.Aluminium, 4),
+                        GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.Aluminium, 4),
                         new ItemStack(Blocks.chest))
                 .itemOutputs(ItemList.Battery_Buffer_4by4_EV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_MV)
                 .addTo(assemblerRecipes);


### PR DESCRIPTION
These buffers are crafted universally with wires, not cables. This keeps that consistency.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19366