### PR TITLE
Change T1 air filter controller recipe to use proper casing

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -4514,7 +4514,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Hull_LV.get(1L),
-                        ItemList.Casing_Turbine.get(1L),
+                        ItemList.Casing_AirFilter_Turbine_T1.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Steel, 1L),
                         ItemList.Electric_Motor_LV.get(2L),
                         ItemList.Electric_Pump_LV.get(1L),
@@ -4527,7 +4527,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Hull_LV.get(1L),
-                        ItemList.Casing_Turbine.get(1L),
+                        ItemList.Casing_AirFilter_Turbine_T1.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Steel, 1L),
                         ItemList.Electric_Motor_LV.get(2L),
                         ItemList.Electric_Pump_LV.get(1L),
@@ -4539,7 +4539,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Hull_LV.get(1L),
-                        ItemList.Casing_Turbine.get(1L),
+                        ItemList.Casing_AirFilter_Turbine_T1.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Steel, 1L),
                         ItemList.Electric_Motor_LV.get(2L),
                         ItemList.Electric_Pump_LV.get(1L),


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19696

Changes the T1 air filter controller to use an air filter turbine casing rather than a normal turbine casing, matching the structure of the multiblock