### PR TITLE
Convert Travellers Gear armor stands to a chest

### DIFF
--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -10,6 +10,7 @@ import static gregtech.api.enums.Mods.Railcraft;
 import static gregtech.api.enums.Mods.SGCraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.TinkerConstruct;
+import static gregtech.api.enums.Mods.TravellersGear;
 import static gregtech.api.enums.Mods.TwilightForest;
 import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.enums.Mods.ZTones;
@@ -77,6 +78,7 @@ import com.dreammaster.scripts.ScriptLoader;
 import com.dreammaster.thaumcraft.TCLoader;
 import com.dreammaster.tinkersConstruct.SmelteryFluidTypes;
 import com.dreammaster.tinkersConstruct.TiCoLoader;
+import com.dreammaster.travellersgear.TGConverter;
 import com.dreammaster.witchery.WitcheryPlugin;
 
 import bartworks.system.material.WerkstoffLoader;
@@ -516,6 +518,8 @@ public class MainRegistry {
         if (Thaumcraft.isModLoaded()) TCLoader.run();
 
         if (TinkerConstruct.isModLoaded()) TiCoLoader.doPostInitialization();
+
+        if (!TravellersGear.isModLoaded()) TGConverter.doPostInitialization();
     }
 
     @Mod.EventHandler

--- a/src/main/java/com/dreammaster/travellersgear/TGConverter.java
+++ b/src/main/java/com/dreammaster/travellersgear/TGConverter.java
@@ -1,0 +1,43 @@
+package com.dreammaster.travellersgear;
+
+import static com.gtnewhorizons.postea.utility.PosteaUtilities.cleanseNBT;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+
+import com.gtnewhorizons.postea.api.TileEntityReplacementManager;
+import com.gtnewhorizons.postea.utility.BlockInfo;
+
+import cpw.mods.fml.common.registry.GameRegistry;
+
+public class TGConverter {
+
+    public static void doPostInitialization() {
+        TileEntityReplacementManager.tileEntityTransformer(
+                "TravellersGear.ArmorStand",
+                (tag, world) -> new BlockInfo(Blocks.chest, 0, TGConverter::chestTransformer));
+    }
+
+    private static NBTTagCompound chestTransformer(NBTTagCompound oldTag) {
+        NBTTagList items = oldTag.getTagList("Inv", 10);
+
+        // These armor stands had recipes to swap between them before. Seems fair to give this one.
+        Item stand = GameRegistry.findItem("BiblioCraft", "Armor Stand");
+        if (stand != null) {
+            NBTTagCompound replacementStand = new NBTTagCompound();
+            replacementStand.setByte("Count", (byte) 1);
+            replacementStand.setByte("Slot", (byte) 26);
+            replacementStand.setShort("Damage", (short) 0);
+            replacementStand.setShort("id", (short) Item.getIdFromItem(stand));
+            items.appendTag(replacementStand);
+        }
+
+        NBTTagCompound newTag = cleanseNBT("Chest", oldTag);
+
+        newTag.setTag("Items", items);
+
+        return newTag;
+    }
+}


### PR DESCRIPTION
Chest contains the stand's items and a Bibliocraft armor stand (they were interchangeable before TG was removed).
Only happens when TG is not loaded.

Example (TG items aren't transferred, obviously):
<img width="694" height="435" alt="image" src="https://github.com/user-attachments/assets/1346b574-74f2-4441-bdc1-1069e3ae1559" />
<img width="691" height="335" alt="image" src="https://github.com/user-attachments/assets/c6989620-f994-491d-8149-73fa5328d7b1" />
