### PR TITLE
update dtpf infinity circuit to not share circuit with cosmicneut

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -576,7 +576,7 @@ public class DTPFRecipes implements Runnable {
                     GTValues.RA.stdBuilder()
                             .itemInputs(
                                     GTModHandler.getModItem(Avaritia.ID, "Resource", 1L, 5),
-                                    GTUtility.getIntegratedCircuit(1))
+                                    GTUtility.getIntegratedCircuit(5))
                             .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(infinity.getCatalystAmount(2)))
                             .fluidOutputs(
                                     MaterialsUEVplus.DimensionallyTranscendentResidue


### PR DESCRIPTION
The case this is addressing
- dtpf with hypogen coils
- player wants to use comb recipes
- player wants to use the faster, but more expensive infinity recipe using awakened draconium coils. 

This requires program circuit 1, for cosmic neutronium, and program circuit 3 for infinity. In 2.7.x, circuit priorities were deterministic, and a knowledgeable player could order them in the bus such that 3 would take priority over 1, and both recipes would work as expected. 

However, on 2.8.x, (tested on build 1003). circuit priority is currently not deterministic. meaning the player can no longer use the recipes above in the same CRIB/bus.

If we were to change the program circuit used for the non-comb hypogen recipe to be one which is not shared with other recipes, the conflict goes away, and we no longer need to care about circuit priority in this case. 


This is my first contribution, so if I need to make other changes elsewhere, please let me know. 