### PR TITLE
Buff the Recipe for the Incense Altar

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
@@ -3559,6 +3559,46 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addWarpToResearch("RODBLOODWOODSTAFF", 7);
         TCHelper.refreshResearchPages("CAP_blood_iron");
         TCHelper.refreshResearchPages("ROD_blood_wood");
+        new ResearchItem(
+                "INCENSECRUCIBLE",
+                "BLOODMAGIC",
+                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("victus"), 18)
+                        .add(Aspect.getAspect("potentia"), 6),
+                6,
+                -2,
+                3,
+                getModItem(BloodMagic.ID, "blockCrucible", 1, 0, missing)).setParents("SACRIFICIALKNIFE").setConcealed()
+                        .setPages(new ResearchPage("tc.research_page.INCENSECRUCIBLE")).registerResearchItem();
+        ThaumcraftApi.addArcaneCraftingRecipe(
+                "INCENSECRUCIBLE",
+                getModItem(BloodMagic.ID, "blockCrucible", 1, 0, missing),
+                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("aer"), 15)
+                        .add(Aspect.getAspect("ordo"), 15),
+                "abc",
+                "def",
+                "ghi",
+                'a',
+                "plateAluminium",
+                'b',
+                getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing),
+                'c',
+                "plateAluminium",
+                'd',
+                "plateAluminium",
+                'e',
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 0, missing),
+                'f',
+                "plateAluminium",
+                'g',
+                getModItem(Minecraft.ID, "stone_slab", 1, 0, missing),
+                'h',
+                getModItem(Minecraft.ID, "stone_slab", 1, 0, missing),
+                'i',
+                getModItem(Minecraft.ID, "stone_slab", 1, 0, missing));
+        TCHelper.addResearchPage(
+                "INCENSECRUCIBLE",
+                new ResearchPage(TCHelper.findArcaneRecipe(getModItem(BloodMagic.ID, "blockCrucible", 1, 0, missing))));
+        ThaumcraftApi.addWarpToResearch("INCENSECRUCIBLE", 2);
     }
 
     private void orbRecipes() {
@@ -4262,30 +4302,6 @@ public class ScriptBloodMagic implements IScriptLoader {
                         getModItem(BloodMagic.ID, "simpleCatalyst", 1, 0, missing),
                         'i',
                         getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing)));
-        GameRegistry.addRecipe(
-                new ShapedBloodOrbRecipe(
-                        getModItem(BloodMagic.ID, "blockCrucible", 1, 0, missing),
-                        "abc",
-                        "def",
-                        "ghi",
-                        'a',
-                        "plateAluminium",
-                        'b',
-                        getModItem(BloodMagic.ID, "apprenticeBloodOrb", 1, 0, missing),
-                        'c',
-                        "plateAluminium",
-                        'd',
-                        "plateAluminium",
-                        'e',
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 0, missing),
-                        'f',
-                        "plateAluminium",
-                        'g',
-                        getModItem(Minecraft.ID, "stone_slab", 1, 0, missing),
-                        'h',
-                        getModItem(Minecraft.ID, "stone_slab", 1, 0, missing),
-                        'i',
-                        getModItem(Minecraft.ID, "stone_slab", 1, 0, missing)));
         GameRegistry.addRecipe(
                 new ShapedBloodOrbRecipe(
                         getModItem(BloodMagic.ID, "blockConduit", 1, 0, missing),

--- a/src/main/resources/assets/dreamcraft/lang/en_US.lang
+++ b/src/main/resources/assets/dreamcraft/lang/en_US.lang
@@ -1533,6 +1533,9 @@ kosh.research_page.RUNEDTABLET=Your desire get to the boss? DO IT !!!
 tc.research_name.CRIMSONRITES=Crimson Rites
 tc.research_text.CRIMSONRITES=Unlocking the Unknown
 tc.research_page.CRIMSONRITES=You have seen glimpses of powerful magic users. You think you might have found a way to unlock their secrets.
+tc.research_name.INCENSECRUCIBLE=Incense Crucible
+tc.research_text.INCENSECRUCIBLE=[BM] Doesn't make you smell good IRL
+tc.research_page.INCENSECRUCIBLE=Because somehow, smelling good makes you bleed more.
 
 # Tinker's Construct manual contents
 item.tconstruct.manual.common.recipes=Recipes


### PR DESCRIPTION
This PR aims to buff the recipe for the incense altar by swapping out the apprentice blood orb with a blank slate.
It also adds a research page since it's now been moved to the arcane crafting table.
![image](https://github.com/user-attachments/assets/a19a3c5b-e77b-4418-83e6-b766e9773146)
![image](https://github.com/user-attachments/assets/ab2eac44-97e9-4868-9de7-fca64f7d5200)

