### PR TITLE
Changes EU/t of Bio SOC recipe to be in line with other circuits

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CircuitAssemblerRecipes.java
@@ -262,8 +262,7 @@ public class CircuitAssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.NiobiumTitanium, 16),
                         MaterialsElements.STANDALONE.CHRONOMATIC_GLASS.getBolt(8))
                 .itemOutputs(ItemList.Circuit_Bioprocessor.get(1L)).fluidInputs(new FluidStack(solderUEV, 144))
-                .requiresCleanRoom().duration(3 * SECONDS + 15 * TICKS).eut(TierEU.RECIPE_UEV)
-                .addTo(circuitAssemblerRecipes);
+                .requiresCleanRoom().duration(3 * SECONDS + 15 * TICKS).eut(2457600).addTo(circuitAssemblerRecipes);
 
         GTValues.RA.stdBuilder()
                 .itemInputs(


### PR DESCRIPTION
discussed in meta-dev, this will allow Bio SOC in quad CAL setups to share the energy hatch, instead of making it share one ehatch per 2 cal's (or 1:1 if lazy). this makes mainframes the only non standardized circuit, which can be left unchanged or for a separate PR.


<img width="503" height="423" alt="image" src="https://github.com/user-attachments/assets/9baf0798-fef8-4935-b96a-907510268e61" />

