### PR TITLE
Update calls to GTModHandler#addMachineCraftingRecipe

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,32 +1,32 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.395:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.409:dev")
     api("com.github.GTNewHorizons:Yamcl:0.7.1:dev")
     api("com.github.GTNewHorizons:Baubles-Expanded:2.1.9-GTNH:dev")
 
     implementation("com.github.GTNewHorizons:GTNHLib:0.6.38:dev")
 
     compileOnly("com.github.GTNewHorizons:AkashicTome:1.2.4:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Avaritia:1.68:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Avaritia:1.70:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Irontanks:1.4.2:dev") { transitive = false }
     compileOnly("secondderivative.irontankminecarts:IronTankMinecarts:1.0.5:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:twilightforest:2.7.8:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Mantle:0.5.1:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.40-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.46-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:WitcheryExtras:1.3.1:dev") { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:witchery-69673:2234410")
-    compileOnly("com.github.GTNewHorizons:Chisel:2.16.5-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Botania:1.12.18-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Chisel:2.16.8-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Botania:1.12.21-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:BloodMagic:1.7.46:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:extra-utilities-225561:2264384")
     compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.26:deobf") { transitive = false }
     compileOnly("com.github.GTNewHorizons:amunra:0.8.2:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Galacticraft:3.3.9-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.14:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:MatterManipulator:0.0.37-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:IguanaTweaksTConstruct:2.6.4:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Galacticraft:3.3.10-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.10.16:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:MatterManipulator:0.0.38-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:IguanaTweaksTConstruct:2.6.5:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.5.3-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:Backhand:1.6.38:dev") { transitive = false }
     //compileOnly("com.github.Roadhog360:Et-Futurum-Requiem:2.6.2:dev") { transitive = false }

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
@@ -1176,7 +1176,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'C',
@@ -1185,7 +1184,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'C',
@@ -1194,7 +1192,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'C',
@@ -1203,7 +1200,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'C',
@@ -1212,7 +1208,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', ItemList.Hull_UEV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'C',
@@ -1221,7 +1216,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', ItemList.Hull_UIV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'C',
@@ -1230,7 +1224,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', ItemList.Hull_UMV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'C',
@@ -1242,7 +1235,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable4(), },
@@ -1250,7 +1242,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable4(), },
@@ -1258,7 +1249,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable4(), },
@@ -1266,7 +1256,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable4(), },
@@ -1274,7 +1263,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable4(), },
@@ -1282,7 +1270,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable4(), },
@@ -1290,7 +1277,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable4(), },
@@ -1300,7 +1286,6 @@ public class GT_Loader_Machines {
     private void registerAssemblingMachine() {
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -1309,7 +1294,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -1318,7 +1302,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -1327,7 +1310,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -1336,7 +1318,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', ItemList.Hull_UEV, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
                         'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -1345,7 +1326,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', ItemList.Hull_UIV, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
                         'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -1354,7 +1334,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', ItemList.Hull_UMV, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
                         'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -1366,7 +1345,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'I',
@@ -1376,7 +1354,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'I',
@@ -1386,7 +1363,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'I',
@@ -1396,7 +1372,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'I',
@@ -1406,7 +1381,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'I',
@@ -1416,7 +1390,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'I',
@@ -1426,7 +1399,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'I',
@@ -1439,7 +1411,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -1448,7 +1419,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -1457,7 +1427,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -1466,7 +1435,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -1475,7 +1443,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -1483,7 +1450,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -1491,7 +1457,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -1502,7 +1467,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable() },
@@ -1510,7 +1474,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable() },
@@ -1518,7 +1481,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable() },
@@ -1526,7 +1488,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable() },
@@ -1534,7 +1495,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -1542,7 +1502,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -1550,7 +1509,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -1561,7 +1519,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -1571,7 +1528,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -1581,7 +1537,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -1591,7 +1546,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -1601,7 +1555,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G',
@@ -1610,7 +1563,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G',
@@ -1619,7 +1571,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G',
@@ -1632,7 +1583,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'B', OrePrefixes.pipeMedium.get(Materials.Enderium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -1642,7 +1592,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'B', OrePrefixes.pipeMedium.get(Materials.Naquadah), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -1652,7 +1601,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'B', OrePrefixes.pipeMedium.get(Materials.Neutronium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -1662,7 +1610,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'B', OrePrefixes.pipeLarge.get(Materials.Neutronium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -1672,7 +1619,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'B',
                         OrePrefixes.pipeHuge.get(Materials.Neutronium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -1682,7 +1628,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'B',
                         OrePrefixes.pipeMedium.get(Materials.Infinity), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -1692,7 +1637,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'B',
                         OrePrefixes.pipeMedium.get(MaterialsUEVplus.SpaceTime), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -1705,7 +1649,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'C',
@@ -1714,7 +1657,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'C',
@@ -1723,7 +1665,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'C',
@@ -1732,7 +1673,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'C',
@@ -1741,7 +1681,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', ItemList.Hull_UEV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'C',
@@ -1750,7 +1689,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', ItemList.Hull_UIV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'C',
@@ -1759,7 +1697,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', ItemList.Hull_UMV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'C',
@@ -1771,7 +1708,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'I',
@@ -1781,7 +1717,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'I',
@@ -1791,7 +1726,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'I',
@@ -1801,7 +1735,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'I',
@@ -1811,7 +1744,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'I',
@@ -1821,7 +1753,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'I',
@@ -1831,7 +1762,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'I',
@@ -1844,7 +1774,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1854,7 +1783,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1864,7 +1792,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1874,7 +1801,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1884,7 +1810,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', ItemList.Hull_UEV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1894,7 +1819,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', ItemList.Hull_UIV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1904,7 +1828,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', ItemList.Hull_UMV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1917,7 +1840,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -1927,7 +1849,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -1937,7 +1858,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -1947,7 +1867,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -1957,7 +1876,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.PISTON,
                         'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -1967,7 +1885,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.PISTON,
                         'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -1977,7 +1894,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.PISTON,
                         'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -1991,7 +1907,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                         MTEBasicMachineWithRecipe.X.PISTON, 'E', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'P', GT_CustomLoader.AdvancedGTMaterials.LuV.getPipe(), 'C',
@@ -2000,7 +1915,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                         MTEBasicMachineWithRecipe.X.PISTON, 'E', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'P', GT_CustomLoader.AdvancedGTMaterials.ZPM.getPipe(), 'C',
@@ -2009,7 +1923,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                         MTEBasicMachineWithRecipe.X.PISTON, 'E', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'P', GT_CustomLoader.AdvancedGTMaterials.UV.getPipe(), 'C',
@@ -2018,7 +1931,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                         MTEBasicMachineWithRecipe.X.PISTON, 'E', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'P', GT_CustomLoader.AdvancedGTMaterials.UHV.getPipe(), 'C',
@@ -2027,7 +1939,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', ItemList.Hull_UEV, 'X', MTEBasicMachineWithRecipe.X.PISTON,
                         'E', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'P',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getPipe(), 'C',
@@ -2036,7 +1947,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', ItemList.Hull_UIV, 'X', MTEBasicMachineWithRecipe.X.PISTON,
                         'E', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'P',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getPipe(), 'C',
@@ -2045,7 +1955,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', ItemList.Hull_UMV, 'X', MTEBasicMachineWithRecipe.X.PISTON,
                         'E', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'P',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getPipe(), 'C',
@@ -2058,7 +1967,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'G',
@@ -2067,7 +1975,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'G',
@@ -2076,7 +1983,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'G',
@@ -2085,7 +1991,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'G',
@@ -2094,7 +1999,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G',
@@ -2103,7 +2007,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G',
@@ -2112,7 +2015,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G',
@@ -2125,7 +2027,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable() },
@@ -2133,7 +2034,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable() },
@@ -2141,7 +2041,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable() },
@@ -2149,7 +2048,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable() },
@@ -2157,7 +2055,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -2165,7 +2062,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -2173,7 +2069,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -2185,7 +2080,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'O',
@@ -2194,7 +2088,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'O',
@@ -2203,7 +2096,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'O',
@@ -2212,7 +2104,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'O',
@@ -2221,7 +2112,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'O',
@@ -2230,7 +2120,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'O',
@@ -2239,7 +2128,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'O',
@@ -2252,7 +2140,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2262,7 +2149,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2272,7 +2158,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2282,7 +2167,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2292,7 +2176,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'D',
@@ -2301,7 +2184,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'D',
@@ -2310,7 +2192,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'D',
@@ -2323,7 +2204,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2332,7 +2212,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2341,7 +2220,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2350,7 +2228,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2359,7 +2236,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.EMITTER,
                         'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -2368,7 +2244,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.EMITTER,
                         'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -2377,7 +2252,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.EMITTER,
                         'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -2390,7 +2264,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2399,7 +2272,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2408,7 +2280,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2417,7 +2288,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2426,7 +2296,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G', OreDictNames.craftingGrinder },
