### PR TITLE
Gets Rid of Duplicate Tumbaga Recipes

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptGregtechPlusPlus.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGregtechPlusPlus.java
@@ -58,40 +58,6 @@ public class ScriptGregtechPlusPlus implements IScriptLoader {
     @Override
     public void loadRecipes() {
 
-        addShapedRecipe(
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                "craftingToolFile",
-                null,
-                null,
-                null,
-                MaterialsAlloy.TUMBAGA.getIngot(1),
-                null,
-                null,
-                null,
-                null);
-        addShapedRecipe(
-                MaterialsAlloy.TUMBAGA.getFrameBox(2),
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                "craftingToolWrench",
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                MaterialsAlloy.TUMBAGA.getRod(1));
-        addShapedRecipe(
-                MaterialsAlloy.TUMBAGA.getGear(1),
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                MaterialsAlloy.TUMBAGA.getPlate(1),
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                MaterialsAlloy.TUMBAGA.getPlate(1),
-                "craftingToolWrench",
-                MaterialsAlloy.TUMBAGA.getPlate(1),
-                MaterialsAlloy.TUMBAGA.getRod(1),
-                MaterialsAlloy.TUMBAGA.getPlate(1),
-                MaterialsAlloy.TUMBAGA.getRod(1));
-
         // Fish Trap
         addShapedRecipe(
                 GregtechItemList.FishTrap.get(1),


### PR DESCRIPTION
### Changes:
As title states, there were duplicate recipes for tumbaga gear, frame box, and rod. I assume they were put their initially as supplemental but they are no longer needed. 

This will fix and close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20602