### PR TITLE
switch GalaxySpace addShapedRecipe to GTModHandler.addCraftingRecipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptGalaxySpace.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalaxySpace.java
@@ -829,4 +829,9 @@ public class ScriptGalaxySpace implements IScriptLoader {
     private static ItemStack getGSItem(String name, int amount, int meta) {
         return getModItem(GalaxySpace.ID, name, amount, meta, missing);
     }
+
+    @Override
+    public boolean addShapedRecipe(ItemStack aOutput, Object... inputs) {
+        return GTModHandler.addCraftingRecipe(aOutput, GTModHandler.RecipeBits.NOT_REMOVABLE, inputs);
+    }
 }


### PR DESCRIPTION
We really need to centralize the way crafting recipes are added in the pack

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19790