@@ -2434,7 +2303,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G', OreDictNames.craftingGrinder },
@@ -2442,7 +2310,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G', OreDictNames.craftingGrinder },
@@ -2454,7 +2321,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                         MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -2463,7 +2329,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                         MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -2472,7 +2337,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                         MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -2481,7 +2345,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2491,7 +2354,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'R',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getWire(), 'L',
@@ -2500,7 +2362,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'R',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getWire(), 'L',
@@ -2509,7 +2370,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'R',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getWire(), 'L',
@@ -2522,7 +2382,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                         OrePrefixes.rotor.get(LuVMat2), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2531,7 +2390,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                         OrePrefixes.rotor.get(Materials.Iridium), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2540,7 +2398,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                         OrePrefixes.rotor.get(Materials.Osmium), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2549,7 +2406,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                         OrePrefixes.rotor.get(Materials.Neutronium), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2558,7 +2414,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', ItemList.Hull_UEV, 'R',
                         OrePrefixes.rotor.get(Materials.CosmicNeutronium), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -2567,7 +2422,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', ItemList.Hull_UIV, 'R',
                         OrePrefixes.rotor.get(Materials.Infinity), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -2576,7 +2430,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', ItemList.Hull_UMV, 'R',
                         OrePrefixes.rotor.get(MaterialsUEVplus.SpaceTime), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -2589,7 +2442,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt02.get(Materials.Osmium), 'W',
