### PR TITLE
Add Missing Recipes for Computronics Floppy Disks + Portable Tape Drive

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -10780,7 +10780,7 @@ public class AssemblerRecipes implements Runnable {
                         .itemOutputs(GTModHandler.getModItem(Computronics.ID, "computronics.ocParts", 1L, 2))
                         .fluidInputs(tMat.getMolten(144L * tMultiplier / 2L)).duration(12 * SECONDS + 10 * TICKS)
                         .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
-                // Particel Card
+                // Particle Card
 
                 GTValues.RA.stdBuilder()
                         .itemInputs(
@@ -10816,7 +10816,7 @@ public class AssemblerRecipes implements Runnable {
                         .itemOutputs(GTModHandler.getModItem(Computronics.ID, "computronics.ocParts", 1L, 5))
                         .fluidInputs(tMat.getMolten(144L * tMultiplier / 2L)).duration(12 * SECONDS + 10 * TICKS)
                         .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
-                // Self Destruction Card
+                // Self Destructing Card
 
                 GTValues.RA.stdBuilder()
                         .itemInputs(
@@ -10954,6 +10954,19 @@ public class AssemblerRecipes implements Runnable {
                                 GTOreDictUnificator.get(OrePrefixes.itemCasing, Materials.Aluminium, 2L),
                                 GTUtility.getIntegratedCircuit(1))
                         .itemOutputs(GTModHandler.getModItem(Computronics.ID, "computronics.dockingUpgrade", 1L, 0))
+                        .fluidInputs(tMat.getMolten(144L * tMultiplier / 2L)).duration(12 * SECONDS + 10 * TICKS)
+                        .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
+                // Portable Tape Drive
+
+                GTValues.RA.stdBuilder()
+                        .itemInputs(
+                                GTModHandler.getModItem(Computronics.ID, "computronics.tape", 1L, 1),
+                                ItemList.Circuit_Board_Epoxy_Advanced.get(1L),
+                                GTModHandler.getModItem(OpenComputers.ID, "item", 2L, 25),
+                                ItemList.Circuit_Parts_TransistorSMD.get(2L),
+                                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Plastic, 2L),
+                                GTUtility.getIntegratedCircuit(1))
+                        .itemOutputs(GTModHandler.getModItem(Computronics.ID, "computronics.portableTapeDrive", 1L, 0))
                         .fluidInputs(tMat.getMolten(144L * tMultiplier / 2L)).duration(12 * SECONDS + 10 * TICKS)
                         .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
             }

--- a/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
@@ -308,6 +308,8 @@ public class LaserEngraverRecipes implements Runnable {
             makeFloppy("Digger", "dig", 3, 9);
             makeFloppy("Mazer", "maze", 14, 10);
             makeFloppy("OpenIRC (IRC Client)", "irc", 12, 11);
+            makeFloppy("Taper", "tape", 15, 12);
+            makeFloppy("Exploder", "explode", 1, 13);
             // eeprom with lua bios
             makeLuaBios();
         }


### PR DESCRIPTION
As the title says. Unsure if they were just forgotten or got removed by accident.
Portable Tape Drive:
![image](https://github.com/user-attachments/assets/bb8d15c4-c12b-4489-8881-de02b106739a)
Floppies:
![image](https://github.com/user-attachments/assets/d01013ac-e95e-44df-8289-5528e06911ca)
![image](https://github.com/user-attachments/assets/5248fa1f-c512-4987-a788-b514bb085931)

I'm very open to suggested recipe changes for the Tape Drive; this was created from scratch.