### PR TITLE
Nerf amount of calcite obtained from geodes

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptEFR.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEFR.java
@@ -540,7 +540,7 @@ public class ScriptEFR implements IScriptLoader {
         ChiselHelper.addVariationFromStack("EFRHoneyBlock", getModItem(BiomesOPlenty.ID, "honeyBlock", 1L));
         ChiselHelper.addVariationFromStack("EFRHoneyBlock", getModItem(EtFuturumRequiem.ID, "honey_block", 1L));
 
-        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Calcite, 9L))
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Calcite, 2L))
                 .itemOutputs(getModItem(EtFuturumRequiem.ID, "calcite", 1, 0, missing)).duration(8 * SECONDS).eut(2)
                 .addTo(compressorRecipes);
 
@@ -549,7 +549,7 @@ public class ScriptEFR implements IScriptLoader {
                 .eut(2).addTo(compressorRecipes);
 
         GTValues.RA.stdBuilder().itemInputs(getModItem(EtFuturumRequiem.ID, "calcite", 1, 0, missing))
-                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Calcite, 9L)).duration(8 * SECONDS)
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Calcite, 2L)).duration(8 * SECONDS)
                 .eut(2).addTo(hammerRecipes);
 
         GTValues.RA.stdBuilder().itemInputs(getModItem(EtFuturumRequiem.ID, "leaves", 1, 1, missing))


### PR DESCRIPTION
Making it a 2:1 ratio makes it consistent with obsidian, and easier to make 1 calcite block for ore finder wand.

Calcite geodes currently give a ton of calcite, with a geode being able to have from 6-16 stacks of calcite blocks, which can currently make up to 144 stacks of calcite dust, which can make 5.5 million oxygen rather cheap and easily at 2 eu per oxygen at 1.6 seconds per 1000 oxygen for 1 mv electrolyzer. 

Getting around 12-32 stacks of calcite per geode is more reasonable, and it fulfills any early game BBF requirements with just 1 geode.