@@ -2598,7 +2450,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt04.get(Materials.Osmium), 'W',
@@ -2607,7 +2458,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt08.get(Materials.Osmium), 'W',
@@ -2616,7 +2466,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt08.get(Materials.Osmium), 'W',
@@ -2625,7 +2474,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', ItemList.Hull_UEV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt08.get(Materials.Osmium), 'W',
@@ -2634,7 +2482,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', ItemList.Hull_UIV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt08.get(Materials.Osmium), 'W',
@@ -2643,7 +2490,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', ItemList.Hull_UMV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt08.get(Materials.Osmium), 'W',
@@ -2656,7 +2502,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'G',
@@ -2665,7 +2510,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'G',
@@ -2674,7 +2518,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'G',
@@ -2683,7 +2526,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'G',
@@ -2692,7 +2534,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G',
@@ -2701,7 +2542,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G',
@@ -2710,7 +2550,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G',
@@ -2723,7 +2562,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2732,7 +2570,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2741,7 +2578,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2750,7 +2586,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2759,7 +2594,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'F', OreDictNames.craftingFilter, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -2767,7 +2601,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'F', OreDictNames.craftingFilter, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -2775,7 +2608,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'F', OreDictNames.craftingFilter, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -2787,7 +2619,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2796,7 +2627,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2805,7 +2635,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2814,7 +2643,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2823,7 +2651,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', ItemList.Hull_UEV.get(1), 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -2832,7 +2659,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', ItemList.Hull_UIV.get(1), 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -2841,7 +2667,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', ItemList.Hull_UMV.get(1), 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -2854,7 +2679,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'O',
@@ -2863,7 +2687,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'O',
@@ -2872,7 +2695,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'O',
@@ -2881,7 +2703,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'O',
@@ -2890,7 +2711,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'O',
@@ -2899,7 +2719,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'O',
@@ -2908,7 +2727,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'O',
@@ -2921,7 +2739,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable() },
@@ -2929,7 +2746,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable() },
@@ -2937,7 +2753,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable() },
@@ -2945,7 +2760,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable() },
@@ -2953,7 +2767,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -2961,7 +2774,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -2969,7 +2781,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -2981,7 +2792,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(LuVMat2), 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable4(), 'G',
@@ -2990,7 +2800,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(Materials.Iridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -3000,7 +2809,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -3010,7 +2818,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateTriple.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -3020,7 +2827,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', ItemList.Hull_UEV, 'P',
                         OrePrefixes.plateQuadruple.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -3030,7 +2836,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', ItemList.Hull_UIV, 'P',
                         OrePrefixes.plateDouble.get(Materials.Osmiridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -3040,7 +2845,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', ItemList.Hull_UMV, 'P',
                         OrePrefixes.plateQuadruple.get(Materials.Osmiridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -3054,7 +2858,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable() },
@@ -3062,7 +2865,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable() },
@@ -3070,7 +2872,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable() },
@@ -3078,7 +2879,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', ItemList.Hull_MAX, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCable() },
@@ -3086,7 +2886,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -3094,7 +2893,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -3102,7 +2900,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -3114,7 +2911,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(LuVMat2), 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable4(), 'T', MTEBasicMachineWithRecipe.X.PUMP,
@@ -3123,7 +2919,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(Materials.Iridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -3133,7 +2928,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -3143,7 +2937,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateTriple.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -3153,7 +2946,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', ItemList.Hull_UEV, 'P',
                         OrePrefixes.plateQuadruple.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -3163,7 +2955,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', ItemList.Hull_UIV, 'P',
                         OrePrefixes.plateDouble.get(Materials.Osmiridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -3173,7 +2964,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', ItemList.Hull_UMV, 'P',
                         OrePrefixes.plateQuadruple.get(Materials.Osmiridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -3185,7 +2975,6 @@ public class GT_Loader_Machines {
     private void registerCanningMachine() {
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'G',
@@ -3194,7 +2983,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'G',
@@ -3203,7 +2991,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -3211,7 +2998,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'G',
@@ -3220,7 +3006,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -3228,7 +3013,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -3236,7 +3020,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -3246,7 +3029,6 @@ public class GT_Loader_Machines {
     private void registerChemicalBath() {
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathLuV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -3255,7 +3037,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathZPM.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -3264,7 +3045,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathUV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -3273,7 +3053,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathUHV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -3282,7 +3061,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathUEV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G',
@@ -3291,7 +3069,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathUIV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G',
@@ -3300,7 +3077,6 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathUMV.get(1L),
-                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G',

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
@@ -26,9 +26,6 @@ import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 
 public class GT_Loader_Machines {
 
-    public static long bitsd = GTModHandler.RecipeBits.DISMANTLEABLE | GTModHandler.RecipeBits.NOT_REMOVABLE
-            | GTModHandler.RecipeBits.REVERSIBLE
-            | GTModHandler.RecipeBits.BUFFERED;
     private Materials LuVMat2;
 
     public void run() {
@@ -108,7 +105,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Generator_Plasma_ZPMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "UCU", "FMF", "WCW", 'M', ItemList.Hull_UV, 'F', ItemList.Field_Generator_ZPM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
                         OrePrefixes.wireGt08.get(Materials.SuperconductorUHV), 'U',
@@ -116,7 +113,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Generator_Plasma_UV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "UCU", "FMF", "WCW", 'M', ItemList.Hull_UV, 'F', ItemList.Field_Generator_UV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         OrePrefixes.wireGt12.get(Materials.SuperconductorUHV), 'U',
@@ -124,209 +121,209 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MassFabricatorLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CFC", "WMW", "CFC", 'M', ItemList.Hull_LuV, 'F', ItemList.Field_Generator_LuV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MassFabricatorZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CFC", "WMW", "CFC", 'M', ItemList.Hull_ZPM, 'F', ItemList.Field_Generator_ZPM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MassFabricatorUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CFC", "WMW", "CFC", 'M', ItemList.Hull_UV, 'F', ItemList.Field_Generator_UV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MassFabricatorUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CFC", "WMW", "CFC", 'M', ItemList.Hull_MAX, 'F', ItemList.Field_Generator_UHV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCable4() });
         GTModHandler.addCraftingRecipe(
                 ItemList.MassFabricatorUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CFC", "WMW", "CFC", 'M', ItemList.Hull_UEV, 'F', ItemList.Field_Generator_UEV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MassFabricatorUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CFC", "WMW", "CFC", 'M', ItemList.Hull_UIV, 'F', ItemList.Field_Generator_UIV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MassFabricatorUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CFC", "WMW", "CFC", 'M', ItemList.Hull_UMV, 'F', ItemList.Field_Generator_UMV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ReplicatorLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EFE", "CMC", "EWE", 'M', ItemList.Hull_LuV, 'F', ItemList.Field_Generator_LuV, 'E',
                         ItemList.Emitter_LuV, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ReplicatorZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EFE", "CMC", "EWE", 'M', ItemList.Hull_ZPM, 'F', ItemList.Field_Generator_ZPM, 'E',
                         ItemList.Emitter_ZPM, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ReplicatorUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EFE", "CMC", "EWE", 'M', ItemList.Hull_UV, 'F', ItemList.Field_Generator_UV, 'E',
                         ItemList.Emitter_UV, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ReplicatorUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EFE", "CMC", "EWE", 'M', ItemList.Hull_MAX, 'F', ItemList.Field_Generator_UHV, 'E',
                         ItemList.Emitter_UHV, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ReplicatorUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EFE", "CMC", "EWE", 'M', ItemList.Hull_UEV, 'F', ItemList.Field_Generator_UEV, 'E',
                         ItemList.Emitter_UEV, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ReplicatorUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EFE", "CMC", "EWE", 'M', ItemList.Hull_UIV, 'F', ItemList.Field_Generator_UIV, 'E',
                         ItemList.Emitter_UIV, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ReplicatorUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EFE", "CMC", "EWE", 'M', ItemList.Hull_UMV, 'F', ItemList.Field_Generator_UMV, 'E',
                         ItemList.Emitter_UMV, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable4() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ScannerLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CTC", "WMW", "CRC", 'M', ItemList.Hull_LuV, 'T', ItemList.Emitter_LuV, 'R',
                         ItemList.Sensor_LuV, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCable() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ScannerZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CTC", "WMW", "CRC", 'M', ItemList.Hull_ZPM, 'T', ItemList.Emitter_ZPM, 'R',
                         ItemList.Sensor_ZPM, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ScannerUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CTC", "WMW", "CRC", 'M', ItemList.Hull_UV, 'T', ItemList.Emitter_UV, 'R',
                         ItemList.Sensor_UV, 'C', OrePrefixes.circuit.get(Materials.UHV), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ScannerUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CTC", "WMW", "CRC", 'M', ItemList.Hull_MAX, 'T', ItemList.Emitter_UHV, 'R',
                         ItemList.Sensor_UHV, 'C', OrePrefixes.circuit.get(Materials.UEV), 'W',
                         OrePrefixes.cableGt01.get(Materials.Bedrockium) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ScannerUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CTC", "WMW", "CRC", 'M', ItemList.Hull_UEV, 'T', ItemList.Emitter_UEV, 'R',
                         ItemList.Sensor_UEV, 'C', OrePrefixes.circuit.get(Materials.UIV), 'W',
                         OrePrefixes.cableGt01.get(Materials.Draconium) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ScannerUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CTC", "WMW", "CRC", 'M', ItemList.Hull_UIV, 'T', ItemList.Emitter_UIV, 'R',
                         ItemList.Sensor_UIV, 'C', OrePrefixes.circuit.get(Materials.UMV), 'W',
                         OrePrefixes.cableGt01.get(Materials.Draconium) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ScannerUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CTC", "WMW", "CRC", 'M', ItemList.Hull_UMV, 'T', ItemList.Emitter_UMV, 'R',
                         ItemList.Sensor_UMV, 'C', OrePrefixes.circuit.get(Materials.UXV), 'W',
                         OrePrefixes.cableGt01.get(Materials.Draconium) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.AcceleratorLV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RMR", "PBC", "IMI", 'R', ItemList.Robot_Arm_LV, 'M', ItemList.Electric_Motor_LV, 'P',
                         ItemList.Electric_Pump_LV, 'B', ItemList.Hull_LV, 'C', ItemList.Conveyor_Module_LV, 'I',
                         ItemList.Electric_Piston_LV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.AcceleratorMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RMR", "PBC", "IMI", 'R', ItemList.Robot_Arm_MV, 'M', ItemList.Electric_Motor_MV, 'P',
                         ItemList.Electric_Pump_MV, 'B', ItemList.Hull_MV, 'C', ItemList.Conveyor_Module_MV, 'I',
                         ItemList.Electric_Piston_MV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.AcceleratorHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RMR", "PBC", "IMI", 'R', ItemList.Robot_Arm_HV, 'M', ItemList.Electric_Motor_HV, 'P',
                         ItemList.Electric_Pump_HV, 'B', ItemList.Hull_HV, 'C', ItemList.Conveyor_Module_HV, 'I',
                         ItemList.Electric_Piston_HV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.AcceleratorEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RMR", "PBC", "IMI", 'R', ItemList.Robot_Arm_EV, 'M', ItemList.Electric_Motor_EV, 'P',
                         ItemList.Electric_Pump_EV, 'B', ItemList.Hull_EV, 'C', ItemList.Conveyor_Module_EV, 'I',
                         ItemList.Electric_Piston_EV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.AcceleratorIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RMR", "PBC", "IMI", 'R', ItemList.Robot_Arm_IV, 'M', ItemList.Electric_Motor_IV, 'P',
                         ItemList.Electric_Pump_IV, 'B', ItemList.Hull_IV, 'C', ItemList.Conveyor_Module_IV, 'I',
                         ItemList.Electric_Piston_IV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.AcceleratorLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RMR", "PBC", "IMI", 'R', ItemList.Robot_Arm_LuV, 'M', ItemList.Electric_Motor_LuV, 'P',
                         ItemList.Electric_Pump_LuV, 'B', ItemList.Hull_LuV, 'C', ItemList.Conveyor_Module_LuV, 'I',
                         ItemList.Electric_Piston_LuV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.AcceleratorZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RMR", "PBC", "IMI", 'R', ItemList.Robot_Arm_ZPM, 'M', ItemList.Electric_Motor_ZPM, 'P',
                         ItemList.Electric_Pump_ZPM, 'B', ItemList.Hull_ZPM, 'C', ItemList.Conveyor_Module_ZPM, 'I',
                         ItemList.Electric_Piston_ZPM });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.AcceleratorUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RMR", "PBC", "IMI", 'R', ItemList.Robot_Arm_UV, 'M', ItemList.Electric_Motor_UV, 'P',
                         ItemList.Electric_Pump_UV, 'B', ItemList.Hull_UV, 'C', ItemList.Conveyor_Module_UV, 'I',
                         ItemList.Electric_Piston_UV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.BreweryLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GPG", "WBW", "CZC", 'W', OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'P',
                         ItemList.Electric_Pump_LuV, 'B', ItemList.Hull_LuV, 'C', OrePrefixes.circuit.get(Materials.LuV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.LuV.getGlass(), 'Z',
@@ -334,7 +331,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.BreweryZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GPG", "WBW", "CZC", 'W', OrePrefixes.cableGt01.get(Materials.Naquadah), 'P',
                         ItemList.Electric_Pump_ZPM, 'B', ItemList.Hull_ZPM, 'C', OrePrefixes.circuit.get(Materials.ZPM),
                         'G', GT_CustomLoader.AdvancedGTMaterials.ZPM.getGlass(), 'Z',
@@ -342,14 +339,14 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.BreweryUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GPG", "WBW", "CZC", 'W', OrePrefixes.cableGt01.get(Materials.ElectrumFlux), 'P',
                         ItemList.Electric_Pump_UV, 'B', ItemList.Hull_UV, 'C', OrePrefixes.circuit.get(Materials.UV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UV.getGlass(), 'Z',
                         new ItemStack(Items.brewing_stand, 1, 32767) });
         GTModHandler.addCraftingRecipe(
                 ItemList.BreweryUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GPG", "WBW", "CZC", 'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'P',
                         ItemList.Electric_Pump_UHV, 'B', ItemList.Hull_MAX, 'C', OrePrefixes.circuit.get(Materials.UHV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UHV.getGlass(), 'Z',
@@ -357,7 +354,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.BreweryUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GPG", "WBW", "CZC", 'W', OrePrefixes.cableGt01.get(Materials.Draconium), 'P',
                         ItemList.Electric_Pump_UEV, 'B', ItemList.Hull_UEV, 'C', OrePrefixes.circuit.get(Materials.UEV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UEV.getGlass(), 'Z',
@@ -365,7 +362,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.BreweryUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GPG", "WBW", "CZC", 'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'P',
                         ItemList.Electric_Pump_UIV, 'B', ItemList.Hull_UIV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'G',
@@ -374,7 +371,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.BreweryUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GPG", "WBW", "CZC", 'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'P',
                         ItemList.Electric_Pump_UMV, 'B', ItemList.Hull_UMV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'G',
@@ -383,7 +380,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ChemicalReactorLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PRP", "WMW", "CHC", 'H', ItemList.Hull_LuV, 'R', OrePrefixes.rotor.get(LuVMat2), 'P',
                         OrePrefixes.pipeMedium.get(Materials.PolyvinylChloride), 'M', ItemList.Electric_Motor_LuV, 'C',
                         OrePrefixes.circuit.get(Materials.LuV), 'W',
@@ -391,7 +388,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ChemicalReactorZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PRP", "WMW", "CHC", 'H', ItemList.Hull_ZPM, 'R',
                         OrePrefixes.rotor.get(Materials.Iridium), 'P',
                         OrePrefixes.pipeLarge.get(Materials.PolyvinylChloride), 'M', ItemList.Electric_Motor_ZPM, 'C',
@@ -399,7 +396,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ChemicalReactorUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PRP", "WMW", "CHC", 'H', ItemList.Hull_UV, 'R', OrePrefixes.rotor.get(Materials.Osmium),
                         'P', OrePrefixes.pipeHuge.get(Materials.PolyvinylChloride), 'M', ItemList.Electric_Motor_UV,
                         'C', OrePrefixes.circuit.get(Materials.UV), 'W',
@@ -407,7 +404,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ChemicalReactorUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PRP", "WMW", "CHC", 'H', ItemList.Hull_MAX, 'R',
                         OrePrefixes.rotor.get(Materials.Osmiridium), 'P',
                         OrePrefixes.pipeHuge.get(Materials.PolyvinylChloride), 'M', ItemList.Electric_Motor_UHV, 'C',
@@ -416,7 +413,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ChemicalReactorUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PRP", "WMW", "CHC", 'H', ItemList.Hull_UEV, 'R',
                         OrePrefixes.rotor.get(Materials.InfinityCatalyst), 'P',
                         OrePrefixes.pipeHuge.get(Materials.PolyvinylChloride), 'M', ItemList.Electric_Motor_UEV, 'C',
@@ -425,7 +422,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ChemicalReactorUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PRP", "WMW", "CHC", 'H', ItemList.Hull_UIV, 'R',
                         OrePrefixes.rotor.get(Materials.Infinity), 'P',
                         OrePrefixes.pipeMedium.get(Materials.Polybenzimidazole), 'M', ItemList.Electric_Motor_UIV, 'C',
@@ -434,7 +431,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.ChemicalReactorUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PRP", "WMW", "CHC", 'H', ItemList.Hull_UMV, 'R',
                         OrePrefixes.rotor.get(MaterialsUEVplus.TranscendentMetal), 'P',
                         OrePrefixes.pipeLarge.get(Materials.Polybenzimidazole), 'M', ItemList.Electric_Motor_UMV, 'C',
@@ -443,105 +440,105 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FermenterLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "GBG", "WCW", 'W', OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'P',
                         ItemList.Electric_Pump_LuV, 'B', ItemList.Hull_LuV, 'C', OrePrefixes.circuit.get(Materials.LuV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.LuV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FermenterZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "GBG", "WCW", 'W', OrePrefixes.cableGt01.get(Materials.Naquadah), 'P',
                         ItemList.Electric_Pump_ZPM, 'B', ItemList.Hull_ZPM, 'C', OrePrefixes.circuit.get(Materials.ZPM),
                         'G', GT_CustomLoader.AdvancedGTMaterials.ZPM.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FermenterUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "GBG", "WCW", 'W', OrePrefixes.cableGt01.get(Materials.ElectrumFlux), 'P',
                         ItemList.Electric_Pump_UV, 'B', ItemList.Hull_UV, 'C', OrePrefixes.circuit.get(Materials.UV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FermenterUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "GBG", "WCW", 'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'P',
                         ItemList.Electric_Pump_UHV, 'B', ItemList.Hull_MAX, 'C', OrePrefixes.circuit.get(Materials.UHV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UHV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FermenterUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "GBG", "WCW", 'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'P',
                         ItemList.Electric_Pump_UEV, 'B', ItemList.Hull_UEV, 'C', OrePrefixes.circuit.get(Materials.UEV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UEV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FermenterUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "GBG", "WCW", 'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'P',
                         ItemList.Electric_Pump_UIV, 'B', ItemList.Hull_UIV, 'C', OrePrefixes.circuit.get(Materials.UIV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UIV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FermenterUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "GBG", "WCW", 'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'P',
                         ItemList.Electric_Pump_UMV, 'B', ItemList.Hull_UMV, 'C', OrePrefixes.circuit.get(Materials.UMV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UMV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidCannerLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "GBG", "WPW", 'W', OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'P',
                         ItemList.Electric_Pump_LuV, 'B', ItemList.Hull_LuV, 'C', OrePrefixes.circuit.get(Materials.LuV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.LuV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidCannerZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "GBG", "WPW", 'W', OrePrefixes.cableGt01.get(Materials.Naquadah), 'P',
                         ItemList.Electric_Pump_ZPM, 'B', ItemList.Hull_ZPM, 'C', OrePrefixes.circuit.get(Materials.ZPM),
                         'G', GT_CustomLoader.AdvancedGTMaterials.ZPM.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidCannerUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "GBG", "WPW", 'W', OrePrefixes.cableGt01.get(Materials.ElectrumFlux), 'P',
                         ItemList.Electric_Pump_UV, 'B', ItemList.Hull_UV, 'C', OrePrefixes.circuit.get(Materials.UV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidCannerUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "GBG", "WPW", 'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'P',
                         ItemList.Electric_Pump_UHV, 'B', ItemList.Hull_MAX, 'C', OrePrefixes.circuit.get(Materials.UV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UHV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidCannerUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "GBG", "WPW", 'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'P',
                         ItemList.Electric_Pump_UEV, 'B', ItemList.Hull_UEV, 'C', OrePrefixes.circuit.get(Materials.UV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UEV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidCannerUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "GBG", "WPW", 'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'P',
                         ItemList.Electric_Pump_UIV, 'B', ItemList.Hull_UIV, 'C', OrePrefixes.circuit.get(Materials.UV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UIV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidCannerUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "GBG", "WPW", 'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'P',
                         ItemList.Electric_Pump_UMV, 'B', ItemList.Hull_UMV, 'C', OrePrefixes.circuit.get(Materials.UV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UMV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidExtractorLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GEG", "WPW", "CMC", 'M', ItemList.Hull_LuV, 'E', ItemList.Electric_Piston_LuV, 'P',
                         ItemList.Electric_Pump_LuV, 'C', OrePrefixes.circuit.get(Materials.LuV), 'W',
                         OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'G',
@@ -549,7 +546,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidExtractorZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GEG", "WPW", "CMC", 'M', ItemList.Hull_ZPM, 'E', ItemList.Electric_Piston_ZPM, 'P',
                         ItemList.Electric_Pump_ZPM, 'C', OrePrefixes.circuit.get(Materials.ZPM), 'W',
                         OrePrefixes.cableGt01.get(Materials.Naquadah), 'G',
@@ -557,7 +554,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidExtractorUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GEG", "WPW", "CMC", 'M', ItemList.Hull_UV, 'E', ItemList.Electric_Piston_UV, 'P',
                         ItemList.Electric_Pump_UV, 'C', OrePrefixes.circuit.get(Materials.UV), 'W',
                         OrePrefixes.cableGt01.get(Materials.ElectrumFlux), 'G',
@@ -565,7 +562,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidExtractorUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GEG", "WPW", "CMC", 'M', ItemList.Hull_MAX, 'E', ItemList.Electric_Piston_UHV, 'P',
                         ItemList.Electric_Pump_UHV, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'G',
@@ -573,7 +570,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidExtractorUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GEG", "WPW", "CMC", 'M', ItemList.Hull_UEV, 'E', ItemList.Electric_Piston_UEV, 'P',
                         ItemList.Electric_Pump_UEV, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G',
@@ -581,7 +578,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidExtractorUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GEG", "WPW", "CMC", 'M', ItemList.Hull_UIV, 'E', ItemList.Electric_Piston_UIV, 'P',
                         ItemList.Electric_Pump_UIV, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G',
@@ -589,7 +586,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidExtractorUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GEG", "WPW", "CMC", 'M', ItemList.Hull_UMV, 'E', ItemList.Electric_Piston_UMV, 'P',
                         ItemList.Electric_Pump_UMV, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G',
@@ -597,7 +594,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidHeaterLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "PMP", "RCR", 'M', ItemList.Hull_LuV, 'P', ItemList.Electric_Pump_LuV, 'C',
                         OrePrefixes.circuit.get(Materials.LuV), 'W',
                         OrePrefixes.wireGt04.get(Materials.NiobiumTitanium), 'R',
@@ -606,7 +603,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidHeaterZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "PMP", "WCW", 'M', ItemList.Hull_ZPM, 'P', ItemList.Electric_Pump_ZPM, 'C',
                         OrePrefixes.circuit.get(Materials.ZPM), 'W', OrePrefixes.wireGt04.get(Materials.Naquadah), 'R',
                         OrePrefixes.cableGt01.get(Materials.Naquadah), 'G',
@@ -614,7 +611,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidHeaterUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "PMP", "WCW", 'M', ItemList.Hull_UV, 'P', ItemList.Electric_Pump_UV, 'C',
                         OrePrefixes.circuit.get(Materials.UV), 'W', OrePrefixes.wireGt04.get(Materials.NaquadahAlloy),
                         'R', OrePrefixes.cableGt01.get(Materials.ElectrumFlux), 'G',
@@ -622,7 +619,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidHeaterUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "PMP", "WCW", 'M', ItemList.Hull_MAX, 'P', ItemList.Electric_Pump_UHV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getHCoil(), 'R',
@@ -631,7 +628,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidHeaterUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "PMP", "WCW", 'M', ItemList.Hull_UEV, 'P', ItemList.Electric_Pump_UEV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getHCoil(), 'R',
@@ -640,7 +637,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidHeaterUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "PMP", "WCW", 'M', ItemList.Hull_UIV, 'P', ItemList.Electric_Pump_UIV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getHCoil(), 'R',
@@ -649,7 +646,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.FluidHeaterUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "PMP", "WCW", 'M', ItemList.Hull_UMV, 'P', ItemList.Electric_Pump_UMV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getHCoil(), 'R',
@@ -658,7 +655,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MixerLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GRG", "GMG", "CBC", 'R', OrePrefixes.rotor.get(LuVMat2), 'M',
                         ItemList.Electric_Motor_LuV, 'B', ItemList.Hull_LuV, 'C',
                         OrePrefixes.circuit.get(Materials.LuV), 'G',
@@ -666,7 +663,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MixerZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GRG", "GMG", "CBC", 'R', OrePrefixes.rotor.get(Materials.Iridium), 'M',
                         ItemList.Electric_Motor_ZPM, 'B', ItemList.Hull_ZPM, 'C',
                         OrePrefixes.circuit.get(Materials.ZPM), 'G',
@@ -674,14 +671,14 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MixerUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GRG", "GMG", "CBC", 'R', OrePrefixes.rotor.get(Materials.Osmium), 'M',
                         ItemList.Electric_Motor_UV, 'B', ItemList.Hull_UV, 'C', OrePrefixes.circuit.get(Materials.UV),
                         'G', GT_CustomLoader.AdvancedGTMaterials.UV.getGlass() });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MixerUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GRG", "GMG", "CBC", 'R', OrePrefixes.rotor.get(Materials.Neutronium), 'M',
                         ItemList.Electric_Motor_UHV, 'B', ItemList.Hull_MAX, 'C',
                         OrePrefixes.circuit.get(Materials.UHV), 'G',
@@ -689,7 +686,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MixerUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GRG", "GMG", "CBC", 'R', OrePrefixes.rotor.get(Materials.Neutronium), 'M',
                         ItemList.Electric_Motor_UEV, 'B', ItemList.Hull_UEV, 'C',
                         OrePrefixes.circuit.get(Materials.UEV), 'G',
@@ -697,7 +694,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MixerUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GRG", "GMG", "CBC", 'R', OrePrefixes.rotor.get(Materials.CosmicNeutronium), 'M',
                         ItemList.Electric_Motor_UIV, 'B', ItemList.Hull_UIV, 'C',
                         OrePrefixes.circuit.get(Materials.UIV), 'G',
@@ -705,7 +702,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.MixerUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GRG", "GMG", "CBC", 'R', OrePrefixes.rotor.get(Materials.CosmicNeutronium), 'M',
                         ItemList.Electric_Motor_UMV, 'B', ItemList.Hull_UMV, 'C',
                         OrePrefixes.circuit.get(Materials.UMV), 'G',
@@ -713,178 +710,178 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_UEV_UHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_MAX, 'C',
                         OrePrefixes.wireGt01.get(Materials.Draconium), 'B',
                         OrePrefixes.wireGt04.get(Materials.SuperconductorUHV), 'K', ItemList.Circuit_Chip_PPIC });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_UIV_UEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_UEV, 'C',
                         OrePrefixes.wireGt01.get(Materials.NetherStar), 'B',
                         OrePrefixes.wireGt04.get(Materials.Draconium), 'K', ItemList.Circuit_Chip_QPIC });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_UMV_UIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_UIV, 'C',
                         OrePrefixes.wireGt01.get(Materials.Quantium), 'B',
                         OrePrefixes.wireGt04.get(Materials.NetherStar), 'K', ItemList.Circuit_Chip_QPIC });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_UXV_UMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_UMV, 'C',
                         OrePrefixes.wireGt01.get(Materials.BlackPlutonium), 'B',
                         OrePrefixes.wireGt04.get(Materials.Quantium), 'K', ItemList.Circuit_Chip_QPIC });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_MAX_UXV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_UXV, 'C',
                         OrePrefixes.wireGt01.get(Materials.Infinity), 'B',
                         OrePrefixes.wireGt04.get(Materials.BlackPlutonium), 'K', ItemList.Circuit_Chip_QPIC });
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_4by4_UEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UEV, 'W', OrePrefixes.wireGt16.get(Materials.Draconium),
                         'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_3by3_UIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UIV, 'W',
                         OrePrefixes.wireGt08.get(Materials.NetherStar), 'T', OreDictNames.craftingChest });
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_3by3_UMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UMV, 'W', OrePrefixes.wireGt08.get(Materials.Quantium),
                         'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_3by3_UXV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UXV, 'W',
                         OrePrefixes.wireGt08.get(Materials.BlackPlutonium), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_2by2_UEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UEV, 'W', OrePrefixes.wireGt04.get(Materials.Draconium),
                         'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_2by2_UIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UIV, 'W',
                         OrePrefixes.wireGt04.get(Materials.NetherStar), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_2by2_UMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UMV, 'W', OrePrefixes.wireGt04.get(Materials.Quantium),
                         'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_2by2_UXV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UXV, 'W',
                         OrePrefixes.wireGt04.get(Materials.BlackPlutonium), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_1by1_UEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UEV, 'W', OrePrefixes.wireGt01.get(Materials.Draconium),
                         'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_1by1_UIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UIV, 'W',
                         OrePrefixes.wireGt01.get(Materials.NetherStar), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_1by1_UMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UMV, 'W', OrePrefixes.wireGt01.get(Materials.Quantium),
                         'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_1by1_UXV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UXV, 'W',
                         OrePrefixes.wireGt01.get(Materials.BlackPlutonium), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_4by4_UIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UIV, 'W',
                         OrePrefixes.wireGt16.get(Materials.NetherStar), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_4by4_UMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UMV, 'W', OrePrefixes.wireGt16.get(Materials.Quantium),
                         'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_4by4_UXV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UXV, 'W',
                         OrePrefixes.wireGt16.get(Materials.BlackPlutonium), 'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_3by3_UEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WTW", "WMW", 'M', ItemList.Hull_UEV, 'W', OrePrefixes.wireGt08.get(Materials.Draconium),
                         'T', OreDictNames.craftingChest });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_TurboCharger_4by4_ULV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "BTB", "CMC", "BXB", 'T', ItemList.WetTransformer_LV_ULV, 'M',
                         ItemList.Battery_Charger_4by4_ULV, 'B', ItemList.Battery_RE_ULV_Tantalum, 'C',
                         OrePrefixes.cableGt16.get(Materials.Lead), 'X', OrePrefixes.circuit.get(Materials.ULV) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_TurboCharger_4by4_LV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "BTB", "CMC", "BXB", 'T', ItemList.WetTransformer_MV_LV, 'M',
                         ItemList.Battery_Charger_4by4_LV, 'B', ItemList.Battery_RE_LV_Lithium, 'C',
                         OrePrefixes.cableGt16.get(Materials.Tin), 'X', OrePrefixes.circuit.get(Materials.LV) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_TurboCharger_4by4_MV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "BTB", "CMC", "BXB", 'T', ItemList.WetTransformer_HV_MV, 'M',
                         ItemList.Battery_Charger_4by4_MV, 'B', ItemList.Battery_RE_MV_Lithium, 'C',
                         OrePrefixes.cableGt16.get(Materials.AnyCopper), 'X', OrePrefixes.circuit.get(Materials.MV) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_TurboCharger_4by4_HV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "BTB", "CMC", "BXB", 'T', ItemList.WetTransformer_EV_HV, 'M',
                         ItemList.Battery_Charger_4by4_HV, 'B', ItemList.Battery_RE_HV_Lithium, 'C',
                         OrePrefixes.cableGt16.get(Materials.Gold), 'X', OrePrefixes.circuit.get(Materials.HV) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_TurboCharger_4by4_EV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "BTB", "CMC", "BXB", 'T', ItemList.WetTransformer_IV_EV, 'M',
                         ItemList.Battery_Charger_4by4_EV, 'B', OrePrefixes.battery.get(Materials.EV), 'C',
                         OrePrefixes.cableGt16.get(Materials.Aluminium), 'X', OrePrefixes.circuit.get(Materials.EV) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_TurboCharger_4by4_IV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "BTB", "CMC", "BXB", 'T', ItemList.WetTransformer_LuV_IV, 'M',
                         ItemList.Battery_Charger_4by4_IV, 'B', ItemList.Energy_LapotronicOrb, 'C',
                         OrePrefixes.cableGt16.get(Materials.Tungsten), 'X', OrePrefixes.circuit.get(Materials.IV) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_TurboCharger_4by4_LuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "BTB", "CMC", "BXB", 'T', ItemList.WetTransformer_ZPM_LuV, 'M',
                         ItemList.Battery_Charger_4by4_LuV, 'B', ItemList.Energy_LapotronicOrb2, 'C',
                         OrePrefixes.cableGt16.get(Materials.VanadiumGallium), 'X',
@@ -892,14 +889,14 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_TurboCharger_4by4_ZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "BTB", "CMC", "BXB", 'T', ItemList.WetTransformer_UV_ZPM, 'M',
                         ItemList.Battery_Charger_4by4_ZPM, 'B', ItemList.Energy_LapotronicOrb2, 'C',
                         OrePrefixes.cableGt16.get(Materials.Naquadah), 'X', OrePrefixes.circuit.get(Materials.ZPM) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_TurboCharger_4by4_UV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "BTB", "CMC", "BXB", 'T', ItemList.WetTransformer_UHV_UV, 'M',
                         ItemList.Battery_Charger_4by4_UV, 'B', ItemList.ZPM2, 'C',
                         OrePrefixes.cableGt16.get(Materials.NaquadahAlloy), 'X',
@@ -907,7 +904,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_TurboCharger_4by4_UHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "BTB", "CMC", "BXB", 'T', ItemList.WetTransformer_UEV_UHV, 'M',
                         ItemList.Battery_Charger_4by4_UHV, 'B', ItemList.ZPM2, 'C',
                         OrePrefixes.wireGt16.get(Materials.SuperconductorUHV), 'X',
@@ -915,74 +912,74 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Automation_ChestBuffer_UEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CMV", " X ", 'M', ItemList.Hull_UEV, 'V', ItemList.Conveyor_Module_UEV, 'C',
                         OreDictNames.craftingChest, 'X', OrePrefixes.circuit.get(Materials.UEV) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Automation_ChestBuffer_UIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CMV", " X ", 'M', ItemList.Hull_UIV, 'V', ItemList.Conveyor_Module_UIV, 'C',
                         OreDictNames.craftingChest, 'X', OrePrefixes.circuit.get(Materials.UIV) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Automation_ChestBuffer_UMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CMV", " X ", 'M', ItemList.Hull_UMV, 'V', ItemList.Conveyor_Module_UMV, 'C',
                         OreDictNames.craftingChest, 'X', OrePrefixes.circuit.get(Materials.UMV) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.NameRemover.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "SsS", "VMV", "SXS", 'M', ItemList.Hull_ULV, 'V',
                         OrePrefixes.gearGtSmall.get(Materials.AnyBronze), 'S', OrePrefixes.screw.get(Materials.AnyIron),
                         'X', OreDictNames.craftingPiston });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.RockBreakerLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PED", "WMW", "GGG", 'P', ItemList.Electric_Piston_LuV, 'E', ItemList.Electric_Motor_LuV,
                         'D', OreDictNames.craftingGrinder, 'G', GT_CustomLoader.AdvancedGTMaterials.LuV.getGlass(), 'W',
                         OrePrefixes.cableGt01.get(Materials.VanadiumGallium), 'M', ItemList.Hull_LuV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.RockBreakerZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PED", "WMW", "GGG", 'P', ItemList.Electric_Piston_ZPM, 'E', ItemList.Electric_Motor_ZPM,
                         'D', OreDictNames.craftingGrinder, 'G', GT_CustomLoader.AdvancedGTMaterials.ZPM.getGlass(), 'W',
                         OrePrefixes.cableGt01.get(Materials.Naquadah), 'M', ItemList.Hull_ZPM });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.RockBreakerUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PED", "WMW", "GGG", 'P', ItemList.Electric_Piston_UV, 'E', ItemList.Electric_Motor_UV,
                         'D', OreDictNames.craftingGrinder, 'G', GT_CustomLoader.AdvancedGTMaterials.UV.getGlass(), 'W',
                         OrePrefixes.cableGt01.get(Materials.NaquadahAlloy), 'M', ItemList.Hull_UV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.RockBreakerUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PED", "WMW", "GGG", 'P', ItemList.Electric_Piston_UHV, 'E', ItemList.Electric_Motor_UHV,
                         'D', OreDictNames.craftingGrinder, 'G', GT_CustomLoader.AdvancedGTMaterials.UHV.getGlass(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'M', ItemList.Hull_MAX });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.RockBreakerUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PED", "WMW", "GGG", 'P', ItemList.Electric_Piston_UEV, 'E', ItemList.Electric_Motor_UEV,
                         'D', OreDictNames.craftingGrinder, 'G', GT_CustomLoader.AdvancedGTMaterials.UEV.getGlass(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'M', ItemList.Hull_UEV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.RockBreakerUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PED", "WMW", "GGG", 'P', ItemList.Electric_Piston_UIV, 'E', ItemList.Electric_Motor_UIV,
                         'D', OreDictNames.craftingGrinder, 'G', GT_CustomLoader.AdvancedGTMaterials.UIV.getGlass(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'M', ItemList.Hull_UIV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.RockBreakerUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PED", "WMW", "GGG", 'P', ItemList.Electric_Piston_UMV, 'E', ItemList.Electric_Motor_UMV,
                         'D', OreDictNames.craftingGrinder, 'G', GT_CustomLoader.AdvancedGTMaterials.UMV.getGlass(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'M', ItemList.Hull_UMV });
@@ -993,40 +990,40 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_HA_UEV_UHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Transformer_UEV_UHV, 'C',
                         OrePrefixes.wireGt04.get(Materials.Draconium), 'B',
                         OrePrefixes.wireGt04.get(Materials.Bedrockium), 'K', ItemList.Casing_Coil_Superconductor });
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_HA_UIV_UEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Transformer_UIV_UEV, 'C',
                         OrePrefixes.wireGt04.get(Materials.NetherStar), 'B',
                         OrePrefixes.wireGt04.get(Materials.Draconium), 'K', ItemList.Casing_Fusion_Coil });
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_HA_UMV_UIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "KBB", "CMK", "KBB", 'M', ItemList.Transformer_UMV_UIV, 'C',
                         OrePrefixes.wireGt04.get(Materials.Quantium), 'B',
                         OrePrefixes.wireGt04.get(Materials.NetherStar), 'K', ItemList.Casing_Fusion_Coil });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_HA_UXV_UMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "KBB", "CMK", "KBB", 'M', ItemList.Transformer_UXV_UMV, 'C',
                         OrePrefixes.wireGt04.get(Materials.BlackPlutonium), 'B',
                         OrePrefixes.wireGt04.get(Materials.Quantium), 'K', ItemList.Casing_Fusion_Coil });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_HA_MAX_UXV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "KBB", "CMK", "KBB", 'M', ItemList.Transformer_MAX_UXV, 'C',
                         OrePrefixes.wireGt04.get(Materials.Infinity), 'B',
                         OrePrefixes.wireGt04.get(Materials.BlackPlutonium), 'K', ItemList.Casing_Coil_Infinity });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_LV_ULV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Lead), 'C',
                         OrePrefixes.cableGt16.get(Materials.Lead), 'S', OrePrefixes.spring.get(Materials.Tin), 'X',
                         OrePrefixes.cableGt08.get(Materials.Tin), 'O', OrePrefixes.cell.get(Materials.Lubricant), 'P',
