### PR TITLE
Ic2 furnace replace

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptAutomagy.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAutomagy.java
@@ -1,8 +1,25 @@
 package com.dreammaster.scripts;
 
+import com.dreammaster.thaumcraft.TCHelper;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GTOreDictUnificator;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.item.ItemStack;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.research.ResearchItem;
+import thaumcraft.api.research.ResearchPage;
+
+import java.util.Arrays;
+import java.util.List;
+
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.Automagy;
 import static gregtech.api.enums.Mods.BuildCraftFactory;
+import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Mods.Genetics;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.Minecraft;
@@ -10,24 +27,6 @@ import static gregtech.api.enums.Mods.ProjectRedIntegration;
 import static gregtech.api.enums.Mods.Railcraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.util.GTModHandler.getModItem;
-
-import java.util.Arrays;
-import java.util.List;
-
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.item.ItemStack;
-
-import com.dreammaster.thaumcraft.TCHelper;
-
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
-import thaumcraft.api.ThaumcraftApi;
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.api.research.ResearchItem;
-import thaumcraft.api.research.ResearchPage;
 
 public class ScriptAutomagy implements IScriptLoader {
 
@@ -93,7 +92,7 @@ public class ScriptAutomagy implements IScriptLoader {
                 'A',
                 getModItem(Railcraft.ID, "machine.beta", 1, 4, missing),
                 'F',
-                getModItem(IndustrialCraft2.ID, "blockMachine", 1, 1, missing),
+                getModItem(EtFuturumRequiem.ID, "blast_furnace", 1, 0, missing),
                 'B',
                 getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0, missing),
                 'S',

--- a/src/main/java/com/dreammaster/scripts/ScriptAutomagy.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAutomagy.java
@@ -1,21 +1,5 @@
 package com.dreammaster.scripts;
 
-import com.dreammaster.thaumcraft.TCHelper;
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
-import net.minecraft.enchantment.Enchantment;
-import net.minecraft.item.ItemStack;
-import thaumcraft.api.ThaumcraftApi;
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.api.research.ResearchItem;
-import thaumcraft.api.research.ResearchPage;
-
-import java.util.Arrays;
-import java.util.List;
-
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.Automagy;
 import static gregtech.api.enums.Mods.BuildCraftFactory;
@@ -27,6 +11,24 @@ import static gregtech.api.enums.Mods.ProjectRedIntegration;
 import static gregtech.api.enums.Mods.Railcraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.util.GTModHandler.getModItem;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.item.ItemStack;
+
+import com.dreammaster.thaumcraft.TCHelper;
+
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GTOreDictUnificator;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.research.ResearchItem;
+import thaumcraft.api.research.ResearchPage;
 
 public class ScriptAutomagy implements IScriptLoader {
 

--- a/src/main/java/com/dreammaster/scripts/ScriptDraconicEvolution.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptDraconicEvolution.java
@@ -1,22 +1,5 @@
 package com.dreammaster.scripts;
 
-import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.item.NHItemList;
-import fox.spiteful.avaritia.compat.ticon.Tonkers;
-import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
-import gregtech.api.enums.GTValues;
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTModHandler;
-import gregtech.api.util.GTOreDictUnificator;
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidRegistry;
-import tconstruct.tools.TinkerTools;
-
-import java.util.Arrays;
-import java.util.List;
-
 import static gregtech.api.enums.Mods.AvaritiaAddons;
 import static gregtech.api.enums.Mods.BloodArsenal;
 import static gregtech.api.enums.Mods.BloodMagic;
@@ -42,6 +25,25 @@ import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gtPlusPlus.core.recipe.common.CI.bits;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidRegistry;
+
+import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.item.NHItemList;
+
+import fox.spiteful.avaritia.compat.ticon.Tonkers;
+import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GTModHandler;
+import gregtech.api.util.GTOreDictUnificator;
+import tconstruct.tools.TinkerTools;
 
 public class ScriptDraconicEvolution implements IScriptLoader {
 

--- a/src/main/java/com/dreammaster/scripts/ScriptDraconicEvolution.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptDraconicEvolution.java
@@ -1,11 +1,29 @@
 package com.dreammaster.scripts;
 
+import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.item.NHItemList;
+import fox.spiteful.avaritia.compat.ticon.Tonkers;
+import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GTModHandler;
+import gregtech.api.util.GTOreDictUnificator;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidRegistry;
+import tconstruct.tools.TinkerTools;
+
+import java.util.Arrays;
+import java.util.List;
+
 import static gregtech.api.enums.Mods.AvaritiaAddons;
 import static gregtech.api.enums.Mods.BloodArsenal;
 import static gregtech.api.enums.Mods.BloodMagic;
 import static gregtech.api.enums.Mods.BuildCraftTransport;
 import static gregtech.api.enums.Mods.DraconicEvolution;
 import static gregtech.api.enums.Mods.EnderIO;
+import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.Minecraft;
@@ -24,25 +42,6 @@ import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gtPlusPlus.core.recipe.common.CI.bits;
-
-import java.util.Arrays;
-import java.util.List;
-
-import net.minecraft.item.ItemStack;
-import net.minecraftforge.fluids.FluidRegistry;
-
-import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.item.NHItemList;
-
-import fox.spiteful.avaritia.compat.ticon.Tonkers;
-import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
-import gregtech.api.enums.GTValues;
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTModHandler;
-import gregtech.api.util.GTOreDictUnificator;
-import tconstruct.tools.TinkerTools;
 
 public class ScriptDraconicEvolution implements IScriptLoader {
 
@@ -87,7 +86,7 @@ public class ScriptDraconicEvolution implements IScriptLoader {
                 "plateObsidian",
                 getModItem(EnderIO.ID, "blockCapBank", 1, 1, missing),
                 "plateObsidian",
-                getModItem(IndustrialCraft2.ID, "blockMachine", 1, 1, missing),
+                getModItem(EtFuturumRequiem.ID, "blast_furnace", 1, 0, missing),
                 getModItem(AvaritiaAddons.ID, "CompressedChest", 1, 0, missing),
                 ItemList.Cover_Crafting.get(1L),
                 "plateObsidian",

--- a/src/main/java/com/dreammaster/scripts/ScriptStevesCarts.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptStevesCarts.java
@@ -1,19 +1,5 @@
 package com.dreammaster.scripts;
 
-import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.item.NHItemList;
-import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
-import gregtech.api.enums.GTValues;
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
-import gregtech.api.util.GTUtility;
-import net.minecraftforge.fluids.FluidRegistry;
-
-import java.util.Arrays;
-import java.util.List;
-
 import static gregtech.api.enums.Mods.Backpack;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.Botany;
@@ -47,6 +33,22 @@ import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeConstants.UniversalChemical;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.minecraftforge.fluids.FluidRegistry;
+
+import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.item.NHItemList;
+
+import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GTOreDictUnificator;
+import gregtech.api.util.GTUtility;
 
 public class ScriptStevesCarts implements IScriptLoader {
 

--- a/src/main/java/com/dreammaster/scripts/ScriptStevesCarts.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptStevesCarts.java
@@ -1,11 +1,26 @@
 package com.dreammaster.scripts;
 
+import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.item.NHItemList;
+import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GTOreDictUnificator;
+import gregtech.api.util.GTUtility;
+import net.minecraftforge.fluids.FluidRegistry;
+
+import java.util.Arrays;
+import java.util.List;
+
 import static gregtech.api.enums.Mods.Backpack;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.Botany;
 import static gregtech.api.enums.Mods.BuildCraftFactory;
 import static gregtech.api.enums.Mods.BuildCraftSilicon;
 import static gregtech.api.enums.Mods.EnderIO;
+import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Mods.ExtraBees;
 import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.Forestry;
@@ -32,22 +47,6 @@ import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeConstants.UniversalChemical;
-
-import java.util.Arrays;
-import java.util.List;
-
-import net.minecraftforge.fluids.FluidRegistry;
-
-import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.item.NHItemList;
-
-import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
-import gregtech.api.enums.GTValues;
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
-import gregtech.api.util.GTUtility;
 
 public class ScriptStevesCarts implements IScriptLoader {
 
@@ -1790,7 +1789,7 @@ public class ScriptStevesCarts implements IScriptLoader {
                 .addTo(assemblerRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        getModItem(IndustrialCraft2.ID, "blockMachine", 1, 1, missing),
+                        getModItem(EtFuturumRequiem.ID, "blast_furnace", 1, 0, missing),
                         getModItem(StevesCarts2.ID, "ModuleComponents", 2, 9, missing))
                 .itemOutputs(getModItem(StevesCarts2.ID, "CartModule", 1, 91, missing)).duration(15 * SECONDS).eut(30)
                 .addTo(assemblerRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptWitchery.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptWitchery.java
@@ -1,8 +1,30 @@
 package com.dreammaster.scripts;
 
+import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.thaumcraft.TCHelper;
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GTOreDictUnificator;
+import gregtech.api.util.GTUtility;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.FluidRegistry;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchItem;
+import thaumcraft.api.research.ResearchPage;
+
+import java.util.Arrays;
+import java.util.List;
+
 import static gregtech.api.enums.Mods.Backpack;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.BloodArsenal;
+import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Railcraft;
@@ -16,29 +38,6 @@ import static gregtech.api.recipe.RecipeMaps.mixerRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
-
-import java.util.Arrays;
-import java.util.List;
-
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fluids.FluidRegistry;
-
-import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.thaumcraft.TCHelper;
-
-import gregtech.api.enums.GTValues;
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
-import gregtech.api.util.GTUtility;
-import thaumcraft.api.ThaumcraftApi;
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.api.research.ResearchCategories;
-import thaumcraft.api.research.ResearchItem;
-import thaumcraft.api.research.ResearchPage;
 
 public class ScriptWitchery implements IScriptLoader {
 
@@ -328,7 +327,7 @@ public class ScriptWitchery implements IScriptLoader {
                 'g',
                 getModItem(IndustrialCraft2.ID, "blockFenceIron", 1, 0, missing),
                 'h',
-                getModItem(IndustrialCraft2.ID, "blockMachine", 1, 1, missing),
+                getModItem(EtFuturumRequiem.ID, "blast_furnace", 1, 0, missing),
                 'i',
                 getModItem(IndustrialCraft2.ID, "blockFenceIron", 1, 0, missing));
         TCHelper.addResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptWitchery.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptWitchery.java
@@ -1,26 +1,5 @@
 package com.dreammaster.scripts;
 
-import com.dreammaster.gthandler.CustomItemList;
-import com.dreammaster.thaumcraft.TCHelper;
-import gregtech.api.enums.GTValues;
-import gregtech.api.enums.ItemList;
-import gregtech.api.enums.Materials;
-import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
-import gregtech.api.util.GTUtility;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fluids.FluidRegistry;
-import thaumcraft.api.ThaumcraftApi;
-import thaumcraft.api.aspects.Aspect;
-import thaumcraft.api.aspects.AspectList;
-import thaumcraft.api.research.ResearchCategories;
-import thaumcraft.api.research.ResearchItem;
-import thaumcraft.api.research.ResearchPage;
-
-import java.util.Arrays;
-import java.util.List;
-
 import static gregtech.api.enums.Mods.Backpack;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.BloodArsenal;
@@ -38,6 +17,29 @@ import static gregtech.api.recipe.RecipeMaps.mixerRecipes;
 import static gregtech.api.util.GTModHandler.getModItem;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fluids.FluidRegistry;
+
+import com.dreammaster.gthandler.CustomItemList;
+import com.dreammaster.thaumcraft.TCHelper;
+
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.util.GTOreDictUnificator;
+import gregtech.api.util.GTUtility;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchItem;
+import thaumcraft.api.research.ResearchPage;
 
 public class ScriptWitchery implements IScriptLoader {
 


### PR DESCRIPTION
As requested change recipes that use ic2 furnace to use EFR blast furnace

I think I changed all the ones in coremod, but someone shoul check it, since there are many recipes left that I didnt found in coremod
![image](https://github.com/user-attachments/assets/3faf2aab-22fc-45f6-96fc-d55a9d319cc1)
