### PR TITLE
Add comparator compatibility to Baby Chest

### DIFF
--- a/src/main/java/com/dreammaster/modbabychest/BlockBabyChest.java
+++ b/src/main/java/com/dreammaster/modbabychest/BlockBabyChest.java
@@ -11,6 +11,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -172,4 +173,20 @@ public class BlockBabyChest extends BlockContainer implements ITileEntityProvide
     public void registerBlockIcons(IIconRegister pIconRegister) {
         blockIcon = pIconRegister.registerIcon("minecraft:planks_oak");
     }
+
+    @Override
+    public boolean hasComparatorInputOverride() {
+        return true;
+    }
+
+    @Override
+    public int getComparatorInputOverride(World pWorld, int pX, int pY, int pZ, int pSide) {
+        TileEntity tileentity = pWorld.getTileEntity(pX, pY, pZ);
+        if (tileentity instanceof IInventory) {
+            IInventory inventory = (IInventory) tileentity;
+            return Container.calcRedstoneFromInventory(inventory);
+        }
+        return 0;
+    }
+
 }


### PR DESCRIPTION
As Title says, makes comparator able to give out a redstone signla, depending on how full the chest is.
Before, comparator didnt give out a signal, even tho the chest was full:
![image](https://github.com/user-attachments/assets/111d675e-95c8-446b-9375-4f0e6a30fdd4)
![image](https://github.com/user-attachments/assets/f49e6b7c-0ff8-4e4b-a62e-a95315ac86ef)

Now, it outputs a Signal depending on the Fill-%:
8 Items (1/8 Full): 
![image](https://github.com/user-attachments/assets/73eac2c8-2f50-4d8d-b8a2-164286a98ae5)

32 Items (Half Full):
![image](https://github.com/user-attachments/assets/0c28bd60-7ebd-4113-9925-b22ce91a538c)

64 Items (Completely Full): 
![image](https://github.com/user-attachments/assets/d2f90455-e252-46d5-82f2-dbc5efd40ca6)

(partially closes) https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/10413
If anything is off, ill take tips 👍 