### PR TITLE
Add recipes for new blocks

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.BloodArsenal;
 import static gregtech.api.enums.Mods.BloodMagic;
+import static gregtech.api.enums.Mods.Botania;
 import static gregtech.api.enums.Mods.ExtraTrees;
 import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.Forestry;
@@ -174,6 +175,17 @@ public class CompressorRecipes implements Runnable {
             GTValues.RA.stdBuilder().itemInputs(getModItem(OpenComputers.ID, "item", 9L, 96))
                     .itemOutputs(getModItem(OpenComputers.ID, "chameliumBlock", 1L, 0)).duration(15 * SECONDS).eut(2)
                     .addTo(compressorRecipes);
+        }
+        if (Botania.isModLoaded()) {
+            // Mana Pearl Block
+            GTValues.RA.stdBuilder().itemInputs(getModItem(Botania.ID, "manaResource", 9L, 1))
+                    .itemOutputs(BlockList.ManaPearl.getIS(1)).duration(15 * SECONDS).eut(2).addTo(compressorRecipes);
+            // Mana Powder Block
+            GTValues.RA.stdBuilder().itemInputs(getModItem(Botania.ID, "manaResource", 9L, 23))
+                    .itemOutputs(BlockList.ManaPowder.getIS(1)).duration(15 * SECONDS).eut(2).addTo(compressorRecipes);
+            // Pixie Dust Block
+            GTValues.RA.stdBuilder().itemInputs(getModItem(Botania.ID, "manaResource", 9L, 8))
+                    .itemOutputs(BlockList.PixieDust.getIS(1)).duration(15 * SECONDS).eut(2).addTo(compressorRecipes);
         }
 
         if (IndustrialCraft2.isModLoaded()) {

--- a/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
@@ -1,6 +1,7 @@
 package com.dreammaster.gthandler.recipes;
 
 import static gregtech.api.enums.Mods.Avaritia;
+import static gregtech.api.enums.Mods.Botania;
 import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.recipe.RecipeMaps.fluidSolidifierRecipes;
@@ -12,6 +13,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.dreammaster.block.BlockList;
 import com.dreammaster.gthandler.CustomItemList;
 import com.dreammaster.item.NHItemList;
 import com.dreammaster.tinkersConstruct.SmelteryFluidTypes;
@@ -20,6 +22,7 @@ import bartworks.common.loaders.ItemRegistry;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
+import gregtech.api.enums.MaterialsBotania;
 import gregtech.api.enums.MaterialsUEVplus;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
@@ -119,6 +122,11 @@ public class FluidSolidifierRecipes implements Runnable {
                 .fluidInputs(MaterialsUEVplus.ExcitedDTRC.getFluid(1000L))
                 .itemOutputs(ItemList.GlassQuarkContainment.get(1)).eut(TierEU.RECIPE_UEV).duration(5 * SECONDS)
                 .addTo(fluidSolidifierRecipes);
+        if (Botania.isModLoaded()) {
+            GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(Botania.ID, "bifrostPerm", 1L))
+                    .itemOutputs(BlockList.Gaia.getIS(1)).fluidInputs(MaterialsBotania.GaiaSpirit.getMolten(1296L))
+                    .duration(2 * SECONDS).eut(TierEU.RECIPE_IV).addTo(fluidSolidifierRecipes);
+        }
 
         if (TinkerConstruct.isModLoaded()) {
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/ForgeHammerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ForgeHammerRecipes.java
@@ -1,5 +1,6 @@
 package com.dreammaster.gthandler.recipes;
 
+import static gregtech.api.enums.Mods.Botania;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Railcraft;
@@ -14,6 +15,8 @@ import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 import com.dreammaster.block.BlockList;
 import com.dreammaster.gthandler.CustomItemList;
@@ -122,6 +125,24 @@ public class ForgeHammerRecipes implements Runnable {
             GTValues.RA.stdBuilder().itemInputs(GTModHandler.getModItem(Thaumcraft.ID, "ItemEldritchObject", 1L, 3))
                     .itemOutputs(CustomItemList.PrimordialPearlFragment.get(3L)).duration(16 * TICKS)
                     .eut(TierEU.RECIPE_IV).addTo(hammerRecipes);
+        }
+        if (Botania.isModLoaded()) {
+            GTValues.RA.stdBuilder().itemInputs(BlockList.Gaia.getIS(1))
+                    .itemOutputs(GTModHandler.getModItem(Botania.ID, "manaResource", 32L, 5))
+                    .fluidInputs(new FluidStack(FluidRegistry.getFluid("prismaticacid"), 1152)).duration(16 * TICKS)
+                    .eut(TierEU.RECIPE_LuV).addTo(hammerRecipes);
+
+            GTValues.RA.stdBuilder().itemInputs(BlockList.ManaPearl.getIS(1))
+                    .itemOutputs(GTModHandler.getModItem(Botania.ID, "manaResource", 9L, 1)).duration(16 * TICKS)
+                    .eut(TierEU.RECIPE_LV).addTo(hammerRecipes);
+
+            GTValues.RA.stdBuilder().itemInputs(BlockList.ManaPowder.getIS(1))
+                    .itemOutputs(GTModHandler.getModItem(Botania.ID, "manaResource", 9L, 23)).duration(16 * TICKS)
+                    .eut(TierEU.RECIPE_LV).addTo(hammerRecipes);
+
+            GTValues.RA.stdBuilder().itemInputs(BlockList.PixieDust.getIS(1))
+                    .itemOutputs(GTModHandler.getModItem(Botania.ID, "manaResource", 9L, 8)).duration(16 * TICKS)
+                    .eut(TierEU.RECIPE_LV).addTo(hammerRecipes);
         }
 
         // Raw optical chip


### PR DESCRIPTION
Add gt machine recipes for mana powder block, mana pearl block, pixie dust block, and gaia ingot block, and its decompression recipes
Needs https://github.com/GTNewHorizons/GT5-Unofficial/pull/4281 since it uses prismatic acid to turn gaia ingot block back into gaia spirits

![image](https://github.com/user-attachments/assets/948adc35-0c45-447f-be83-b80df62dc286)
![image](https://github.com/user-attachments/assets/43ce7696-61fa-443e-8f5d-5d83fe9353af)
![image](https://github.com/user-attachments/assets/c2cc28f7-ebf7-462c-a51c-2730f5cd634b)
![image](https://github.com/user-attachments/assets/30eb6f47-0c60-4e15-9bc3-8c7d9b2cf726)
![image](https://github.com/user-attachments/assets/adfa1007-3603-494d-8277-df2a867b5597)
![image](https://github.com/user-attachments/assets/c7268fb5-12d4-403b-8135-0fd930265fae)
![image](https://github.com/user-attachments/assets/9ba531f8-36aa-4c5b-9640-c73b8a67048d)
![image](https://github.com/user-attachments/assets/0611faed-0569-436c-9125-0a34ed03bb00)
