### PR TITLE
Remove access to GTMod isclient methods

### DIFF
--- a/src/main/java/com/dreammaster/main/ClientProxy.java
+++ b/src/main/java/com/dreammaster/main/ClientProxy.java
@@ -49,6 +49,11 @@ public class ClientProxy extends CommonProxy implements IResourceManagerReloadLi
     }
 
     @Override
+    public boolean isClient() {
+        return true;
+    }
+
+    @Override
     public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
         return null;
     }

--- a/src/main/java/com/dreammaster/main/CommonProxy.java
+++ b/src/main/java/com/dreammaster/main/CommonProxy.java
@@ -13,6 +13,10 @@ public class CommonProxy implements IGuiHandler {
 
     public void registerRenderInfo() {}
 
+    public boolean isClient() {
+        return false;
+    }
+
     @Override
     public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
         return null;

--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -155,7 +155,7 @@ public class MainRegistry {
      * Returns true on a client
      */
     public static boolean isClient() {
-        return proxy instanceof ClientProxy;
+        return proxy.isClient();
     }
 
     /**

--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -151,6 +151,20 @@ public class MainRegistry {
         }
     }
 
+    /**
+     * Returns true on a client
+     */
+    public static boolean isClient() {
+        return proxy instanceof ClientProxy;
+    }
+
+    /**
+     * Returns true on a dedicated server
+     */
+    public static boolean isServer() {
+        return !isClient();
+    }
+
     public MainRegistry() {
         if (DetravScannerMod.isModLoaded()) GregTechAPI.sAfterGTPreload.add(ScannerTools::new);
     }

--- a/src/main/java/com/dreammaster/scripts/ScriptZZClientOnly.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptZZClientOnly.java
@@ -26,7 +26,6 @@ import cpw.mods.fml.common.gameevent.PlayerEvent;
 import forestry.api.recipes.RecipeManagers;
 import forestry.core.recipes.ShapedRecipeCustom;
 import forestry.factory.recipes.CarpenterRecipe;
-import gregtech.GTMod;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Mods;
@@ -406,7 +405,7 @@ public class ScriptZZClientOnly implements IScriptLoader {
                         .fluidInputs(FluidRegistry.getFluidStack("ender", 48000)).duration(30 * SECONDS).eut(30720)
                         .disabled().hidden().addTo(assemblerRecipes));
 
-        if (GTMod.gregtechproxy.isServerSide() && CoreConfig.ForestryStampsAndChunkLoaderCoinsServerEnabled) {
+        if (MainRegistry.isServer() && CoreConfig.ForestryStampsAndChunkLoaderCoinsServerEnabled) {
             stamps(true);
             coins.forEach(r -> {
                 r.mEnabled = true;
@@ -423,12 +422,14 @@ public class ScriptZZClientOnly implements IScriptLoader {
     @SuppressWarnings("unused")
     @SubscribeEvent
     public void onPlayerJoin(PlayerEvent.PlayerLoggedInEvent pEvent) {
-        if (pEvent.player instanceof EntityPlayerMP) {
-            if (GTMod.gregtechproxy.isClientSide()) // We are on single player
-                MainRegistry.NW.sendTo(
-                        new ZZClientOnlySyncMessage(CoreConfig.ForestryStampsAndChunkLoaderCoinsEnabled),
-                        (EntityPlayerMP) pEvent.player);
-            else MainRegistry.NW.sendTo(
+        if (MainRegistry.isClient()) {
+            // this runs on the server thread of a client
+            // -> we are playing single player
+            MainRegistry.NW.sendTo(
+                    new ZZClientOnlySyncMessage(CoreConfig.ForestryStampsAndChunkLoaderCoinsEnabled),
+                    (EntityPlayerMP) pEvent.player);
+        } else {
+            MainRegistry.NW.sendTo(
                     new ZZClientOnlySyncMessage(CoreConfig.ForestryStampsAndChunkLoaderCoinsServerEnabled),
                     (EntityPlayerMP) pEvent.player);
         }


### PR DESCRIPTION
This PR removes a dependency on GT methods that are being deleted,
It must be merged and build before the linked PR. https://github.com/GTNewHorizons/GT5-Unofficial/pull/4541