@@ -1034,7 +1031,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_MV_LV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Tin), 'C',
                         OrePrefixes.cableGt16.get(Materials.Tin), 'S', OrePrefixes.spring.get(Materials.AnyCopper), 'X',
                         OrePrefixes.cableGt08.get(Materials.AnyCopper), 'O', OrePrefixes.cell.get(Materials.Lubricant),
@@ -1042,7 +1039,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_HV_MV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.AnyCopper), 'C',
                         OrePrefixes.cableGt16.get(Materials.AnyCopper), 'S', OrePrefixes.spring.get(Materials.Gold),
                         'X', OrePrefixes.cableGt08.get(Materials.Gold), 'O', OrePrefixes.cell.get(Materials.Lubricant),
@@ -1050,7 +1047,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_EV_HV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Gold), 'C',
                         OrePrefixes.cableGt16.get(Materials.Gold), 'S', OrePrefixes.spring.get(Materials.Aluminium),
                         'X', OrePrefixes.cableGt08.get(Materials.Aluminium), 'O',
@@ -1059,7 +1056,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_IV_EV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Aluminium), 'C',
                         OrePrefixes.cableGt16.get(Materials.Aluminium), 'S', OrePrefixes.spring.get(Materials.Tungsten),
                         'X', OrePrefixes.cableGt08.get(Materials.Tungsten), 'O',
