### PR TITLE
GC Raw Meteoric Iron OreDict

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
@@ -142,6 +142,10 @@ public class GT_Loader_OreDictionary extends gregtech.loaders.preload.LoaderGTOr
                 .registerOre(OrePrefixes.bars, Materials.TungstenSteel, NHItemList.TungstenSteelBars.getIS());
 
         GTOreDictUnificator.registerOre(
+                OrePrefixes.rawOre,
+                Materials.MeteoricIron,
+                GTModHandler.getModItem(GalacticraftCore.ID, "item.meteoricIronRaw", 1L));
+        GTOreDictUnificator.registerOre(
                 OrePrefixes.ore,
                 Materials.Desh,
                 GTModHandler.getModItem(GalacticraftMars.ID, "tile.mars", 1L, 2));

--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -1841,12 +1841,6 @@ public class ScriptGalacticraft implements IScriptLoader {
         GTValues.RA.stdBuilder().itemInputs(getModItem(GalacticraftMars.ID, "item.itemBasicAsteroids", 2, 4, missing))
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Titanium, 1L))
                 .duration(1 * MINUTES + 15 * SECONDS).eut(120).specialValue(1500).addTo(blastFurnaceRecipes);
-        GTValues.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "item.meteoricIronRaw", 1, 0, missing))
-                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.MeteoricIron, 1L))
-                .duration(1 * MINUTES).eut(120).specialValue(1000).addTo(blastFurnaceRecipes);
-        GTValues.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "tile.fallenMeteor", 1, 0, missing))
-                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.MeteoricIron, 2L))
-                .duration(1 * MINUTES).eut(120).specialValue(1000).addTo(blastFurnaceRecipes);
     }
 
     private void cannerRecipes() {


### PR DESCRIPTION
I have been staring at Galacticraft's Raw Meteoric Iron and thinking, With the addition of Raw Ores in 2.7.0, it would be perfect if it had the same OreDict with GT's Raw Meteoric Iron.

For this to work without issue, I had to remove the recipes for Meteoric Iron in the EBF using the Fallen Meteor and Raw Meteoric Iron.
<img width="496" height="95" alt="Meteoric Iron Before" src="https://github.com/user-attachments/assets/ca9a4322-5fe6-4c4e-a5ed-f74ef1263159" />
<img width="682" height="119" alt="Meteoric Iron After" src="https://github.com/user-attachments/assets/022f1f10-2155-49e1-a62a-c9062d3bca38" />

New EBF Recipes
<img width="506" height="912" alt="EBF Recipes" src="https://github.com/user-attachments/assets/07949fe9-9e79-402a-aea9-3c258557926a" />

New Macerator Recipes
<img width="427" height="334" alt="Macerator Recipes" src="https://github.com/user-attachments/assets/532b3020-3688-4412-9b87-c8e27df62cdd" />
The Recipes above are all Ore Dictionaried with GT's Raw Meteoric Iron.

This also works when mining the Fallen Meteor to produce GT's Raw Meteoric Iron.

https://github.com/user-attachments/assets/80c03166-2e01-4605-8a18-ec3d95a1d628