### PR TITLE
Fixes Decompression Recipes for Coal & Charcoal

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/ForgeHammerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ForgeHammerRecipes.java
@@ -50,8 +50,8 @@ public class ForgeHammerRecipes implements Runnable {
 
         // Uncompressed coal variants
         GTValues.RA.stdBuilder().itemInputs(BlockList.CompressedCharcoal.getIS(1))
-                .itemOutputs(Materials.Charcoal.getGems(9)).duration(15 * SECONDS).eut(2).addTo(hammerRecipes);
-        GTValues.RA.stdBuilder().itemInputs(BlockList.CompressedCoal.getIS(1)).itemOutputs(Materials.Coal.getGems(9))
+                .itemOutputs(Materials.Charcoal.getBlocks(9)).duration(15 * SECONDS).eut(2).addTo(hammerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(BlockList.CompressedCoal.getIS(1)).itemOutputs(Materials.Coal.getBlocks(9))
                 .duration(15 * SECONDS).eut(2).addTo(hammerRecipes);
         GTValues.RA.stdBuilder().itemInputs(BlockList.CompressedCoalCoke.getIS(1))
                 .itemOutputs(getModItem(Railcraft.ID, "cube", 9, 0, missing)).duration(15 * SECONDS).eut(2)


### PR DESCRIPTION
## Changes:
- Fixes forge hammer recipes for double compressed coal and charcoal, now outputting 9 of their compressed block variety rather than the gem itself. 

I will also follow this up by adding decompression recipes for cactus coal, cactus coke, sugar coal, and sugar coke, but in GT5u where their compression recipes are also located

This will fix and close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20532.