@@ -1068,7 +1065,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_LuV_IV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Tungsten), 'C',
                         OrePrefixes.cableGt16.get(Materials.Tungsten), 'S',
                         OrePrefixes.spring.get(Materials.VanadiumGallium), 'X',
@@ -1078,7 +1075,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_ZPM_LuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.VanadiumGallium), 'C',
                         OrePrefixes.cableGt16.get(Materials.VanadiumGallium), 'S',
                         OrePrefixes.spring.get(Materials.Naquadah), 'X', OrePrefixes.cableGt08.get(Materials.Naquadah),
@@ -1087,7 +1084,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_UV_ZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Naquadah), 'C',
                         OrePrefixes.cableGt16.get(Materials.Naquadah), 'S',
                         OrePrefixes.spring.get(Materials.NaquadahAlloy), 'X',
@@ -1097,7 +1094,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_UHV_UV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.NaquadahAlloy), 'C',
                         OrePrefixes.cableGt16.get(Materials.NaquadahAlloy), 'S',
                         OrePrefixes.spring.get(Materials.Neutronium), 'X',
@@ -1106,7 +1103,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_UEV_UHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Neutronium), 'C',
                         OrePrefixes.wireGt16.get(Materials.SuperconductorUHV), 'S',
                         OrePrefixes.spring.get(Materials.Draconium), 'X', OrePrefixes.wireGt08.get(Materials.Draconium),
