### PR TITLE
Allow EFR blastfurnace to be used as iron furnace in recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_OreDictionary.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.BloodArsenal;
 import static gregtech.api.enums.Mods.Computronics;
 import static gregtech.api.enums.Mods.EnderIO;
+import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.GalacticraftCore;
@@ -338,5 +339,10 @@ public class GT_Loader_OreDictionary extends gregtech.loaders.preload.LoaderGTOr
         // Add ore dictionary entries for sand and red sand to craft unfired coke oven bricks.
         GTOreDictUnificator.registerOre("sand", new ItemStack(Blocks.sand, 1, 0));
         GTOreDictUnificator.registerOre("sand", new ItemStack(Blocks.sand, 1, 1));
+
+        // Allow EFR blast furnace to be used instead of GT iron furnace.
+        GTOreDictUnificator.registerOre(
+                "craftingIronFurnace",
+                GTModHandler.getModItem(EtFuturumRequiem.ID, "blast_furnace", 1L, 0));
     }
 }


### PR DESCRIPTION
This is part of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20717 and allows all remaining recipes (besides a bartworks sterling water pump recipe, addressed in a second PR in GT-U) to use EFR Blast furnace as a substitute for Ic2 iron furnace. Tested against latest nightly. Will adjust quests in a seperate PR, but does not block this as iron furnace is still allowed for any of the quests at issue (such as small coal boiler)