### PR TITLE
Hide nano forge renderer from NEI

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.374:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.389:dev")
     api("com.github.GTNewHorizons:Yamcl:0.7.1:dev")
     api("com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH:dev")
 

--- a/src/main/java/com/dreammaster/auxiliary/NEIGTNewHorizonsConfig.java
+++ b/src/main/java/com/dreammaster/auxiliary/NEIGTNewHorizonsConfig.java
@@ -30,6 +30,7 @@ public class NEIGTNewHorizonsConfig implements IConfigureNEI {
         API.hideItem(new ItemStack(GregTechAPI.sDroneRender));
         API.hideItem(new ItemStack(GregTechAPI.sWormholeRender));
         API.hideItem(new ItemStack(GregTechAPI.sBlackholeRender));
+        API.hideItem(new ItemStack(GregTechAPI.nanoForgeRender));
         API.hideItem(new ItemStack(TTCasingsContainer.eyeOfHarmonyRenderBlock));
         API.hideItem(new ItemStack(TTCasingsContainer.forgeOfGodsRenderBlock));
 

--- a/src/main/java/com/dreammaster/modcustomdrops/CustomDropsHandler.java
+++ b/src/main/java/com/dreammaster/modcustomdrops/CustomDropsHandler.java
@@ -45,7 +45,7 @@ import gregtech.api.enums.Mods;
 import io.netty.buffer.ByteBuf;
 import thaumcraft.common.lib.FakeThaumcraftPlayer;
 
-@Optional.Interface(iface = "com.kuba6000.mobsinfo.api.IMobExtraInfoProvider", modid = Mods.Names.MOBS_INFO)
+@Optional.Interface(iface = "com.kuba6000.mobsinfo.api.IMobExtraInfoProvider", modid = Mods.ModIDs.MOBS_INFO)
 public class CustomDropsHandler implements IMobExtraInfoProvider {
 
     private LogHelper _mLogger = MainRegistry.Logger;
@@ -221,7 +221,7 @@ public class CustomDropsHandler implements IMobExtraInfoProvider {
         }
     }
 
-    @Optional.Method(modid = Mods.Names.MOBS_INFO)
+    @Optional.Method(modid = Mods.ModIDs.MOBS_INFO)
     @Override
     public void provideExtraDropsInformation(@NotNull String entityString, @NotNull ArrayList<MobDrop> drops,
             @NotNull MobRecipe recipe) {

--- a/src/main/java/com/dreammaster/modfixes/biomesoplenty/BlockHarvestToolFix.java
+++ b/src/main/java/com/dreammaster/modfixes/biomesoplenty/BlockHarvestToolFix.java
@@ -8,7 +8,7 @@ import gregtech.api.enums.Mods;
 public class BlockHarvestToolFix {
 
     public static void fixBOPHarvestTools() {
-        Block flesh = GameRegistry.findBlock(Mods.Names.BIOMES_O_PLENTY, "flesh");
+        Block flesh = GameRegistry.findBlock(Mods.ModIDs.BIOMES_O_PLENTY, "flesh");
         if (flesh != null) {
             flesh.setHarvestLevel("shovel", 0);
         }

--- a/src/main/java/com/dreammaster/scripts/ScriptAmunRa.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAmunRa.java
@@ -504,7 +504,7 @@ public class ScriptAmunRa implements IScriptLoader {
                 .eut(TierEU.RECIPE_UEV).addTo(GTRecipeConstants.AssemblyLine);
     }
 
-    @Optional.Method(modid = Mods.Names.GALACTICRAFT_AMUN_RA)
+    @Optional.Method(modid = Mods.ModIDs.GALACTICRAFT_AMUN_RA)
     private static void setMothershipRecipe() {
         final HashMap<Object, Integer> recipe = new HashMap<>();
 

--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -2836,7 +2836,7 @@ public class ScriptGalacticraft implements IScriptLoader {
                 .eut(TierEU.RECIPE_HV).addTo(mixerRecipes);
     }
 
-    @Optional.Method(modid = Mods.Names.GALACTICRAFT_CORE)
+    @Optional.Method(modid = Mods.ModIDs.GALACTICRAFT_CORE)
     private static void spaceStationRecipes() {
         final HashMap<Object, Integer> inputMap = new HashMap<>();
         inputMap.put(new ItemStack(GCBlocks.basicBlock, 1, 4), 231);
@@ -2847,7 +2847,7 @@ public class ScriptGalacticraft implements IScriptLoader {
                 new SpaceStationType(ConfigManagerCore.idDimensionOverworldOrbit, 0, new SpaceStationRecipe(inputMap)));
     }
 
-    @Optional.Method(modid = Mods.Names.GALACTICRAFT_CORE)
+    @Optional.Method(modid = Mods.ModIDs.GALACTICRAFT_CORE)
     private static void buggyRecipes() {
         HashMap<Integer, ItemStack> input = new HashMap<>();
         HashMap<Integer, ItemStack> input2;
@@ -3012,7 +3012,7 @@ public class ScriptGalacticraft implements IScriptLoader {
                 new PositionedStack(new ItemStack(GCItems.buggy, 1, 3), 143 - x, 64 - y));
     }
 
-    @Optional.Method(modid = Mods.Names.GALACTICRAFT_CORE)
+    @Optional.Method(modid = Mods.ModIDs.GALACTICRAFT_CORE)
     private static void cargoRecipes() {
         HashMap<Integer, ItemStack> input = new HashMap<>();
         HashMap<Integer, ItemStack> input2;
@@ -3103,7 +3103,7 @@ public class ScriptGalacticraft implements IScriptLoader {
                 new PositionedStack(new ItemStack(MarsItems.spaceship, 1, 13), 134 - x, 73 - y));
     }
 
-    @Optional.Method(modid = Mods.Names.GALACTICRAFT_CORE)
+    @Optional.Method(modid = Mods.ModIDs.GALACTICRAFT_CORE)
     private static void astroMinerRecipes() {
         final HashMap<Integer, ItemStack> input = new HashMap<>();
         for (int i = 1; i <= 8; i++) {

--- a/src/main/java/com/dreammaster/scripts/ScriptGregtechPlusPlus.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGregtechPlusPlus.java
@@ -118,7 +118,7 @@ public class ScriptGregtechPlusPlus implements IScriptLoader {
         addForestryRecipes();
     }
 
-    @Optional.Method(modid = Mods.Names.FORESTRY)
+    @Optional.Method(modid = Mods.ModIDs.FORESTRY)
     private void addForestryRecipes() {
 
         // Arborist Frame

--- a/src/main/java/com/dreammaster/scripts/ScriptZZClientOnly.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptZZClientOnly.java
@@ -51,7 +51,7 @@ public class ScriptZZClientOnly implements IScriptLoader {
     Object[] stamps = null;
     ArrayList<GTRecipe> coins = new ArrayList<>();
 
-    @Optional.Method(modid = Mods.Names.FORESTRY)
+    @Optional.Method(modid = Mods.ModIDs.FORESTRY)
     void stamps(boolean enabled) {
         if (stamps == null) {
             stamps = new CarpenterRecipe[] {


### PR DESCRIPTION
This PR hides the nano forge t4 renderer block from nei.
This required bumping the gt5u dep, which caused issues because of leftovers from this PR <https://github.com/GTNewHorizons/GT5-Unofficial/pull/4541>, which also have been fixed here