@@ -1115,7 +1112,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_UIV_UEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Draconium), 'C',
                         OrePrefixes.wireGt16.get(Materials.Draconium), 'S',
                         OrePrefixes.spring.get(Materials.BlackPlutonium), 'X',
@@ -1124,7 +1121,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_UMV_UIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.BlackPlutonium), 'C',
                         OrePrefixes.wireGt16.get(Materials.NetherStar), 'S', OrePrefixes.spring.get(Materials.Quantium),
                         'X', OrePrefixes.wireGt08.get(Materials.Quantium), 'O', ItemList.Reactor_Coolant_He_6, 'P',
@@ -1132,7 +1129,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_UXV_UMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(MaterialsUEVplus.SpaceTime), 'C',
                         OrePrefixes.wireGt16.get(Materials.Quantium), 'S', OrePrefixes.spring.get(Materials.Infinity),
                         'X', OrePrefixes.wireGt08.get(Materials.BlackPlutonium), 'O', ItemList.Reactor_Coolant_Sp_1,
@@ -1140,7 +1137,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_MAX_UXV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(MaterialsUEVplus.Universium), 'C',
                         OrePrefixes.wireGt16.get(Materials.BlackPlutonium), 'S',
                         OrePrefixes.spring.get(MaterialsUEVplus.SpaceTime), 'X',
