### PR TITLE
Remove old recipe for Infused Quantum Chestplate

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptEMT.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEMT.java
@@ -149,8 +149,8 @@ public class ScriptEMT implements IScriptLoader {
         TCHelper.removeInfusionRecipe(getModItem(ElectroMagicTools.ID, "EMTBaubles", 1, 1, missing));
         TCHelper.removeArcaneRecipe(
                 createItemStack(ElectroMagicTools.ID, "ElectricGogglesRevealing", 1, 164, "{charge:10.0d}", missing));
-        TCHelper.removeArcaneRecipe(
-                createItemStack(ElectroMagicTools.ID, "ElectricGogglesRevealing", 1, 164, "{charge:10.0d}", missing));
+        TCHelper.removeInfusionRecipe(
+                createItemStack(ElectroMagicTools.ID, "itemArmorQuantumChestplate", 1, 26, "{charge:10.0d}", missing));
         TCHelper.removeInfusionRecipe(
                 createItemStack(ElectroMagicTools.ID, "NanosuitGogglesRevealing", 1, 26, "{charge:10.0d}", missing));
         TCHelper.removeInfusionRecipe(


### PR DESCRIPTION
as title says, removes the original Recipe for the Infused Quantum Chestplate from EMT.
also removes duplicate Recipe removal of the Electric Goggles of Revealing.
The recipe ws only visible, when looking for "usage" recipes of IC2 Quantum Chestplate.
closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19703

Before: (The 3rd recipe is Quantum Wings recipe) 
![image](https://github.com/user-attachments/assets/b9b13e14-7f16-4a50-9b80-266cb3235edf)
![image](https://github.com/user-attachments/assets/2b78a57c-6e42-4f72-b0f0-83da66dac000)


After: (The 2nd recipe is Quantum Wings recipe) 
![image](https://github.com/user-attachments/assets/b6b65efc-e5fd-4c28-b025-d825b9e317a7)