@@ -1179,7 +1176,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'C',
@@ -1188,7 +1185,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'C',
@@ -1197,7 +1194,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'C',
@@ -1206,7 +1203,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'C',
@@ -1215,7 +1212,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', ItemList.Hull_UEV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'C',
@@ -1224,7 +1221,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', ItemList.Hull_UIV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'C',
@@ -1233,7 +1230,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AlloySmelterUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ECE", "CMC", "WCW", 'M', ItemList.Hull_UMV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'C',
@@ -1245,7 +1242,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable4(), },
@@ -1253,7 +1250,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable4(), },
@@ -1261,7 +1258,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable4(), },
@@ -1269,7 +1266,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable4(), },
@@ -1277,7 +1274,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable4(), },
@@ -1285,7 +1282,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable4(), },
@@ -1293,7 +1290,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AmplifabricatorUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "PMP", "CPC", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable4(), },
@@ -1303,7 +1300,7 @@ public class GT_Loader_Machines {
     private void registerAssemblingMachine() {
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -1312,7 +1309,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -1321,7 +1318,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -1330,7 +1327,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -1339,7 +1336,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', ItemList.Hull_UEV, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
                         'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -1348,7 +1345,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', ItemList.Hull_UIV, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
                         'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -1357,7 +1354,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AssemblingMachineUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ACA", "VMV", "WCW", 'M', ItemList.Hull_UMV, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
                         'A', MTEBasicMachineWithRecipe.X.ROBOT_ARM, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -1369,7 +1366,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'I',
@@ -1379,7 +1376,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'I',
@@ -1389,7 +1386,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'I',
@@ -1399,7 +1396,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'I',
@@ -1409,7 +1406,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'I',
@@ -1419,7 +1416,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'I',
@@ -1429,7 +1426,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.AutoclaveUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CPC", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'I',
@@ -1442,7 +1439,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -1451,7 +1448,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -1460,7 +1457,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -1469,7 +1466,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -1478,7 +1475,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -1486,7 +1483,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -1494,7 +1491,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.BendingMachineUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PWP", "CMC", "EWE", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -1505,7 +1502,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable() },
@@ -1513,7 +1510,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable() },
@@ -1521,7 +1518,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable() },
@@ -1529,7 +1526,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable() },
@@ -1537,7 +1534,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -1545,7 +1542,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -1553,7 +1550,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CompressorUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMP", "WCW", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -1564,7 +1561,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -1574,7 +1571,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -1584,7 +1581,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -1594,7 +1591,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -1604,7 +1601,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G',
@@ -1613,7 +1610,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G',
@@ -1622,7 +1619,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CuttingMachineUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCG", "VMB", "CWE", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G',
@@ -1635,7 +1632,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'B', OrePrefixes.pipeMedium.get(Materials.Enderium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -1645,7 +1642,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'B', OrePrefixes.pipeMedium.get(Materials.Naquadah), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -1655,7 +1652,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'B', OrePrefixes.pipeMedium.get(Materials.Neutronium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -1665,7 +1662,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'B', OrePrefixes.pipeLarge.get(Materials.Neutronium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -1675,7 +1672,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'B',
                         OrePrefixes.pipeHuge.get(Materials.Neutronium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -1685,7 +1682,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'B',
                         OrePrefixes.pipeMedium.get(Materials.Infinity), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -1695,7 +1692,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.DistilleryUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GBG", "CMC", "WPW", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'B',
                         OrePrefixes.pipeMedium.get(MaterialsUEVplus.SpaceTime), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -1708,7 +1705,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'C',
@@ -1717,7 +1714,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'C',
@@ -1726,7 +1723,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'C',
@@ -1735,7 +1732,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'C',
@@ -1744,7 +1741,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', ItemList.Hull_UEV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'C',
@@ -1753,7 +1750,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', ItemList.Hull_UIV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'C',
@@ -1762,7 +1759,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectricFurnaceUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "CMC", "ECE", 'M', ItemList.Hull_UMV, 'E',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'C',
@@ -1774,7 +1771,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'I',
@@ -1784,7 +1781,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'I',
@@ -1794,7 +1791,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'I',
@@ -1804,7 +1801,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'I',
@@ -1814,7 +1811,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'I',
@@ -1824,7 +1821,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'I',
@@ -1834,7 +1831,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectrolyzerUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "IGI", "IMI", "CWC", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'I',
@@ -1847,7 +1844,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1857,7 +1854,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1867,7 +1864,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1877,7 +1874,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1887,7 +1884,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', ItemList.Hull_UEV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1897,7 +1894,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', ItemList.Hull_UIV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1907,7 +1904,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ElectromagneticSeparatorUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VWZ", "WMS", "CWZ", 'M', ItemList.Hull_UMV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getWire(), 'V', MTEBasicMachineWithRecipe.X.CONVEYOR,
@@ -1920,7 +1917,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -1930,7 +1927,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -1940,7 +1937,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -1950,7 +1947,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.PISTON, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -1960,7 +1957,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.PISTON,
                         'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -1970,7 +1967,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.PISTON,
                         'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -1980,7 +1977,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtractorUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "EMP", "WCW", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.PISTON,
                         'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -1994,7 +1991,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                         MTEBasicMachineWithRecipe.X.PISTON, 'E', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'P', GT_CustomLoader.AdvancedGTMaterials.LuV.getPipe(), 'C',
@@ -2003,7 +2000,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                         MTEBasicMachineWithRecipe.X.PISTON, 'E', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'P', GT_CustomLoader.AdvancedGTMaterials.ZPM.getPipe(), 'C',
@@ -2012,7 +2009,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                         MTEBasicMachineWithRecipe.X.PISTON, 'E', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'P', GT_CustomLoader.AdvancedGTMaterials.UV.getPipe(), 'C',
@@ -2021,7 +2018,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'X',
                         MTEBasicMachineWithRecipe.X.PISTON, 'E', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'P', GT_CustomLoader.AdvancedGTMaterials.UHV.getPipe(), 'C',
@@ -2030,7 +2027,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', ItemList.Hull_UEV, 'X', MTEBasicMachineWithRecipe.X.PISTON,
                         'E', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'P',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getPipe(), 'C',
@@ -2039,7 +2036,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', ItemList.Hull_UIV, 'X', MTEBasicMachineWithRecipe.X.PISTON,
                         'E', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'P',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getPipe(), 'C',
@@ -2048,7 +2045,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ExtruderUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CCE", "XMP", "CCE", 'M', ItemList.Hull_UMV, 'X', MTEBasicMachineWithRecipe.X.PISTON,
                         'E', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'P',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getPipe(), 'C',
@@ -2061,7 +2058,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'G',
@@ -2070,7 +2067,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'G',
@@ -2079,7 +2076,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'G',
@@ -2088,7 +2085,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'G',
@@ -2097,7 +2094,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G',
@@ -2106,7 +2103,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G',
@@ -2115,7 +2112,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FluidSolidifierUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PGP", "WMW", "CBC", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G',
@@ -2128,7 +2125,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable() },
@@ -2136,7 +2133,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable() },
@@ -2144,7 +2141,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable() },
@@ -2152,7 +2149,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable() },
@@ -2160,7 +2157,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -2168,7 +2165,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -2176,7 +2173,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.FormingPressUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WPW", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -2188,7 +2185,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'O',
@@ -2197,7 +2194,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'O',
@@ -2206,7 +2203,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'O',
@@ -2215,7 +2212,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'O',
@@ -2224,7 +2221,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'O',
@@ -2233,7 +2230,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'O',
@@ -2242,7 +2239,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ForgeHammerUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "WAW", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'O',
@@ -2255,7 +2252,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2265,7 +2262,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2275,7 +2272,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2285,7 +2282,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2295,7 +2292,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'D',
@@ -2304,7 +2301,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'D',
@@ -2313,7 +2310,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.LatheUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "EMD", "CWP", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'D',
@@ -2326,7 +2323,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2335,7 +2332,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2344,7 +2341,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2353,7 +2350,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2362,7 +2359,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.EMITTER,
                         'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -2371,7 +2368,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.EMITTER,
                         'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -2380,7 +2377,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PrecisionLaserEngraverUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEP", "CMC", "WCW", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.EMITTER,
                         'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -2393,7 +2390,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2402,7 +2399,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2411,7 +2408,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2420,7 +2417,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'P', MTEBasicMachineWithRecipe.X.PISTON, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2429,7 +2426,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G', OreDictNames.craftingGrinder },
@@ -2437,7 +2434,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G', OreDictNames.craftingGrinder },
@@ -2445,7 +2442,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MaceratorUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "PEG", "WWM", "CCW", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G', OreDictNames.craftingGrinder },
@@ -2457,7 +2454,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                         MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -2466,7 +2463,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                         MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -2475,7 +2472,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                         MTEBasicMachineWithRecipe.X.CIRCUIT, 'W', MTEBasicMachineWithRecipe.X.WIRE, 'L',
@@ -2484,7 +2481,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'R', MTEBasicMachineWithRecipe.X.EMITTER, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2494,7 +2491,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'R',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getWire(), 'L',
@@ -2503,7 +2500,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'R',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getWire(), 'L',
@@ -2512,7 +2509,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.MicrowaveUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "LWC", "LMR", "LEC", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'R',
                         MTEBasicMachineWithRecipe.X.EMITTER, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getWire(), 'L',
@@ -2525,7 +2522,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                         OrePrefixes.rotor.get(LuVMat2), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2534,7 +2531,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                         OrePrefixes.rotor.get(Materials.Iridium), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2543,7 +2540,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                         OrePrefixes.rotor.get(Materials.Osmium), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2552,7 +2549,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'R',
                         OrePrefixes.rotor.get(Materials.Neutronium), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2561,7 +2558,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', ItemList.Hull_UEV, 'R',
                         OrePrefixes.rotor.get(Materials.CosmicNeutronium), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -2570,7 +2567,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', ItemList.Hull_UIV, 'R',
                         OrePrefixes.rotor.get(Materials.Infinity), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -2579,7 +2576,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.OreWashingPlantUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RGR", "CEC", "WMW", 'M', ItemList.Hull_UMV, 'R',
                         OrePrefixes.rotor.get(MaterialsUEVplus.SpaceTime), 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -2592,7 +2589,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt02.get(Materials.Osmium), 'W',
@@ -2601,7 +2598,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt04.get(Materials.Osmium), 'W',
@@ -2610,7 +2607,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt08.get(Materials.Osmium), 'W',
@@ -2619,7 +2616,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', MTEBasicMachineWithRecipe.X.HULL, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt08.get(Materials.Osmium), 'W',
@@ -2628,7 +2625,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', ItemList.Hull_UEV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt08.get(Materials.Osmium), 'W',
@@ -2637,7 +2634,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', ItemList.Hull_UIV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt08.get(Materials.Osmium), 'W',
@@ -2646,7 +2643,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PolarizerUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "ZSZ", "WMW", "ZSZ", 'M', ItemList.Hull_UMV, 'S',
                         MTEBasicMachineWithRecipe.X.STICK_ELECTROMAGNETIC, 'Z',
                         OrePrefixes.wireGt08.get(Materials.Osmium), 'W',
@@ -2659,7 +2656,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'G',
@@ -2668,7 +2665,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'G',
@@ -2677,7 +2674,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'G',
@@ -2686,7 +2683,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'G',
@@ -2695,7 +2692,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G',
@@ -2704,7 +2701,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G',
@@ -2713,7 +2710,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.RecyclerUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "GCG", "PMP", "WCW", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G',
@@ -2726,7 +2723,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2735,7 +2732,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2744,7 +2741,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2753,7 +2750,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'F', OreDictNames.craftingFilter, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2762,7 +2759,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'F', OreDictNames.craftingFilter, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -2770,7 +2767,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'F', OreDictNames.craftingFilter, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -2778,7 +2775,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SiftingMachineUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WFW", "PMP", "CFC", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PISTON,
                         'F', OreDictNames.craftingFilter, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -2790,7 +2787,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -2799,7 +2796,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -2808,7 +2805,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -2817,7 +2814,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -2826,7 +2823,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', ItemList.Hull_UEV.get(1), 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -2835,7 +2832,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', ItemList.Hull_UIV.get(1), 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -2844,7 +2841,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.SlicingMachineUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WCW", "PMV", "WCW", 'M', ItemList.Hull_UMV.get(1), 'P',
                         MTEBasicMachineWithRecipe.X.PISTON, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -2857,7 +2854,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'O',
@@ -2866,7 +2863,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'O',
@@ -2875,7 +2872,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'O',
@@ -2884,7 +2881,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'O',
@@ -2893,7 +2890,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'O',
@@ -2902,7 +2899,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'O',
@@ -2911,7 +2908,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ThermalCentrifugeUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "OMO", "WEW", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'O',
@@ -2924,7 +2921,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable() },
@@ -2932,7 +2929,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable() },
@@ -2940,7 +2937,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable() },
@@ -2948,7 +2945,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable() },
@@ -2956,7 +2953,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -2964,7 +2961,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -2972,7 +2969,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.WiremillUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "EWE", "CMC", "EWE", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -2984,7 +2981,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(LuVMat2), 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable4(), 'G',
@@ -2993,7 +2990,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(Materials.Iridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -3003,7 +3000,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -3013,7 +3010,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateTriple.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -3023,7 +3020,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', ItemList.Hull_UEV, 'P',
                         OrePrefixes.plateQuadruple.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -3033,7 +3030,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', ItemList.Hull_UIV, 'P',
                         OrePrefixes.plateDouble.get(Materials.Osmiridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -3043,7 +3040,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ArcFurnaceUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "PPP", 'M', ItemList.Hull_UMV, 'P',
                         OrePrefixes.plateQuadruple.get(Materials.Osmiridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -3057,7 +3054,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable() },
@@ -3065,7 +3062,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable() },
@@ -3073,7 +3070,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'E',
                         MTEBasicMachineWithRecipe.X.MOTOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UV.getCable() },
@@ -3081,7 +3078,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', ItemList.Hull_MAX, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCable() },
@@ -3089,7 +3086,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', ItemList.Hull_UEV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable() },
@@ -3097,7 +3094,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', ItemList.Hull_UIV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable() },
@@ -3105,7 +3102,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CentrifugeUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "CEC", "WMW", "CEC", 'M', ItemList.Hull_UMV, 'E', MTEBasicMachineWithRecipe.X.MOTOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable() },
@@ -3117,7 +3114,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(LuVMat2), 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable4(), 'T', MTEBasicMachineWithRecipe.X.PUMP,
@@ -3126,7 +3123,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(Materials.Iridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -3136,7 +3133,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateDouble.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -3146,7 +3143,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         OrePrefixes.plateTriple.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -3156,7 +3153,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', ItemList.Hull_UEV, 'P',
                         OrePrefixes.plateQuadruple.get(Materials.Osmium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -3166,7 +3163,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', ItemList.Hull_UIV, 'P',
                         OrePrefixes.plateDouble.get(Materials.Osmiridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
@@ -3176,7 +3173,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.PlasmaArcFurnaceUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WGW", "CMC", "TPT", 'M', ItemList.Hull_UMV, 'P',
                         OrePrefixes.plateQuadruple.get(Materials.Osmiridium), 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
@@ -3188,7 +3185,7 @@ public class GT_Loader_Machines {
     private void registerCanningMachine() {
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.LuV.getCable(), 'G',
@@ -3197,7 +3194,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.ZPM.getCable(), 'G',
@@ -3206,7 +3203,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCable(), 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -3214,7 +3211,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'C', GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UHV.getCable(), 'G',
@@ -3223,7 +3220,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -3231,7 +3228,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -3239,7 +3236,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.CanningMachineUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "WPW", "CMC", "GGG", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(), 'W',
                         GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G', MTEBasicMachineWithRecipe.X.GLASS },
@@ -3249,7 +3246,7 @@ public class GT_Loader_Machines {
     private void registerChemicalBath() {
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathLuV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.LuV.getCircuit(), 'W',
@@ -3258,7 +3255,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathZPM.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.ZPM.getCircuit(), 'W',
@@ -3267,7 +3264,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathUV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UV.getCircuit(), 'W',
@@ -3276,7 +3273,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', MTEBasicMachineWithRecipe.X.HULL, 'P',
                         MTEBasicMachineWithRecipe.X.PUMP, 'V', MTEBasicMachineWithRecipe.X.CONVEYOR, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UHV.getCircuit(), 'W',
@@ -3285,7 +3282,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', ItemList.Hull_UEV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UEV.getCable(), 'G',
@@ -3294,7 +3291,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', ItemList.Hull_UIV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UIV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UIV.getCable(), 'G',
@@ -3303,7 +3300,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addMachineCraftingRecipe(
                 ItemList.ChemicalBathUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "VGW", "PGV", "CMC", 'M', ItemList.Hull_UMV, 'P', MTEBasicMachineWithRecipe.X.PUMP, 'V',
                         MTEBasicMachineWithRecipe.X.CONVEYOR, 'C', GT_CustomLoader.AdvancedGTMaterials.UMV.getCircuit(),
                         'W', GT_CustomLoader.AdvancedGTMaterials.UMV.getCable(), 'G',
@@ -3314,7 +3311,7 @@ public class GT_Loader_Machines {
     private void registerCircuitAssembler() {
         GTModHandler.addCraftingRecipe(
                 ItemList.CircuitAssemblerUHV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RCE", "KHK", "WCW", 'R', ItemList.Robot_Arm_UHV, 'E', ItemList.Emitter_UHV, 'H',
                         ItemList.Hull_MAX, 'K', ItemList.Conveyor_Module_UHV, 'C',
                         GT_CustomLoader.AdvancedGTMaterials.UEV.getCircuit(), 'W',
@@ -3322,7 +3319,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.CircuitAssemblerUEV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RCE", "KHK", "WCW", 'R', ItemList.Robot_Arm_UEV, 'E', ItemList.Emitter_UEV, 'H',
                         ItemList.Hull_UEV, 'K', ItemList.Conveyor_Module_UEV, 'C',
                         OrePrefixes.circuit.get(Materials.UIV), 'W',
@@ -3330,7 +3327,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.CircuitAssemblerUIV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RCE", "KHK", "WCW", 'R', ItemList.Robot_Arm_UIV, 'E', ItemList.Emitter_UIV, 'H',
                         ItemList.Hull_UIV, 'K', ItemList.Conveyor_Module_UIV, 'C',
                         OrePrefixes.circuit.get(Materials.UMV), 'W',
@@ -3338,7 +3335,7 @@ public class GT_Loader_Machines {
 
         GTModHandler.addCraftingRecipe(
                 ItemList.CircuitAssemblerUMV.get(1L),
-                bitsd,
+                GTModHandler.RecipeBits.BITSD,
                 new Object[] { "RCE", "KHK", "WCW", 'R', ItemList.Robot_Arm_UMV, 'E', ItemList.Emitter_UMV, 'H',
                         ItemList.Hull_UMV, 'K', ItemList.Conveyor_Module_UMV, 'C',
                         OrePrefixes.circuit.get(Materials.UXV), 'W',


### PR DESCRIPTION
for compatibility with changes made into GT https://github.com/GTNewHorizons/GT5-Unofficial/pull/4643

I also deleted the BITSD parameter from calls to GTModHandler.addMachineCraftingRecipe as it is now the default