### PR TITLE
refactor infusion recipes to use oredict strict variants from tc4tweaks api

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,6 +7,8 @@ dependencies {
 
     implementation("com.github.GTNewHorizons:GTNHLib:0.6.38:dev")
 
+    implementation("net.glease:tc4recipelib:1.5.37:dev")
+
     compileOnly("com.github.GTNewHorizons:AkashicTome:1.2.6:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Avaritia:1.72:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Irontanks:1.4.2:dev") { transitive = false }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -14,4 +14,15 @@ repositories {
             artifact()
         }
     }
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = 'glease'
+                url = 'https://maven.glease.net/repos/releases/'
+            }
+        }
+        filter {
+            includeGroup('net.glease')
+        }
+    }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptAutomagy.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAutomagy.java
@@ -604,7 +604,7 @@ public class ScriptAutomagy implements IScriptLoader {
                 GTOreDictUnificator.get(OrePrefixes.ingot, Materials.InfusedGold, 1L))
                         .setPages(new ResearchPage("tc.research_page.InfusedGoldGTNH.1"))
                         .setParents("INFUSION", "THAUMIUM").registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "InfusedGoldGTNH",
                 GTOreDictUnificator.get(OrePrefixes.ingot, Materials.InfusedGold, 1L),
                 2,
@@ -612,10 +612,10 @@ public class ScriptAutomagy implements IScriptLoader {
                         .add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("praecantatio"), 4)
                         .add(Aspect.getAspect("aer"), 4),
                 getModItem(Minecraft.ID, "gold_ingot", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L), });
+                OrePrefixes.dust.get(Materials.Thaumium),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                OrePrefixes.dust.get(Materials.Thaumium));
         TCHelper.addResearchPage(
                 "InfusedGoldGTNH",
                 new ResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptAvaritia.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAvaritia.java
@@ -66,7 +66,6 @@ import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.tools.TinkerTools;
 import tconstruct.tools.items.Pattern;
 import tconstruct.weaponry.TinkerWeaponry;
-import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import vexatos.tgregworks.reference.PartTypes;
@@ -912,30 +911,30 @@ public class ScriptAvaritia implements IScriptLoader {
                 .duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);
 
         TCHelper.removeInfusionRecipe(getModItem(Avaritia.ID, "Akashic_Record", 1, 0, missing));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "AKASHIC",
                 getModItem(Avaritia.ID, "Akashic_Record", 1, 0, missing),
                 24,
                 new AspectList().add(Aspect.getAspect("praecantatio"), 512).add(Aspect.getAspect("cognitio"), 128)
                         .add(Aspect.getAspect("sensus"), 96).add(Aspect.getAspect("luxuria"), 96)
                         .add(Aspect.getAspect("tempus"), 64).add(Aspect.getAspect("terminus"), 128),
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Infinity, 1L),
-                new ItemStack[] { getModItem(TaintedMagic.ID, "ItemFocusTime", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(Avaritia.ID, "big_pearl", 1, 0, missing),
-                        getModItem(Gadomancy.ID, "BlockKnowledgeBook", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
-                        getModItem(TaintedMagic.ID, "ItemFocusMeteorology", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 1, missing),
-                        getModItem(Gadomancy.ID, "BlockKnowledgeBook", 1, 0, missing),
-                        getModItem(Avaritia.ID, "big_pearl", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing), });
+                OrePrefixes.plate.get(Materials.Infinity),
+                getModItem(TaintedMagic.ID, "ItemFocusTime", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(Avaritia.ID, "big_pearl", 1, 0, missing),
+                getModItem(Gadomancy.ID, "BlockKnowledgeBook", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
+                getModItem(TaintedMagic.ID, "ItemFocusMeteorology", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 1, missing),
+                getModItem(Gadomancy.ID, "BlockKnowledgeBook", 1, 0, missing),
+                getModItem(Avaritia.ID, "big_pearl", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing));
         TCHelper.refreshResearchPages("AKASHIC");
 
         registerTinkerPartsRecipes();

--- a/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
@@ -475,7 +475,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                                 new ResearchPage("tc.research_page.LIFEINFUSER.1"),
                                 new ResearchPage("tc.research_page.LIFEINFUSER.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "LIFEINFUSER",
                 getModItem(BloodArsenal.ID, "life_infuser", 1, 0, missing),
                 5,
@@ -483,15 +483,15 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("auram"), 16)
                         .add(Aspect.getAspect("fames"), 8).add(Aspect.getAspect("terra"), 8),
                 getModItem(BloodMagic.ID, "Altar", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.BloodInfusedIron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.BloodInfusedIron, 1L),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "heavyPlate", 1, 251, missing),
-                        getModItem(TinkerConstruct.ID, "heavyPlate", 1, 251, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.BloodInfusedIron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.BloodInfusedIron, 1L), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                OrePrefixes.stickLong.get(Materials.BloodInfusedIron),
+                OrePrefixes.stickLong.get(Materials.BloodInfusedIron),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "heavyPlate", 1, 251, missing),
+                getModItem(TinkerConstruct.ID, "heavyPlate", 1, 251, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                OrePrefixes.stickLong.get(Materials.BloodInfusedIron),
+                OrePrefixes.stickLong.get(Materials.BloodInfusedIron));
         TCHelper.addResearchPage(
                 "LIFEINFUSER",
                 new ResearchPage(
@@ -629,7 +629,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                                 new ResearchPage("tc.research_page.ALCHEMICCHEMSTRYSET.1"),
                                 new ResearchPage("tc.research_page.ALCHEMICCHEMSTRYSET.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ALCHEMICCHEMSTRYSET",
                 getModItem(BloodMagic.ID, "blockWritingTable", 1, 0, missing),
                 5,
@@ -637,13 +637,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("victus"), 12)
                         .add(Aspect.getAspect("ignis"), 12),
                 getModItem(Minecraft.ID, "brewing_stand", 1, 0, missing),
-                new ItemStack[] { Materials.LifeEssence.getCells(1),
-                        getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing), Materials.LifeEssence.getCells(1),
-                        getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing), Materials.LifeEssence.getCells(1),
-                        getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing), Materials.LifeEssence.getCells(1),
-                        getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing), Materials.LifeEssence.getCells(1),
-                        getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing), Materials.LifeEssence.getCells(1),
-                        getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing), });
+                Materials.LifeEssence.getCells(1),
+                getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing),
+                Materials.LifeEssence.getCells(1),
+                getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing),
+                Materials.LifeEssence.getCells(1),
+                getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing),
+                Materials.LifeEssence.getCells(1),
+                getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing),
+                Materials.LifeEssence.getCells(1),
+                getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing),
+                Materials.LifeEssence.getCells(1),
+                getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "ALCHEMICCHEMSTRYSET",
                 new ResearchPage(
@@ -661,7 +666,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing))
                         .setParents("INFUSION", "ALCHEMICCHEMSTRYSET").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.AMORPHICCATALYST")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "AMORPHICCATALYST",
                 getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
                 5,
@@ -669,16 +674,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("aer"), 16)
                         .add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("perditio"), 16),
                 getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "simpleCatalyst", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "crystallos", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "sanctus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "crepitous", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "simpleCatalyst", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
+                getModItem(BloodMagic.ID, "crystallos", 1, 0, missing),
+                getModItem(BloodMagic.ID, "sanctus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(BloodMagic.ID, "crepitous", 1, 0, missing),
+                getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing));
         TCHelper.addResearchPage(
                 "AMORPHICCATALYST",
                 new ResearchPage(
@@ -696,7 +701,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0, missing))
                         .setParents("INFUSION", "AMORPHICCATALYST").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.BIDIAMONDBLOCK")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "BIDIAMONDBLOCK",
                 getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0, missing),
                 7,
@@ -704,15 +709,15 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("victus"), 24).add(Aspect.getAspect("ignis"), 48)
                         .add(Aspect.getAspect("aqua"), 64).add(Aspect.getAspect("perditio"), 16),
                 getModItem(Minecraft.ID, "diamond_block", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing), });
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0, missing));
         TCHelper.addResearchPage(
                 "BIDIAMONDBLOCK",
                 new ResearchPage(
@@ -734,7 +739,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                                 new ResearchPage("tc.research_page.DIVINATIONSIGIL.1"),
                                 new ResearchPage("tc.research_page.DIVINATIONSIGIL.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "DIVINATIONSIGIL",
                 getModItem(BloodMagic.ID, "divinationSigil", 1, 0, missing),
                 3,
@@ -742,14 +747,14 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("instrumentum"), 6)
                         .add(Aspect.getAspect("metallum"), 4),
                 getModItem(BloodMagic.ID, "blankSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing));
         TCHelper.addResearchPage(
                 "DIVINATIONSIGIL",
                 new ResearchPage(
@@ -769,7 +774,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                                 new ResearchPage("tc.research_page.SPEEDRUNE.1"),
                                 new ResearchPage("tc.research_page.SPEEDRUNE.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SPEEDRUNE",
                 getModItem(BloodMagic.ID, "speedRune", 1, 0, missing),
                 4,
@@ -777,12 +782,12 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 18).add(Aspect.getAspect("aer"), 12)
                         .add(Aspect.getAspect("fames"), 4),
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SPEEDRUNE",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "speedRune", 1, 0, missing))));
@@ -860,7 +865,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "ritualStone", 1, 0, missing)).setParents("INFUSION", "IMPERFECTRITUALSTONE")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.RITUALSTONE"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RITUALSTONE",
                 getModItem(BloodMagic.ID, "ritualStone", 1, 0, missing),
                 6,
@@ -868,12 +873,12 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("praecantatio"), 3)
                         .add(Aspect.getAspect("aer"), 2),
                 getModItem(BloodMagic.ID, "imperfectRitualStone", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "RITUALSTONE",
                 getModItem(BloodMagic.ID, "ritualStone", 1, 0, missing),
@@ -959,7 +964,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "masterStone", 1, 0, missing)).setParents("INFUSION", "RITUALSTONE")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.MASTERRITUALSTONE"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MASTERRITUALSTONE",
                 getModItem(BloodMagic.ID, "masterStone", 1, 0, missing),
                 8,
@@ -967,16 +972,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("cognitio"), 8),
                 getModItem(BloodMagic.ID, "ritualStone", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing),
-                        getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing), });
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing),
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing));
         TCHelper.addResearchPage(
                 "MASTERRITUALSTONE",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "masterStone", 1, 0, missing))));
@@ -993,7 +998,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "waterSigil", 1, 0, missing)).setParents("INFUSION", "DIVINATIONSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.WATERSIGIL"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WATERSIGIL",
                 getModItem(BloodMagic.ID, "waterSigil", 1, 0, missing),
                 5,
@@ -1001,15 +1006,15 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("instrumentum"), 16)
                         .add(Aspect.getAspect("metallum"), 8),
                 getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(Witchery.ID, "divinerwater", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 1, missing),
-                        getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 1, missing),
-                        getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 1, missing),
-                        getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 1, missing), });
+                getModItem(Witchery.ID, "divinerwater", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 1, missing),
+                getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 1, missing),
+                getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 1, missing),
+                getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 1, missing));
         TCHelper.addResearchPage(
                 "WATERSIGIL",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "waterSigil", 1, 0, missing))));
@@ -1025,7 +1030,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 3,
                 getModItem(BloodMagic.ID, "lavaSigil", 1, 0, missing)).setParents("INFUSION", "SIGILOFTHEBLOODLAMP")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.LAVASIGIL")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "LAVASIGIL",
                 getModItem(BloodMagic.ID, "lavaSigil", 1, 0, missing),
                 7,
@@ -1033,16 +1038,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("instrumentum"), 24)
                         .add(Aspect.getAspect("metallum"), 16),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(Witchery.ID, "divinerlava", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "lavaCrystal", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 2, missing), });
+                getModItem(Witchery.ID, "divinerlava", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 2, missing),
+                getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
+                getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 2, missing),
+                getModItem(BloodMagic.ID, "lavaCrystal", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 2, missing),
+                getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
+                getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 2, missing));
         TCHelper.addResearchPage(
                 "LAVASIGIL",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "lavaSigil", 1, 0, missing))));
@@ -1101,7 +1106,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "lavaCrystal", 1, 0, missing))
                         .setParents("INFUSION", "EMPTYCORE", "LAVACRYSTAL", "WARDEDARCANA").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.BMLAVACRYSTAL")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "BMLAVACRYSTAL",
                 getModItem(BloodMagic.ID, "lavaCrystal", 1, 0, missing),
                 4,
@@ -1109,10 +1114,10 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("infernus"), 6)
                         .add(Aspect.getAspect("aer"), 6),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 1, missing),
-                new ItemStack[] { getModItem(TinkerConstruct.ID, "materials", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing), });
+                getModItem(TinkerConstruct.ID, "materials", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing));
         TCHelper.addResearchPage(
                 "BMLAVACRYSTAL",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "lavaCrystal", 1, 0, missing))));
@@ -1128,7 +1133,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "runeOfSacrifice", 1, 0, missing)).setParents("INFUSION", "SPEEDRUNE")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.RUNESACRIFICE"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNESACRIFICE",
                 getModItem(BloodMagic.ID, "runeOfSacrifice", 1, 0, missing),
                 5,
@@ -1136,14 +1141,14 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 18).add(Aspect.getAspect("praecantatio"), 12)
                         .add(Aspect.getAspect("terra"), 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "RUNESACRIFICE",
                 new ResearchPage(
@@ -1160,7 +1165,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "runeOfSelfSacrifice", 1, 0, missing)).setParents("INFUSION", "SPEEDRUNE")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.RUNESELFSACRIFICE"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNESELFSACRIFICE",
                 getModItem(BloodMagic.ID, "runeOfSelfSacrifice", 1, 0, missing),
                 5,
@@ -1168,14 +1173,14 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 18).add(Aspect.getAspect("praecantatio"), 12)
                         .add(Aspect.getAspect("terra"), 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "sanctus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "sanctus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "sanctus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "sanctus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "RUNESELFSACRIFICE",
                 new ResearchPage(
@@ -1192,7 +1197,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 3,
                 getModItem(BloodMagic.ID, "airSigil", 1, 0, missing)).setParents("INFUSION", "LAVASIGIL").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.AIRSIGIL")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "AIRSIGIL",
                 getModItem(BloodMagic.ID, "airSigil", 1, 0, missing),
                 9,
@@ -1201,18 +1206,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("iter"), 18).add(Aspect.getAspect("potentia"), 12)
                         .add(Aspect.getAspect("cognitio"), 6),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.cell, Materials.Helium, 1L),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.cell, Materials.Helium, 1L),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.cell, Materials.Helium, 1L),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.cell, Materials.Helium, 1L),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing), });
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                OrePrefixes.cell.get(Materials.Helium),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                OrePrefixes.cell.get(Materials.Helium),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                OrePrefixes.cell.get(Materials.Helium),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                OrePrefixes.cell.get(Materials.Helium),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing));
         TCHelper.addResearchPage(
                 "AIRSIGIL",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "airSigil", 1, 0, missing))));
@@ -1229,7 +1234,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "sigilOfTheFastMiner", 1, 0, missing))
                         .setParents("INFUSION", "DIVINATIONSIGIL").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.FASTERMINING")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FASTERMINING",
                 getModItem(BloodMagic.ID, "sigilOfTheFastMiner", 1, 0, missing),
                 5,
@@ -1237,15 +1242,15 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("perfodio"), 12)
                         .add(Aspect.getAspect("motus"), 8),
                 getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemPickThaumium", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemShovelThaumium", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemAxeThaumium", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemPickThaumium", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemShovelThaumium", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemAxeThaumium", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing));
         TCHelper.addResearchPage(
                 "FASTERMINING",
                 new ResearchPage(
@@ -1262,7 +1267,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 3,
                 getModItem(BloodMagic.ID, "growthSigil", 1, 0, missing)).setParents("INFUSION", "DIVINATIONSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.GREENGROW")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "GREENGROW",
                 getModItem(BloodMagic.ID, "growthSigil", 1, 0, missing),
                 5,
@@ -1270,16 +1275,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("herba"), 18).add(Aspect.getAspect("arbor"), 12)
                         .add(Aspect.getAspect("victus"), 8),
                 getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(Witchery.ID, "witchsapling", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
-                        getModItem(Witchery.ID, "witchsapling", 1, 1, missing),
-                        getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 1, missing),
-                        getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "slime.sapling", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "terrae", 1, 0, missing), });
+                getModItem(Witchery.ID, "witchsapling", 1, 0, missing),
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
+                getModItem(Witchery.ID, "witchsapling", 1, 1, missing),
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 1, missing),
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 0, missing),
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "slime.sapling", 1, 0, missing),
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing));
         TCHelper.addResearchPage(
                 "GREENGROW",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "growthSigil", 1, 0, missing))));
@@ -1295,7 +1300,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 3,
                 getModItem(BloodMagic.ID, "voidSigil", 1, 0, missing)).setParents("INFUSION", "WATERSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.VOIDSIGIL")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "VOIDSIGIL",
                 getModItem(BloodMagic.ID, "voidSigil", 1, 0, missing),
                 7,
@@ -1303,18 +1308,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("auram"), 24)
                         .add(Aspect.getAspect("metallum"), 16),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodArsenal.ID, "blood_burned_string", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Minecraft.ID, "bucket", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bucket", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_burned_string", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bucket", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bucket", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                getModItem(BloodArsenal.ID, "blood_burned_string", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_burned_string", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void));
         TCHelper.addResearchPage(
                 "VOIDSIGIL",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "voidSigil", 1, 0, missing))));
@@ -1332,7 +1337,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodArsenal.ID, "sigil_of_swimming", 1, 0, missing)).setParents("INFUSION", "VOIDSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.SIGILOFSWIMMING"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFSWIMMING",
                 getModItem(BloodArsenal.ID, "sigil_of_swimming", 1, 0, missing),
                 12,
@@ -1341,12 +1346,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("auram"), 24)
                         .add(Aspect.getAspect("metallum"), 16),
                 getModItem(BloodMagic.ID, "voidSigil", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        Materials.FishOil.getCells(1), Materials.LiquidOxygen.getCells(1),
-                        Materials.FishOil.getCells(1), Materials.LiquidOxygen.getCells(1),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing), Materials.LiquidOxygen.getCells(1),
-                        Materials.FishOil.getCells(1), Materials.LiquidOxygen.getCells(1),
-                        Materials.FishOil.getCells(1), });
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                Materials.FishOil.getCells(1),
+                Materials.LiquidOxygen.getCells(1),
+                Materials.FishOil.getCells(1),
+                Materials.LiquidOxygen.getCells(1),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                Materials.LiquidOxygen.getCells(1),
+                Materials.FishOil.getCells(1),
+                Materials.LiquidOxygen.getCells(1),
+                Materials.FishOil.getCells(1));
         TCHelper.addResearchPage(
                 "SIGILOFSWIMMING",
                 new ResearchPage(
@@ -1869,7 +1878,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                                 new ResearchPage("tc.research_page.SOULARMORFORGE.1"),
                                 new ResearchPage("tc.research_page.SOULARMORFORGE.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SOULARMORFORGE",
                 getModItem(BloodMagic.ID, "armourForge", 1, 0, missing),
                 7,
@@ -1877,18 +1886,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("auram"), 24)
                         .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("exanimis"), 8),
                 getModItem(TinkerConstruct.ID, "ToolForgeBlock", 1, 6, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "bloodSocket", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 3, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "bloodSocket", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodSocket", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "bloodSocket", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 3, missing), });
+                getModItem(BloodMagic.ID, "bloodSocket", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 3, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
+                getModItem(BloodMagic.ID, "bloodSocket", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodSocket", 1, 0, missing),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
+                getModItem(BloodMagic.ID, "bloodSocket", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 3, missing));
         TCHelper.addResearchPage(
                 "SOULARMORFORGE",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "armourForge", 1, 0, missing))));
@@ -1905,7 +1914,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 1, missing))
                         .setParents("INFUSION", "RUNESACRIFICE").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.RUNEOFARGUMENTEDCAPACITY")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNEOFARGUMENTEDCAPACITY",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 1, missing),
                 7,
@@ -1913,16 +1922,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("fames"), 18).add(Aspect.getAspect("praecantatio"), 12)
                         .add(Aspect.getAspect("terra"), 8).add(Aspect.getAspect("vacuos"), 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing),
-                new ItemStack[] { getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing), });
+                getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "RUNEOFARGUMENTEDCAPACITY",
                 new ResearchPage(
@@ -1939,7 +1948,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 2, missing))
                         .setParents("INFUSION", "RUNESACRIFICE").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.RUNEOFDISLOCATION")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNEOFDISLOCATION",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 2, missing),
                 7,
@@ -1947,15 +1956,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("motus"), 18).add(Aspect.getAspect("tempus"), 12)
                         .add(Aspect.getAspect("terra"), 8).add(Aspect.getAspect("cognitio"), 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 1, missing),
-                new ItemStack[] { ItemList.Electric_Pump_EV.get(1L),
-                        getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing), ItemList.Electric_Pump_EV.get(1L),
-                        getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing), });
+                ItemList.Electric_Pump_EV.get(1L),
+                getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                ItemList.Electric_Pump_EV.get(1L),
+                getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "RUNEOFDISLOCATION",
                 new ResearchPage(
@@ -1975,7 +1985,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "sigilOfElementalAffinity", 1, 0, missing)).setParents("INFUSION", "AIRSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.SIGILOFELEMENTALAFFINITY"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFELEMENTALAFFINITY",
                 getModItem(BloodMagic.ID, "sigilOfElementalAffinity", 1, 0, missing),
                 9,
@@ -1985,18 +1995,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("iter"), 18).add(Aspect.getAspect("potentia"), 12)
                         .add(Aspect.getAspect("cognitio"), 6),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "earthScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "lavaSigil", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "fireScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "waterSigil", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "waterScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "airSigil", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "airScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "earthScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
+                getModItem(BloodMagic.ID, "lavaSigil", 1, 0, missing),
+                getModItem(BloodMagic.ID, "fireScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
+                getModItem(BloodMagic.ID, "waterSigil", 1, 0, missing),
+                getModItem(BloodMagic.ID, "waterScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
+                getModItem(BloodMagic.ID, "airSigil", 1, 0, missing),
+                getModItem(BloodMagic.ID, "airScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFELEMENTALAFFINITY",
                 new ResearchPage(
@@ -2019,7 +2029,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                                 new ResearchPage("tc.research_page.SIGILOFLIGHTNING.1"),
                                 new ResearchPage("tc.research_page.SIGILOFLIGHTNING.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFLIGHTNING",
                 getModItem(BloodArsenal.ID, "sigil_of_lightning", 1, 0, missing),
                 15,
@@ -2028,14 +2038,14 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("tenebrae"), 8)
                         .add(Aspect.getAspect("ira"), 8).add(Aspect.getAspect("electrum"), 16),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "airSigil", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "waterSigil", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "airSigil", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0, missing),
+                getModItem(BloodMagic.ID, "waterSigil", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFLIGHTNING",
                 new ResearchPage(
@@ -2053,7 +2063,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "sigilOfHolding", 1, 0, missing)).setParents("INFUSION", "SIGILOFMAGNETISM")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.SIGILOFHOLDING"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFHOLDING",
                 getModItem(BloodMagic.ID, "sigilOfHolding", 1, 0, missing),
                 9,
@@ -2061,16 +2071,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("gula"), 16).add(Aspect.getAspect("superbia"), 16)
                         .add(Aspect.getAspect("limus"), 16).add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(IronChests.ID, "BlockIronChest", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "crepitous", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "crepitous", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing), });
+                getModItem(IronChests.ID, "BlockIronChest", 1, 0, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(BloodMagic.ID, "crepitous", 1, 0, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "crepitous", 1, 0, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFHOLDING",
                 new ResearchPage(
@@ -2089,7 +2099,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodArsenal.ID, "sigil_of_augmented_holding", 1, 0, missing))
                         .setParents("INFUSION", "SIGILOFHOLDING").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.SIGILOFAUGMENTETHOLDING")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFAUGMENTETHOLDING",
                 getModItem(BloodArsenal.ID, "sigil_of_augmented_holding", 1, 0, missing),
                 15,
@@ -2098,18 +2108,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("superbia"), 16).add(Aspect.getAspect("limus"), 16)
                         .add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(BloodMagic.ID, "sigilOfHolding", 1, 0, missing),
-                new ItemStack[] { getModItem(IronChests.ID, "BlockIronChest", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.BloodInfusedIron, 1L),
-                        getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.BloodInfusedIron, 1L),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing), });
+                getModItem(IronChests.ID, "BlockIronChest", 1, 2, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.BloodInfusedIron),
+                getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.BloodInfusedIron),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFAUGMENTETHOLDING",
                 new ResearchPage(
@@ -2128,7 +2138,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "sigilOfTheBridge", 1, 0, missing)).setParents("INFUSION", "VOIDSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.SIGILOFPHANTOMBRIDGE"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFPHANTOMBRIDGE",
                 getModItem(BloodMagic.ID, "sigilOfTheBridge", 1, 0, missing),
                 9,
@@ -2136,18 +2146,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("iter"), 24).add(Aspect.getAspect("vitreus"), 16)
                         .add(Aspect.getAspect("potentia"), 8).add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 1, missing),
-                        getModItem(EnderIO.ID, "blockIngotStorage", 1, 7, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 1, missing),
-                        getModItem(EnderIO.ID, "blockIngotStorage", 1, 7, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 1, missing),
-                        getModItem(EnderIO.ID, "blockIngotStorage", 1, 7, missing),
-                        getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 1, missing),
-                        getModItem(EnderIO.ID, "blockIngotStorage", 1, 7, missing), });
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 1, missing),
+                getModItem(EnderIO.ID, "blockIngotStorage", 1, 7, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 1, missing),
+                getModItem(EnderIO.ID, "blockIngotStorage", 1, 7, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 1, missing),
+                getModItem(EnderIO.ID, "blockIngotStorage", 1, 7, missing),
+                getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 1, missing),
+                getModItem(EnderIO.ID, "blockIngotStorage", 1, 7, missing));
         TCHelper.addResearchPage(
                 "SIGILOFPHANTOMBRIDGE",
                 new ResearchPage(
@@ -2165,7 +2175,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "sigilOfMagnetism", 1, 0, missing)).setParents("INFUSION", "WATERSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.SIGILOFMAGNETISM"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFMAGNETISM",
                 getModItem(BloodMagic.ID, "sigilOfMagnetism", 1, 0, missing),
                 9,
@@ -2173,18 +2183,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("electrum"), 24).add(Aspect.getAspect("auram"), 16)
                         .add(Aspect.getAspect("cognitio"), 12).add(Aspect.getAspect("praecantatio"), 6),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.block, Materials.NeodymiumMagnetic, 1L),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.NeodymiumMagnetic, 1L),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.NeodymiumMagnetic, 1L),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.NeodymiumMagnetic, 1L),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing), });
+                OrePrefixes.block.get(Materials.NeodymiumMagnetic),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                OrePrefixes.block.get(Materials.NeodymiumMagnetic),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                OrePrefixes.block.get(Materials.NeodymiumMagnetic),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing),
+                OrePrefixes.block.get(Materials.NeodymiumMagnetic),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFMAGNETISM",
                 new ResearchPage(
@@ -2202,7 +2212,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "itemBloodLightSigil", 1, 0, missing)).setParents("INFUSION", "WATERSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.SIGILOFTHEBLOODLAMP"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFTHEBLOODLAMP",
                 getModItem(BloodMagic.ID, "itemBloodLightSigil", 1, 0, missing),
                 4,
@@ -2210,14 +2220,14 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("potentia"), 24)
                         .add(Aspect.getAspect("sensus"), 16).add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(ThaumicTinkerer.ID, "brightNitor", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 6, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 6, missing),
-                        getModItem(ThaumicTinkerer.ID, "brightNitor", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 6, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 6, missing), });
+                getModItem(ThaumicTinkerer.ID, "brightNitor", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 6, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 6, missing),
+                getModItem(ThaumicTinkerer.ID, "brightNitor", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 6, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 2, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 6, missing));
         TCHelper.addResearchPage(
                 "SIGILOFTHEBLOODLAMP",
                 new ResearchPage(
@@ -2235,7 +2245,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "seerSigil", 1, 0, missing)).setParents("INFUSION", "DIVINATIONSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.SIGILOFSIGHT"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFSIGHT",
                 getModItem(BloodMagic.ID, "seerSigil", 1, 0, missing),
                 3,
@@ -2243,14 +2253,14 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("cognitio"), 12).add(Aspect.getAspect("vitreus"), 6)
                         .add(Aspect.getAspect("praecantatio"), 4),
                 getModItem(BloodMagic.ID, "divinationSigil", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "crystallos", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "crystallos", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
+                getModItem(BloodMagic.ID, "crystallos", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing),
+                getModItem(BloodMagic.ID, "crystallos", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "GlassPane", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFSIGHT",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "seerSigil", 1, 0, missing))));
@@ -2266,7 +2276,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 0, missing))
                         .setParents("INFUSION", "MASTERRITUALSTONE").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.RITUALDIVINER.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RITUALDIVINER",
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 0, missing),
                 3,
@@ -2274,22 +2284,22 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("aqua"), 32)
                         .add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("ordo"), 16),
                 getModItem(BloodMagic.ID, "seerSigil", 1, 0, missing),
-                new ItemStack[] { getModItem(Witchery.ID, "chalkritual", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "waterScribeTool", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(BloodMagic.ID, "fireScribeTool", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Emerald, 1L),
-                        getModItem(BloodMagic.ID, "earthScribeTool", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(BloodMagic.ID, "airScribeTool", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Emerald, 1L), });
+                getModItem(Witchery.ID, "chalkritual", 1, 0, missing),
+                getModItem(BloodMagic.ID, "waterScribeTool", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(BloodMagic.ID, "fireScribeTool", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Emerald),
+                getModItem(BloodMagic.ID, "earthScribeTool", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(BloodMagic.ID, "airScribeTool", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Emerald));
         TCHelper.addResearchPage(
                 "RITUALDIVINER",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 0, missing))));
         ThaumcraftApi.addWarpToResearch("RITUALDIVINER", 3);
         TCHelper.addResearchPage("RITUALDIVINER", new ResearchPage("tc.research_page.RITUALDIVINER.2"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RITUALDIVINER",
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 1, missing),
                 6,
@@ -2297,19 +2307,19 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 48).add(Aspect.getAspect("aqua"), 48)
                         .add(Aspect.getAspect("perditio"), 24).add(Aspect.getAspect("ordo"), 24),
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "RITUALDIVINER",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 1, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RITUALDIVINER",
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 2, missing),
                 9,
@@ -2317,14 +2327,14 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 64).add(Aspect.getAspect("aqua"), 64)
                         .add(Aspect.getAspect("perditio"), 32).add(Aspect.getAspect("ordo"), 32),
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 1, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
-                        getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
-                        getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
-                        getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
-                        getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
+                getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
+                getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
+                getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
+                getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing));
         TCHelper.addResearchPage(
                 "RITUALDIVINER",
                 new ResearchPage(
@@ -2341,7 +2351,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 3, missing))
                         .setParents("INFUSION", "RUNESACRIFICE").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.RUNEOFTHEORB")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNEOFTHEORB",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 3, missing),
                 6,
@@ -2349,16 +2359,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("motus"), 16).add(Aspect.getAspect("lucrum"), 8)
                         .add(Aspect.getAspect("praecantatio"), 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 1, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 1, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing), });
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 1, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 1, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing));
         TCHelper.addResearchPage(
                 "RUNEOFTHEORB",
                 new ResearchPage(
@@ -2379,7 +2389,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                                 new ResearchPage("tc.research_page.RUNEOFSUPERIORCAPACITY.1"),
                                 new ResearchPage("tc.research_page.RUNEOFSUPERIORCAPACITY.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNEOFSUPERIORCAPACITY",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 4, missing),
                 8,
@@ -2387,18 +2397,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("cognitio"), 24).add(Aspect.getAspect("lucrum"), 16)
                         .add(Aspect.getAspect("praecantatio"), 8).add(Aspect.getAspect("alienis"), 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
-                new ItemStack[] { getModItem(IronTanks.ID, "diamondTank", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(IronTanks.ID, "diamondTank", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing), });
+                getModItem(IronTanks.ID, "diamondTank", 1, 0, missing),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(IronTanks.ID, "diamondTank", 1, 0, missing),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 3, missing),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "RUNEOFSUPERIORCAPACITY",
                 new ResearchPage(
@@ -2417,7 +2427,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 5, missing))
                         .setParents("INFUSION", "RUNEOFARGUMENTEDCAPACITY", "RUNEOFDISLOCATION").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.RUNEOFACCELERATION")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNEOFACCELERATION",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 5, missing),
                 10,
@@ -2426,17 +2436,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tempus"), 16).add(Aspect.getAspect("praecantatio"), 8)
                         .add(Aspect.getAspect("terra"), 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing), ItemList.Electric_Pump_IV.get(1L),
-                        getModItem(BloodMagic.ID, "speedRune", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing),
-                        ItemList.Electric_Pump_IV.get(1L), });
+                getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 2, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing),
+                ItemList.Electric_Pump_IV.get(1L),
+                getModItem(BloodMagic.ID, "speedRune", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing),
+                ItemList.Electric_Pump_IV.get(1L));
         TCHelper.addResearchPage(
                 "RUNEOFACCELERATION",
                 new ResearchPage(
@@ -2458,7 +2469,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                                 new ResearchPage("tc.research_page.RUNEOFQUICKNESS.1"),
                                 new ResearchPage("tc.research_page.RUNEOFQUICKNESS.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNEOFQUICKNESS",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 6, missing),
                 15,
@@ -2467,18 +2478,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tempus"), 32).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("terra"), 8),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 5, missing),
-                        ItemList.AcceleratorLuV.get(1L, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
-                        getModItem(BloodMagic.ID, "speedRune", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing),
-                        getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 5, missing),
-                        ItemList.AcceleratorLuV.get(1L, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
-                        getModItem(BloodMagic.ID, "speedRune", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing), });
+                getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 5, missing),
+                ItemList.AcceleratorLuV.get(1L, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
+                getModItem(BloodMagic.ID, "speedRune", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing),
+                getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 5, missing),
+                ItemList.AcceleratorLuV.get(1L, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24, missing),
+                getModItem(BloodMagic.ID, "speedRune", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing));
         TCHelper.addResearchPage(
                 "RUNEOFQUICKNESS",
                 new ResearchPage(
@@ -2528,7 +2539,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         TCHelper.addResearchPage(
                 "ARCANEPEDESTALANDPLINTH",
                 new ResearchPage("tc.research_page.ARCANEPEDESTALANDPLINTH.2"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ARCANEPEDESTALANDPLINTH",
                 getModItem(BloodMagic.ID, "blockPlinth", 1, 0, missing),
                 10,
@@ -2536,18 +2547,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("tenebrae"), 24)
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("alienis"), 8),
                 getModItem(BloodMagic.ID, "blockPedestal", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 130, missing),
-                        getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 130, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 130, missing),
-                        getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 130, missing), });
+                getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 130, missing),
+                getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
+                getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 130, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 130, missing),
+                getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0, missing),
+                getModItem(BloodMagic.ID, "weakBloodShard", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 130, missing));
         TCHelper.addResearchPage(
                 "ARCANEPEDESTALANDPLINTH",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "blockPlinth", 1, 0, missing))));
@@ -2791,7 +2802,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "blockCrystal", 1, 0, missing)).setParents("INFUSION", "RUNEOFACCELERATION")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.CRYSTALCLUSTER"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CRYSTALCLUSTER",
                 getModItem(BloodMagic.ID, "blockCrystal", 1, 0, missing),
                 15,
@@ -2800,16 +2811,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("alienis"), 16)
                         .add(Aspect.getAspect("cognitio"), 16),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing), });
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing));
         TCHelper.addResearchPage(
                 "CRYSTALCLUSTER",
                 new ResearchPage(
@@ -2831,7 +2842,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                                 new ResearchPage("tc.research_page.ICHORIUMBLOCK.1"),
                                 new ResearchPage("tc.research_page.ICHORIUMBLOCK.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHORIUMBLOCK",
                 GTOreDictUnificator.get(OrePrefixes.block, Materials.Ichorium, 1L),
                 12,
@@ -2840,14 +2851,14 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("superbia"), 16)
                         .add(Aspect.getAspect("terra"), 8),
                 BlockList.Mytryl.getIS(),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "standardBindingAgent", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 4, missing), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
+                getModItem(BloodMagic.ID, "standardBindingAgent", 1, 0, missing),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 4, missing));
         TCHelper.addResearchPage(
                 "ICHORIUMBLOCK",
                 new ResearchPage(
@@ -3054,7 +3065,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "sigilOfHaste", 1, 0, missing)).setParents("INFUSION", "AIRSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.SIGILOFHASTE"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFHASTE",
                 getModItem(BloodMagic.ID, "sigilOfHaste", 1, 0, missing),
                 8,
@@ -3063,16 +3074,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("alienis"), 8)
                         .add(Aspect.getAspect("cognitio"), 8),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(Minecraft.ID, "cookie", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(Minecraft.ID, "sugar", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(Minecraft.ID, "sugar", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(Minecraft.ID, "cookie", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(Minecraft.ID, "cookie", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(Minecraft.ID, "sugar", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(Minecraft.ID, "sugar", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(Minecraft.ID, "cookie", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFHASTE",
                 new ResearchPage(
@@ -3091,7 +3102,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "sigilOfWind", 1, 0, missing)).setParents("INFUSION", "AIRSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.SIGILOFWHIRLWIND"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFWHIRLWIND",
                 getModItem(BloodMagic.ID, "sigilOfWind", 1, 0, missing),
                 12,
@@ -3100,18 +3111,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("sano"), 16).add(Aspect.getAspect("cognitio"), 16)
                         .add(Aspect.getAspect("superbia"), 8).add(Aspect.getAspect("nebrisum"), 8),
                 getModItem(BloodMagic.ID, "airSigil", 1, 0, missing),
-                new ItemStack[] { getModItem(TwilightForest.ID, "item.tfFeather", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(TwilightForest.ID, "item.tfFeather", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing), });
+                getModItem(TwilightForest.ID, "item.tfFeather", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(TwilightForest.ID, "item.tfFeather", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFWHIRLWIND",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodMagic.ID, "sigilOfWind", 1, 0, missing))));
@@ -3129,7 +3140,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "sigilOfSupression", 1, 0, missing)).setParents("INFUSION", "VOIDSIGIL")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.SIGILOFSUPRESSION"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFSUPRESSION",
                 getModItem(BloodMagic.ID, "sigilOfSupression", 1, 0, missing),
                 15,
@@ -3138,18 +3149,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("terra"), 32)
                         .add(Aspect.getAspect("motus"), 16),
                 getModItem(BloodMagic.ID, "voidSigil", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "blockTeleposer", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bucket", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bucket", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bucket", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bucket", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bucket", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "blockTeleposer", 1, 0, missing),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFSUPRESSION",
                 new ResearchPage(
@@ -3168,7 +3179,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "sigilOfEnderSeverance", 1, 0, missing))
                         .setParents("INFUSION", "SIGILOFELEMENTALAFFINITY", "OCULUS").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.SIGILOFENDERSEVERANCE")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFENDERSEVERANCE",
                 getModItem(BloodMagic.ID, "sigilOfEnderSeverance", 1, 0, missing),
                 17,
@@ -3177,16 +3188,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vinculum"), 48).add(Aspect.getAspect("limus"), 32)
                         .add(Aspect.getAspect("nebrisum"), 8),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(StevesCarts2.ID, "ModuleComponents", 1, 45, missing),
-                        getModItem(TinkerConstruct.ID, "slime.gel", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 7, missing),
-                        ItemList.QuantumEye.get(1L),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 7, missing),
-                        getModItem(TinkerConstruct.ID, "slime.gel", 1, 2, missing),
-                        getModItem(StevesCarts2.ID, "ModuleComponents", 1, 45, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(StevesCarts2.ID, "ModuleComponents", 1, 45, missing),
+                getModItem(TinkerConstruct.ID, "slime.gel", 1, 2, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 7, missing),
+                ItemList.QuantumEye.get(1L),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 7, missing),
+                getModItem(TinkerConstruct.ID, "slime.gel", 1, 2, missing),
+                getModItem(StevesCarts2.ID, "ModuleComponents", 1, 45, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFENDERSEVERANCE",
                 new ResearchPage(
@@ -3206,7 +3217,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodArsenal.ID, "sigil_of_ender", 1, 0, missing))
                         .setParents("INFUSION", "SIGILOFENDERSEVERANCE").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.ENDERSIGIL")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ENDERSIGIL",
                 getModItem(BloodArsenal.ID, "sigil_of_ender", 1, 0, missing),
                 20,
@@ -3215,12 +3226,15 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("vinculum"), 48)
                         .add(Aspect.getAspect("limus"), 32).add(Aspect.getAspect("nebrisum"), 8),
                 getModItem(BloodMagic.ID, "sigilOfEnderSeverance", 1, 0, missing),
-                new ItemStack[] { getModItem(EnderStorage.ID, "enderChest", 1, 0, missing), ItemList.Gravistar.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.HeeEndium, 1L),
-                        ItemList.QuantumEye.get(1L), getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ender_eye", 1, 0, missing), ItemList.QuantumEye.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.HeeEndium, 1L),
-                        ItemList.Gravistar.get(1L), });
+                getModItem(EnderStorage.ID, "enderChest", 1, 0, missing),
+                ItemList.Gravistar.get(1L),
+                OrePrefixes.plate.get(Materials.HeeEndium),
+                ItemList.QuantumEye.get(1L),
+                getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
+                getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
+                ItemList.QuantumEye.get(1L),
+                OrePrefixes.plate.get(Materials.HeeEndium),
+                ItemList.Gravistar.get(1L));
         TCHelper.addResearchPage(
                 "ENDERSIGIL",
                 new ResearchPage(
@@ -3239,7 +3253,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodArsenal.ID, "sigil_of_divinity", 1, 0, missing))
                         .setParents("INFUSION", "SIGILOFENDERSEVERANCE").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.SIGILOFDIVINITY")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFDIVINITY",
                 getModItem(BloodArsenal.ID, "sigil_of_divinity", 1, 0, missing),
                 25,
@@ -3248,17 +3262,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("ordo"), 32)
                         .add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("sano"), 8),
                 getModItem(BloodMagic.ID, "sigilOfElementalAffinity", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing),
-                        getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "diamondApple", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing), ItemList.Gravistar.get(1L),
-                        getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "diamondApple", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing), });
+                getModItem(BloodArsenal.ID, "blood_stone", 1, 4, missing),
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "diamondApple", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                ItemList.Gravistar.get(1L),
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "diamondApple", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SIGILOFDIVINITY",
                 new ResearchPage(
@@ -3277,7 +3292,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "itemHarvestSigil", 1, 0, missing))
                         .setParents("INFUSION", "SIGILOFENDERSEVERANCE").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.HARVESTGODDESSSIGIL")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "HARVESTGODDESSSIGIL",
                 getModItem(BloodMagic.ID, "itemHarvestSigil", 1, 0, missing),
                 20,
@@ -3286,14 +3301,14 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("cognitio"), 24).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("alienis"), 16),
                 getModItem(BloodMagic.ID, "growthSigil", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodArsenal.ID, "bound_sickle", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 2, missing), });
+                getModItem(BloodArsenal.ID, "bound_sickle", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 2, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 2, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 2, missing));
         TCHelper.addResearchPage(
                 "HARVESTGODDESSSIGIL",
                 new ResearchPage(
@@ -3311,7 +3326,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "itemCompressionSigil", 1, 0, missing))
                         .setParents("INFUSION", "SIGILOFMAGNETISM").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.SIGILOFCOMPRESSION")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SIGILOFCOMPRESSION",
                 getModItem(BloodMagic.ID, "itemCompressionSigil", 1, 0, missing),
                 10,
@@ -3319,11 +3334,14 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("machina"), 16).add(Aspect.getAspect("lucrum"), 16)
                         .add(Aspect.getAspect("superbia"), 8),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        ItemList.Electric_Piston_IV.get(1L), ItemList.Cover_Crafting.get(1L),
-                        ItemList.Electric_Motor_IV.get(1L), getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        ItemList.Electric_Motor_IV.get(1L), ItemList.Cover_Crafting.get(1L),
-                        ItemList.Electric_Piston_IV.get(1L), });
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                ItemList.Electric_Piston_IV.get(1L),
+                ItemList.Cover_Crafting.get(1L),
+                ItemList.Electric_Motor_IV.get(1L),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                ItemList.Electric_Motor_IV.get(1L),
+                ItemList.Cover_Crafting.get(1L),
+                ItemList.Electric_Piston_IV.get(1L));
         TCHelper.addResearchPage(
                 "SIGILOFCOMPRESSION",
                 new ResearchPage(
@@ -3386,7 +3404,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "energyBazookaSecondTier", 1, 0, missing))
                         .setParents("INFUSION", "ENERGYBAZOOKAI").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.ENERGYBAZOOKAII")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ENERGYBAZOOKAII",
                 getModItem(BloodMagic.ID, "energyBazookaSecondTier", 1, 0, missing),
                 15,
@@ -3395,16 +3413,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("superbia"), 32).add(Aspect.getAspect("fames"), 32)
                         .add(Aspect.getAspect("nebrisum"), 16).add(Aspect.getAspect("ira"), 8),
                 getModItem(BloodMagic.ID, "energyBazooka", 1, 0, missing),
-                new ItemStack[] { getModItem(DraconicEvolution.ID, "draconium", 1, 2, missing),
-                        getModItem(DraconicEvolution.ID, "draconicCore", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing),
-                        getModItem(DraconicEvolution.ID, "wyvernCore", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
-                        getModItem(DraconicEvolution.ID, "draconium", 1, 2, missing),
-                        getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
-                        getModItem(DraconicEvolution.ID, "draconicCore", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing),
-                        getModItem(DraconicEvolution.ID, "wyvernCore", 1, 0, missing), });
+                getModItem(DraconicEvolution.ID, "draconium", 1, 2, missing),
+                getModItem(DraconicEvolution.ID, "draconicCore", 1, 0, missing),
+                getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing),
+                getModItem(DraconicEvolution.ID, "wyvernCore", 1, 0, missing),
+                getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
+                getModItem(DraconicEvolution.ID, "draconium", 1, 2, missing),
+                getModItem(BloodMagic.ID, "duskScribeTool", 1, 0, missing),
+                getModItem(DraconicEvolution.ID, "draconicCore", 1, 0, missing),
+                getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0, missing),
+                getModItem(DraconicEvolution.ID, "wyvernCore", 1, 0, missing));
         TCHelper.addResearchPage(
                 "ENERGYBAZOOKAII",
                 new ResearchPage(
@@ -3425,7 +3443,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "energyBazookaThirdTier", 1, 0, missing))
                         .setParents("INFUSION", "ENERGYBAZOOKAII").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.ENERGYBAZOOKAIII")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ENERGYBAZOOKAIII",
                 getModItem(BloodMagic.ID, "energyBazookaThirdTier", 1, 0, missing),
                 20,
@@ -3435,15 +3453,15 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("fames"), 32).add(Aspect.getAspect("nebrisum"), 16)
                         .add(Aspect.getAspect("ira"), 8),
                 getModItem(BloodMagic.ID, "energyBazookaSecondTier", 1, 0, missing),
-                new ItemStack[] { getModItem(Avaritia.ID, "big_pearl", 1, 0, missing),
-                        getModItem(Avaritia.ID, "Resource", 1, 6, missing),
-                        getModItem(DraconicEvolution.ID, "awakenedCore", 1, 0, missing),
-                        getModItem(Avaritia.ID, "Resource_Block", 1, 0, missing),
-                        getModItem(Avaritia.ID, "Resource", 1, 6, missing),
-                        getModItem(Avaritia.ID, "Resource", 1, 6, missing),
-                        getModItem(Avaritia.ID, "Resource_Block", 1, 0, missing),
-                        getModItem(DraconicEvolution.ID, "chaoticCore", 1, 0, missing),
-                        getModItem(Avaritia.ID, "Resource", 1, 6, missing), });
+                getModItem(Avaritia.ID, "big_pearl", 1, 0, missing),
+                getModItem(Avaritia.ID, "Resource", 1, 6, missing),
+                getModItem(DraconicEvolution.ID, "awakenedCore", 1, 0, missing),
+                getModItem(Avaritia.ID, "Resource_Block", 1, 0, missing),
+                getModItem(Avaritia.ID, "Resource", 1, 6, missing),
+                getModItem(Avaritia.ID, "Resource", 1, 6, missing),
+                getModItem(Avaritia.ID, "Resource_Block", 1, 0, missing),
+                getModItem(DraconicEvolution.ID, "chaoticCore", 1, 0, missing),
+                getModItem(Avaritia.ID, "Resource", 1, 6, missing));
         TCHelper.addResearchPage(
                 "ENERGYBAZOOKAIII",
                 new ResearchPage(
@@ -3452,7 +3470,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addWarpToResearch("ENERGYBAZOOKAIII", 20);
         TCHelper.clearPages("CAP_blood_iron");
         TCHelper.addResearchPage("CAP_blood_iron", new ResearchPage("blood_arsenal.research_page.CAP_blood_iron.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_blood_iron",
                 getModItem(BloodArsenal.ID, "wand_caps", 1, 0, missing),
                 10,
@@ -3460,18 +3478,18 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("victus"), 24).add(Aspect.getAspect("metallum"), 16)
                         .add(Aspect.getAspect("ignis"), 8),
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.BloodInfusedIron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.BloodInfusedIron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.BloodInfusedIron, 1L),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.BloodInfusedIron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.BloodInfusedIron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.BloodInfusedIron, 1L),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing), });
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.BloodInfusedIron),
+                OrePrefixes.ring.get(Materials.BloodInfusedIron),
+                OrePrefixes.plate.get(Materials.BloodInfusedIron),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.BloodInfusedIron),
+                OrePrefixes.ring.get(Materials.BloodInfusedIron),
+                OrePrefixes.plate.get(Materials.BloodInfusedIron),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing));
         TCHelper.addResearchPage(
                 "CAP_blood_iron",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodArsenal.ID, "wand_caps", 1, 0, missing))));
@@ -3485,7 +3503,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         TCHelper.clearPages("ROD_blood_wood");
         TCHelper.addResearchPage("ROD_blood_wood", new ResearchPage("blood_arsenal.research_page.ROD_blood_wood.1"));
         TCHelper.addResearchPage("ROD_blood_wood", new ResearchPage("blood_arsenal.research_page.ROD_blood_wood.2"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_blood_wood",
                 getModItem(BloodArsenal.ID, "wand_cores", 1, 0, missing),
                 8,
@@ -3493,16 +3511,16 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("victus"), 32).add(Aspect.getAspect("arbor"), 16)
                         .add(Aspect.getAspect("potentia"), 8),
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 3, missing),
-                new ItemStack[] { getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing), });
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing));
         TCHelper.addResearchPage(
                 "ROD_blood_wood",
                 new ResearchPage(
@@ -3529,7 +3547,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .setParents("ROD_blood_staff", "ROD_blood_wood").setConcealed().setSpecial()
                         .setPages(new ResearchPage("blood_arsenal.research_page.ROD_blood_wood_staff.1"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RODBLOODWOODSTAFF",
                 getModItem(BloodArsenal.ID, "wand_cores", 1, 1, missing),
                 12,
@@ -3538,20 +3556,20 @@ public class ScriptBloodMagic implements IScriptLoader {
                         .add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("ignis"), 16)
                         .add(Aspect.getAspect("infernus"), 8).add(Aspect.getAspect("arbor"), 32),
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 9, missing),
-                new ItemStack[] { getModItem(BloodArsenal.ID, "wand_cores", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "wand_cores", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
-                        getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing), });
+                getModItem(BloodArsenal.ID, "wand_cores", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "wand_cores", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_wood", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0, missing),
+                getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0, missing));
         TCHelper.addResearchPage(
                 "RODBLOODWOODSTAFF",
                 new ResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptEFR.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEFR.java
@@ -1146,7 +1146,7 @@ public class ScriptEFR implements IScriptLoader {
                         .setConcealed().setRound()
                         .setPages(new ResearchPage("EtFuturumRequiem.research_page.UNDYINGTOTEM.1"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UNDYINGTOTEM",
                 getModItem(EtFuturumRequiem.ID, "totem_of_undying", 1, 0, missing),
                 15,
@@ -1154,18 +1154,18 @@ public class ScriptEFR implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 150).add(Aspect.getAspect("sano"), 200)
                         .add(Aspect.getAspect("praecantatio"), 200),
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 5, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        getModItem(ThaumicBases.ID, "oldGold", 1, 0, missing),
-                        getModItem(StevesCarts2.ID, "BlockMetalStorage", 1, 2, missing),
-                        getModItem(ThaumicBases.ID, "oldGold", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedGold, 1L),
-                        getModItem(EnderIO.ID, "itemFrankenSkull", 1, 5, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedGold, 1L),
-                        getModItem(ThaumicBases.ID, "oldGold", 1, 0, missing),
-                        getModItem(StevesCarts2.ID, "BlockMetalStorage", 1, 2, missing),
-                        getModItem(ThaumicBases.ID, "oldGold", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.GreenSapphire, 1L), });
+                OrePrefixes.plate.get(Materials.InfusedGold),
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                getModItem(ThaumicBases.ID, "oldGold", 1, 0, missing),
+                getModItem(StevesCarts2.ID, "BlockMetalStorage", 1, 2, missing),
+                getModItem(ThaumicBases.ID, "oldGold", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.InfusedGold),
+                getModItem(EnderIO.ID, "itemFrankenSkull", 1, 5, missing),
+                OrePrefixes.plate.get(Materials.InfusedGold),
+                getModItem(ThaumicBases.ID, "oldGold", 1, 0, missing),
+                getModItem(StevesCarts2.ID, "BlockMetalStorage", 1, 2, missing),
+                getModItem(ThaumicBases.ID, "oldGold", 1, 0, missing),
+                OrePrefixes.gemExquisite.get(Materials.GreenSapphire));
         TCHelper.addResearchPage(
                 "UNDYINGTOTEM",
                 new ResearchPage(
@@ -1835,7 +1835,7 @@ public class ScriptEFR implements IScriptLoader {
                 3,
                 getModItem(EtFuturumRequiem.ID, "elytra", 1, 0, missing)).setParents("FeatherWings").setConcealed()
                         .setPages(new ResearchPage("EtFuturumRequiem.research_page.ELYTRA.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ELYTRA",
                 getModItem(EtFuturumRequiem.ID, "elytra", 1, 0, missing),
                 15,
@@ -1843,14 +1843,14 @@ public class ScriptEFR implements IScriptLoader {
                         .add(Aspect.getAspect("motus"), 150).add(Aspect.getAspect("tempestas"), 200)
                         .add(Aspect.getAspect("praecantatio"), 200),
                 getModItem(WitchingGadgets.ID, "item.WG_Kama", 1, 4, missing),
-                new ItemStack[] { getModItem(EnderIO.ID, "itemGliderWing", 1, 1, missing),
-                        GregtechItemList.MagicFeather.get(1),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 14, missing),
-                        getModItem(StevesCarts2.ID, "CartModule", 1, 59, missing),
-                        getModItem(Botania.ID, "manaBeacon", 1, 10, missing),
-                        getModItem(StevesCarts2.ID, "CartModule", 1, 59, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 14, missing),
-                        GregtechItemList.MagicFeather.get(1), });
+                getModItem(EnderIO.ID, "itemGliderWing", 1, 1, missing),
+                GregtechItemList.MagicFeather.get(1),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 14, missing),
+                getModItem(StevesCarts2.ID, "CartModule", 1, 59, missing),
+                getModItem(Botania.ID, "manaBeacon", 1, 10, missing),
+                getModItem(StevesCarts2.ID, "CartModule", 1, 59, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 14, missing),
+                GregtechItemList.MagicFeather.get(1));
         TCHelper.addResearchPage(
                 "ELYTRA",
                 new ResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptEMT.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEMT.java
@@ -24,7 +24,6 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 
 import com.dreammaster.gthandler.CustomItemList;
@@ -509,7 +508,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "NanosuitWing", 1, 0, missing)).setParents("ThaumiumReinforcedWings")
                         .setConcealed().setRound().setPages(new ResearchPage("tc.research_page.NanosuitWings"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "NanosuitWings",
                 getModItem(ElectroMagicTools.ID, "NanosuitWing", 1, 27, missing),
                 5,
@@ -518,16 +517,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("vitium"), 8)
                         .add(Aspect.getAspect("terra"), 8),
                 getModItem(ElectroMagicTools.ID, "ThaumiumWing", 1, 0, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorNanoChestplate", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Titanium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartCarbonPlate", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Titanium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartCarbonPlate", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Titanium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartCarbonPlate", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Titanium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartCarbonPlate", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Titanium, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorNanoChestplate", 1, wildcard, missing),
+                OrePrefixes.wireFine.get(Materials.Titanium),
+                getModItem(IndustrialCraft2.ID, "itemPartCarbonPlate", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Titanium),
+                getModItem(IndustrialCraft2.ID, "itemPartCarbonPlate", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Titanium),
+                getModItem(IndustrialCraft2.ID, "itemPartCarbonPlate", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Titanium),
+                getModItem(IndustrialCraft2.ID, "itemPartCarbonPlate", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Titanium));
         TCHelper.addResearchPage(
                 "NanosuitWings",
                 new ResearchPage(
@@ -549,7 +548,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "QuantumWing", 1, 0, missing)).setParents("NanosuitWings")
                         .setConcealed().setRound().setPages(new ResearchPage("tc.research_page.QuantumWings"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "QuantumWings",
                 getModItem(ElectroMagicTools.ID, "QuantumWing", 1, 27, missing),
                 10,
@@ -558,16 +557,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("volatus"), 48).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("vitium"), 16).add(Aspect.getAspect("terra"), 16),
                 getModItem(ElectroMagicTools.ID, "NanosuitWing", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorQuantumChestplate", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Osmium, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorQuantumChestplate", 1, wildcard, missing),
+                OrePrefixes.wireFine.get(Materials.Osmium),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Osmium),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Osmium),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Osmium),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Osmium));
         TCHelper.addResearchPage(
                 "QuantumWings",
                 new ResearchPage(
@@ -589,7 +588,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "itemArmorQuantumChestplate", 1, 0, missing))
                         .setParents("QuantumWings").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.InfusedQuantumArmor")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "InfusedQuantumArmor",
                 getModItem(ElectroMagicTools.ID, "itemArmorQuantumChestplate", 1, 27, missing),
                 15,
@@ -599,18 +598,18 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("vitium"), 16).add(Aspect.getAspect("terra"), 16)
                         .add(Aspect.getAspect("lucrum"), 8),
                 getModItem(IndustrialCraft2.ID, "itemArmorQuantumChestplate", 1, wildcard, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "ShieldBlock", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Naquadah, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Naquadah, 1L),
-                        getModItem(ElectroMagicTools.ID, "ShieldBlock", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Naquadah, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Naquadah, 1L), });
+                getModItem(ElectroMagicTools.ID, "ShieldBlock", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Naquadah),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Naquadah),
+                getModItem(ElectroMagicTools.ID, "ShieldBlock", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Naquadah),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.wireFine.get(Materials.Naquadah));
         TCHelper.addResearchPage(
                 "InfusedQuantumArmor",
                 new ResearchPage(
@@ -674,7 +673,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "Diamond Omnitool", 1, 0, missing)).setParents("IronOmnitool")
                         .setParentsHidden("DiamondChainsaw").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.DiamondOmnitool")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "DiamondOmnitool",
                 getModItem(ElectroMagicTools.ID, "Diamond Omnitool", 1, 27, missing),
                 6,
@@ -688,16 +687,16 @@ public class ScriptEMT implements IScriptLoader {
                         102,
                         "{ench:[0:{lvl:2s,id:35s}],GT.ToolStats:{PrimaryMaterial:\"Thaumium\",SpecialData:-1L,MaxDamage:51200L,Tier:2L,MaxCharge:400000L,Voltage:128L,Electric:1b,SecondaryMaterial:\"Titanium\"},GT.ItemCharge:400000L}",
                         missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "DiamondChainsaw", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 1L), });
+                getModItem(ElectroMagicTools.ID, "DiamondChainsaw", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Diamond),
+                getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Diamond),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Diamond),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Diamond),
+                getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Diamond));
         TCHelper.addResearchPage(
                 "DiamondOmnitool",
                 new ResearchPage(
@@ -717,7 +716,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "ThaumiumOmnitool", 1, 0, missing)).setParents("DiamondOmnitool")
                         .setParentsHidden("ThaumiumChainsaw", "ThaumiumDrill").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.ThaumiumOmnitool")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ThaumiumOmnitool",
                 getModItem(ElectroMagicTools.ID, "ThaumiumOmnitool", 1, 27, missing),
                 8,
@@ -726,16 +725,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 16).add(Aspect.getAspect("terra"), 8)
                         .add(Aspect.getAspect("praecantatio"), 16),
                 getModItem(ElectroMagicTools.ID, "ThaumiumChainsaw", 1, wildcard, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "ThaumiumDrill", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L),
-                        ItemList.Circuit_Elite.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Titanium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Titanium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        ItemList.Circuit_Elite.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L), });
+                getModItem(ElectroMagicTools.ID, "ThaumiumDrill", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.TungstenSteel),
+                ItemList.Circuit_Elite.get(1L),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.screw.get(Materials.Titanium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.screw.get(Materials.Titanium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                ItemList.Circuit_Elite.get(1L),
+                OrePrefixes.plate.get(Materials.TungstenSteel));
         TCHelper.addResearchPage(
                 "ThaumiumOmnitool",
                 new ResearchPage(
@@ -757,7 +756,7 @@ public class ScriptEMT implements IScriptLoader {
                         .setParentsHidden("ElectricMagicTools").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.ElectricBootsoftheTraveller"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ElectricBootsoftheTraveller",
                 getModItem(ElectroMagicTools.ID, "ElectricBootsTraveller", 1, 27, missing),
                 3,
@@ -765,14 +764,14 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 8)
                         .add(Aspect.getAspect("volatus"), 8).add(Aspect.getAspect("iter"), 8),
                 getModItem(Thaumcraft.ID, "BootsTraveller", 1, 0, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemStaticBoots", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 1L),
-                        ItemList.Electric_Motor_MV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt02, Materials.Copper, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemAdvBat", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt02, Materials.Copper, 1L),
-                        ItemList.Electric_Motor_MV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemStaticBoots", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Diamond),
+                ItemList.Electric_Motor_MV.get(1L),
+                OrePrefixes.wireGt02.get(Materials.Copper),
+                getModItem(IndustrialCraft2.ID, "itemAdvBat", 1, wildcard, missing),
+                OrePrefixes.wireGt02.get(Materials.Copper),
+                ItemList.Electric_Motor_MV.get(1L),
+                OrePrefixes.plate.get(Materials.Diamond));
         TCHelper.addResearchPage(
                 "ElectricBootsoftheTraveller",
                 new ResearchPage(
@@ -792,7 +791,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "NanoBootsTraveller", 1, 0, missing))
                         .setParents("ElectricBootsoftheTraveller").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.NanoBootsoftheTraveller")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "NanoBootsoftheTraveller",
                 getModItem(ElectroMagicTools.ID, "NanoBootsTraveller", 1, 27, missing),
                 6,
@@ -800,14 +799,14 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("volatus"), 8).add(Aspect.getAspect("iter"), 16),
                 getModItem(ElectroMagicTools.ID, "ElectricBootsTraveller", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        ItemList.Electric_Motor_HV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1L),
-                        ItemList.Electric_Motor_HV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                ItemList.Electric_Motor_HV.get(1L),
+                OrePrefixes.wireGt04.get(Materials.Electrum),
+                getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
+                OrePrefixes.wireGt04.get(Materials.Electrum),
+                ItemList.Electric_Motor_HV.get(1L),
+                OrePrefixes.plate.get(Materials.Thaumium));
         TCHelper.addResearchPage(
                 "NanoBootsoftheTraveller",
                 new ResearchPage(
@@ -830,7 +829,7 @@ public class ScriptEMT implements IScriptLoader {
                         .setParents("NanoBootsoftheTraveller").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.QuantumBootsoftheTraveller"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "QuantumBootsoftheTraveller",
                 getModItem(ElectroMagicTools.ID, "QuantumBootsTraveller", 1, 27, missing),
                 9,
@@ -839,16 +838,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("volatus"), 16).add(Aspect.getAspect("iter"), 24)
                         .add(Aspect.getAspect("aer"), 8),
                 getModItem(ElectroMagicTools.ID, "NanoBootsTraveller", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        ItemList.Electric_Motor_EV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Titanium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Titanium, 1L),
-                        ItemList.Electric_Motor_EV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                ItemList.Electric_Motor_EV.get(1L),
+                OrePrefixes.wireGt08.get(Materials.Titanium),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.wireGt08.get(Materials.Titanium),
+                ItemList.Electric_Motor_EV.get(1L),
+                OrePrefixes.plate.get(Materials.Void));
         TCHelper.addResearchPage(
                 "QuantumBootsoftheTraveller",
                 new ResearchPage(
@@ -869,7 +868,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "ThaumiumDrill", 1, 0, missing)).setParents("ElectricMagicTools")
                         .setConcealed().setRound().setPages(new ResearchPage("tc.research_page.ThaumiumDrill"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ThaumiumDrill",
                 getModItem(ElectroMagicTools.ID, "ThaumiumDrill", 1, 27, missing),
                 7,
@@ -883,14 +882,14 @@ public class ScriptEMT implements IScriptLoader {
                         102,
                         "{ench:[0:{lvl:2s,id:35s}],GT.ToolStats:{PrimaryMaterial:\"Thaumium\",SpecialData:-1L,MaxDamage:51200L,Tier:2L,MaxCharge:400000L,Voltage:128L,Electric:1b,SecondaryMaterial:\"Aluminium\"},GT.ItemCharge:400000L}",
                         missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.screw, Materials.Titanium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        ItemList.Circuit_Elite.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Titanium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        ItemList.Circuit_Elite.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L), });
+                OrePrefixes.screw.get(Materials.Titanium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                ItemList.Circuit_Elite.get(1L),
+                OrePrefixes.plate.get(Materials.TungstenSteel),
+                OrePrefixes.screw.get(Materials.Titanium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                ItemList.Circuit_Elite.get(1L),
+                OrePrefixes.plate.get(Materials.TungstenSteel));
         TCHelper.addResearchPage(
                 "ThaumiumDrill",
                 new ResearchPage(
@@ -912,7 +911,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "DrillRockbreaker", 1, 0, missing)).setParents("ThaumiumDrill")
                         .setConcealed().setRound().setPages(new ResearchPage("tc.research_page.DrilloftheRockbreaker"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "DrilloftheRockbreaker",
                 getModItem(ElectroMagicTools.ID, "DrillRockbreaker", 1, 27, missing),
                 10,
@@ -920,16 +919,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("lucrum"), 32)
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("ignis"), 8),
                 getModItem(ElectroMagicTools.ID, "ThaumiumDrill", 1, wildcard, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        ItemList.Circuit_Master.get(1L),
-                        getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
-                        ItemList.Circuit_Master.get(1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                ItemList.Circuit_Master.get(1L),
+                getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
+                ItemList.Circuit_Master.get(1L),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing));
         TCHelper.addResearchPage(
                 "DrilloftheRockbreaker",
                 new ResearchPage(
@@ -950,7 +949,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "ThaumiumChainsaw", 1, 0, missing)).setParents("DiamondChainsaw")
                         .setConcealed().setRound().setPages(new ResearchPage("tc.research_page.ThaumiumChainsaw"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ThaumiumChainsaw",
                 getModItem(ElectroMagicTools.ID, "ThaumiumChainsaw", 1, 27, missing),
                 7,
@@ -958,14 +957,14 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 24).add(Aspect.getAspect("lucrum"), 16)
                         .add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(ElectroMagicTools.ID, "DiamondChainsaw", 1, wildcard, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.screw, Materials.Titanium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        ItemList.Circuit_Elite.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Titanium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        ItemList.Circuit_Elite.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L), });
+                OrePrefixes.screw.get(Materials.Titanium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                ItemList.Circuit_Elite.get(1L),
+                OrePrefixes.plate.get(Materials.TungstenSteel),
+                OrePrefixes.screw.get(Materials.Titanium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                ItemList.Circuit_Elite.get(1L),
+                OrePrefixes.plate.get(Materials.TungstenSteel));
         TCHelper.addResearchPage(
                 "ThaumiumChainsaw",
                 new ResearchPage(
@@ -986,7 +985,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "ChainsawStream", 1, 0, missing)).setParents("ThaumiumChainsaw")
                         .setConcealed().setRound().setPages(new ResearchPage("tc.research_page.ChainsawoftheStream"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ChainsawoftheStream",
                 getModItem(ElectroMagicTools.ID, "ChainsawStream", 1, 27, missing),
                 10,
@@ -994,16 +993,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("lucrum"), 24)
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("aer"), 8),
                 getModItem(ElectroMagicTools.ID, "ThaumiumChainsaw", 1, wildcard, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        ItemList.Circuit_Master.get(1L),
-                        getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Railcraft.ID, "tool.steel.shears", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
-                        ItemList.Circuit_Master.get(1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                ItemList.Circuit_Master.get(1L),
+                getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Railcraft.ID, "tool.steel.shears", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
+                ItemList.Circuit_Master.get(1L),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing));
         TCHelper.addResearchPage(
                 "ChainsawoftheStream",
                 new ResearchPage(
@@ -1024,7 +1023,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "EMTBaubles", 1, 1, missing)).setParentsHidden("ElectricMagicTools")
                         .setConcealed().setRound().setPages(new ResearchPage("tc.research_page.InventoryChargingRing"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "InventoryChargingRing",
                 getModItem(ElectroMagicTools.ID, "EMTBaubles", 1, 1, missing),
                 7,
@@ -1032,15 +1031,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("electrum"), 16)
                         .add(Aspect.getAspect("auram"), 8),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 1, missing),
-                new ItemStack[] { ItemList.IC2_EnergyCrystal.get(1), ItemList.MagicEnergyAbsorber_LV.get(1),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Silver, 4L),
-                        ItemList.Generator_Steam_Turbine_LV.get(1),
-                        getModItem(IndustrialCraft2.ID, "blockKineticGenerator", 1, 1, missing),
-                        getModItem(IndustrialCraft2.ID, "itemStaticBoots", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "blockKineticGenerator", 1, 2, missing),
-                        getModItem(IndustrialCraft2.ID, "blockHeatGenerator", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Silver, 4L),
-                        ItemList.Cover_SolarPanel_LV.get(1) });
+                ItemList.IC2_EnergyCrystal.get(1),
+                ItemList.MagicEnergyAbsorber_LV.get(1),
+                OrePrefixes.wireGt04.get(Materials.Silver),
+                ItemList.Generator_Steam_Turbine_LV.get(1),
+                getModItem(IndustrialCraft2.ID, "blockKineticGenerator", 1, 1, missing),
+                getModItem(IndustrialCraft2.ID, "itemStaticBoots", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "blockKineticGenerator", 1, 2, missing),
+                getModItem(IndustrialCraft2.ID, "blockHeatGenerator", 1, 0, missing),
+                OrePrefixes.wireGt04.get(Materials.Silver),
+                ItemList.Cover_SolarPanel_LV.get(1));
         TCHelper.addResearchPage(
                 "InventoryChargingRing",
                 new ResearchPage(
@@ -1060,7 +1060,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "EMTBaubles", 1, 0, missing)).setParents("InventoryChargingRing")
                         .setConcealed().setRound().setPages(new ResearchPage("tc.research_page.ArmorChargingRing"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ArmorChargingRing",
                 getModItem(ElectroMagicTools.ID, "EMTBaubles", 1, 0, missing),
                 8,
@@ -1068,15 +1068,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("electrum"), 16)
                         .add(Aspect.getAspect("auram"), 8),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 1, missing),
-                new ItemStack[] { ItemList.IC2_EnergyCrystal.get(1), ItemList.MagicEnergyAbsorber_LV.get(1),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.BlueAlloy, 4L),
-                        ItemList.Generator_Steam_Turbine_LV.get(1),
-                        getModItem(IndustrialCraft2.ID, "blockKineticGenerator", 1, 1, missing),
-                        getModItem(IndustrialCraft2.ID, "itemStaticBoots", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "blockKineticGenerator", 1, 2, missing),
-                        getModItem(IndustrialCraft2.ID, "blockHeatGenerator", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.BlueAlloy, 4L),
-                        ItemList.Cover_SolarPanel_LV.get(1) });
+                ItemList.IC2_EnergyCrystal.get(1),
+                ItemList.MagicEnergyAbsorber_LV.get(1),
+                OrePrefixes.wireGt04.get(Materials.BlueAlloy),
+                ItemList.Generator_Steam_Turbine_LV.get(1),
+                getModItem(IndustrialCraft2.ID, "blockKineticGenerator", 1, 1, missing),
+                getModItem(IndustrialCraft2.ID, "itemStaticBoots", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "blockKineticGenerator", 1, 2, missing),
+                getModItem(IndustrialCraft2.ID, "blockHeatGenerator", 1, 0, missing),
+                OrePrefixes.wireGt04.get(Materials.BlueAlloy),
+                ItemList.Cover_SolarPanel_LV.get(1));
         TCHelper.addResearchPage(
                 "ArmorChargingRing",
                 new ResearchPage(
@@ -1146,7 +1147,7 @@ public class ScriptEMT implements IScriptLoader {
                         .setParents("ElectricGogglesofRevealing").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.NanosuitGogglesofRevealing"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "NanosuitGogglesofRevealing",
                 getModItem(ElectroMagicTools.ID, "NanosuitGogglesRevealing", 1, 27, missing),
                 6,
@@ -1154,16 +1155,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("sensus"), 24).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("auram"), 8).add(Aspect.getAspect("electrum"), 8),
                 getModItem(ElectroMagicTools.ID, "ElectricGogglesRevealing", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorNanoHelmet", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 1, 0, missing),
-                        ItemList.Sensor_HV.get(1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                        ItemList.Sensor_HV.get(1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorNanoHelmet", 1, wildcard, missing),
+                OrePrefixes.wireGt04.get(Materials.Electrum),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 1, 0, missing),
+                ItemList.Sensor_HV.get(1L),
+                getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
+                ItemList.Sensor_HV.get(1L),
+                getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.wireGt04.get(Materials.Electrum));
         TCHelper.addResearchPage(
                 "NanosuitGogglesofRevealing",
                 new ResearchPage(
@@ -1184,7 +1185,7 @@ public class ScriptEMT implements IScriptLoader {
                         .setParents("NanosuitGogglesofRevealing").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.QuantumGogglesofRevealing"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "QuantumGogglesofRevealing",
                 getModItem(ElectroMagicTools.ID, "QuantumGogglesRevealing", 1, 27, missing),
                 9,
@@ -1193,14 +1194,18 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("auram"), 16).add(Aspect.getAspect("electrum"), 16)
                         .add(Aspect.getAspect("lucrum"), 8),
                 getModItem(ElectroMagicTools.ID, "NanosuitGogglesRevealing", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorQuantumHelmet", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Titanium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), ItemList.Circuit_Elite.get(1L),
-                        ItemList.Sensor_EV.get(1L), getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing), ItemList.Sensor_EV.get(1L),
-                        ItemList.Circuit_Elite.get(1L), GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Titanium, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorQuantumHelmet", 1, wildcard, missing),
+                OrePrefixes.wireGt08.get(Materials.Titanium),
+                OrePrefixes.plate.get(Materials.Void),
+                ItemList.Circuit_Elite.get(1L),
+                ItemList.Sensor_EV.get(1L),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                ItemList.Sensor_EV.get(1L),
+                ItemList.Circuit_Elite.get(1L),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.wireGt08.get(Materials.Titanium));
         TCHelper.addResearchPage(
                 "QuantumGogglesofRevealing",
                 new ResearchPage(
@@ -1223,7 +1228,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "SolarHelmetRevealing", 1, 0, missing))
                         .setParents("QuantumGogglesofRevealing", "CompressedSolars").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.SolarHelmetofRevealing")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SolarHelmetofRevealing",
                 getModItem(ElectroMagicTools.ID, "SolarHelmetRevealing", 1, 27, missing),
                 12,
@@ -1233,14 +1238,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 8).add(Aspect.getAspect("aer"), 16)
                         .add(Aspect.getAspect("lux"), 32),
                 getModItem(ElectroMagicTools.ID, "QuantumGogglesRevealing", 1, wildcard, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt12, Materials.Osmium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Naquadah, 1L), ItemList.Sensor_IV.get(1L),
-                        CustomItemList.MysteriousCrystal.get(1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
-                        CustomItemList.MysteriousCrystal.get(1L), ItemList.Sensor_IV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Naquadah, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt12, Materials.Osmium, 1L), });
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
+                OrePrefixes.wireGt12.get(Materials.Osmium),
+                OrePrefixes.plate.get(Materials.Naquadah),
+                ItemList.Sensor_IV.get(1L),
+                CustomItemList.MysteriousCrystal.get(1L),
+                getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
+                CustomItemList.MysteriousCrystal.get(1L),
+                ItemList.Sensor_IV.get(1L),
+                OrePrefixes.plate.get(Materials.Naquadah),
+                OrePrefixes.wireGt12.get(Materials.Osmium));
         TCHelper.addResearchPage(
                 "SolarHelmetofRevealing",
                 new ResearchPage(
@@ -1322,7 +1329,7 @@ public class ScriptEMT implements IScriptLoader {
                 "CompressedSolars",
                 new ResearchPage(
                         TCHelper.findArcaneRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
                 15,
@@ -1330,21 +1337,21 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 150).add(Aspect.getAspect("ignis"), 150)
                         .add(Aspect.getAspect("ordo"), 150).add(Aspect.getAspect("perditio"), 150),
                 CustomItemList.IrradiantReinforcedTungstenSteelPlate.get(1L),
-                new ItemStack[] { CustomItemList.IrradiantReinforcedTungstenSteelPlate.get(1L),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
-                        CustomItemList.IrradiantReinforcedTungstenSteelPlate.get(1L),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing), });
+                CustomItemList.IrradiantReinforcedTungstenSteelPlate.get(1L),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
+                CustomItemList.IrradiantReinforcedTungstenSteelPlate.get(1L),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1, missing));
         TCHelper.addResearchPage(
                 "CompressedSolars",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
                 20,
@@ -1352,21 +1359,21 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 300).add(Aspect.getAspect("ignis"), 300)
                         .add(Aspect.getAspect("ordo"), 300).add(Aspect.getAspect("perditio"), 300),
                 CustomItemList.IrradiantReinforcedChromePlate.get(1L),
-                new ItemStack[] { CustomItemList.IrradiantReinforcedChromePlate.get(1L),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
-                        CustomItemList.IrradiantReinforcedChromePlate.get(1L),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing), });
+                CustomItemList.IrradiantReinforcedChromePlate.get(1L),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
+                CustomItemList.IrradiantReinforcedChromePlate.get(1L),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2, missing));
         TCHelper.addResearchPage(
                 "CompressedSolars",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
                 20,
@@ -1374,21 +1381,21 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 600).add(Aspect.getAspect("ignis"), 600)
                         .add(Aspect.getAspect("ordo"), 600).add(Aspect.getAspect("perditio"), 600),
                 getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 8, missing),
-                new ItemStack[] { getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 8, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
-                        getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 8, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing), });
+                getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 8, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
+                getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 8, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0, missing));
         TCHelper.addResearchPage(
                 "CompressedSolars",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
                 20,
@@ -1396,21 +1403,21 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 1200).add(Aspect.getAspect("ignis"), 1200)
                         .add(Aspect.getAspect("ordo"), 1200).add(Aspect.getAspect("perditio"), 1200),
                 CustomItemList.IrradiantReinforcedNaquadriaPlate.get(1L),
-                new ItemStack[] { CustomItemList.IrradiantReinforcedNaquadriaPlate.get(1L),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
-                        CustomItemList.IrradiantReinforcedNaquadriaPlate.get(1L),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing), });
+                CustomItemList.IrradiantReinforcedNaquadriaPlate.get(1L),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
+                CustomItemList.IrradiantReinforcedNaquadriaPlate.get(1L),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7, missing));
         TCHelper.addResearchPage(
                 "CompressedSolars",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
                 20,
@@ -1418,21 +1425,21 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 2400).add(Aspect.getAspect("ignis"), 2400)
                         .add(Aspect.getAspect("ordo"), 2400).add(Aspect.getAspect("perditio"), 2400),
                 CustomItemList.IrradiantReinforcedNeutroniumPlate.get(1L),
-                new ItemStack[] { CustomItemList.IrradiantReinforcedNeutroniumPlate.get(1L),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
-                        CustomItemList.IrradiantReinforcedNeutroniumPlate.get(1L),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing), });
+                CustomItemList.IrradiantReinforcedNeutroniumPlate.get(1L),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
+                CustomItemList.IrradiantReinforcedNeutroniumPlate.get(1L),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14, missing));
         TCHelper.addResearchPage(
                 "CompressedSolars",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 12, missing),
                 20,
@@ -1440,16 +1447,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 4800).add(Aspect.getAspect("ignis"), 4800)
                         .add(Aspect.getAspect("ordo"), 4800).add(Aspect.getAspect("perditio"), 4800),
                 getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 13, missing),
-                new ItemStack[] { getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 13, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
-                        getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 13, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing), });
+                getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 13, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
+                getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 13, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing),
+                getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5, missing));
         TCHelper.addResearchPage(
                 "CompressedSolars",
                 new ResearchPage(
@@ -2032,7 +2039,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "ElectricHoeGrowth", 1, 0, missing))
                         .setParents("ELEMENTALHOE", "ElectricMagicTools").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.ElectricHoeofGrowth")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ElectricHoeofGrowth",
                 getModItem(ElectroMagicTools.ID, "ElectricHoeGrowth", 1, 1561, missing),
                 8,
@@ -2040,16 +2047,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("herba"), 16)
                         .add(Aspect.getAspect("electrum"), 8),
                 getModItem(Thaumcraft.ID, "ItemHoeElemental", 1, 0, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemToolHoe", 1, wildcard, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        ItemList.Circuit_Master.get(1L),
-                        getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
-                        ItemList.Circuit_Master.get(1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing), });
+                getModItem(IndustrialCraft2.ID, "itemToolHoe", 1, wildcard, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                ItemList.Circuit_Master.get(1L),
+                getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0, missing),
+                ItemList.Circuit_Master.get(1L),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing));
         TCHelper.addResearchPage(
                 "ElectricHoeofGrowth",
                 new ResearchPage(
@@ -2119,7 +2126,7 @@ public class ScriptEMT implements IScriptLoader {
         ResearchCategories.getResearch("Mjolnirnew").setConcealed();
         ResearchCategories.getResearch("Mjolnirnew").setRound();
         TCHelper.addResearchPage("Mjolnirnew", new ResearchPage("tc.research_page.Mjolnirnew"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "Mjolnirnew",
                 getModItem(ElectroMagicTools.ID, "Mjolnir", 1, 0, missing),
                 10,
@@ -2127,18 +2134,18 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("ira"), 24)
                         .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("ignis"), 16),
                 getModItem(ElectroMagicTools.ID, "TaintedMjolnir", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Rubber, 1),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Rubber, 1),
-                        getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                        getModItem(Thaumcraft.ID, "FocusShock", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Rubber, 1),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Rubber, 1), });
+                getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Rubber),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Rubber),
+                getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
+                getModItem(Thaumcraft.ID, "FocusShock", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Rubber),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 6, missing),
+                OrePrefixes.plate.get(Materials.Rubber));
         TCHelper.addResearchPage(
                 "Mjolnirnew",
                 new ResearchPage(
@@ -2158,7 +2165,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "SuperchargedMjolnir", 1, 0, missing))
                         .setParents("Mjolnirnew", "FOCUSHELLBAT", "ALUMENTUM").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.SuperchargedMjolnir")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SuperchargedMjolnir",
                 getModItem(ElectroMagicTools.ID, "SuperchargedMjolnir", 1, 27, missing),
                 15,
@@ -2167,18 +2174,18 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("ignis"), 24)
                         .add(Aspect.getAspect("bestia"), 16),
                 getModItem(ElectroMagicTools.ID, "Mjolnir", 1, 0, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemNanoSaber", 1, wildcard, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
-                        getModItem(Thaumcraft.ID, "FocusHellbat", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing), });
+                getModItem(IndustrialCraft2.ID, "itemNanoSaber", 1, wildcard, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
+                getModItem(Thaumcraft.ID, "FocusHellbat", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SuperchargedMjolnir",
                 new ResearchPage(
@@ -2198,7 +2205,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 6, missing))
                         .setParents("FOCUSSHOCK", "NITOR", "ALUMENTUM").setConcealed().setRound()
                         .setPages(new ResearchPage("tc.research_page.LightningSummoner")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "LightningSummoner",
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 6, missing),
                 9,
@@ -2206,15 +2213,15 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("nebrisum"), 8)
                         .add(Aspect.getAspect("permutatio"), 8),
                 getModItem(Thaumcraft.ID, "FocusShock", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 4, missing),
-                        getModItem(Minecraft.ID, "tnt", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 4, missing),
-                        getModItem(Minecraft.ID, "tnt", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 4, missing),
-                        getModItem(Minecraft.ID, "tnt", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(Minecraft.ID, "skull", 1, 4, missing),
+                getModItem(Minecraft.ID, "tnt", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
+                getModItem(Minecraft.ID, "skull", 1, 4, missing),
+                getModItem(Minecraft.ID, "tnt", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(Minecraft.ID, "skull", 1, 4, missing),
+                getModItem(Minecraft.ID, "tnt", 1, 0, missing));
         TCHelper.addResearchPage(
                 "LightningSummoner",
                 new ResearchPage(
@@ -2267,7 +2274,7 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 new ResearchPage(
                         TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 getModItem(Minecraft.ID, "coal", 16, 0, missing),
                 6,
@@ -2275,12 +2282,12 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
                         .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
                 getModItem(Minecraft.ID, "coal", 1, 1, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Minecraft.ID, "coal", 1, 0, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 getModItem(Minecraft.ID, "glowstone", 1, 0, missing),
                 3,
@@ -2288,11 +2295,11 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("ignis"), 4)
                         .add(Aspect.getAspect("perditio"), 4).add(Aspect.getAspect("ordo"), 8),
                 getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Minecraft.ID, "glowstone", 1, 0, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Iron, 32L),
                 6,
@@ -2300,42 +2307,42 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
                         .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
                 getModItem(Minecraft.ID, "iron_ingot", 1, 0, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Iron, 1L))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Copper, 32L),
                 6,
                 new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
                         .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
-                GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Copper, 1L),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                OrePrefixes.ingot.get(Materials.Copper),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Copper, 1L))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Tin, 32L),
                 6,
                 new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
                         .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
-                GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Tin, 1L),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                OrePrefixes.ingot.get(Materials.Tin),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Tin, 1L))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Gold, 32L),
                 6,
@@ -2343,13 +2350,13 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
                         .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
                 getModItem(Minecraft.ID, "gold_ingot", 1, 0, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Gold, 1L))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Uranium, 32L),
                 6,
@@ -2357,43 +2364,43 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
                         .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
                 ItemList.IC2_Uranium_238.get(1),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Uranium, 1L))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Silver, 32L),
                 6,
                 new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
                         .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
-                GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Silver, 1L),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                OrePrefixes.ingot.get(Materials.Silver),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Silver, 1L))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Lead, 32L),
                 6,
                 new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
                         .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
-                GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Lead, 1L),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                OrePrefixes.ingot.get(Materials.Lead),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Lead, 1L))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Redstone, 24L),
                 9,
@@ -2401,15 +2408,15 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 24).add(Aspect.getAspect("ignis"), 12)
                         .add(Aspect.getAspect("perditio"), 12).add(Aspect.getAspect("ordo"), 24),
                 getModItem(Minecraft.ID, "redstone", 1, 0, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Redstone, 1L))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Lapis, 24L),
                 9,
@@ -2417,15 +2424,15 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 24).add(Aspect.getAspect("ignis"), 12)
                         .add(Aspect.getAspect("perditio"), 12).add(Aspect.getAspect("ordo"), 24),
                 getModItem(Minecraft.ID, "dye", 1, 4, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Lapis, 1L))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 getModItem(Minecraft.ID, "gold_ingot", 2, 0, missing),
                 9,
@@ -2433,13 +2440,13 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
                         .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
                 getModItem(Minecraft.ID, "iron_ingot", 1, 0, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Minecraft.ID, "gold_ingot", 1, 0, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 getModItem(Minecraft.ID, "diamond", 1, 0, missing),
                 12,
@@ -2447,14 +2454,14 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("ignis"), 16)
                         .add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("ordo"), 32),
                 getModItem(Minecraft.ID, "gold_ingot", 1, 0, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Minecraft.ID, "diamond", 1, 0, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 ItemList.IC2_Uranium_238.get(2),
                 15,
@@ -2462,18 +2469,18 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 48).add(Aspect.getAspect("ignis"), 24)
                         .add(Aspect.getAspect("perditio"), 24).add(Aspect.getAspect("ordo"), 48),
                 getModItem(Minecraft.ID, "diamond", 1, 0, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(TCHelper.findInfusionRecipe(ItemList.IC2_Uranium_238.get(1))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UUMatterInfusion",
                 getModItem(IndustrialCraft2.ID, "itemOreIridium", 2, 0, missing),
                 18,
@@ -2481,18 +2488,18 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 64).add(Aspect.getAspect("ignis"), 32)
                         .add(Aspect.getAspect("perditio"), 32).add(Aspect.getAspect("ordo"), 64),
                 ItemList.IC2_Uranium_238.get(1),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15, missing));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(
@@ -2530,7 +2537,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "ShieldFocus", 1, 0, missing)).setParentsHidden("ElectricMagicTools")
                         .setParents("FOCUSPORTABLEHOLE").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.ShieldFocus")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ShieldFocus",
                 getModItem(ElectroMagicTools.ID, "ShieldFocus", 1, 0, missing),
                 9,
@@ -2538,16 +2545,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("victus"), 16).add(Aspect.getAspect("vinculum"), 24)
                         .add(Aspect.getAspect("vitreus"), 16).add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.ReinforceGlass, 1),
-                        ItemList.Block_TungstenSteelReinforced.get(1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartAlloy", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Reinforced, 1L),
-                        ItemList.Block_TungstenSteelReinforced.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.ReinforceGlass, 1),
-                        ItemList.Block_TungstenSteelReinforced.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Reinforced, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartAlloy", 1, 0, missing),
-                        ItemList.Block_TungstenSteelReinforced.get(1L), });
+                OrePrefixes.plate.get(Materials.ReinforceGlass),
+                ItemList.Block_TungstenSteelReinforced.get(1L),
+                getModItem(IndustrialCraft2.ID, "itemPartAlloy", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Reinforced),
+                ItemList.Block_TungstenSteelReinforced.get(1L),
+                OrePrefixes.plate.get(Materials.ReinforceGlass),
+                ItemList.Block_TungstenSteelReinforced.get(1L),
+                OrePrefixes.plate.get(Materials.Reinforced),
+                getModItem(IndustrialCraft2.ID, "itemPartAlloy", 1, 0, missing),
+                ItemList.Block_TungstenSteelReinforced.get(1L));
         TCHelper.addResearchPage(
                 "ShieldFocus",
                 new ResearchPage(
@@ -2653,21 +2660,21 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "EnergyBallFocus", 1, 0, missing))
                         .setParentsHidden("ElectricMagicTools").setParents("FOCUSSHOCK").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.EnergyBallFocus")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "EnergyBallFocus",
                 getModItem(ElectroMagicTools.ID, "EnergyBallFocus", 1, 0, missing),
                 6,
                 new AspectList().add(Aspect.getAspect("potentia"), 24).add(Aspect.getAspect("praecantatio"), 30)
                         .add(Aspect.getAspect("victus"), 12).add(Aspect.getAspect("cognitio"), 6),
                 getModItem(Thaumcraft.ID, "FocusShock", 1, 0, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "blockMachine2", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt02, Materials.Silver, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt02, Materials.Silver, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt02, Materials.Silver, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt02, Materials.Silver, 1L), });
+                getModItem(IndustrialCraft2.ID, "blockMachine2", 1, 1, missing),
+                OrePrefixes.wireGt02.get(Materials.Silver),
+                getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
+                OrePrefixes.wireGt02.get(Materials.Silver),
+                getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
+                OrePrefixes.wireGt02.get(Materials.Silver),
+                getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
+                OrePrefixes.wireGt02.get(Materials.Silver));
         TCHelper.addResearchPage(
                 "EnergyBallFocus",
                 new ResearchPage(
@@ -2688,7 +2695,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "ExplosionFocus", 1, 0, missing))
                         .setParentsHidden("ElectricMagicTools").setParents("FOCUSHELLBAT").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.ExplosionFocus")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ExplosionFocus",
                 getModItem(ElectroMagicTools.ID, "ExplosionFocus", 1, 0, missing),
                 9,
@@ -2696,16 +2703,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("motus"), 48).add(Aspect.getAspect("telum"), 32)
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("potentia"), 10),
                 getModItem(Thaumcraft.ID, "FocusHellbat", 1, 0, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemToolMiningLaser", 1, wildcard, missing),
-                        CustomItemList.ReinforcedGlassLense.get(1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(Minecraft.ID, "firework_charge", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "PrimalArrow", 1, 1, missing), // Fire Arrow
-                        getModItem(Minecraft.ID, "tnt", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "PrimalArrow", 1, 1, missing), // Fire Arrow
-                        getModItem(Minecraft.ID, "firework_charge", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
-                        CustomItemList.ReinforcedGlassLense.get(1L), });
+                getModItem(IndustrialCraft2.ID, "itemToolMiningLaser", 1, wildcard, missing),
+                CustomItemList.ReinforcedGlassLense.get(1L),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(Minecraft.ID, "firework_charge", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "PrimalArrow", 1, 1, missing), // Fire Arrow
+                getModItem(Minecraft.ID, "tnt", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "PrimalArrow", 1, 1, missing), // Fire Arrow
+                getModItem(Minecraft.ID, "firework_charge", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
+                CustomItemList.ReinforcedGlassLense.get(1L));
         TCHelper.addResearchPage(
                 "ExplosionFocus",
                 new ResearchPage(
@@ -2726,7 +2733,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "ChargingFocus", 1, 0, missing)).setParentsHidden("ElectricMagicTools")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.WandFocusCharging"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WandFocusCharging",
                 getModItem(ElectroMagicTools.ID, "ChargingFocus", 1, 0, missing),
                 9,
@@ -2734,16 +2741,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("machina"), 32).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("cognitio"), 8),
                 getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                new ItemStack[] { ItemList.Transformer_HV_MV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Thaumium, 1L),
-                        ItemList.Electric_Motor_MV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.gearGtSmall, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Silver, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gearGtSmall, Materials.Thaumium, 1L),
-                        ItemList.Electric_Motor_MV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Thaumium, 1L), });
+                ItemList.Transformer_HV_MV.get(1L),
+                OrePrefixes.rotor.get(Materials.Thaumium),
+                ItemList.Electric_Motor_MV.get(1L),
+                OrePrefixes.gearGtSmall.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                OrePrefixes.wireGt01.get(Materials.Silver),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                OrePrefixes.gearGtSmall.get(Materials.Thaumium),
+                ItemList.Electric_Motor_MV.get(1L),
+                OrePrefixes.rotor.get(Materials.Thaumium));
         TCHelper.addResearchPage(
                 "WandFocusCharging",
                 new ResearchPage(
@@ -2764,7 +2771,7 @@ public class ScriptEMT implements IScriptLoader {
         TCHelper.addResearchPrereq("WandFocusWandCharging", "IndustrialWandChargingStation", true);
         ResearchCategories.getResearch("WandFocusWandCharging").setConcealed();
         TCHelper.addResearchPage("WandFocusWandCharging", new ResearchPage("tc.research_page.WandFocusWandCharging"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WandFocusWandCharging",
                 getModItem(ElectroMagicTools.ID, "WandChargingFocus", 1, 0, missing),
                 15,
@@ -2773,16 +2780,16 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("cognitio"), 8)
                         .add(Aspect.getAspect("auram"), 32),
                 getModItem(ElectroMagicTools.ID, "ChargingFocus", 1, 0, missing),
-                new ItemStack[] { getModItem(ElectroMagicTools.ID, "EMTMachines", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gearGtSmall, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.TungstenSteel, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.TungstenSteel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gearGtSmall, Materials.Void, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing), });
+                getModItem(ElectroMagicTools.ID, "EMTMachines", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.gearGtSmall.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.wireGt01.get(Materials.TungstenSteel),
+                getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
+                OrePrefixes.wireGt01.get(Materials.TungstenSteel),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.gearGtSmall.get(Materials.Void),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing));
         TCHelper.addResearchPage(
                 "WandFocusWandCharging",
                 new ResearchPage(
@@ -2807,7 +2814,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 0, missing))
                         .setParentsHidden("ElectricMagicTools").setParents("JARLABEL", "FOCUSTRADE").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.PotentiaGenerator")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PotentiaGenerator",
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 0, missing),
                 6,
@@ -2815,14 +2822,18 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("machina"), 16).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("metallum"), 32),
                 GregtechItemList.Generator_SemiFluid_LV.get(1),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "FocusTrade", 1, 0, missing), ItemList.Emitter_MV.get(1L),
-                        getModItem(Minecraft.ID, "hopper", 1, 0, missing), ItemList.Electric_Motor_MV.get(1L),
-                        getModItem(IndustrialCraft2.ID, "blockElectric", 1, 7, missing),
-                        ItemList.Transformer_HV_MV.get(1L), getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "blockMachine", 1, 12, missing),
-                        getModItem(IndustrialCraft2.ID, "blockElectric", 1, 7, missing),
-                        ItemList.Electric_Motor_MV.get(1L), getModItem(Minecraft.ID, "hopper", 1, 0, missing),
-                        ItemList.Emitter_MV.get(1L), });
+                getModItem(Thaumcraft.ID, "FocusTrade", 1, 0, missing),
+                ItemList.Emitter_MV.get(1L),
+                getModItem(Minecraft.ID, "hopper", 1, 0, missing),
+                ItemList.Electric_Motor_MV.get(1L),
+                getModItem(IndustrialCraft2.ID, "blockElectric", 1, 7, missing),
+                ItemList.Transformer_HV_MV.get(1L),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "blockMachine", 1, 12, missing),
+                getModItem(IndustrialCraft2.ID, "blockElectric", 1, 7, missing),
+                ItemList.Electric_Motor_MV.get(1L),
+                getModItem(Minecraft.ID, "hopper", 1, 0, missing),
+                ItemList.Emitter_MV.get(1L));
         TCHelper.addResearchPage(
                 "PotentiaGenerator",
                 new ResearchPage(
@@ -2944,25 +2955,25 @@ public class ScriptEMT implements IScriptLoader {
                                 "ArborGenerator")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.LucrumGenerator"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "LucrumGenerator",
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 5, missing),
                 10,
                 new AspectList().add(Aspect.getAspect("permutatio"), 128).add(Aspect.getAspect("lucrum"), 256)
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("nebrisum"), 16),
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                        getModItem(Minecraft.ID, "gold_block", 1, 0, missing), });
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
+                getModItem(Minecraft.ID, "gold_block", 1, 0, missing));
         TCHelper.addResearchPage(
                 "LucrumGenerator",
                 new ResearchPage(
@@ -2982,7 +2993,7 @@ public class ScriptEMT implements IScriptLoader {
                         .setParents("PotentiaGenerator", "WANDPED", "JARLABEL").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.IndustrialWandChargingStation"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "IndustrialWandChargingStation",
                 getModItem(ElectroMagicTools.ID, "EMTMachines", 1, 0, missing),
                 9,
@@ -2990,14 +3001,14 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("fabrico"), 48).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("lucrum"), 64).add(Aspect.getAspect("cognitio"), 16),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 5, missing),
-                new ItemStack[] { ItemList.Machine_IV_Replicator.get(1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing), });
+                ItemList.Machine_IV_Replicator.get(1L),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing));
         TCHelper.addResearchPage(
                 "IndustrialWandChargingStation",
                 new ResearchPage(
@@ -3015,7 +3026,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "EMTMachines", 1, 1, missing)).setParentsHidden("ElectricMagicTools")
                         .setParents("BELLOWS", "DISTILESSENTIA", "INFERNALFURNACE", "PotentiaGenerator").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.EtheralProcessor")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "EtheralProcessor",
                 getModItem(ElectroMagicTools.ID, "EMTMachines", 1, 1, missing),
                 9,
@@ -3023,14 +3034,14 @@ public class ScriptEMT implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 24).add(Aspect.getAspect("praecantatio"), 28)
                         .add(Aspect.getAspect("cognitio"), 8),
                 ItemList.Machine_MV_Macerator.get(1L),
-                new ItemStack[] { ItemList.Machine_MV_E_Furnace.get(1L),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9, missing), });
+                ItemList.Machine_MV_E_Furnace.get(1L),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9, missing));
         TCHelper.addResearchPage(
                 "EtheralProcessor",
                 new ResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
@@ -1395,7 +1395,7 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 .itemOutputs(getModItem(ExtraUtilities.ID, "cobblestone_compressed", 1, 14, missing))
                 .duration(5 * SECONDS).eut(16).addTo(assemblerRecipes);
 
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0, missing),
                 30,
@@ -1409,58 +1409,60 @@ public class ScriptExtraUtilities implements IScriptLoader {
                         0,
                         "{TinkerArmor:{BaseDurability:1035,BaseDefense:2.0d,Built:1b,MaxDefense:8.0d,Damage:0,BonusDurability:0,Modifiers:3,DamageReduction:0.0d,TotalDurability:1035,ModDurability:0.0f,Broken:0b}}",
                         missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ring, Materials.Iridium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Tritanium, 1L),
-                        NHItemList.EngravedGoldChip.getIS(1),
-                        getModItem(ExtraUtilities.ID, "angelBlock", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing), GregtechItemList.MagicFeather.get(1),
-                        getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(Avaritia.ID, "big_pearl", 1, 0, missing),
-                        getModItem(Minecraft.ID, "nether_star", 1, 0, missing), GregtechItemList.MagicFeather.get(1),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(ExtraUtilities.ID, "angelBlock", 1, 0, missing),
-                        NHItemList.EngravedGoldChip.getIS(1),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Tritanium, 1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                OrePrefixes.ring.get(Materials.Iridium),
+                OrePrefixes.screw.get(Materials.Tritanium),
+                NHItemList.EngravedGoldChip.getIS(1),
+                getModItem(ExtraUtilities.ID, "angelBlock", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                GregtechItemList.MagicFeather.get(1),
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(Avaritia.ID, "big_pearl", 1, 0, missing),
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                GregtechItemList.MagicFeather.get(1),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(ExtraUtilities.ID, "angelBlock", 1, 0, missing),
+                NHItemList.EngravedGoldChip.getIS(1),
+                OrePrefixes.screw.get(Materials.Tritanium));
+        TCHelper.addInfusionCraftingRecipe(
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 1, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("permutatio"), 50).add(Aspect.getAspect("volatus"), 50)
                         .add(Aspect.getAspect("aer"), 50),
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(TinkerConstruct.ID, "fletching", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "fletching", 1, 0, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(TinkerConstruct.ID, "fletching", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "fletching", 1, 0, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 2, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("permutatio"), 50).add(Aspect.getAspect("volatus"), 50)
                         .add(Aspect.getAspect("auram"), 50),
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(TwilightForest.ID, "tile.TFCicada", 1, 0, missing),
-                        getModItem(TwilightForest.ID, "tile.TFFirefly", 1, 0, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(TwilightForest.ID, "tile.TFCicada", 1, 0, missing),
+                getModItem(TwilightForest.ID, "tile.TFFirefly", 1, 0, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 3, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("permutatio"), 50).add(Aspect.getAspect("bestia"), 50)
                         .add(Aspect.getAspect("infernus"), 50),
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Minecraft.ID, "dragon_egg", 1, 0, missing),
-                        getModItem(Botania.ID, "manaResource", 1, 9, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Minecraft.ID, "dragon_egg", 1, 0, missing),
+                getModItem(Botania.ID, "manaResource", 1, 9, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 4, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("permutatio"), 50).add(Aspect.getAspect("metallum"), 50)
                         .add(Aspect.getAspect("lucrum"), 50),
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.foil, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.foil, Materials.RoseGold, 1L), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.foil.get(Materials.RoseGold),
+                OrePrefixes.foil.get(Materials.RoseGold));
         new ResearchItem(
                 "EXURINGS",
                 "ARTIFICE",

--- a/src/main/java/com/dreammaster/scripts/ScriptForbiddenMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptForbiddenMagic.java
@@ -168,7 +168,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "nuggetThaumium",
                 new AspectList().add(Aspect.getAspect("permutatio"), 4).add(Aspect.getAspect("ordo"), 2)
                         .add(Aspect.getAspect("vitreus"), 2));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_witchwood",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 4, missing),
                 6,
@@ -176,18 +176,18 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("herba"), 32).add(Aspect.getAspect("instrumentum"), 24)
                         .add(Aspect.getAspect("vacuos"), 24),
                 getModItem(Witchery.ID, "ingredient", 1, 82, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gem, Materials.Vinteum, 1),
-                        getModItem(Witchery.ID, "witchsapling", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 34, missing),
-                        getModItem(Witchery.ID, "witchsapling", 1, 1, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 36, missing),
-                        getModItem(Witchery.ID, "witchsapling", 1, 2, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gem, Materials.Vinteum, 1),
-                        getModItem(Witchery.ID, "witchsapling", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 34, missing),
-                        getModItem(Witchery.ID, "witchsapling", 1, 1, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 36, missing),
-                        getModItem(Witchery.ID, "witchsapling", 1, 2, missing), });
+                OrePrefixes.gem.get(Materials.Vinteum),
+                getModItem(Witchery.ID, "witchsapling", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 34, missing),
+                getModItem(Witchery.ID, "witchsapling", 1, 1, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 36, missing),
+                getModItem(Witchery.ID, "witchsapling", 1, 2, missing),
+                OrePrefixes.gem.get(Materials.Vinteum),
+                getModItem(Witchery.ID, "witchsapling", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 34, missing),
+                getModItem(Witchery.ID, "witchsapling", 1, 1, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 36, missing),
+                getModItem(Witchery.ID, "witchsapling", 1, 2, missing));
         new ResearchItem(
                 "JOURNEY",
                 "FORBIDDEN",
@@ -294,7 +294,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 2,
                 3,
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 3, missing)).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_manasteel",
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 4, missing),
                 6,
@@ -302,16 +302,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("electrum"), 32).add(Aspect.getAspect("instrumentum"), 24)
                         .add(Aspect.getAspect("machina"), 24),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 4, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.dust, Materials.AstralSilver, 1L),
-                        getModItem(Botania.ID, "manaResource", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.AstralSilver, 1L),
-                        getModItem(Botania.ID, "manaResource", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.AstralSilver, 1L),
-                        getModItem(Botania.ID, "manaResource", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.AstralSilver, 1L),
-                        getModItem(Botania.ID, "manaResource", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.AstralSilver, 1L),
-                        getModItem(Botania.ID, "manaResource", 1, 0, missing), });
+                OrePrefixes.dust.get(Materials.AstralSilver),
+                getModItem(Botania.ID, "manaResource", 1, 0, missing),
+                OrePrefixes.dust.get(Materials.AstralSilver),
+                getModItem(Botania.ID, "manaResource", 1, 0, missing),
+                OrePrefixes.dust.get(Materials.AstralSilver),
+                getModItem(Botania.ID, "manaResource", 1, 0, missing),
+                OrePrefixes.dust.get(Materials.AstralSilver),
+                getModItem(Botania.ID, "manaResource", 1, 0, missing),
+                OrePrefixes.dust.get(Materials.AstralSilver),
+                getModItem(Botania.ID, "manaResource", 1, 0, missing));
         TCHelper.addResearchPage("CAP_manasteel", new ResearchPage("derp.research_page.CAP_manasteel"));
         TCHelper.addResearchPage(
                 "CAP_manasteel",
@@ -332,7 +332,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 2,
                 3,
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 2, missing)).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_terrasteel",
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 2, missing),
                 6,
@@ -340,16 +340,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("metallum"), 64).add(Aspect.getAspect("superbia"), 20)
                         .add(Aspect.getAspect("strontio"), 10),
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 3, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steeleaf, 1L),
-                        getModItem(Botania.ID, "manaResource", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Botania.ID, "manaResource", 1, 4, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steeleaf, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing), });
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                OrePrefixes.plate.get(Materials.Steeleaf),
+                getModItem(Botania.ID, "manaResource", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Botania.ID, "manaResource", 1, 4, missing),
+                OrePrefixes.plate.get(Materials.Steeleaf),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing));
         TCHelper.addResearchPage("CAP_terrasteel", new ResearchPage("derp.research_page.CAP_terrasteel"));
         TCHelper.addResearchPage(
                 "CAP_terrasteel",
@@ -645,7 +645,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("sensus"), 9).add(Aspect.getAspect("lucrum"), 6)
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("BLOODWELL", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUSBLINK",
                 getModItem(ForbiddenMagic.ID, "BlinkFocus", 1, 0, missing),
                 8,
@@ -653,14 +653,18 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("iter"), 32).add(Aspect.getAspect("perditio"), 32)
                         .add(Aspect.getAspect("alienis"), 8).add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
-                new ItemStack[] { getModItem(Witchery.ID, "ingredient", 1, 92, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing), ItemList.QuantumEye.get(1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing), ItemList.QuantumEye.get(1L),
-                        getModItem(Witchery.ID, "ingredient", 1, 92, missing), ItemList.QuantumEye.get(1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing), ItemList.QuantumEye.get(1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing), });
+                getModItem(Witchery.ID, "ingredient", 1, 92, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing),
+                ItemList.QuantumEye.get(1L),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing),
+                ItemList.QuantumEye.get(1L),
+                getModItem(Witchery.ID, "ingredient", 1, 92, missing),
+                ItemList.QuantumEye.get(1L),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing),
+                ItemList.QuantumEye.get(1L),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing));
         TCHelper.setResearchAspects(
                 "FOCUSBLINK",
                 new AspectList().add(Aspect.getAspect("desidia"), 21).add(Aspect.getAspect("iter"), 18)
@@ -668,7 +672,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("tenebrae"), 6)
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("FOCUSBLINK", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ARCANECAKE",
                 getModItem(ForbiddenMagic.ID, "ArcaneCakeItem", 1, 0, missing),
                 6,
@@ -676,40 +680,40 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("gula"), 16).add(Aspect.getAspect("aqua"), 64)
                         .add(Aspect.getAspect("limus"), 16).add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(Minecraft.ID, "cake", 1, 0, missing),
-                new ItemStack[] { getModItem(ForbiddenMagic.ID, "StarBlock", 1, 0, missing),
-                        getModItem(Minecraft.ID, "milk_bucket", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
-                        getModItem(Minecraft.ID, "egg", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "StarBlock", 1, 0, missing),
-                        getModItem(Minecraft.ID, "egg", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
-                        getModItem(Minecraft.ID, "milk_bucket", 1, 0, missing), });
+                getModItem(ForbiddenMagic.ID, "StarBlock", 1, 0, missing),
+                getModItem(Minecraft.ID, "milk_bucket", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
+                getModItem(Minecraft.ID, "egg", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "StarBlock", 1, 0, missing),
+                getModItem(Minecraft.ID, "egg", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
+                getModItem(Minecraft.ID, "milk_bucket", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ARCANECAKE",
                 new AspectList().add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("gula"), 15)
                         .add(Aspect.getAspect("fames"), 12).add(Aspect.getAspect("fabrico"), 9)
                         .add(Aspect.getAspect("limus"), 6).add(Aspect.getAspect("aqua"), 3));
         TCHelper.setResearchComplexity("ARCANECAKE", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FORK",
                 getModItem(ForbiddenMagic.ID, "DiabolistFork", 1, 0, missing),
                 10,
                 new AspectList().add(Aspect.getAspect("telum"), 32).add(Aspect.getAspect("infernus"), 24)
                         .add(Aspect.getAspect("potentia"), 16).add(Aspect.getAspect("machina"), 8),
                 getModItem(Thaumcraft.ID, "ItemSwordThaumium", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.stick, Materials.BloodInfusedIron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.InfusedFire, 1L),
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.BloodInfusedIron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.InfusedFire, 1L),
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.BloodInfusedIron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.InfusedFire, 1L),
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1, missing), });
+                OrePrefixes.stick.get(Materials.BloodInfusedIron),
+                OrePrefixes.screw.get(Materials.InfusedFire),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1, missing),
+                OrePrefixes.stick.get(Materials.BloodInfusedIron),
+                OrePrefixes.screw.get(Materials.InfusedFire),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1, missing),
+                OrePrefixes.stick.get(Materials.BloodInfusedIron),
+                OrePrefixes.screw.get(Materials.InfusedFire),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1, missing));
         TCHelper.setResearchAspects(
                 "FORK",
                 new AspectList().add(Aspect.getAspect("tenebrae"), 18).add(Aspect.getAspect("praecantatio"), 15)
@@ -717,7 +721,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("instrumentum"), 6).add(Aspect.getAspect("telum"), 3));
         TCHelper.setResearchComplexity("FORK", 3);
         ThaumcraftApi.addWarpToResearch("FORK", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SKULLAXE",
                 getModItem(ForbiddenMagic.ID, "SkullAxe", 1, 0, missing),
                 10,
@@ -725,16 +729,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 24).add(Aspect.getAspect("potentia"), 16)
                         .add(Aspect.getAspect("mortuus"), 8),
                 getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
-                new ItemStack[] { getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 1, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Ruby, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 2, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 4, missing), });
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(Minecraft.ID, "skull", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(Minecraft.ID, "skull", 1, 1, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                OrePrefixes.gemExquisite.get(Materials.Ruby),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(Minecraft.ID, "skull", 1, 2, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(Minecraft.ID, "skull", 1, 4, missing));
         TCHelper.setResearchAspects(
                 "SKULLAXE",
                 new AspectList().add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("instrumentum"), 15)
@@ -742,7 +746,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 6).add(Aspect.getAspect("infernus"), 3));
         TCHelper.setResearchComplexity("SKULLAXE", 3);
         ThaumcraftApi.addWarpToResearch("SKULLAXE", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "BLOODRAPIER",
                 getModItem(ForbiddenMagic.ID, "BloodRapier", 1, 0, missing),
                 10,
@@ -750,16 +754,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 16).add(Aspect.getAspect("fames"), 32)
                         .add(Aspect.getAspect("gula"), 8),
                 getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "feather", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
-                        getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Amber, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
-                        getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing), });
+                getModItem(Minecraft.ID, "feather", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
+                getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
+                OrePrefixes.gemExquisite.get(Materials.Amber),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
+                getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "BLOODRAPIER",
                 new AspectList().add(Aspect.getAspect("tenebrae"), 18).add(Aspect.getAspect("gula"), 15)
@@ -778,7 +782,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("terra"), 6)
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("TRANSEMERALD", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WRATHCAGE",
                 getModItem(ForbiddenMagic.ID, "WrathCage", 1, 0, missing),
                 15,
@@ -787,19 +791,19 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("exanimis"), 16)
                         .add(Aspect.getAspect("praecantatio"), 32),
                 getModItem(EnderIO.ID, "itemBrokenSpawner", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.block, Materials.Thaumium, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "MobCrystal", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "MobCrystal", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "MobCrystal", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "MobCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing), });
+                OrePrefixes.block.get(Materials.Thaumium),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "MobCrystal", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "MobCrystal", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "MobCrystal", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "MobCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing));
         ThaumcraftApi.addCrucibleRecipe(
                 "WRATHCAGE",
                 getModItem(ForbiddenMagic.ID, "MobCrystal", 1, 0, missing),
@@ -814,7 +818,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("exanimis"), 3));
         TCHelper.setResearchComplexity("WRATHCAGE", 3);
         ThaumcraftApi.addWarpToResearch("WRATHCAGE", 5);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MORPHTOOLS",
                 getModItem(ForbiddenMagic.ID, "MorphPickaxe", 1, 0, missing),
                 10,
@@ -822,17 +826,17 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("cognitio"), 8)
                         .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("potentia"), 8),
                 getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Ruby, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Ruby),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "MORPHTOOLS",
                 getModItem(ForbiddenMagic.ID, "MorphAxe", 1, 0, missing),
                 10,
@@ -840,17 +844,17 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("cognitio"), 8)
                         .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("potentia"), 8),
                 getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Ruby, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Ruby),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "MORPHTOOLS",
                 getModItem(ForbiddenMagic.ID, "MorphShovel", 1, 0, missing),
                 10,
@@ -858,17 +862,17 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("cognitio"), 8)
                         .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("potentia"), 8),
                 getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Ruby, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Ruby),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "MORPHTOOLS",
                 getModItem(ForbiddenMagic.ID, "MorphSword", 1, 0, missing),
                 10,
@@ -876,16 +880,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("cognitio"), 8)
                         .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("potentia"), 8),
                 getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Ruby, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing), });
+                getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Ruby),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing));
         TCHelper.setResearchAspects(
                 "MORPHTOOLS",
                 new AspectList().add(Aspect.getAspect("invidia"), 18).add(Aspect.getAspect("instrumentum"), 15)
@@ -893,7 +897,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("potentia"), 3));
         TCHelper.setResearchComplexity("MORPHTOOLS", 3);
         ThaumcraftApi.addWarpToResearch("MORPHTOOLS", 5);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TAINTSHOVEL",
                 getModItem(ForbiddenMagic.ID, "TaintShovel", 1, 0, missing),
                 10,
@@ -901,15 +905,15 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vitreus"), 32).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("limus"), 8).add(Aspect.getAspect("instrumentum"), 8),
                 getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Amber, 1L),
-                        getModItem(TinkerConstruct.ID, "strangeFood", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "strangeFood", 1, 0, missing),
-                        getModItem(Minecraft.ID, "slime_ball", 1, 0, missing),
-                        getModItem(Minecraft.ID, "slime_ball", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Sapphire, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing), });
+                getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                OrePrefixes.gemExquisite.get(Materials.Amber),
+                getModItem(TinkerConstruct.ID, "strangeFood", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "strangeFood", 1, 0, missing),
+                getModItem(Minecraft.ID, "slime_ball", 1, 0, missing),
+                getModItem(Minecraft.ID, "slime_ball", 1, 0, missing),
+                OrePrefixes.gemExquisite.get(Materials.Sapphire),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing));
         TCHelper.setResearchAspects(
                 "TAINTSHOVEL",
                 new AspectList().add(Aspect.getAspect("vitreus"), 21).add(Aspect.getAspect("vitium"), 18)
@@ -917,7 +921,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("venenum"), 6)
                         .add(Aspect.getAspect("permutatio"), 3));
         TCHelper.setResearchComplexity("TAINTSHOVEL", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TAINTPICK",
                 getModItem(ForbiddenMagic.ID, "TaintPickaxe", 1, 0, missing),
                 10,
@@ -925,15 +929,15 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vitium"), 16).add(Aspect.getAspect("perditio"), 32)
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("mortuus"), 8),
                 getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "WandRod", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Amber, 1L),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Amethyst, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing), });
+                getModItem(Thaumcraft.ID, "WandRod", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                OrePrefixes.gemExquisite.get(Materials.Amber),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                OrePrefixes.gemExquisite.get(Materials.Amethyst),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing));
         TCHelper.setResearchAspects(
                 "TAINTPICK",
                 new AspectList().add(Aspect.getAspect("vitium"), 18).add(Aspect.getAspect("perditio"), 15)
@@ -981,7 +985,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("vitium"), 9)
                         .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("ordo"), 3));
         TCHelper.setResearchComplexity("TAINTSTONE", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ELDRITCHORB",
                 getModItem(ForbiddenMagic.ID, "EldritchOrb", 1, 0, missing),
                 15,
@@ -989,16 +993,18 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("victus"), 64)
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("vitreus"), 8),
                 getModItem(BloodArsenal.ID, "transparent_orb", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), ItemList.QuantumEye.get(1L),
-                        ItemList.Gravistar.get(1L), ItemList.QuantumEye.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                ItemList.QuantumEye.get(1L),
+                ItemList.Gravistar.get(1L),
+                ItemList.QuantumEye.get(1L),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ELDRITCHORB",
                 new AspectList().add(Aspect.getAspect("vacuos"), 18).add(Aspect.getAspect("victus"), 15)
@@ -1040,7 +1046,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("volatus"), 6).add(Aspect.getAspect("ordo"), 3));
         TCHelper.setResearchComplexity("PRIMEWELL", 3);
         ThaumcraftApi.addWarpToResearch("PRIMEWELL", 1);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SUBCOLLAR",
                 getModItem(ForbiddenMagic.ID, "SubCollar", 1, 0, missing),
                 10,
@@ -1048,15 +1054,15 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("auram"), 16).add(Aspect.getAspect("corpus"), 16)
                         .add(Aspect.getAspect("luxuria"), 8).add(Aspect.getAspect("praecantatio"), 32),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemAmuletVis", 1, 1, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
-                        getModItem(Minecraft.ID, "lead", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
-                        getModItem(Minecraft.ID, "lead", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
-                        getModItem(Minecraft.ID, "lead", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
-                        getModItem(Minecraft.ID, "lead", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemAmuletVis", 1, 1, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
+                getModItem(Minecraft.ID, "lead", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
+                getModItem(Minecraft.ID, "lead", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
+                getModItem(Minecraft.ID, "lead", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
+                getModItem(Minecraft.ID, "lead", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "SUBCOLLAR",
                 new AspectList().add(Aspect.getAspect("vinculum"), 18).add(Aspect.getAspect("auram"), 15)
@@ -1069,7 +1075,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("iter"), 12).add(Aspect.getAspect("praecantatio"), 9)
                         .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("lux"), 3));
         TCHelper.setResearchComplexity("HELLFIRE", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_infernal",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 1, missing),
                 7,
@@ -1077,16 +1083,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("infernus"), 32).add(Aspect.getAspect("ignis"), 48)
                         .add(Aspect.getAspect("instrumentum"), 8),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 6, missing),
-                new ItemStack[] { getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Soularium, 1L),
-                        getModItem(Minecraft.ID, "skull", 1, 1, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
-                        getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Soularium, 1L), });
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
+                OrePrefixes.plate.get(Materials.Soularium),
+                getModItem(Minecraft.ID, "skull", 1, 1, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
+                getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Soularium));
         TCHelper.setResearchAspects(
                 "ROD_infernal",
                 new AspectList().add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("ignis"), 12)
@@ -1094,7 +1100,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("instrumentum"), 3));
         TCHelper.setResearchComplexity("ROD_infernal", 3);
         ThaumcraftApi.addWarpToResearch("ROD_infernal", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_blood",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 6, missing),
                 9,
@@ -1102,18 +1108,18 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("victus"), 24).add(Aspect.getAspect("exanimis"), 8)
                         .add(Aspect.getAspect("alienis"), 8),
                 getModItem(BloodMagic.ID, "masterBloodOrb", 1, 0, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "sanctus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aether", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "crystallos", 1, 0, missing),
-                        getModItem(BloodMagic.ID, "crepitous", 1, 0, missing), });
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "sanctus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(BloodMagic.ID, "incendium", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aether", 1, 0, missing),
+                getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 0, missing),
+                getModItem(BloodMagic.ID, "demonicSlate", 1, 0, missing),
+                getModItem(BloodMagic.ID, "terrae", 1, 0, missing),
+                getModItem(BloodMagic.ID, "tennebrae", 1, 0, missing),
+                getModItem(BloodMagic.ID, "aquasalus", 1, 0, missing),
+                getModItem(BloodMagic.ID, "crystallos", 1, 0, missing),
+                getModItem(BloodMagic.ID, "crepitous", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ROD_blood",
                 new AspectList().add(Aspect.getAspect("victus"), 15).add(Aspect.getAspect("aqua"), 12)
@@ -1172,7 +1178,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("infernus"), 12).add(Aspect.getAspect("potentia"), 9)
                         .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("ignis"), 3));
         TCHelper.setResearchComplexity("CLUSTER", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_tainted",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 0, missing),
                 12,
@@ -1180,18 +1186,18 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("perditio"), 48).add(Aspect.getAspect("venenum"), 24)
                         .add(Aspect.getAspect("alienis"), 8).add(Aspect.getAspect("tenebrae"), 32),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 1, missing),
-                new ItemStack[] { getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing), });
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing));
         TCHelper.setResearchAspects(
                 "ROD_tainted",
                 new AspectList().add(Aspect.getAspect("vitium"), 18).add(Aspect.getAspect("praecantatio"), 15)
@@ -1235,7 +1241,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         ThaumcraftApi.addWarpToResearch("ROD_blood_staff", 4);
         TCHelper.clearPages("CAP_alchemical");
         TCHelper.addResearchPage("CAP_alchemical", new ResearchPage("forbidden.research_page.CAP_alchemical.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_alchemical",
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 0, missing),
                 6,
@@ -1243,16 +1249,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("permutatio"), 8)
                         .add(Aspect.getAspect("metallum"), 8),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 1, missing),
-                new ItemStack[] { getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L), });
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                OrePrefixes.dust.get(Materials.Thaumium));
         TCHelper.addResearchPage(
                 "CAP_alchemical",
                 new ResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptForestry.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptForestry.java
@@ -327,21 +327,21 @@ public class ScriptForestry implements IScriptLoader {
                 3,
                 getModItem(Forestry.ID, "grafterProven", 1, 0, missing)).setParents("MB_Scoop").setConcealed()
                         .setPages(new ResearchPage("Forestry.research_page.PROVENGRAFTER")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PROVENGRAFTER",
                 getModItem(Forestry.ID, "grafterProven", 1, 0, missing),
                 3,
                 new AspectList().add(Aspect.getAspect("instrumentum"), 25).add(Aspect.getAspect("permutatio"), 25)
                         .add(Aspect.getAspect("metallum"), 20).add(Aspect.getAspect("arbor"), 10),
                 getModItem(Forestry.ID, "grafter", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "sapling", 1, 1, missing),
-                        getModItem(Minecraft.ID, "sapling", 1, 2, missing),
-                        getModItem(Forestry.ID, "pollen", 1, 0, missing),
-                        getModItem(Minecraft.ID, "sapling", 1, 3, missing),
-                        getModItem(Minecraft.ID, "sapling", 1, 4, missing),
-                        getModItem(Minecraft.ID, "sapling", 1, 5, missing),
-                        getModItem(Forestry.ID, "pollen", 1, 1, missing),
-                        getModItem(Minecraft.ID, "sapling", 1, 0, missing), });
+                getModItem(Minecraft.ID, "sapling", 1, 1, missing),
+                getModItem(Minecraft.ID, "sapling", 1, 2, missing),
+                getModItem(Forestry.ID, "pollen", 1, 0, missing),
+                getModItem(Minecraft.ID, "sapling", 1, 3, missing),
+                getModItem(Minecraft.ID, "sapling", 1, 4, missing),
+                getModItem(Minecraft.ID, "sapling", 1, 5, missing),
+                getModItem(Forestry.ID, "pollen", 1, 1, missing),
+                getModItem(Minecraft.ID, "sapling", 1, 0, missing));
         TCHelper.addResearchPage(
                 "PROVENGRAFTER",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Forestry.ID, "grafterProven", 1, 0, missing))));

--- a/src/main/java/com/dreammaster/scripts/ScriptGadomancy.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGadomancy.java
@@ -11,7 +11,6 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 
 import com.dreammaster.thaumcraft.TCHelper;
@@ -21,7 +20,6 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
 import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -100,7 +98,7 @@ public class ScriptGadomancy implements IScriptLoader {
         TCHelper.removeArcaneRecipe(getModItem(Gadomancy.ID, "BlockAuraPylon", 1, 1, missing));
         TCHelper.removeArcaneRecipe(getModItem(Gadomancy.ID, "BlockKnowledgeBook", 1, 0, missing));
         TCHelper.removeArcaneRecipe(getModItem(Gadomancy.ID, "BlockEssentiaCompressor", 3, 0, missing));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.GOLEMSILVERWOOD",
                 getModItem(Gadomancy.ID, "itemSilverwoodGolemPlacer", 1, 8, missing),
                 8,
@@ -108,16 +106,16 @@ public class ScriptGadomancy implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("sensus"), 16)
                         .add(Aspect.getAspect("cognitio"), 8).add(Aspect.getAspect("ordo"), 32),
                 getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 1, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 9, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 9, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing), });
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 9, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 9, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing));
         TCHelper.setResearchAspects(
                 "GADOMANCY.GOLEMSILVERWOOD",
                 new AspectList().add(Aspect.getAspect("cognitio"), 21).add(Aspect.getAspect("motus"), 18)
@@ -125,7 +123,7 @@ public class ScriptGadomancy implements IScriptLoader {
                         .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("corpus"), 6)
                         .add(Aspect.getAspect("permutatio"), 3));
         TCHelper.setResearchComplexity("GADOMANCY.GOLEMSILVERWOOD", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.GOLEMCOREBREAK",
                 getModItem(Gadomancy.ID, "ItemGolemCoreBreak", 1, 0, missing),
                 6,
@@ -133,22 +131,22 @@ public class ScriptGadomancy implements IScriptLoader {
                         .add(Aspect.getAspect("machina"), 24).add(Aspect.getAspect("praecantatio"), 8)
                         .add(Aspect.getAspect("perfodio"), 8),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 3, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing), });
+                getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing));
         TCHelper.setResearchAspects(
                 "GADOMANCY.GOLEMCOREBREAK",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("perditio"), 12)
                         .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("praecantatio"), 6)
                         .add(Aspect.getAspect("perfodio"), 3));
         TCHelper.setResearchComplexity("GADOMANCY.GOLEMCOREBREAK", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.GOLEMCOREBODYGUARD",
                 getModItem(Gadomancy.ID, "ItemGolemCoreBreak", 1, 1, missing),
                 9,
@@ -156,12 +154,14 @@ public class ScriptGadomancy implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 16).add(Aspect.getAspect("tutamen"), 24)
                         .add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("auram"), 8),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 4, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemHelmetThaumium", 1, 0, missing), ItemList.QuantumEye.get(1L),
-                        getModItem(Thaumcraft.ID, "ItemChestplateThaumium", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "BootsTraveller", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemLeggingsThaumium", 1, 0, missing), ItemList.QuantumEye.get(1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing), });
+                getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemHelmetThaumium", 1, 0, missing),
+                ItemList.QuantumEye.get(1L),
+                getModItem(Thaumcraft.ID, "ItemChestplateThaumium", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "BootsTraveller", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemLeggingsThaumium", 1, 0, missing),
+                ItemList.QuantumEye.get(1L),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing));
         TCHelper.setResearchAspects(
                 "GADOMANCY.GOLEMCOREBODYGUARD",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 18).add(Aspect.getAspect("ordo"), 15)
@@ -212,7 +212,7 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 11, missing),
                 new AspectList().add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("perditio"), 12)
                         .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("terra"), 8));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.NODE_MANIPULATOR",
                 getModItem(Gadomancy.ID, "BlockNodeManipulator", 1, 5, missing),
                 10,
@@ -221,19 +221,19 @@ public class ScriptGadomancy implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("permutatio"), 24)
                         .add(Aspect.getAspect("motus"), 8),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 5, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 11, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 11, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                OrePrefixes.plateDense.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 11, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 11, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.NODE_MANIPULATOR",
                 getModItem(Gadomancy.ID, "BlockStoneMachine", 1, 0, missing),
                 10,
@@ -242,16 +242,16 @@ public class ScriptGadomancy implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("nebrisum"), 8)
                         .add(Aspect.getAspect("lucrum"), 16),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 8, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                OrePrefixes.ring.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.ring.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing));
         TCHelper.setResearchAspects(
                 "GADOMANCY.NODE_MANIPULATOR",
                 new AspectList().add(Aspect.getAspect("nebrisum"), 27).add(Aspect.getAspect("alienis"), 24)
@@ -260,7 +260,7 @@ public class ScriptGadomancy implements IScriptLoader {
                         .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("tenebrae"), 6)
                         .add(Aspect.getAspect("permutatio"), 3));
         TCHelper.setResearchComplexity("GADOMANCY.NODE_MANIPULATOR", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.INFUSIONCLAW",
                 getModItem(Gadomancy.ID, "BlockInfusionClaw", 1, 0, missing),
                 15,
@@ -269,18 +269,18 @@ public class ScriptGadomancy implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("motus"), 16)
                         .add(Aspect.getAspect("cognitio"), 8),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 5, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 8, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing), });
+                getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 8, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
+                OrePrefixes.stick.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
+                OrePrefixes.stick.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
+                OrePrefixes.stick.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
+                OrePrefixes.stick.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing));
         TCHelper.setResearchAspects(
                 "GADOMANCY.INFUSIONCLAW",
                 new AspectList().add(Aspect.getAspect("alienis"), 21).add(Aspect.getAspect("machina"), 18)
@@ -442,7 +442,7 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 15, missing),
                 'i',
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 11, missing));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.E_PORTAL_CREATOR",
                 getModItem(Gadomancy.ID, "BlockStoneMachine", 1, 3, missing),
                 10,
@@ -451,16 +451,16 @@ public class ScriptGadomancy implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("auram"), 16)
                         .add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 8, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing), });
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                OrePrefixes.ring.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.ring.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing));
         TCHelper.setResearchAspects(
                 "GADOMANCY.E_PORTAL_CREATOR",
                 new AspectList().add(Aspect.getAspect("tenebrae"), 21).add(Aspect.getAspect("auram"), 18)

--- a/src/main/java/com/dreammaster/scripts/ScriptMagicBees.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMagicBees.java
@@ -430,7 +430,7 @@ public class ScriptMagicBees implements IScriptLoader {
                 getModItem(MagicBees.ID, "magicApiary", 1, 0, missing)).setParents("MB_DimensionalSingularity")
                         .setConcealed().setRound().setPages(new ResearchPage("MagicBees.research_page.MAGICAPIARY"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MAGICAPIARY",
                 getModItem(MagicBees.ID, "magicApiary", 1, 0, missing),
                 3,
@@ -438,10 +438,11 @@ public class ScriptMagicBees implements IScriptLoader {
                         .add(Aspect.getAspect("ignis"), 50).add(Aspect.getAspect("lucrum"), 50)
                         .add(Aspect.getAspect("exanimis"), 25).add(Aspect.getAspect("herba"), 20),
                 getModItem(Forestry.ID, "apiculture", 1, 0, missing),
-                new ItemStack[] { getModItem(MagicBees.ID, "wax", 1, 0, missing),
-                        getModItem(MagicBees.ID, "wax", 1, 1, missing), getModItem(MagicBees.ID, "wax", 1, 2, missing),
-                        getModItem(MagicBees.ID, "pollen", 1, 0, missing),
-                        getModItem(MagicBees.ID, "pollen", 1, 1, missing), });
+                getModItem(MagicBees.ID, "wax", 1, 0, missing),
+                getModItem(MagicBees.ID, "wax", 1, 1, missing),
+                getModItem(MagicBees.ID, "wax", 1, 2, missing),
+                getModItem(MagicBees.ID, "pollen", 1, 0, missing),
+                getModItem(MagicBees.ID, "pollen", 1, 1, missing));
         TCHelper.addResearchPage(
                 "MAGICAPIARY",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(MagicBees.ID, "magicApiary", 1, 0, missing))));
@@ -600,19 +601,19 @@ public class ScriptMagicBees implements IScriptLoader {
         TCHelper.addResearchPage(
                 "MB_DimensionalSingularity",
                 new ResearchPage("tc.research_page.MB_DimensionalSingularity.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MB_DimensionalSingularity",
                 getModItem(MagicBees.ID, "miscResources", 1, 17, missing),
                 6,
                 new AspectList().add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("permutatio"), 24)
                         .add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("tenebrae"), 16),
                 getModItem(Minecraft.ID, "gold_block", 1, 0, missing),
-                new ItemStack[] { getModItem(MagicBees.ID, "propolis", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
-                        getModItem(MagicBees.ID, "propolis", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
-                        getModItem(MagicBees.ID, "propolis", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ender_eye", 1, 0, missing), });
+                getModItem(MagicBees.ID, "propolis", 1, 0, missing),
+                getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
+                getModItem(MagicBees.ID, "propolis", 1, 0, missing),
+                getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
+                getModItem(MagicBees.ID, "propolis", 1, 0, missing),
+                getModItem(Minecraft.ID, "ender_eye", 1, 0, missing));
         TCHelper.addResearchPage(
                 "MB_DimensionalSingularity",
                 new ResearchPage(
@@ -625,16 +626,16 @@ public class ScriptMagicBees implements IScriptLoader {
         TCHelper.moveResearch("MB_EssenceOblivion", "MAGICBEES", -7, 4);
         TCHelper.clearPages("MB_EssenceOblivion");
         TCHelper.addResearchPage("MB_EssenceOblivion", new ResearchPage("tc.research_page.MB_EssenceOblivion.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MB_EssenceOblivion",
                 getModItem(MagicBees.ID, "miscResources", 1, 11, missing),
                 8,
                 new AspectList().add(Aspect.getAspect("alienis"), 100).add(Aspect.getAspect("praecantatio"), 100)
                         .add(Aspect.getAspect("lucrum"), 75).add(Aspect.getAspect("bestia"), 75),
                 getModItem(Minecraft.ID, "dragon_egg", 1, 0, missing),
-                new ItemStack[] { getModItem(MagicBees.ID, "miscResources", 1, 17, missing),
-                        getModItem(MagicBees.ID, "miscResources", 1, 17, missing),
-                        getModItem(MagicBees.ID, "miscResources", 1, 17, missing), });
+                getModItem(MagicBees.ID, "miscResources", 1, 17, missing),
+                getModItem(MagicBees.ID, "miscResources", 1, 17, missing),
+                getModItem(MagicBees.ID, "miscResources", 1, 17, missing));
         TCHelper.addResearchPage(
                 "MB_EssenceOblivion",
                 new ResearchPage(
@@ -1120,16 +1121,19 @@ public class ScriptMagicBees implements IScriptLoader {
         TCHelper.setResearchComplexity("MB_ApimancersDrainer", 5);
         ResearchCategories.getResearch("MB_ApimancersDrainer").setConcealed();
         ThaumcraftApi.addWarpToResearch("MB_ApimancersDrainer", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MB_ApimancersDrainer",
                 getModItem(MagicBees.ID, "apimancersDrainer", 1, 0, missing),
                 5,
                 new AspectList().add(Aspect.MAGIC, 100).add(Aspect.HARVEST, 75).add(Aspect.getAspect("tempus"), 50),
                 getModItem(Thaumcraft.ID, "blockEssentiaReservoir", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockTube", 1, 2, missing),
-                        getModItem(MagicBees.ID, "pollen", 1, 0, missing), new ItemStack(Loaders.essentiaCell, 1, 0),
-                        new ItemStack(Loaders.essentiaCell, 1, 0), new ItemStack(Loaders.essentiaCell, 1, 0),
-                        new ItemStack(Loaders.essentiaCell, 1, 0), getModItem(MagicBees.ID, "pollen", 1, 1, missing) });
+                getModItem(Thaumcraft.ID, "blockTube", 1, 2, missing),
+                getModItem(MagicBees.ID, "pollen", 1, 0, missing),
+                new ItemStack(Loaders.essentiaCell, 1, 0),
+                new ItemStack(Loaders.essentiaCell, 1, 0),
+                new ItemStack(Loaders.essentiaCell, 1, 0),
+                new ItemStack(Loaders.essentiaCell, 1, 0),
+                getModItem(MagicBees.ID, "pollen", 1, 1, missing));
         TCHelper.refreshResearchPages("MB_VisAuraProvider");
         TCHelper.refreshResearchPages("MB_EssenceLife");
         TCHelper.refreshResearchPages("MB_EssenceDeath");

--- a/src/main/java/com/dreammaster/scripts/ScriptOpenBlocks.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptOpenBlocks.java
@@ -737,19 +737,19 @@ public class ScriptOpenBlocks implements IScriptLoader {
                 getModItem(OpenBlocks.ID, "goldenegg", 1, 0, missing)).setParents("MB_DimensionalSingularity")
                         .setConcealed().setPages(new ResearchPage("OpenBlocks.research_page.GOLDENEGG"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "GOLDENEGG",
                 getModItem(OpenBlocks.ID, "goldenegg", 1, 0, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("alienis"), 75).add(Aspect.getAspect("bestia"), 50)
                         .add(Aspect.getAspect("victus"), 50).add(Aspect.getAspect("humanus"), 25),
                 getModItem(Minecraft.ID, "egg", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Gold, 1L),
-                        getModItem(Minecraft.ID, "skull", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Gold, 1L),
-                        getModItem(Minecraft.ID, "skull", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Gold, 1L),
-                        getModItem(Minecraft.ID, "skull", 1, 3, missing), });
+                OrePrefixes.plateDense.get(Materials.Gold),
+                getModItem(Minecraft.ID, "skull", 1, 3, missing),
+                OrePrefixes.plateDense.get(Materials.Gold),
+                getModItem(Minecraft.ID, "skull", 1, 3, missing),
+                OrePrefixes.plateDense.get(Materials.Gold),
+                getModItem(Minecraft.ID, "skull", 1, 3, missing));
         TCHelper.addResearchPage(
                 "GOLDENEGG",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(OpenBlocks.ID, "goldenegg", 1, 0, missing))));

--- a/src/main/java/com/dreammaster/scripts/ScriptRunicTablet.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptRunicTablet.java
@@ -9,8 +9,6 @@ import static gregtech.api.util.GTModHandler.getModItem;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.item.ItemStack;
-
 import com.dreammaster.thaumcraft.TCHelper;
 
 import gregtech.api.enums.Mods;
@@ -47,7 +45,7 @@ public class ScriptRunicTablet implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 2, missing)).setParents("OCULUS")
                         .setSiblings("OCULUS").setConcealed()
                         .setPages(new ResearchPage("kosh.research_page.RUNEDTABLET")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNEDTABLET",
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 2, missing),
                 10,
@@ -55,14 +53,14 @@ public class ScriptRunicTablet implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("vacuos"), 32)
                         .add(Aspect.getAspect("cognitio"), 64).add(Aspect.getAspect("praecantatio"), 128),
                 getModItem(DraconicEvolution.ID, "infoTablet", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        getModItem(ThaumicExploration.ID, "pureZombieBrain", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        getModItem(Automagy.ID, "crystalBrain", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing), });
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                getModItem(ThaumicExploration.ID, "pureZombieBrain", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                getModItem(Automagy.ID, "crystalBrain", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing));
         TCHelper.addResearchPage(
                 "RUNEDTABLET",
                 new ResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptTB.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTB.java
@@ -8,13 +8,11 @@ import static gregtech.api.util.GTModHandler.getModItem;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.item.ItemStack;
+import com.dreammaster.thaumcraft.TCHelper;
 
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
-import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 
@@ -36,7 +34,7 @@ public class ScriptTB implements IScriptLoader {
         // VoidWalker boots
 
         // Electric -> Nano
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TB_EMT_Tainted_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemNanoVoid", 1, 27, missing),
                 6,
@@ -44,17 +42,17 @@ public class ScriptTB implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("volatus"), 8).add(Aspect.getAspect("iter"), 16),
                 getModItem(ThaumicBoots.ID, "item.ItemElectricVoid", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        ItemList.Electric_Motor_HV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1L),
-                        ItemList.Electric_Motor_HV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                ItemList.Electric_Motor_HV.get(1L),
+                OrePrefixes.wireGt04.get(Materials.Electrum),
+                getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
+                OrePrefixes.wireGt04.get(Materials.Electrum),
+                ItemList.Electric_Motor_HV.get(1L),
+                OrePrefixes.plate.get(Materials.Thaumium));
 
         // Nano -> Quantum
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TB_EMT_Tainted_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemQuantumVoid", 1, 27, missing),
                 9,
@@ -63,21 +61,21 @@ public class ScriptTB implements IScriptLoader {
                         .add(Aspect.getAspect("volatus"), 16).add(Aspect.getAspect("iter"), 24)
                         .add(Aspect.getAspect("aer"), 8),
                 getModItem(ThaumicBoots.ID, "item.ItemNanoVoid", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        ItemList.Electric_Motor_EV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Titanium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Titanium, 1L),
-                        ItemList.Electric_Motor_EV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                ItemList.Electric_Motor_EV.get(1L),
+                OrePrefixes.wireGt08.get(Materials.Titanium),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.wireGt08.get(Materials.Titanium),
+                ItemList.Electric_Motor_EV.get(1L),
+                OrePrefixes.plate.get(Materials.Void));
 
         // Meteor
 
         // Electric -> Nano
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TB_Explorations_EMT_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemNanoMeteor", 1, 27, missing),
                 6,
@@ -85,17 +83,17 @@ public class ScriptTB implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("volatus"), 8).add(Aspect.getAspect("iter"), 16),
                 getModItem(ThaumicBoots.ID, "item.ItemElectricMeteor", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        ItemList.Electric_Motor_HV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1L),
-                        ItemList.Electric_Motor_HV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                ItemList.Electric_Motor_HV.get(1L),
+                OrePrefixes.wireGt04.get(Materials.Electrum),
+                getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
+                OrePrefixes.wireGt04.get(Materials.Electrum),
+                ItemList.Electric_Motor_HV.get(1L),
+                OrePrefixes.plate.get(Materials.Thaumium));
 
         // Nano -> Quantum
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TB_Explorations_EMT_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemQuantumMeteor", 1, 27, missing),
                 9,
@@ -104,21 +102,21 @@ public class ScriptTB implements IScriptLoader {
                         .add(Aspect.getAspect("volatus"), 16).add(Aspect.getAspect("iter"), 24)
                         .add(Aspect.getAspect("aer"), 8),
                 getModItem(ThaumicBoots.ID, "item.ItemNanoMeteor", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        ItemList.Electric_Motor_EV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Titanium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Titanium, 1L),
-                        ItemList.Electric_Motor_EV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                ItemList.Electric_Motor_EV.get(1L),
+                OrePrefixes.wireGt08.get(Materials.Titanium),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.wireGt08.get(Materials.Titanium),
+                ItemList.Electric_Motor_EV.get(1L),
+                OrePrefixes.plate.get(Materials.Void));
 
         // Comet
 
         // Electric -> Nano
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TB_Explorations_EMT_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemNanoComet", 1, 27, missing),
                 6,
@@ -126,17 +124,17 @@ public class ScriptTB implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("volatus"), 8).add(Aspect.getAspect("iter"), 16),
                 getModItem(ThaumicBoots.ID, "item.ItemElectricComet", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        ItemList.Electric_Motor_HV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1L),
-                        ItemList.Electric_Motor_HV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                ItemList.Electric_Motor_HV.get(1L),
+                OrePrefixes.wireGt04.get(Materials.Electrum),
+                getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard, missing),
+                OrePrefixes.wireGt04.get(Materials.Electrum),
+                ItemList.Electric_Motor_HV.get(1L),
+                OrePrefixes.plate.get(Materials.Thaumium));
 
         // Nano -> Quantum
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TB_Explorations_EMT_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemQuantumComet", 1, 27, missing),
                 9,
@@ -145,16 +143,16 @@ public class ScriptTB implements IScriptLoader {
                         .add(Aspect.getAspect("volatus"), 16).add(Aspect.getAspect("iter"), 24)
                         .add(Aspect.getAspect("aer"), 8),
                 getModItem(ThaumicBoots.ID, "item.ItemNanoComet", 1, wildcard, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        ItemList.Electric_Motor_EV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Titanium, 1L),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
-                        getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Titanium, 1L),
-                        ItemList.Electric_Motor_EV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                ItemList.Electric_Motor_EV.get(1L),
+                OrePrefixes.wireGt08.get(Materials.Titanium),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, wildcard, missing),
+                getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0, missing),
+                OrePrefixes.wireGt08.get(Materials.Titanium),
+                ItemList.Electric_Motor_EV.get(1L),
+                OrePrefixes.plate.get(Materials.Void));
 
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptTCCoreMod.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTCCoreMod.java
@@ -98,7 +98,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 new ItemStack(NHItems.WITHER_PROTECTION_RING.get(), 1)).setParents("RUNICARMOR")
                         .setSiblings("RUNICARMOR").setConcealed()
                         .setPages(new ResearchPage("NewHorizons.research_page.WITHERRING")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WITHERRING",
                 new ItemStack(NHItems.WITHER_PROTECTION_RING.get(), 1),
                 3,
@@ -106,11 +106,11 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.getAspect("spiritus"), 30).add(Aspect.getAspect("superbia"), 25)
                         .add(Aspect.getAspect("infernus"), 15),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 1, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(Minecraft.ID, "milk_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 1, missing),
-                        getModItem(Minecraft.ID, "milk_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 1, missing), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(Minecraft.ID, "milk_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "skull", 1, 1, missing),
+                getModItem(Minecraft.ID, "milk_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "skull", 1, 1, missing));
         TCHelper.addResearchPage(
                 "WITHERRING",
                 new ResearchPage(TCHelper.findInfusionRecipe(new ItemStack(NHItems.WITHER_PROTECTION_RING.get(), 1))));
@@ -168,7 +168,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 getModItem(ExtraUtilities.ID, "dark_portal", 1, 2, missing)).setParents("EMINENCESTONE", "OCULUS")
                         .setConcealed().setPages(new ResearchPage("ExtraUtilities.research_page.PORTALMILLENIUM"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PORTALMILLENIUM",
                 getModItem(ExtraUtilities.ID, "dark_portal", 1, 2, missing),
                 4,
@@ -176,14 +176,14 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 75).add(Aspect.getAspect("terra"), 25)
                         .add(Aspect.getAspect("vacuos"), 75),
                 getModItem(Minecraft.ID, "clock", 1, 0, missing),
-                new ItemStack[] { getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 14, missing),
-                        getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 2, missing),
-                        getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 14, missing),
-                        getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 2, missing),
-                        getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 14, missing),
-                        getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 2, missing),
-                        getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 14, missing),
-                        getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 2, missing), });
+                getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 14, missing),
+                getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 2, missing),
+                getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 14, missing),
+                getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 2, missing),
+                getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 14, missing),
+                getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 2, missing),
+                getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 14, missing),
+                getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 2, missing));
         TCHelper.addResearchPage(
                 "PORTALMILLENIUM",
                 new ResearchPage(
@@ -201,7 +201,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 getModItem(ExtraUtilities.ID, "dark_portal", 1, 0, missing)).setParents("PORTALMILLENIUM", "ICHOR")
                         .setConcealed().setPages(new ResearchPage("ExtraUtilities.research_page.PORTALDEEPDARK"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PORTALDEEPDARK",
                 getModItem(ExtraUtilities.ID, "dark_portal", 1, 0, missing),
                 32,
@@ -210,14 +210,14 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.getAspect("terminus"), 512).add(Aspect.getAspect("gula"), 512)
                         .add(Aspect.getAspect("superbia"), 512),
                 ItemList.Block_BedrockiumCompressed.get(1L),
-                new ItemStack[] { ItemList.Field_Generator_UIV.get(1L),
-                        getModItem(EternalSingularity.ID, "eternal_singularity", 1, 0, missing),
-                        ItemList.Field_Generator_UIV.get(1L),
-                        getModItem(EternalSingularity.ID, "eternal_singularity", 1, 0, missing),
-                        ItemList.Field_Generator_UIV.get(1L),
-                        getModItem(EternalSingularity.ID, "eternal_singularity", 1, 0, missing),
-                        ItemList.Field_Generator_UIV.get(1L),
-                        getModItem(EternalSingularity.ID, "eternal_singularity", 1, 0, missing), });
+                ItemList.Field_Generator_UIV.get(1L),
+                getModItem(EternalSingularity.ID, "eternal_singularity", 1, 0, missing),
+                ItemList.Field_Generator_UIV.get(1L),
+                getModItem(EternalSingularity.ID, "eternal_singularity", 1, 0, missing),
+                ItemList.Field_Generator_UIV.get(1L),
+                getModItem(EternalSingularity.ID, "eternal_singularity", 1, 0, missing),
+                ItemList.Field_Generator_UIV.get(1L),
+                getModItem(EternalSingularity.ID, "eternal_singularity", 1, 0, missing));
         TCHelper.addResearchPage(
                 "PORTALDEEPDARK",
                 new ResearchPage(
@@ -317,7 +317,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 getModItem(DraconicEvolution.ID, "dezilsMarshmallow", 1, 0, missing)).setParents("INFUSION")
                         .setSpecial().setPages(new ResearchPage("de.research_page.DEZILSMARSHMALLOW"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "DEZILSMARSHMALLOW",
                 getModItem(DraconicEvolution.ID, "dezilsMarshmallow", 1, 0, missing),
                 5,
@@ -325,12 +325,12 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.getAspect("superbia"), 24).add(Aspect.getAspect("sano"), 28)
                         .add(Aspect.getAspect("iter"), 20).add(Aspect.getAspect("potentia"), 12),
                 CustomItemList.Marshmallow.get(1L),
-                new ItemStack[] { getModItem(PamsHarvestCraft.ID, "epicbaconItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "deluxechickencurryItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "meatfeastpizzaItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "beefwellingtonItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "sausageinbreadItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "heartybreakfastItem", 1, 0, missing), });
+                getModItem(PamsHarvestCraft.ID, "epicbaconItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "deluxechickencurryItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "meatfeastpizzaItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "beefwellingtonItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "sausageinbreadItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "heartybreakfastItem", 1, 0, missing));
         TCHelper.addResearchPage(
                 "DEZILSMARSHMALLOW",
                 new ResearchPage(
@@ -502,7 +502,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 3,
                 getModItem(Minecraft.ID, "beacon", 1, 0, missing)).setParents("INFUSION")
                         .setPages(new ResearchPage("Minecraft.research_page.BEACON")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "BEACON",
                 getModItem(Minecraft.ID, "beacon", 1, 0, missing),
                 6,
@@ -510,18 +510,18 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.getAspect("lux"), 64).add(Aspect.getAspect("ordo"), 64)
                         .add(Aspect.getAspect("ignis"), 64).add(Aspect.getAspect("terra"), 64),
                 getModItem(Minecraft.ID, "diamond_block", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "glass", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.NetherStar, 1L),
-                        getModItem(Minecraft.ID, "glass", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.NetherStar, 1L),
-                        getModItem(Minecraft.ID, "glass", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.NetherStar, 1L),
-                        getModItem(Minecraft.ID, "glass", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.NetherStar, 1L), });
+                getModItem(Minecraft.ID, "glass", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Obsidian),
+                OrePrefixes.lens.get(Materials.NetherStar),
+                getModItem(Minecraft.ID, "glass", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Obsidian),
+                OrePrefixes.lens.get(Materials.NetherStar),
+                getModItem(Minecraft.ID, "glass", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Obsidian),
+                OrePrefixes.lens.get(Materials.NetherStar),
+                getModItem(Minecraft.ID, "glass", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Obsidian),
+                OrePrefixes.lens.get(Materials.NetherStar));
         TCHelper.addResearchPage(
                 "BEACON",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Minecraft.ID, "beacon", 1, 0, missing))));
@@ -537,21 +537,21 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 getModItem(Minecraft.ID, "dragon_egg", 1, 0, missing)).setParents("MB_DimensionalSingularity")
                         .setSiblings("INFUSION").setConcealed()
                         .setPages(new ResearchPage("Minecraft.research_page.DRAGONEGG")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "DRAGONEGG",
                 getModItem(Minecraft.ID, "dragon_egg", 1, 0, missing),
                 6,
                 new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("bestia"), 56)
                         .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("victus"), 48),
                 getModItem(MagicBees.ID, "miscResources", 1, 7, missing),
-                new ItemStack[] { getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
-                        getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
-                        getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
-                        getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
-                        getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
-                        getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
-                        getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
-                        getModItem(MagicBees.ID, "miscResources", 1, 6, missing), });
+                getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
+                getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
+                getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
+                getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
+                getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
+                getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
+                getModItem(MagicBees.ID, "miscResources", 1, 6, missing),
+                getModItem(MagicBees.ID, "miscResources", 1, 6, missing));
         TCHelper.addResearchPage(
                 "DRAGONEGG",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Minecraft.ID, "dragon_egg", 1, 0, missing))));
@@ -599,20 +599,20 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "SILKYCRYSTAL",
                 new ResearchPage(
                         TCHelper.findArcaneRecipe(getModItem(TinkerConstruct.ID, "materials", 1, 25, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SILKYCRYSTAL",
                 getModItem(TinkerConstruct.ID, "materials", 1, 26, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("terra"), 20)
                         .add(Aspect.getAspect("ordo"), 35).add(Aspect.getAspect("praecantatio"), 35)
                         .add(Aspect.getAspect("vitreus"), 20),
-                GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                new ItemStack[] { getModItem(TinkerConstruct.ID, "materials", 1, 25, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 25, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 3, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 25, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 4, missing), });
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(TinkerConstruct.ID, "materials", 1, 25, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 25, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 3, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 25, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 4, missing));
         TCHelper.addResearchPage(
                 "SILKYCRYSTAL",
                 new ResearchPage(
@@ -628,21 +628,21 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 getModItem(TinkerConstruct.ID, "materials", 1, 7, missing)).setParents("ENCHANTINGTABLE").setConcealed()
                         .setRound().setPages(new ResearchPage("TConstruct.research_page.LAVACRYSTAL"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "LAVACRYSTAL",
                 getModItem(TinkerConstruct.ID, "materials", 1, 7, missing),
                 3,
                 new AspectList().add(Aspect.getAspect("ignis"), 25).add(Aspect.getAspect("perditio"), 25)
                         .add(Aspect.getAspect("vacuos"), 20).add(Aspect.getAspect("praecantatio"), 35),
                 getModItem(Minecraft.ID, "fire_charge", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                        getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "fire_charge", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 1, missing),
-                        getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                        getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "fire_charge", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 1, missing), });
+                getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
+                getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "fire_charge", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 1, missing),
+                getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
+                getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "fire_charge", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 1, missing));
         TCHelper.addResearchPage(
                 "LAVACRYSTAL",
                 new ResearchPage(
@@ -658,19 +658,19 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 getModItem(TinkerConstruct.ID, "materials", 1, 6, missing)).setParents("SILKYCRYSTAL", "LAVACRYSTAL")
                         .setConcealed().setRound().setPages(new ResearchPage("TConstruct.research_page.BALLOFMOSS"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "BALLOFMOSS",
                 getModItem(TinkerConstruct.ID, "materials", 1, 6, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("sano"), 30).add(Aspect.getAspect("terra"), 25)
                         .add(Aspect.getAspect("instrumentum"), 35),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.dust, Materials.InfusedEarth, 1L),
-                        getModItem(TwilightForest.ID, "tile.TFPlant", 1, 3, missing),
-                        getModItem(BiomesOPlenty.ID, "moss", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.InfusedEarth, 1L),
-                        getModItem(TwilightForest.ID, "tile.TFPlant", 1, 3, missing),
-                        getModItem(BiomesOPlenty.ID, "moss", 1, 0, missing), });
+                OrePrefixes.dust.get(Materials.InfusedEarth),
+                getModItem(TwilightForest.ID, "tile.TFPlant", 1, 3, missing),
+                getModItem(BiomesOPlenty.ID, "moss", 1, 0, missing),
+                OrePrefixes.dust.get(Materials.InfusedEarth),
+                getModItem(TwilightForest.ID, "tile.TFPlant", 1, 3, missing),
+                getModItem(BiomesOPlenty.ID, "moss", 1, 0, missing));
         TCHelper.addResearchPage(
                 "BALLOFMOSS",
                 new ResearchPage(
@@ -711,7 +711,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing))
                         .setParents("RUNICAUGMENTATION", "BALLOFMOSS").setConcealed().setRound()
                         .setPages(new ResearchPage("TConstruct.research_page.REDHEART.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "REDHEART",
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
                 3,
@@ -719,16 +719,16 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 35).add(Aspect.getAspect("sano"), 50)
                         .add(Aspect.getAspect("praecantatio"), 50),
                 getModItem(Minecraft.ID, "golden_apple", 1, 0, missing),
-                new ItemStack[] { getModItem(TinkerConstruct.ID, "jerky", 1, 6, missing),
-                        getModItem(Minecraft.ID, "apple", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "jerky", 1, 7, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        getModItem(TinkerConstruct.ID, "jerky", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "jerky", 1, 1, missing),
-                        getModItem(TinkerConstruct.ID, "jerky", 1, 2, missing),
-                        getModItem(TinkerConstruct.ID, "jerky", 1, 3, missing),
-                        getModItem(TinkerConstruct.ID, "jerky", 1, 4, missing),
-                        getModItem(TinkerConstruct.ID, "jerky", 1, 5, missing), });
+                getModItem(TinkerConstruct.ID, "jerky", 1, 6, missing),
+                getModItem(Minecraft.ID, "apple", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "jerky", 1, 7, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                getModItem(TinkerConstruct.ID, "jerky", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "jerky", 1, 1, missing),
+                getModItem(TinkerConstruct.ID, "jerky", 1, 2, missing),
+                getModItem(TinkerConstruct.ID, "jerky", 1, 3, missing),
+                getModItem(TinkerConstruct.ID, "jerky", 1, 4, missing),
+                getModItem(TinkerConstruct.ID, "jerky", 1, 5, missing));
         TCHelper.addResearchPage(
                 "REDHEART",
                 new ResearchPage(
@@ -780,7 +780,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing)).setParents("REDHEART").setConcealed()
                         .setRound().setPages(new ResearchPage("TConstruct.research_page.YELLOWHEART.1"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "YELLOWHEART",
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
                 3,
@@ -788,16 +788,16 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 75).add(Aspect.getAspect("sano"), 100)
                         .add(Aspect.getAspect("praecantatio"), 100),
                 getModItem(Minecraft.ID, "golden_apple", 1, 1, missing),
-                new ItemStack[] { getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing), });
+                getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                getModItem(TinkerConstruct.ID, "heartCanister", 1, 1, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing));
         TCHelper.addResearchPage(
                 "YELLOWHEART",
                 new ResearchPage(
@@ -853,7 +853,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 5, missing)).setParents("YELLOWHEART").setConcealed()
                         .setRound().setPages(new ResearchPage("TConstruct.research_page.GREENHEART.1"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "GREENHEART",
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 5, missing),
                 3,
@@ -861,16 +861,16 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 150).add(Aspect.getAspect("sano"), 200)
                         .add(Aspect.getAspect("praecantatio"), 200),
                 getModItem(TinkerConstruct.ID, "diamondApple", 1, 0, missing),
-                new ItemStack[] { getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing), });
+                getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                getModItem(TinkerConstruct.ID, "heartCanister", 1, 3, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing));
         TCHelper.addResearchPage(
                 "GREENHEART",
                 new ResearchPage(
@@ -1151,7 +1151,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 getModItem(HardcoreEnderExpansion.ID, "ghost_amulet", 1, 1, missing))
                         .setParents("ENCHANTINGTABLE", "BREWINGSTAND").setConcealed().setRound()
                         .setPages(new ResearchPage("Hee.research_page.GHOSTAMULET.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "GHOSTAMULET",
                 getModItem(HardcoreEnderExpansion.ID, "ghost_amulet", 1, 1, missing),
                 9,
@@ -1160,20 +1160,20 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.getAspect("spiritus"), 32).add(Aspect.getAspect("corpus"), 16)
                         .add(Aspect.getAspect("alienis"), 24).add(Aspect.getAspect("lucrum"), 8),
                 getModItem(HardcoreEnderExpansion.ID, "ghost_amulet", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Draconium, 1L),
-                        getModItem(HardcoreEnderExpansion.ID, "instability_orb", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.HeeEndium, 1L),
-                        getModItem(HardcoreEnderExpansion.ID, "end_powder", 1, 0, missing),
-                        getModItem(HardcoreEnderExpansion.ID, "fire_shard", 1, 0, missing),
-                        getModItem(HardcoreEnderExpansion.ID, "igneous_rock", 1, 0, missing),
-                        getModItem(HardcoreEnderExpansion.ID, "end_powder", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Draconium, 1L),
-                        getModItem(HardcoreEnderExpansion.ID, "instability_orb", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.HeeEndium, 1L),
-                        getModItem(HardcoreEnderExpansion.ID, "end_powder", 1, 0, missing),
-                        getModItem(HardcoreEnderExpansion.ID, "igneous_rock", 1, 0, missing),
-                        getModItem(HardcoreEnderExpansion.ID, "fire_shard", 1, 0, missing),
-                        getModItem(HardcoreEnderExpansion.ID, "end_powder", 1, 0, missing), });
+                OrePrefixes.ingot.get(Materials.Draconium),
+                getModItem(HardcoreEnderExpansion.ID, "instability_orb", 1, 0, missing),
+                OrePrefixes.ring.get(Materials.HeeEndium),
+                getModItem(HardcoreEnderExpansion.ID, "end_powder", 1, 0, missing),
+                getModItem(HardcoreEnderExpansion.ID, "fire_shard", 1, 0, missing),
+                getModItem(HardcoreEnderExpansion.ID, "igneous_rock", 1, 0, missing),
+                getModItem(HardcoreEnderExpansion.ID, "end_powder", 1, 0, missing),
+                OrePrefixes.ingot.get(Materials.Draconium),
+                getModItem(HardcoreEnderExpansion.ID, "instability_orb", 1, 0, missing),
+                OrePrefixes.ring.get(Materials.HeeEndium),
+                getModItem(HardcoreEnderExpansion.ID, "end_powder", 1, 0, missing),
+                getModItem(HardcoreEnderExpansion.ID, "igneous_rock", 1, 0, missing),
+                getModItem(HardcoreEnderExpansion.ID, "fire_shard", 1, 0, missing),
+                getModItem(HardcoreEnderExpansion.ID, "end_powder", 1, 0, missing));
         TCHelper.addResearchPage(
                 "GHOSTAMULET",
                 new ResearchPage(
@@ -1191,7 +1191,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 3,
                 getModItem(Avaritia.ID, "Skull_Sword", 1, 0, missing)).setParents("INFUSION").setConcealed().setRound()
                         .setPages(new ResearchPage("Avaritia.research_page.SFSWORD.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SFSWORD",
                 getModItem(Avaritia.ID, "Skull_Sword", 1, 0, missing),
                 15,
@@ -1199,16 +1199,18 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.getAspect("exanimis"), 64).add(Aspect.getAspect("metallum"), 64)
                         .add(Aspect.getAspect("mortuus"), 64),
                 getModItem(TwilightForest.ID, "item.fierySword", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                        getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
-                        getModItem(Avaritia.ID, "Resource", 1, 0, missing), CustomItemList.LichBone.get(1L),
-                        getModItem(Avaritia.ID, "Resource", 1, 0, missing),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Silver, 1L),
-                        getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
-                        getModItem(Avaritia.ID, "Resource", 1, 0, missing), CustomItemList.LichBone.get(1L),
-                        getModItem(Avaritia.ID, "Resource", 1, 0, missing),
-                        getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing), });
+                getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
+                getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
+                getModItem(Avaritia.ID, "Resource", 1, 0, missing),
+                CustomItemList.LichBone.get(1L),
+                getModItem(Avaritia.ID, "Resource", 1, 0, missing),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                OrePrefixes.ingot.get(Materials.Silver),
+                getModItem(TinkerConstruct.ID, "materials", 1, 8, missing),
+                getModItem(Avaritia.ID, "Resource", 1, 0, missing),
+                CustomItemList.LichBone.get(1L),
+                getModItem(Avaritia.ID, "Resource", 1, 0, missing),
+                getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SFSWORD",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Avaritia.ID, "Skull_Sword", 1, 0, missing))));
@@ -1241,16 +1243,16 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "MAGICOBSIDIAN",
                 new ResearchPage(
                         TCHelper.findArcaneRecipe(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MAGICOBSIDIAN",
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 4, 0, missing),
                 3,
                 new AspectList().add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("tenebrae"), 16)
                         .add(Aspect.getAspect("terra"), 16),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing), });
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing));
         TCHelper.addResearchPage(
                 "MAGICOBSIDIAN",
                 new ResearchPage(
@@ -1267,16 +1269,16 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 3,
                 GTOreDictUnificator.get(OrePrefixes.ingot, Materials.HellishMetal, 1)).setConcealed().setRound()
                         .setPages(new ResearchPage("TConstruct.research_page.HELLISHMETAL.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "HELLISHMETAL",
                 GTOreDictUnificator.get(OrePrefixes.block, Materials.HellishMetal, 1),
                 1,
                 new AspectList().add(Aspect.getAspect("ignis"), 8),
                 MaterialsElements.getInstance().RHODIUM.getBlock(1),
-                new ItemStack[] { getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Thaumium, 1),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Thaumium, 1), });
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing),
+                OrePrefixes.ingot.get(Materials.Thaumium),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing),
+                OrePrefixes.ingot.get(Materials.Thaumium));
         TCHelper.addResearchPage(
                 "HELLISHMETAL",
                 new ResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptTaintedMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTaintedMagic.java
@@ -12,8 +12,6 @@ import static gregtech.api.util.GTModHandler.getModItem;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.item.ItemStack;
-
 import com.dreammaster.item.NHItemList;
 import com.dreammaster.thaumcraft.TCHelper;
 
@@ -330,7 +328,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "BlockWarpwoodSapling", 1, 0, missing)).setParentsHidden("ShadowmetalGTNH")
                         .setParents("EvilshardsGTNH").setConcealed().setPages(new ResearchPage("tm.text.WARPTREE.1"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WarpTreeGTNH",
                 getModItem(TaintedMagic.ID, "BlockWarpwoodSapling", 1, 0, missing),
                 4,
@@ -338,14 +336,14 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 12).add(Aspect.getAspect("vitium"), 8)
                         .add(Aspect.getAspect("permutatio"), 8),
                 getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing), });
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing));
         TCHelper.addResearchPage(
                 "WarpTreeGTNH",
                 new ResearchPage(
@@ -373,7 +371,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         TCHelper.addResearchPrereq("WarpedGogglesGTNH", "GOGGLES", false);
         ResearchCategories.getResearch("WarpedGogglesGTNH").setConcealed();
         TCHelper.addResearchPage("WarpedGogglesGTNH", new ResearchPage("tm.text.WARPEDGOGGLES.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WarpedGogglesGTNH",
                 getModItem(TaintedMagic.ID, "ItemWarpedGoggles", 1, 0, missing),
                 5,
@@ -381,16 +379,16 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 24).add(Aspect.getAspect("tutamen"), 16)
                         .add(Aspect.getAspect("sensus"), 8),
                 getModItem(Thaumcraft.ID, "ItemGoggles", 1, 0, missing),
-                new ItemStack[] { getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.InfusedEntropy, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.bolt, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.InfusedEntropy, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L), });
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
+                OrePrefixes.plate.get(Materials.Shadow),
+                OrePrefixes.ring.get(Materials.Shadow),
+                OrePrefixes.lens.get(Materials.InfusedEntropy),
+                OrePrefixes.screw.get(Materials.Shadow),
+                OrePrefixes.bolt.get(Materials.Shadow),
+                OrePrefixes.screw.get(Materials.Shadow),
+                OrePrefixes.lens.get(Materials.InfusedEntropy),
+                OrePrefixes.ring.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.Shadow));
         TCHelper.addResearchPage(
                 "WarpedGogglesGTNH",
                 new ResearchPage(
@@ -455,7 +453,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemFocusMageMace", 1, 0, missing)).setParentsHidden("TAINTEDMAGIC")
                         .setParents("ShadowmetalGTNH", "FOCUSFIRE").setConcealed()
                         .setPages(new ResearchPage("tm.text.MACEFOCUS.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MaceFocusGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusMageMace", 1, 0, missing),
                 9,
@@ -463,16 +461,16 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("telum"), 64)
                         .add(Aspect.getAspect("cognitio"), 8),
                 getModItem(TaintedMagic.ID, "ItemShadowmetalSword", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Shadow, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.stick, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Shadow, 1L), });
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.screw.get(Materials.Shadow),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                OrePrefixes.plate.get(Materials.NetherQuartz),
+                OrePrefixes.stick.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.stick.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.NetherQuartz),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                OrePrefixes.screw.get(Materials.Shadow));
         TCHelper.addResearchPage(
                 "MaceFocusGTNH",
                 new ResearchPage(
@@ -545,7 +543,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         TCHelper.addResearchPage(
                 "CreationShardGTNH",
                 new ResearchPage(TCHelper.findCrucibleRecipe(NHItemList.VoidEssence.getIS(1))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CreationShardGTNH",
                 getModItem(TaintedMagic.ID, "ItemMaterial", 2, 5, missing),
                 12,
@@ -553,16 +551,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("auram"), 64)
                         .add(Aspect.getAspect("tenebrae"), 64),
                 getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing), NHItemList.VoidEssence.getIS(1),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing), NHItemList.VoidEssence.getIS(1),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing), });
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing));
         TCHelper.addResearchPage(
                 "CreationShardGTNH",
                 new ResearchPage(
@@ -583,7 +583,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .setParentsHidden("ShadowmetalGTNH", "EvilshardsGTNH")
                         .setParents("CreationShardGTNH", "FOCUSPORTABLEHOLE").setConcealed()
                         .setPages(new ResearchPage("tm.text.ELDRITCHFOCUS.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "EldritchFocusGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusEldritch", 1, 0, missing),
                 9,
@@ -591,18 +591,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("tenebrae"), 64)
                         .add(Aspect.getAspect("ira"), 32).add(Aspect.getAspect("potentia"), 16),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 5, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                OrePrefixes.plate.get(Materials.Void));
         TCHelper.addResearchPage(
                 "EldritchFocusGTNH",
                 new ResearchPage(
@@ -850,7 +850,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing))
                         .setParents("ELDRITCHMINOR", "CrimsonRobesGTNH").setConcealed()
                         .setPages(new ResearchPage("tm.text.KNIGHTROBES.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "KnightRobesGTNH",
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
                 6,
@@ -858,23 +858,23 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("alienis"), 32)
                         .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("ignis"), 32)
                         .add(Aspect.getAspect("fames"), 32),
-                GTOreDictUnificator.get(OrePrefixes.plateQuadruple, Materials.Thaumium, 1L),
-                new ItemStack[] { getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.FierySteel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.foil, Materials.Ultimet, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.foil, Materials.Knightmetal, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.foil, Materials.AstralSilver, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.FierySteel, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.FierySteel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.foil, Materials.Ultimet, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.foil, Materials.Knightmetal, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.foil, Materials.AstralSilver, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.FierySteel, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing), });
+                OrePrefixes.plateQuadruple.get(Materials.Thaumium),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
+                OrePrefixes.screw.get(Materials.FierySteel),
+                OrePrefixes.foil.get(Materials.Ultimet),
+                OrePrefixes.foil.get(Materials.Knightmetal),
+                OrePrefixes.foil.get(Materials.AstralSilver),
+                OrePrefixes.screw.get(Materials.FierySteel),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
+                OrePrefixes.screw.get(Materials.FierySteel),
+                OrePrefixes.foil.get(Materials.Ultimet),
+                OrePrefixes.foil.get(Materials.Knightmetal),
+                OrePrefixes.foil.get(Materials.AstralSilver),
+                OrePrefixes.screw.get(Materials.FierySteel),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing));
         TCHelper.addResearchPage(
                 "KnightRobesGTNH",
                 new ResearchPage(
@@ -985,7 +985,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 3,
                 getModItem(Thaumcraft.ID, "ItemHelmetCultistLeaderPlate", 1, 0, missing)).setParents("KnightRobesGTNH")
                         .setConcealed().setPages(new ResearchPage("tm.text.PRAETORARMOR.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PraetorarmorGTNH",
                 getModItem(Thaumcraft.ID, "ItemHelmetCultistLeaderPlate", 1, 0, missing),
                 6,
@@ -993,25 +993,25 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 64).add(Aspect.getAspect("alienis"), 64)
                         .add(Aspect.getAspect("tutamen"), 64),
                 getModItem(Thaumcraft.ID, "ItemHelmetCultistPlate", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L), });
+                OrePrefixes.plate.get(Materials.RoseGold),
+                OrePrefixes.ring.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                OrePrefixes.ring.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.RoseGold),
+                OrePrefixes.ring.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                OrePrefixes.ring.get(Materials.Shadow));
         TCHelper.addResearchPage(
                 "PraetorarmorGTNH",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 getModItem(Thaumcraft.ID, "ItemHelmetCultistLeaderPlate", 1, 0, missing))));
         ThaumcraftApi.addWarpToResearch("PraetorarmorGTNH", 5);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PraetorarmorGTNH",
                 getModItem(Thaumcraft.ID, "ItemChestplateCultistLeaderPlate", 1, 0, missing),
                 6,
@@ -1019,24 +1019,24 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 64).add(Aspect.getAspect("alienis"), 64)
                         .add(Aspect.getAspect("tutamen"), 64),
                 getModItem(Thaumcraft.ID, "ItemChestplateCultistPlate", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L), });
+                OrePrefixes.plate.get(Materials.RoseGold),
+                OrePrefixes.ring.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                OrePrefixes.ring.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.RoseGold),
+                OrePrefixes.ring.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                OrePrefixes.ring.get(Materials.Shadow));
         TCHelper.addResearchPage(
                 "PraetorarmorGTNH",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 getModItem(Thaumcraft.ID, "ItemChestplateCultistLeaderPlate", 1, 0, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PraetorarmorGTNH",
                 getModItem(Thaumcraft.ID, "ItemLeggingsCultistLeaderPlate", 1, 0, missing),
                 6,
@@ -1044,18 +1044,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 64).add(Aspect.getAspect("alienis"), 64)
                         .add(Aspect.getAspect("tutamen"), 64),
                 getModItem(Thaumcraft.ID, "ItemLeggingsCultistPlate", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Shadow, 1L), });
+                OrePrefixes.plate.get(Materials.RoseGold),
+                OrePrefixes.ring.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                OrePrefixes.ring.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.RoseGold),
+                OrePrefixes.ring.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                OrePrefixes.ring.get(Materials.Shadow));
         TCHelper.addResearchPage(
                 "PraetorarmorGTNH",
                 new ResearchPage(
@@ -1099,7 +1099,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 3,
                 getModItem(Thaumcraft.ID, "ItemSwordCrimson", 1, 0, missing)).setParents("PraetorarmorGTNH")
                         .setConcealed().setPages(new ResearchPage("tm.text.CRIMSONBLADE.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CrimsonBladeGTNH",
                 getModItem(Thaumcraft.ID, "ItemSwordCrimson", 1, 0, missing),
                 9,
@@ -1107,18 +1107,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("perditio"), 32).add(Aspect.getAspect("telum"), 64)
                         .add(Aspect.getAspect("vacuos"), 48).add(Aspect.getAspect("tenebrae"), 32),
                 getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0, missing),
-                new ItemStack[] { getModItem(TaintedMagic.ID, "ItemCrystalDagger", 1, 0, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing), });
+                getModItem(TaintedMagic.ID, "ItemCrystalDagger", 1, 0, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
+                OrePrefixes.plate.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing));
         TCHelper.addResearchPage(
                 "CrimsonBladeGTNH",
                 new ResearchPage(
@@ -1139,7 +1139,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemVoidmetalGoggles", 1, 0, missing))
                         .setParents("WarpedGogglesGTNH", "VOIDMETAL").setConcealed()
                         .setPages(new ResearchPage("tm.text.VOIDGOGGLES.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "VoidgogglesGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidmetalGoggles", 1, 0, missing),
                 12,
@@ -1148,16 +1148,16 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vitreus"), 24).add(Aspect.getAspect("alienis"), 8)
                         .add(Aspect.getAspect("metallum"), 16),
                 getModItem(TaintedMagic.ID, "ItemWarpedGoggles", 1, 0, missing),
-                new ItemStack[] { getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.NetherStar, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.bolt, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.NetherStar, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.ring.get(Materials.Void),
+                OrePrefixes.lens.get(Materials.NetherStar),
+                OrePrefixes.screw.get(Materials.Void),
+                OrePrefixes.bolt.get(Materials.Void),
+                OrePrefixes.screw.get(Materials.Void),
+                OrePrefixes.lens.get(Materials.NetherStar),
+                OrePrefixes.ring.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void));
         TCHelper.addResearchPage(
                 "VoidgogglesGTNH",
                 new ResearchPage(
@@ -1178,7 +1178,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemFocusTaint", 1, 0, missing))
                         .setParents("EvilshardsGTNH", "BOTTLETAINT", "TAINTSHOVEL").setConcealed()
                         .setPages(new ResearchPage("tm.text.TAINTFOCUS.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TaintFocusGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusTaint", 1, 0, missing),
                 9,
@@ -1186,19 +1186,19 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 72).add(Aspect.getAspect("vitium"), 72)
                         .add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("potentia"), 32),
                 getModItem(Thaumcraft.ID, "FocusPech", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
-                        getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 12, missing),
+                getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing));
         TCHelper.addResearchPage(
                 "TaintFocusGTNH",
                 new ResearchPage(
@@ -1218,7 +1218,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemFocusTaintedBlast", 1, 0, missing))
                         .setParents("TaintFocusGTNH", "FOCUSFIRE", "ELDRITCHMINOR", "FOCUSSHOCK").setConcealed()
                         .setPages(new ResearchPage("tm.text.FOCUSTAINTEDBLAST.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FocusTaintedBlastGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusTaintedBlast", 1, 0, missing),
                 12,
@@ -1226,18 +1226,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 72).add(Aspect.getAspect("vitium"), 84)
                         .add(Aspect.getAspect("cognitio"), 32).add(Aspect.getAspect("aer"), 48),
                 getModItem(TaintedMagic.ID, "ItemFocusTaint", 1, 0, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
-                        getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing), });
+                getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
+                getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing));
         TCHelper.addResearchPage(
                 "FocusTaintedBlastGTNH",
                 new ResearchPage(
@@ -1290,7 +1290,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         TCHelper.findArcaneRecipe(getModItem(TaintedMagic.ID, "ItemMaterial", 1, 6, missing))));
         ThaumcraftApi.addWarpToResearch("ThaumicdisassemblerGTNH", 4);
         TCHelper.addResearchPage("ThaumicdisassemblerGTNH", new ResearchPage("tm.text.THAUMICDISASSEMBLER.2"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ThaumicdisassemblerGTNH",
                 getModItem(TaintedMagic.ID, "ItemThaumicDisassembler", 1, 0, missing),
                 10,
@@ -1298,14 +1298,14 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 24).add(Aspect.getAspect("vacuos"), 24)
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("potentia"), 16),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 6, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemPickVoid", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        getModItem(Thaumcraft.ID, "ItemShovelVoid", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        getModItem(Thaumcraft.ID, "ItemAxeVoid", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L), });
+                getModItem(Thaumcraft.ID, "ItemPickVoid", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Shadow),
+                getModItem(Thaumcraft.ID, "ItemShovelVoid", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Shadow),
+                getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Shadow),
+                getModItem(Thaumcraft.ID, "ItemAxeVoid", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Shadow));
         TCHelper.addResearchPage(
                 "ThaumicdisassemblerGTNH",
                 new ResearchPage(
@@ -1327,7 +1327,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .setParents("TMELDRITCHMAJOR", "BOOTSTRAVELLER")
                         .setParentsHidden("TAINTEDMAGIC", "ShadowmetalGTNH").setConcealed()
                         .setPages(new ResearchPage("tm.text.VOIDWALKERBOOTS.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "VoidWalkerBootsGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidwalkerBoots", 1, 0, missing),
                 12,
@@ -1335,20 +1335,20 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 72).add(Aspect.getAspect("tutamen"), 64)
                         .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("praecantatio"), 32),
                 getModItem(Thaumcraft.ID, "BootsTraveller", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Polytetrafluoroethylene, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Polytetrafluoroethylene, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plateDouble.get(Materials.Polytetrafluoroethylene),
+                OrePrefixes.plate.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Shadow),
+                OrePrefixes.plateDouble.get(Materials.Polytetrafluoroethylene),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Void));
         TCHelper.addResearchPage(
                 "VoidWalkerBootsGTNH",
                 new ResearchPage(
@@ -1373,7 +1373,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         TCHelper.addResearchPrereq("VoidSashGTNH", "VOIDMETAL", false);
         ResearchCategories.getResearch("VoidSashGTNH").setConcealed();
         TCHelper.addResearchPage("VoidSashGTNH", new ResearchPage("tm.text.VOIDSASH.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "VoidSashGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidwalkerSash", 1, 0, missing),
                 12,
@@ -1382,18 +1382,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("volatus"), 32).add(Aspect.getAspect("alienis"), 24)
                         .add(Aspect.getAspect("aer"), 16),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemGirdleRunic", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Tanzanite, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                getModItem(Thaumcraft.ID, "ItemGirdleRunic", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.gemExquisite.get(Materials.Tanzanite),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.Void));
         TCHelper.addResearchPage(
                 "VoidSashGTNH",
                 new ResearchPage(
@@ -1414,7 +1414,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemVoidFortressHelmet", 1, 0, missing))
                         .setParents("TMELDRITCHMAJOR", "VOIDMETAL", "ARMORFORTRESS").setParentsHidden("ShadowmetalGTNH")
                         .setConcealed().setPages(new ResearchPage("tm.text.VOIDFORTRESS.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "VoidFortressGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidFortressHelmet", 1, 0, missing),
                 12,
@@ -1423,23 +1423,23 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("tenebrae"), 16)
                         .add(Aspect.getAspect("potentia"), 16).add(Aspect.getAspect("victus"), 32),
                 getModItem(Thaumcraft.ID, "ItemHelmetVoid", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateTriple, Materials.Polytetrafluoroethylene, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L), });
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                OrePrefixes.plate.get(Materials.RoseGold),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plateTriple.get(Materials.Polytetrafluoroethylene),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.RoseGold));
         TCHelper.addResearchPage(
                 "VoidFortressGTNH",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 getModItem(TaintedMagic.ID, "ItemVoidFortressHelmet", 1, 0, missing))));
         ThaumcraftApi.addWarpToResearch("VoidFortressGTNH", 5);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "VoidFortressGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidFortressChestplate", 1, 0, missing),
                 12,
@@ -1448,26 +1448,26 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("tenebrae"), 16)
                         .add(Aspect.getAspect("potentia"), 16).add(Aspect.getAspect("cognitio"), 32),
                 getModItem(Thaumcraft.ID, "ItemChestplateVoid", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateTriple, Materials.Polytetrafluoroethylene, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateTriple, Materials.Polytetrafluoroethylene, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plateTriple.get(Materials.Polytetrafluoroethylene),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.RoseGold),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plateTriple.get(Materials.Polytetrafluoroethylene),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void));
         TCHelper.addResearchPage(
                 "VoidFortressGTNH",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 getModItem(TaintedMagic.ID, "ItemVoidFortressChestplate", 1, 0, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "VoidFortressGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidFortressLeggings", 1, 0, missing),
                 12,
@@ -1476,16 +1476,16 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("tenebrae"), 16)
                         .add(Aspect.getAspect("potentia"), 16).add(Aspect.getAspect("terra"), 32),
                 getModItem(Thaumcraft.ID, "ItemLeggingsVoid", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateTriple, Materials.Polytetrafluoroethylene, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L), });
+                getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2, missing),
+                OrePrefixes.plate.get(Materials.RoseGold),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plateTriple.get(Materials.Polytetrafluoroethylene),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.RoseGold));
         TCHelper.addResearchPage(
                 "VoidFortressGTNH",
                 new ResearchPage(
@@ -1506,7 +1506,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemShadowFortressHelmet", 1, 0, missing)).setParents("VoidFortressGTNH")
                         .setParentsHidden("ShadowmetalGTNH").setConcealed()
                         .setPages(new ResearchPage("tm.text.SHADOWFORTRESSARMOR.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ShadowFortressArmorGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowFortressHelmet", 1, 0, missing),
                 16,
@@ -1515,23 +1515,23 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 48).add(Aspect.getAspect("tenebrae"), 32)
                         .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("victus"), 48),
                 getModItem(TaintedMagic.ID, "ItemVoidFortressHelmet", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Polybenzimidazole, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedGold, 1L), });
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                OrePrefixes.plate.get(Materials.InfusedGold),
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.block.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plateDense.get(Materials.Polybenzimidazole),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.InfusedGold));
         TCHelper.addResearchPage(
                 "ShadowFortressArmorGTNH",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 getModItem(TaintedMagic.ID, "ItemShadowFortressHelmet", 1, 0, missing))));
         ThaumcraftApi.addWarpToResearch("ShadowFortressArmorGTNH", 10);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ShadowFortressArmorGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowFortressChestplate", 1, 0, missing),
                 16,
@@ -1540,26 +1540,26 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 48).add(Aspect.getAspect("tenebrae"), 32)
                         .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("cognitio"), 48),
                 getModItem(TaintedMagic.ID, "ItemVoidFortressChestplate", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Polybenzimidazole, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedGold, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Polybenzimidazole, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L), });
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.block.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plateDense.get(Materials.Polybenzimidazole),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.InfusedGold),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plateDense.get(Materials.Polybenzimidazole),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.block.get(Materials.Shadow));
         TCHelper.addResearchPage(
                 "ShadowFortressArmorGTNH",
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(
                                 getModItem(TaintedMagic.ID, "ItemShadowFortressChestplate", 1, 0, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ShadowFortressArmorGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowFortressLeggings", 1, 0, missing),
                 16,
@@ -1568,16 +1568,16 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("tenebrae"), 32)
                         .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("terra"), 48),
                 getModItem(TaintedMagic.ID, "ItemVoidFortressLeggings", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Polybenzimidazole, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedGold, 1L), });
+                getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2, missing),
+                OrePrefixes.plate.get(Materials.InfusedGold),
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.block.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.plateDense.get(Materials.Polybenzimidazole),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1, missing),
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.block.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.InfusedGold));
         TCHelper.addResearchPage(
                 "ShadowFortressArmorGTNH",
                 new ResearchPage(
@@ -1597,7 +1597,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemKatana", 1, 0, missing)).setParents("ARMORFORTRESS")
                         .setParentsHidden("ShadowmetalGTNH").setConcealed()
                         .setPages(new ResearchPage("tm.text.THAUMIUMKATANA.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ThaumiumKatanaGTNH",
                 getModItem(TaintedMagic.ID, "ItemKatana", 1, 0, missing),
                 6,
@@ -1605,18 +1605,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 48).add(Aspect.getAspect("mortuus"), 24)
                         .add(Aspect.getAspect("potentia"), 16).add(Aspect.getAspect("motus"), 8),
                 getModItem(Thaumcraft.ID, "ItemSwordThaumium", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L), });
+                OrePrefixes.plate.get(Materials.Obsidian),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.gemFlawless.get(Materials.Emerald),
+                OrePrefixes.plate.get(Materials.Steel),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Obsidian),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.gemFlawless.get(Materials.Emerald),
+                OrePrefixes.plate.get(Materials.Steel),
+                OrePrefixes.plate.get(Materials.Thaumium));
         TCHelper.addResearchPage(
                 "ThaumiumKatanaGTNH",
                 new ResearchPage(
@@ -1637,7 +1637,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemKatana", 1, 1, missing)).setParents("ThaumiumKatanaGTNH")
                         .setParentsHidden("VOIDMETAL").setConcealed()
                         .setPages(new ResearchPage("tm.text.VOIDMETALKATANA.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "VoidMetalKatanaGTNH",
                 getModItem(TaintedMagic.ID, "ItemKatana", 1, 1, missing),
                 9,
@@ -1646,18 +1646,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("mortuus"), 32).add(Aspect.getAspect("potentia"), 24)
                         .add(Aspect.getAspect("motus"), 16).add(Aspect.getAspect("vacuos"), 32),
                 getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Manyullyn, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Manyullyn, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
+                OrePrefixes.plate.get(Materials.Manyullyn),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.RoseGold),
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                OrePrefixes.plate.get(Materials.Titanium),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.Manyullyn),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.plate.get(Materials.RoseGold),
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                OrePrefixes.plate.get(Materials.Titanium),
+                OrePrefixes.plate.get(Materials.Void));
         TCHelper.addResearchPage(
                 "VoidMetalKatanaGTNH",
                 new ResearchPage(
@@ -1678,7 +1678,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemKatana", 1, 2, missing)).setParents("VoidMetalKatanaGTNH")
                         .setParentsHidden("ShadowmetalGTNH").setConcealed()
                         .setPages(new ResearchPage("tm.text.SHADOWMETALKATANA.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ShadowMetalKatanaGTNH",
                 getModItem(TaintedMagic.ID, "ItemKatana", 1, 2, missing),
                 12,
@@ -1688,18 +1688,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("motus"), 24).add(Aspect.getAspect("vacuos"), 48)
                         .add(Aspect.getAspect("tenebrae"), 48),
                 getModItem(TaintedMagic.ID, "ItemShadowmetalSword", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedGold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.TungstenSteel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L), });
+                OrePrefixes.plate.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.InfusedGold),
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                OrePrefixes.plate.get(Materials.TungstenSteel),
+                OrePrefixes.plate.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.Shadow),
+                OrePrefixes.plate.get(Materials.InfusedGold),
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                OrePrefixes.plate.get(Materials.TungstenSteel),
+                OrePrefixes.plate.get(Materials.Shadow));
         TCHelper.addResearchPage(
                 "ShadowMetalKatanaGTNH",
                 new ResearchPage(
@@ -1746,7 +1746,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemWandRod", 1, 0, missing)).setParentsHidden("ShadowmetalGTNH")
                         .setParents("WarpTreeGTNH", "VOIDMETAL", "VOIDMETAL", "PRIMPEARL", "ROD_primal_staff")
                         .setConcealed().setPages(new ResearchPage("tm.text.ROD_warpwood.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_warpwood",
                 getModItem(TaintedMagic.ID, "ItemWandRod", 1, 0, missing),
                 16,
@@ -1754,22 +1754,22 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("tenebrae"), 48)
                         .add(Aspect.getAspect("instrumentum"), 32).add(Aspect.getAspect("terra"), 24),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
-                new ItemStack[] { getModItem(TaintedMagic.ID, "BlockWarpwoodLog", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Tungsten, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateTriple, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Void, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateTriple, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Tungsten, 1L),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Tungsten, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateTriple, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Void, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateDouble, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateTriple, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Tungsten, 1L), });
+                getModItem(TaintedMagic.ID, "BlockWarpwoodLog", 1, 0, missing),
+                OrePrefixes.ring.get(Materials.Tungsten),
+                OrePrefixes.plateTriple.get(Materials.Shadow),
+                OrePrefixes.plateDouble.get(Materials.Void),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
+                OrePrefixes.plateDouble.get(Materials.Void),
+                OrePrefixes.plateTriple.get(Materials.Shadow),
+                OrePrefixes.ring.get(Materials.Tungsten),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                OrePrefixes.ring.get(Materials.Tungsten),
+                OrePrefixes.plateTriple.get(Materials.Shadow),
+                OrePrefixes.plateDouble.get(Materials.Void),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
+                OrePrefixes.plateDouble.get(Materials.Void),
+                OrePrefixes.plateTriple.get(Materials.Shadow),
+                OrePrefixes.ring.get(Materials.Tungsten));
         TCHelper.addResearchPage(
                 "ROD_warpwood",
                 new ResearchPage(
@@ -1836,7 +1836,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemFocusTime", 1, 0, missing))
                         .setParents("CreationShardGTNH", "FOCUSPORTABLEHOLE", "FOCUSFIRE").setConcealed()
                         .setPages(new ResearchPage("tm.text.FOCUSTIME.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FocusTimeGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusTime", 1, 0, missing),
                 16,
@@ -1845,14 +1845,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("tempus"), 24).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("permutatio"), 16),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 5, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing), NHItemList.VoidEssence.getIS(1),
-                        getModItem(Minecraft.ID, "clock", 1, 0, missing), NHItemList.VoidEssence.getIS(1),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing), NHItemList.VoidEssence.getIS(1),
-                        getModItem(Minecraft.ID, "clock", 1, 0, missing), NHItemList.VoidEssence.getIS(1),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(Minecraft.ID, "clock", 1, 0, missing),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(Minecraft.ID, "clock", 1, 0, missing),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing));
         TCHelper.addResearchPage(
                 "FocusTimeGTNH",
                 new ResearchPage(
@@ -1874,7 +1878,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemFocusMeteorology", 1, 0, missing))
                         .setParents("CreationShardGTNH", "FOCUSSHOCK", "FOCUSFROST").setConcealed()
                         .setPages(new ResearchPage("tm.text.FOCUSWEATHER.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FocusWeatherGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusMeteorology", 1, 0, missing),
                 16,
@@ -1883,14 +1887,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("volatus"), 24)
                         .add(Aspect.getAspect("perditio"), 16),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 5, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "FocusShock", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing), NHItemList.VoidEssence.getIS(1),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing), NHItemList.VoidEssence.getIS(1),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "FocusFrost", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing), NHItemList.VoidEssence.getIS(1),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing), NHItemList.VoidEssence.getIS(1),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing), });
+                getModItem(Thaumcraft.ID, "FocusShock", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "FocusFrost", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing));
         TCHelper.addResearchPage(
                 "FocusWeatherGTNH",
                 new ResearchPage(
@@ -1915,7 +1923,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         TCHelper.addResearchPrereq("PrimalBladeGTNH", "PRIMALCRUSHER", false);
         ResearchCategories.getResearch("PrimalBladeGTNH").setConcealed();
         TCHelper.addResearchPage("PrimalBladeGTNH", new ResearchPage("tm.text.PRIMALBLADE.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PrimalBladeGTNH",
                 getModItem(TaintedMagic.ID, "ItemPrimordialEdge", 1, 0, missing),
                 16,
@@ -1924,21 +1932,21 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 48).add(Aspect.getAspect("auram"), 32)
                         .add(Aspect.getAspect("cognitio"), 24).add(Aspect.getAspect("potentia"), 16),
                 getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemPrimalCrusher", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        NHItemList.VoidEssence.getIS(1),
-                        getModItem(TaintedMagic.ID, "ItemCrystalDagger", 1, 0, missing),
-                        NHItemList.VoidEssence.getIS(1),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Shadow, 1L), });
+                getModItem(Thaumcraft.ID, "ItemPrimalCrusher", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                OrePrefixes.plate.get(Materials.Shadow),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                OrePrefixes.plate.get(Materials.Shadow),
+                NHItemList.VoidEssence.getIS(1),
+                getModItem(TaintedMagic.ID, "ItemCrystalDagger", 1, 0, missing),
+                NHItemList.VoidEssence.getIS(1),
+                OrePrefixes.plate.get(Materials.Shadow),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Shadow));
         TCHelper.addResearchPage(
                 "PrimalBladeGTNH",
                 new ResearchPage(
@@ -2090,7 +2098,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 getModItem(TaintedMagic.ID, "ItemWandCap", 1, 0, missing))
                         .setParents("CAP_shadowcloth", "CAP_void", "PRIMPEARL").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.CAP_shadowmetal")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_shadowmetal",
                 getModItem(TaintedMagic.ID, "ItemWandCap", 1, 0, missing),
                 12,
@@ -2099,18 +2107,18 @@ public class ScriptTaintedMagic implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("cognitio"), 68)
                         .add(Aspect.getAspect("lucrum"), 32).add(Aspect.getAspect("fames"), 32),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "WandCap", 1, 7, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateQuadruple, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateQuadruple, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Tanzanite, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateQuadruple, Materials.Shadow, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateQuadruple, Materials.Shadow, 1L),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing), });
+                getModItem(Thaumcraft.ID, "WandCap", 1, 7, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
+                OrePrefixes.plateQuadruple.get(Materials.Shadow),
+                OrePrefixes.plateDense.get(Materials.Void),
+                OrePrefixes.plateQuadruple.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
+                OrePrefixes.gemExquisite.get(Materials.Tanzanite),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing),
+                OrePrefixes.plateQuadruple.get(Materials.Shadow),
+                OrePrefixes.plateDense.get(Materials.Void),
+                OrePrefixes.plateQuadruple.get(Materials.Shadow),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3, missing));
         TCHelper.addResearchPage(
                 "CAP_shadowmetal",
                 new ResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
@@ -643,19 +643,19 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.addResearchPage(
                 "CAP_silver",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(Thaumcraft.ID, "WandCap", 1, 5, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_silver",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 4, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("auram"), 18).add(Aspect.getAspect("potentia"), 30)
                         .add(Aspect.getAspect("praecantatio"), 18),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 5, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Silver, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Silver, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Silver, 1L), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Silver),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Silver),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Silver));
         TCHelper.addResearchPage(
                 "CAP_silver",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Thaumcraft.ID, "WandCap", 1, 4, missing))));
@@ -690,19 +690,19 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.addResearchPage(
                 "CAP_thaumium",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(Thaumcraft.ID, "WandCap", 1, 6, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_thaumium",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 2, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("auram"), 25).add(Aspect.getAspect("potentia"), 40)
                         .add(Aspect.getAspect("praecantatio"), 25),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 6, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Thaumium));
         TCHelper.addResearchPage(
                 "CAP_thaumium",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Thaumcraft.ID, "WandCap", 1, 2, missing))));
@@ -744,17 +744,17 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 6)
                         .add(Aspect.getAspect("arbor"), 3));
         TCHelper.setResearchComplexity("ROD_greatwood", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_reed",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 5, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("motus"), 12)
                         .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("vitreus"), 6),
                 getModItem(TinkerConstruct.ID, "trap.punji", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ROD_reed",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
@@ -772,85 +772,85 @@ public class ScriptThaumcraft implements IScriptLoader {
                                         45,
                                         "{cap:\"thaumium\",rod:\"reed\",sceptre:1b}",
                                         missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_blaze",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 6, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("bestia"), 12).add(Aspect.getAspect("ignis"), 24)
                         .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("vitreus"), 6),
                 getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing), });
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing));
         TCHelper.setResearchAspects(
                 "ROD_blaze",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
                         .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("herba"), 6)
                         .add(Aspect.getAspect("arbor"), 3));
         TCHelper.setResearchComplexity("ROD_blaze", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_obsidian",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 1, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("tenebrae"), 12)
                         .add(Aspect.getAspect("terra"), 24).add(Aspect.getAspect("vitreus"), 6),
                 getModItem(RandomThings.ID, "ingredient", 1, 1, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing), });
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing));
         TCHelper.setResearchAspects(
                 "ROD_obsidian",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
                         .add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("potentia"), 6)
                         .add(Aspect.getAspect("arbor"), 3));
         TCHelper.setResearchComplexity("ROD_obsidian", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_ice",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 3, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("aqua"), 24).add(Aspect.getAspect("gelum"), 12)
                         .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("vitreus"), 6),
                 getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing), });
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing));
         TCHelper.setResearchAspects(
                 "ROD_ice",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
                         .add(Aspect.getAspect("aqua"), 6).add(Aspect.getAspect("gelum"), 6)
                         .add(Aspect.getAspect("arbor"), 3));
         TCHelper.setResearchComplexity("ROD_ice", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_quartz",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 4, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("ordo"), 24).add(Aspect.getAspect("praecantatio"), 12)
                         .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("vitreus"), 6),
                 NHItemList.ChargedCertusQuartzRod.getIS(1),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing), });
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing));
         TCHelper.setResearchAspects(
                 "ROD_quartz",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
                         .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("ordo"), 6)
                         .add(Aspect.getAspect("arbor"), 3));
         TCHelper.setResearchComplexity("ROD_quartz", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_bone",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 7, missing),
                 3,
                 new AspectList().add(Aspect.getAspect("exanimis"), 12).add(Aspect.getAspect("perditio"), 24)
                         .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("vitreus"), 6),
                 getModItem(TinkerConstruct.ID, "toolRod", 1, 5, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing), });
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing));
         TCHelper.setResearchAspects(
                 "ROD_bone",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
@@ -858,7 +858,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("arbor"), 3));
         TCHelper.setResearchComplexity("ROD_bone", 2);
         ThaumcraftApi.addWarpToResearch("ROD_bone", 1);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_silverwood",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
                 5,
@@ -867,13 +867,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("perditio"), 48).add(Aspect.getAspect("praecantatio"), 48)
                         .add(Aspect.getAspect("terra"), 48),
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing), });
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing));
         TCHelper.setResearchAspects(
                 "ROD_silverwood",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 12)
@@ -1322,44 +1322,44 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("praecantatio"), 9)
                         .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("motus"), 3));
         TCHelper.setResearchComplexity("FOCUSTRADE", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUSWARDING",
                 getModItem(Thaumcraft.ID, "FocusWarding", 1, 0, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("ordo"), 25)
                         .add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("tutamen"), 25)
                         .add(Aspect.getAspect("praecantatio"), 10),
-                GTOreDictUnificator.get(OrePrefixes.lens, Materials.NetherStar, 1L),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Minecraft.ID, "quartz", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Minecraft.ID, "quartz", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing), });
+                OrePrefixes.lens.get(Materials.NetherStar),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Minecraft.ID, "quartz", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Minecraft.ID, "quartz", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing));
         TCHelper.setResearchAspects(
                 "FOCUSWARDING",
                 new AspectList().add(Aspect.getAspect("terra"), 12).add(Aspect.getAspect("cognitio"), 12)
                         .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("tutamen"), 6)
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("FOCUSWARDING", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUSPORTABLEHOLE",
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
                 6,
                 new AspectList().add(Aspect.getAspect("alienis"), 40).add(Aspect.getAspect("iter"), 30)
                         .add(Aspect.getAspect("perditio"), 20).add(Aspect.getAspect("permutatio"), 10)
                         .add(Aspect.getAspect("praecantatio"), 5),
-                GTOreDictUnificator.get(OrePrefixes.lens, Materials.EnderPearl, 1L),
-                new ItemStack[] { getModItem(Minecraft.ID, "quartz", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Minecraft.ID, "quartz", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing), });
+                OrePrefixes.lens.get(Materials.EnderPearl),
+                getModItem(Minecraft.ID, "quartz", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Minecraft.ID, "quartz", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing));
         TCHelper.setResearchAspects(
                 "FOCUSPORTABLEHOLE",
                 new AspectList().add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("iter"), 12)
@@ -1367,22 +1367,22 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("FOCUSPORTABLEHOLE", 3);
         ThaumcraftApi.addWarpToResearch("NODESTABILIZERADV", 1);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUSHELLBAT",
                 getModItem(Thaumcraft.ID, "FocusHellbat", 1, 0, missing),
                 7,
                 new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("ignis"), 40)
                         .add(Aspect.getAspect("bestia"), 20).add(Aspect.getAspect("perditio"), 10)
                         .add(Aspect.getAspect("praecantatio"), 5),
-                GTOreDictUnificator.get(OrePrefixes.lens, Materials.Firestone, 1L),
-                new ItemStack[] { getModItem(Minecraft.ID, "quartz", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Minecraft.ID, "quartz", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing), });
+                OrePrefixes.lens.get(Materials.Firestone),
+                getModItem(Minecraft.ID, "quartz", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Minecraft.ID, "quartz", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "FOCUSHELLBAT",
                 new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("iter"), 9)
@@ -1453,23 +1453,23 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("potentia"), 9)
                         .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("ordo"), 3));
         TCHelper.setResearchComplexity("NODESTABILIZER", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "NODESTABILIZERADV",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10, missing),
                 10,
                 new AspectList().add(Aspect.getAspect("auram"), 32).add(Aspect.getAspect("ordo"), 32)
                         .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("praecantatio"), 32),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 9, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "redstone_block", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(Minecraft.ID, "redstone_block", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
-                        getModItem(Minecraft.ID, "glowstone", 1, 0, missing),
-                        getModItem(Minecraft.ID, "redstone_block", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(Minecraft.ID, "redstone_block", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
-                        getModItem(Minecraft.ID, "glowstone", 1, 0, missing), });
+                getModItem(Minecraft.ID, "redstone_block", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(Minecraft.ID, "redstone_block", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
+                getModItem(Minecraft.ID, "glowstone", 1, 0, missing),
+                getModItem(Minecraft.ID, "redstone_block", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(Minecraft.ID, "redstone_block", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
+                getModItem(Minecraft.ID, "glowstone", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "NODESTABILIZERADV",
                 new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("potentia"), 9)
@@ -1533,23 +1533,23 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("potentia"), 9)
                         .add(Aspect.getAspect("praecantatio"), 3).add(Aspect.getAspect("machina"), 6));
         TCHelper.setResearchComplexity("VISPOWER", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WANDPED",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 5, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("auram"), 10).add(Aspect.getAspect("permutatio"), 15)
                         .add(Aspect.getAspect("praecantatio"), 20).add(Aspect.getAspect("ordo"), 5),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 1, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L), });
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond));
         TCHelper.setResearchAspects(
                 "WANDPED",
                 new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("potentia"), 9)
                         .add(Aspect.getAspect("praecantatio"), 3).add(Aspect.getAspect("permutatio"), 6));
         TCHelper.setResearchComplexity("WANDPED", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "VISAMULET",
                 getModItem(Thaumcraft.ID, "ItemAmuletVis", 1, 1, missing),
                 7,
@@ -1557,21 +1557,21 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 88).add(Aspect.getAspect("praecantatio"), 88)
                         .add(Aspect.getAspect("vitreus"), 24),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing));
         TCHelper.setResearchAspects(
                 "VISAMULET",
                 new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("auram"), 15)
                         .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("potentia"), 12)
                         .add(Aspect.getAspect("vitreus"), 6).add(Aspect.getAspect("tempus"), 3));
         TCHelper.setResearchComplexity("VISAMULET", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WANDPEDFOC",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 8, missing),
                 5,
@@ -1579,14 +1579,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 30).add(Aspect.getAspect("potentia"), 15)
                         .add(Aspect.getAspect("cognitio"), 15),
                 getModItem(ProjectRedIntegration.ID, "projectred.integration.gate", 1, 26, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing), });
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing));
         TCHelper.setResearchAspects(
                 "WANDPEDFOC",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("auram"), 15)
@@ -2287,17 +2287,17 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "paneGlassColorless");
         TCHelper.clearPages("JARVOID");
         TCHelper.addResearchPage("JARVOID", new ResearchPage("tc.research_page.JARVOID.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "JARVOID",
                 getModItem(Thaumcraft.ID, "blockJar", 1, 3, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("vacuos"), 7).add(Aspect.getAspect("praecantatio"), 7)
                         .add(Aspect.getAspect("perditio"), 7).add(Aspect.getAspect("aqua"), 7),
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L),
-                        getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.EnderEye, 1L),
-                        getModItem(Thaumcraft.ID, "ItemNugget", 1, 5, missing), });
+                OrePrefixes.plate.get(Materials.Obsidian),
+                getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.EnderEye),
+                getModItem(Thaumcraft.ID, "ItemNugget", 1, 5, missing));
         TCHelper.addResearchPage(
                 "JARVOID",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Thaumcraft.ID, "blockJar", 1, 3, missing))));
@@ -2332,7 +2332,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.setResearchComplexity("SANESOAP", 3);
         TCHelper.clearPages("ARCANESPA");
         TCHelper.addResearchPage("ARCANESPA", new ResearchPage("tc.research_page.ARCANESPA.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ARCANESPA",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 12, missing),
                 4,
@@ -2340,14 +2340,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("sano"), 16).add(Aspect.getAspect("aqua"), 32)
                         .add(Aspect.getAspect("machina"), 8),
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                new ItemStack[] { CustomItemList.StainlessSteelBars.get(1L),
-                        getModItem(Minecraft.ID, "quartz_block", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemBathSalts", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
-                        getModItem(Minecraft.ID, "quartz_block", 1, 0, missing), });
+                CustomItemList.StainlessSteelBars.get(1L),
+                getModItem(Minecraft.ID, "quartz_block", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemBathSalts", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
+                getModItem(Minecraft.ID, "quartz_block", 1, 0, missing));
         TCHelper.addResearchPage(
                 "ARCANESPA",
                 new ResearchPage(
@@ -3136,37 +3136,37 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("tenebrae"), 3)
                         .add(Aspect.getAspect("sensus"), 6));
         TCHelper.setResearchComplexity("ARCANELAMP", 1);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "LAMPGROWTH",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 8, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("herba"), 20).add(Aspect.getAspect("lux"), 10)
                         .add(Aspect.getAspect("victus"), 20).add(Aspect.getAspect("messis"), 10),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(Minecraft.ID, "dye", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(Minecraft.ID, "dye", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing), });
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(Minecraft.ID, "dye", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(Minecraft.ID, "dye", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing));
         TCHelper.setResearchAspects(
                 "LAMPGROWTH",
                 new AspectList().add(Aspect.getAspect("messis"), 9).add(Aspect.getAspect("lux"), 3)
                         .add(Aspect.getAspect("herba"), 6).add(Aspect.getAspect("victus"), 9));
         TCHelper.setResearchComplexity("LAMPGROWTH", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "LAMPFERTILITY",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 13, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("bestia"), 20).add(Aspect.getAspect("lux"), 10)
                         .add(Aspect.getAspect("victus"), 20).add(Aspect.getAspect("sano"), 10),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(Minecraft.ID, "wheat", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(Minecraft.ID, "golden_carrot", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing), });
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(Minecraft.ID, "wheat", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(Minecraft.ID, "golden_carrot", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing));
         TCHelper.setResearchAspects(
                 "LAMPFERTILITY",
                 new AspectList().add(Aspect.getAspect("bestia"), 9).add(Aspect.getAspect("lux"), 3)
@@ -3366,7 +3366,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("sensus"), 9)
                         .add(Aspect.getAspect("praecantatio"), 3).add(Aspect.getAspect("potentia"), 6));
         TCHelper.setResearchComplexity("ARCANEEAR", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SINSTONE",
                 getModItem(Thaumcraft.ID, "ItemCompassStone", 1, 0, missing),
                 4,
@@ -3374,12 +3374,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("sensus"), 10).add(Aspect.getAspect("tenebrae"), 10)
                         .add(Aspect.getAspect("ordo"), 10),
                 getModItem(Minecraft.ID, "flint", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 9, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 9, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing));
         TCHelper.setResearchAspects(
                 "SINSTONE",
                 new AspectList().add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("sensus"), 3)
@@ -3418,7 +3418,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.setResearchComplexity("BELLOWS", 2);
         TCHelper.clearPages("FLUXSCRUB");
         TCHelper.addResearchPage("FLUXSCRUB", new ResearchPage("tc.research_page.FLUXSCRUB.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FLUXSCRUB",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 14, missing),
                 4,
@@ -3426,12 +3426,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("vinculum"), 10)
                         .add(Aspect.getAspect("vitium"), 5),
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockTube", 1, 0, missing),
-                        CustomItemList.SteelBars.get(1L), getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "blockTube", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing), CustomItemList.SteelBars.get(1L), });
+                getModItem(Thaumcraft.ID, "blockTube", 1, 0, missing),
+                CustomItemList.SteelBars.get(1L),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "blockTube", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
+                CustomItemList.SteelBars.get(1L));
         TCHelper.addResearchPage(
                 "FLUXSCRUB",
                 new ResearchPage(
@@ -3442,47 +3444,47 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("vinculum"), 6)
                         .add(Aspect.getAspect("vitium"), 3));
         TCHelper.setResearchComplexity("FLUXSCRUB", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "BOOTSTRAVELLER",
                 getModItem(Thaumcraft.ID, "BootsTraveller", 1, 0, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("volatus"), 25).add(Aspect.getAspect("aer"), 25)
                         .add(Aspect.getAspect("iter"), 25).add(Aspect.getAspect("aqua"), 5),
                 getModItem(Minecraft.ID, "leather_boots", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(Minecraft.ID, "feather", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(Minecraft.ID, "fish", 1, wildcard, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing), });
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(Minecraft.ID, "feather", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(Minecraft.ID, "fish", 1, wildcard, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing));
         TCHelper.setResearchAspects(
                 "BOOTSTRAVELLER",
                 new AspectList().add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("iter"), 15)
                         .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("volatus"), 12)
                         .add(Aspect.getAspect("aer"), 3));
         TCHelper.setResearchComplexity("BOOTSTRAVELLER", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNICARMOR",
                 getModItem(Thaumcraft.ID, "ItemRingRunic", 1, 1, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("potentia"), 25).add(Aspect.getAspect("tutamen"), 25)
                         .add(Aspect.getAspect("praecantatio"), 25).add(Aspect.getAspect("alienis"), 5),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 1, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Amber, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemInkwell", 1, 0, missing),
-                        getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Amber, 1L), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                OrePrefixes.gemFlawless.get(Materials.Amber),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemInkwell", 1, 0, missing),
+                getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Amber));
         TCHelper.setResearchAspects(
                 "RUNICARMOR",
                 new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("tutamen"), 12)
                         .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("potentia"), 9)
                         .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("RUNICARMOR", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNICCHARGED",
                 getModItem(Thaumcraft.ID, "ItemRingRunic", 1, 2, missing),
                 6,
@@ -3490,14 +3492,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("alienis"), 16)
                         .add(Aspect.getAspect("aer"), 8),
                 getModItem(Thaumcraft.ID, "ItemRingRunic", 1, 1, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "potion", 1, 8226, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Minecraft.ID, "potion", 1, 8226, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing), });
+                getModItem(Minecraft.ID, "potion", 1, 8226, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Minecraft.ID, "potion", 1, 8226, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing));
         TCHelper.setResearchAspects(
                 "RUNICCHARGED",
                 new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("potentia"), 12)
@@ -3505,7 +3507,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("cognitio"), 6)
                         .add(Aspect.getAspect("terra"), 3));
         TCHelper.setResearchComplexity("RUNICCHARGED", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNICHEALING",
                 getModItem(Thaumcraft.ID, "ItemRingRunic", 1, 3, missing),
                 6,
@@ -3513,14 +3515,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("sano"), 32).add(Aspect.getAspect("tutamen"), 32)
                         .add(Aspect.getAspect("aer"), 8),
                 getModItem(Thaumcraft.ID, "ItemRingRunic", 1, 1, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "potion", 1, 8225, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Minecraft.ID, "potion", 1, 8225, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing), });
+                getModItem(Minecraft.ID, "potion", 1, 8225, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Minecraft.ID, "potion", 1, 8225, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing));
         TCHelper.setResearchAspects(
                 "RUNICHEALING",
                 new AspectList().add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("aqua"), 15)
@@ -3528,22 +3530,22 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("aer"), 6)
                         .add(Aspect.getAspect("cognitio"), 3));
         TCHelper.setResearchComplexity("RUNICHEALING", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNICARMOR",
                 getModItem(Thaumcraft.ID, "ItemAmuletRunic", 1, 0, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("potentia"), 40).add(Aspect.getAspect("tutamen"), 40)
                         .add(Aspect.getAspect("praecantatio"), 40).add(Aspect.getAspect("alienis"), 20),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Amber, 1L),
-                        getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemInkwell", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Amber, 1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                OrePrefixes.gemFlawless.get(Materials.Amber),
+                getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemInkwell", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Amber));
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNICEMERGENCY",
                 getModItem(Thaumcraft.ID, "ItemAmuletRunic", 1, 1, missing),
                 8,
@@ -3551,14 +3553,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 64).add(Aspect.getAspect("vacuos"), 32)
                         .add(Aspect.getAspect("sano"), 8),
                 getModItem(Thaumcraft.ID, "ItemAmuletRunic", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "potion", 1, 8233, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Minecraft.ID, "potion", 1, 8233, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing), });
+                getModItem(Minecraft.ID, "potion", 1, 8233, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Minecraft.ID, "potion", 1, 8233, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing));
         TCHelper.setResearchAspects(
                 "RUNICEMERGENCY",
                 new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("praecantatio"), 12)
@@ -3566,24 +3568,24 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("sano"), 6)
                         .add(Aspect.getAspect("cognitio"), 3));
         TCHelper.setResearchComplexity("RUNICEMERGENCY", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNICARMOR",
                 getModItem(Thaumcraft.ID, "ItemGirdleRunic", 1, 0, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("potentia"), 55).add(Aspect.getAspect("tutamen"), 55)
                         .add(Aspect.getAspect("praecantatio"), 55).add(Aspect.getAspect("alienis"), 35),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Amber, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemInkwell", 1, 0, missing),
-                        getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Amber, 1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                OrePrefixes.gemFlawless.get(Materials.Amber),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemInkwell", 1, 0, missing),
+                getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Amber));
+        TCHelper.addInfusionCraftingRecipe(
                 "RUNICKINETIC",
                 getModItem(Thaumcraft.ID, "ItemGirdleRunic", 1, 1, missing),
                 8,
@@ -3591,14 +3593,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 64).add(Aspect.getAspect("bestia"), 32)
                         .add(Aspect.getAspect("telum"), 8),
                 getModItem(Thaumcraft.ID, "ItemGirdleRunic", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "potion", 1, 16428, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Minecraft.ID, "potion", 1, 16428, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing), });
+                getModItem(Minecraft.ID, "potion", 1, 16428, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Minecraft.ID, "potion", 1, 16428, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "RUNICKINETIC",
                 new AspectList().add(Aspect.getAspect("aer"), 18).add(Aspect.getAspect("praecantatio"), 15)
@@ -3606,7 +3608,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("bestia"), 6)
                         .add(Aspect.getAspect("cognitio"), 3));
         TCHelper.setResearchComplexity("RUNICKINETIC", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ARCANEBORE",
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 5, missing),
                 6,
@@ -3614,16 +3616,16 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("perditio"), 64).add(Aspect.getAspect("potentia"), 32)
                         .add(Aspect.getAspect("vacuos"), 32),
                 ItemList.Electric_Piston_MV.get(1L),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShovelThaumium", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "ItemPickThaumium", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.lens.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShovelThaumium", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                OrePrefixes.lens.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "ItemPickThaumium", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ARCANEBORE",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("perfodio"), 12)
@@ -3656,102 +3658,102 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "wireFineSteel",
                 'i',
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ELEMENTALPICK",
                 getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
                 3,
                 new AspectList().add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("perfodio"), 20)
                         .add(Aspect.getAspect("sensus"), 20).add(Aspect.getAspect("lucrum"), 20),
                 getModItem(Thaumcraft.ID, "ItemPickThaumium", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Ruby, 1L),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing), });
+                OrePrefixes.gemFlawless.get(Materials.Ruby),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing));
         TCHelper.setResearchAspects(
                 "ELEMENTALPICK",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("ignis"), 12)
                         .add(Aspect.getAspect("perfodio"), 9).add(Aspect.getAspect("lucrum"), 6)
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("ELEMENTALPICK", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ELEMENTALAXE",
                 getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
                 3,
                 new AspectList().add(Aspect.getAspect("aqua"), 10).add(Aspect.getAspect("arbor"), 20)
                         .add(Aspect.getAspect("fabrico"), 20).add(Aspect.getAspect("motus"), 20),
                 getModItem(Thaumcraft.ID, "ItemAxeThaumium", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Sapphire, 1L),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing), });
+                OrePrefixes.gemFlawless.get(Materials.Sapphire),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing));
         TCHelper.setResearchAspects(
                 "ELEMENTALAXE",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("motus"), 12)
                         .add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("aqua"), 6)
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("ELEMENTALAXE", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ELEMENTALSWORD",
                 getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing),
                 3,
                 new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("motus"), 20)
                         .add(Aspect.getAspect("potentia"), 20).add(Aspect.getAspect("telum"), 20),
                 getModItem(Thaumcraft.ID, "ItemSwordThaumium", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.GarnetYellow, 1L),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing), });
+                OrePrefixes.gemFlawless.get(Materials.GarnetYellow),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ELEMENTALSWORD",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("telum"), 12)
                         .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("aer"), 6)
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("ELEMENTALSWORD", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ELEMENTALSHOVEL",
                 getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing),
                 3,
                 new AspectList().add(Aspect.getAspect("fabrico"), 20).add(Aspect.getAspect("terra"), 20)
                         .add(Aspect.getAspect("perfodio"), 10).add(Aspect.getAspect("praecantatio"), 20),
                 getModItem(Thaumcraft.ID, "ItemShovelThaumium", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Emerald, 1L),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing), });
+                OrePrefixes.gemFlawless.get(Materials.Emerald),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing));
         TCHelper.setResearchAspects(
                 "ELEMENTALSHOVEL",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("terra"), 12)
                         .add(Aspect.getAspect("perfodio"), 9).add(Aspect.getAspect("fabrico"), 6)
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("ELEMENTALSHOVEL", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ELEMENTALHOE",
                 getModItem(Thaumcraft.ID, "ItemHoeElemental", 1, 0, missing),
                 3,
                 new AspectList().add(Aspect.getAspect("meto"), 10).add(Aspect.getAspect("herba"), 20)
                         .add(Aspect.getAspect("terra"), 20).add(Aspect.getAspect("messis"), 20),
                 getModItem(Thaumcraft.ID, "ItemHoeThaumium", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Amber, 1L),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing), });
+                OrePrefixes.gemFlawless.get(Materials.Amber),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing));
         TCHelper.setResearchAspects(
                 "ELEMENTALHOE",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("victus"), 12)
                         .add(Aspect.getAspect("meto"), 9).add(Aspect.getAspect("messis"), 6)
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("ELEMENTALHOE", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "HOVERHARNESS",
                 getModItem(Thaumcraft.ID, "HoverHarness", 1, 0, missing),
                 6,
@@ -3759,23 +3761,23 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("volatus"), 32)
                         .add(Aspect.getAspect("tutamen"), 16),
                 getModItem(Minecraft.ID, "leather_chestplate", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(ProjectRedIntegration.ID, "projectred.integration.gate", 1, 26, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing), });
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Aluminium),
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(ProjectRedIntegration.ID, "projectred.integration.gate", 1, 26, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.plate.get(Materials.Aluminium),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing));
         TCHelper.setResearchAspects(
                 "HOVERHARNESS",
                 new AspectList().add(Aspect.getAspect("volatus"), 15).add(Aspect.getAspect("machina"), 12)
                         .add(Aspect.getAspect("iter"), 9).add(Aspect.getAspect("aer"), 9)
                         .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("tutamen"), 3));
         TCHelper.setResearchComplexity("HOVERHARNESS", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "HOVERGIRDLE",
                 getModItem(Thaumcraft.ID, "ItemGirdleHover", 1, 0, missing),
                 8,
@@ -3783,15 +3785,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("volatus"), 32)
                         .add(Aspect.getAspect("tutamen"), 16),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Minecraft.ID, "feather", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Aluminium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(TwilightForest.ID, "item.tfFeather", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Minecraft.ID, "feather", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.plate.get(Materials.Aluminium),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Aluminium),
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(TwilightForest.ID, "item.tfFeather", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "HOVERGIRDLE",
                 new AspectList().add(Aspect.getAspect("volatus"), 15).add(Aspect.getAspect("motus"), 12)
@@ -3805,21 +3807,21 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("alienis"), 6)
                         .add(Aspect.getAspect("potentia"), 3));
         TCHelper.setResearchComplexity("RUNICARMOR", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MIRROR",
                 getModItem(Thaumcraft.ID, "blockMirror", 1, 0, missing),
                 6,
                 new AspectList().add(Aspect.getAspect("iter"), 32).add(Aspect.getAspect("permutatio"), 24)
                         .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("alienis"), 8),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.VibrantAlloy, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.VibrantAlloy, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L), });
+                OrePrefixes.plate.get(Materials.VibrantAlloy),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.VibrantAlloy),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.screw.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "MIRROR",
                 new AspectList().add(Aspect.getAspect("vitreus"), 15).add(Aspect.getAspect("iter"), 12)
@@ -3827,7 +3829,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("potentia"), 3));
         TCHelper.setResearchComplexity("MIRROR", 3);
         ThaumcraftApi.addWarpToResearch("MIRROR", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MIRRORHAND",
                 getModItem(Thaumcraft.ID, "HandMirror", 1, 0, missing),
                 9,
@@ -3835,14 +3837,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("motus"), 24).add(Aspect.getAspect("alienis"), 16)
                         .add(Aspect.getAspect("potentia"), 8),
                 getModItem(Thaumcraft.ID, "blockMirror", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "compass", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        getModItem(Minecraft.ID, "map", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "WandRod", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L), });
+                getModItem(Minecraft.ID, "compass", 1, 0, missing),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                getModItem(Minecraft.ID, "map", 1, 0, missing),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "WandRod", 1, 0, missing),
+                OrePrefixes.screw.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "MIRRORHAND",
                 new AspectList().add(Aspect.getAspect("iter"), 18).add(Aspect.getAspect("instrumentum"), 15)
@@ -3851,21 +3853,21 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("MIRRORHAND", 3);
         ThaumcraftApi.addWarpToResearch("MIRRORHAND", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MIRRORESSENTIA",
                 getModItem(Thaumcraft.ID, "blockMirror", 1, 6, missing),
                 2,
                 new AspectList().add(Aspect.getAspect("aqua"), 24).add(Aspect.getAspect("iter"), 32)
                         .add(Aspect.getAspect("permutatio"), 16).add(Aspect.getAspect("vitreus"), 8),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Tantalum, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Tantalum, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L), });
+                OrePrefixes.plate.get(Materials.Tantalum),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Steel),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Tantalum),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Steel),
+                OrePrefixes.screw.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "MIRRORESSENTIA",
                 new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("iter"), 12)
@@ -3874,19 +3876,19 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("aqua"), 3));
         TCHelper.setResearchComplexity("MIRRORESSENTIA", 3);
         ThaumcraftApi.addWarpToResearch("MIRRORESSENTIA", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "JARBRAIN",
                 getModItem(Thaumcraft.ID, "blockJar", 1, 1, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("exanimis"), 30)
                         .add(Aspect.getAspect("sensus"), 15).add(Aspect.getAspect("alienis"), 10),
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(Minecraft.ID, "poisonous_potato", 1, 0, missing),
-                        getModItem(Minecraft.ID, "spider_eye", 1, 0, missing),
-                        getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "spider_eye", 1, 0, missing),
-                        getModItem(Minecraft.ID, "poisonous_potato", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(Minecraft.ID, "poisonous_potato", 1, 0, missing),
+                getModItem(Minecraft.ID, "spider_eye", 1, 0, missing),
+                getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "spider_eye", 1, 0, missing),
+                getModItem(Minecraft.ID, "poisonous_potato", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "JARBRAIN",
                 new AspectList().add(Aspect.getAspect("lucrum"), 15).add(Aspect.getAspect("fames"), 12)
@@ -3900,59 +3902,59 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("potentia"), 12)
                         .add(Aspect.getAspect("alienis"), 6));
         TCHelper.setResearchComplexity("INFUSIONENCHANTMENT", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ARMORFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemHelmetFortress", 1, 0, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("victus"), 16),
                 getModItem(Thaumcraft.ID, "ItemHelmetThaumium", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L), });
+                OrePrefixes.gemFlawless.get(Materials.Emerald),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold));
         TCHelper.setResearchAspects(
                 "ARMORFORTRESS",
                 new AspectList().add(Aspect.getAspect("fabrico"), 15).add(Aspect.getAspect("metallum"), 12)
                         .add(Aspect.getAspect("tutamen"), 9).add(Aspect.getAspect("alienis"), 9)
                         .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("potentia"), 3));
         TCHelper.setResearchComplexity("ARMORFORTRESS", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ARMORFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemChestplateFortress", 1, 0, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("tutamen"), 40).add(Aspect.getAspect("cognitio"), 16),
                 getModItem(Thaumcraft.ID, "ItemChestplateThaumium", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium));
+        TCHelper.addInfusionCraftingRecipe(
                 "ARMORFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemLeggingsFortress", 1, 0, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("tutamen"), 24).add(Aspect.getAspect("terra"), 16),
                 getModItem(Thaumcraft.ID, "ItemLeggingsThaumium", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L), });
+                getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold));
         TCHelper.setResearchAspects(
                 "HELMGOGGLES",
                 new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("sensus"), 12)
@@ -4196,21 +4198,21 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("fames"), 9).add(Aspect.getAspect("vacuos"), 6)
                         .add(Aspect.getAspect("iter"), 3));
         TCHelper.setResearchComplexity("HUNGRYCHEST", 1);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TRAVELTRUNK",
                 getModItem(Thaumcraft.ID, "TrunkSpawner", 1, 0, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("iter"), 16).add(Aspect.getAspect("motus"), 16)
                         .add(Aspect.getAspect("spiritus"), 16).add(Aspect.getAspect("vacuos"), 32),
                 getModItem(Thaumcraft.ID, "blockChestHungry", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.StainlessSteel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.StainlessSteel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.StainlessSteel, 1L),
-                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.StainlessSteel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.StainlessSteel, 1L), });
+                OrePrefixes.plate.get(Materials.StainlessSteel),
+                OrePrefixes.ring.get(Materials.StainlessSteel),
+                OrePrefixes.screw.get(Materials.StainlessSteel),
+                getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing),
+                OrePrefixes.screw.get(Materials.StainlessSteel),
+                OrePrefixes.ring.get(Materials.StainlessSteel));
         TCHelper.setResearchAspects(
                 "TRAVELTRUNK",
                 new AspectList().add(Aspect.getAspect("spiritus"), 12).add(Aspect.getAspect("vacuos"), 12)
@@ -4425,17 +4427,17 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.setResearchComplexity("COREFILL", 2);
         TCHelper.clearPages("COREHARVEST");
         TCHelper.addResearchPage("COREHARVEST", new ResearchPage("tc.research_page.COREHARVEST.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "COREHARVEST",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 3, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("messis"), 10).add(Aspect.getAspect("meto"), 10)
                         .add(Aspect.getAspect("herba"), 20),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 100, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(Minecraft.ID, "wheat_seeds", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemHoeThaumium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(Minecraft.ID, "wheat_seeds", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemHoeThaumium", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Gold));
         TCHelper.addResearchPage(
                 "COREHARVEST",
                 new ResearchPage(
@@ -4449,17 +4451,17 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.setResearchComplexity("COREHARVEST", 3);
         TCHelper.clearPages("COREGUARD");
         TCHelper.addResearchPage("COREGUARD", new ResearchPage("tc.research_page.COREGUARD.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "COREGUARD",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 4, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("telum"), 20).add(Aspect.getAspect("vinculum"), 20)
                         .add(Aspect.getAspect("tutamen"), 20),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 100, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L),
-                        getModItem(Thaumcraft.ID, "ItemSwordThaumium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Obsidian),
+                getModItem(Thaumcraft.ID, "ItemSwordThaumium", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Gold));
         TCHelper.addResearchPage(
                 "COREGUARD",
                 new ResearchPage(
@@ -4471,38 +4473,38 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("vinculum"), 12).add(Aspect.getAspect("permutatio"), 9)
                         .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("COREGUARD", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "COREUSE",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 8, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("humanus"), 20).add(Aspect.getAspect("instrumentum"), 20)
                         .add(Aspect.getAspect("machina"), 20).add(Aspect.getAspect("lucrum"), 20),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 1, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(ProjectRedIntegration.ID, "projectred.integration.gate", 1, 26, missing),
-                        getModItem(Minecraft.ID, "lever", 1, 0, missing),
-                        getModItem(Minecraft.ID, "flint_and_steel", 1, wildcard, missing),
-                        getModItem(Minecraft.ID, "stone_pressure_plate", 1, 0, missing),
-                        getModItem(Minecraft.ID, "shears", 1, 0, missing), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(ProjectRedIntegration.ID, "projectred.integration.gate", 1, 26, missing),
+                getModItem(Minecraft.ID, "lever", 1, 0, missing),
+                getModItem(Minecraft.ID, "flint_and_steel", 1, wildcard, missing),
+                getModItem(Minecraft.ID, "stone_pressure_plate", 1, 0, missing),
+                getModItem(Minecraft.ID, "shears", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "COREUSE",
                 new AspectList().add(Aspect.getAspect("humanus"), 12).add(Aspect.getAspect("instrumentum"), 12)
                         .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("permutatio"), 9)
                         .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("COREUSE", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CORESORTING",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 10, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("lucrum"), 20).add(Aspect.getAspect("fames"), 20)
                         .add(Aspect.getAspect("permutatio"), 20).add(Aspect.getAspect("vacuos"), 20),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 100, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 1, missing),
-                        getModItem(Minecraft.ID, "paper", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 0, missing),
-                        getModItem(ProjectRedIntegration.ID, "projectred.integration.gate", 1, 26, missing), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 1, missing),
+                getModItem(Minecraft.ID, "paper", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 0, missing),
+                getModItem(ProjectRedIntegration.ID, "projectred.integration.gate", 1, 26, missing));
         TCHelper.setResearchAspects(
                 "CORESORTING",
                 new AspectList().add(Aspect.getAspect("fames"), 12).add(Aspect.getAspect("vacuos"), 12)
@@ -4511,18 +4513,19 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.setResearchComplexity("CORESORTING", 3);
         TCHelper.clearPages("CORELIQUID");
         TCHelper.addResearchPage("CORELIQUID", new ResearchPage("tc.research_page.CORELIQUID.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CORELIQUID",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 5, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("aqua"), 20).add(Aspect.getAspect("vacuos"), 20)
                         .add(Aspect.getAspect("metallum"), 20).add(Aspect.getAspect("iter"), 20),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0, missing),
-                        getModItem(IguanaTweaksTinkerConstruct.ID, "clayBucketFired", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bucket", 1, 0, missing),
-                        getModItem(Forestry.ID, "canEmpty", 1, 0, missing), Materials.Empty.getCells(1), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0, missing),
+                getModItem(IguanaTweaksTinkerConstruct.ID, "clayBucketFired", 1, 0, missing),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing),
+                getModItem(Forestry.ID, "canEmpty", 1, 0, missing),
+                Materials.Empty.getCells(1));
         TCHelper.addResearchPage(
                 "CORELIQUID",
                 new ResearchPage(
@@ -4534,21 +4537,21 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("permutatio"), 9)
                         .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("CORELIQUID", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "COREALCHEMY",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 6, missing),
                 7,
                 new AspectList().add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("motus"), 32)
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("permutatio"), 32),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 5, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(Minecraft.ID, "potion", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemEssence", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(Minecraft.ID, "potion", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemEssence", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(Minecraft.ID, "potion", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemEssence", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(Minecraft.ID, "potion", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemEssence", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "COREALCHEMY",
                 new AspectList().add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("aqua"), 12)
@@ -4557,19 +4560,19 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.setResearchComplexity("COREALCHEMY", 3);
         TCHelper.clearPages("COREBUTCHER");
         TCHelper.addResearchPage("COREBUTCHER", new ResearchPage("tc.research_page.COREBUTCHER.1"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "COREBUTCHER",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 9, missing),
                 7,
                 new AspectList().add(Aspect.getAspect("bestia"), 32).add(Aspect.getAspect("corpus"), 32)
                         .add(Aspect.getAspect("mortuus"), 32).add(Aspect.getAspect("telum"), 32),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 3, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        MetaGeneratedTool01.INSTANCE.getToolWithStats(BUTCHERYKNIFE.ID, 1, null, null, null),
-                        getModItem(Minecraft.ID, "iron_sword", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bow", 1, 0, missing),
-                        getModItem(Minecraft.ID, "arrow", 1, 0, missing), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                MetaGeneratedTool01.INSTANCE.getToolWithStats(BUTCHERYKNIFE.ID, 1, null, null, null),
+                getModItem(Minecraft.ID, "iron_sword", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(Minecraft.ID, "bow", 1, 0, missing),
+                getModItem(Minecraft.ID, "arrow", 1, 0, missing));
         TCHelper.addResearchPage(
                 "COREBUTCHER",
                 new ResearchPage(
@@ -4581,37 +4584,37 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("COREBUTCHER", 3);
         ThaumcraftApi.addWarpToResearch("COREBUTCHER", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "COREFISHING",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 11, missing),
                 7,
                 new AspectList().add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("meto"), 20)
                         .add(Aspect.getAspect("bestia"), 32).add(Aspect.getAspect("fames"), 32),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 3, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(Minecraft.ID, "fish", 1, 0, missing),
-                        getModItem(Minecraft.ID, "fish", 1, 2, missing),
-                        getModItem(Minecraft.ID, "fish", 1, 3, missing),
-                        getModItem(Minecraft.ID, "fishing_rod", 1, 0, missing),
-                        MetaGeneratedTool01.INSTANCE.getToolWithStats(KNIFE.ID, 1, null, null, null), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(Minecraft.ID, "fish", 1, 0, missing),
+                getModItem(Minecraft.ID, "fish", 1, 2, missing),
+                getModItem(Minecraft.ID, "fish", 1, 3, missing),
+                getModItem(Minecraft.ID, "fishing_rod", 1, 0, missing),
+                MetaGeneratedTool01.INSTANCE.getToolWithStats(KNIFE.ID, 1, null, null, null));
         TCHelper.setResearchAspects(
                 "COREFISHING",
                 new AspectList().add(Aspect.getAspect("fames"), 12).add(Aspect.getAspect("aqua"), 12)
                         .add(Aspect.getAspect("bestia"), 12).add(Aspect.getAspect("meto"), 9)
                         .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("COREFISHING", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CORELUMBER",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 7, missing),
                 7,
                 new AspectList().add(Aspect.getAspect("arbor"), 32).add(Aspect.getAspect("instrumentum"), 32)
                         .add(Aspect.getAspect("meto"), 20).add(Aspect.getAspect("potentia"), 32),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 3, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemAxeThaumium", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemAxeThaumium", 1, 0, missing), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemAxeThaumium", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemAxeThaumium", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "CORELUMBER",
                 new AspectList().add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("arbor"), 12)
@@ -5411,19 +5414,19 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.addResearchPage(
                 "CAP_void",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(Thaumcraft.ID, "WandCap", 1, 8, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_void",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 7, missing),
                 8,
                 new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("auram"), 32)
                         .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("vacuos"), 32),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 8, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing));
         TCHelper.addResearchPage(
                 "CAP_void",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Thaumcraft.ID, "WandCap", 1, 7, missing))));
@@ -5434,21 +5437,21 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("instrumentum"), 6).add(Aspect.getAspect("terra"), 6)
                         .add(Aspect.getAspect("tenebrae"), 3));
         TCHelper.setResearchComplexity("CAP_void", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ESSENTIARESERVOIR",
                 getModItem(Thaumcraft.ID, "blockEssentiaReservoir", 1, 0, missing),
                 8,
                 new AspectList().add(Aspect.getAspect("aqua"), 16).add(Aspect.getAspect("permutatio"), 16)
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("vacuos"), 16),
                 getModItem(Thaumcraft.ID, "blockTube", 1, 4, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing), });
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ESSENTIARESERVOIR",
                 new AspectList().add(Aspect.getAspect("aqua"), 12).add(Aspect.getAspect("permutatio"), 12)
@@ -5489,7 +5492,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("perditio"), 9)
                         .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("FOCUSPRIMAL", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_primal_staff",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 100, missing),
                 10,
@@ -5498,14 +5501,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("ordo"), 64).add(Aspect.getAspect("perditio"), 64)
                         .add(Aspect.getAspect("praecantatio"), 128),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "WandRod", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "WandRod", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "WandRod", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "WandRod", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "WandRod", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "WandRod", 1, 7, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "WandRod", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "WandRod", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "WandRod", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "WandRod", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "WandRod", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "WandRod", 1, 7, missing));
         TCHelper.setResearchAspects(
                 "ROD_primal_staff",
                 new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("ignis"), 15)
@@ -5514,7 +5517,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("instrumentum"), 6)
                         .add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("ROD_primal_staff", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ARMORVOIDFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemHelmetVoidFortress", 1, 0, missing),
                 8,
@@ -5523,16 +5526,16 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 24).add(Aspect.getAspect("vacuos"), 24)
                         .add(Aspect.getAspect("praecantatio"), 24),
                 getModItem(Thaumcraft.ID, "ItemHelmetVoid", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemGoggles", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing), });
+                getModItem(Thaumcraft.ID, "ItemGoggles", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing));
         TCHelper.setResearchAspects(
                 "ARMORVOIDFORTRESS",
                 new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("tenebrae"), 15)
@@ -5540,7 +5543,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("praecantatio"), 9)
                         .add(Aspect.getAspect("sensus"), 6).add(Aspect.getAspect("metallum"), 3));
         TCHelper.setResearchComplexity("ARMORVOIDFORTRESS", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ARMORVOIDFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemChestplateVoidFortress", 1, 0, missing),
                 8,
@@ -5549,17 +5552,17 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("vacuos"), 32)
                         .add(Aspect.getAspect("praecantatio"), 32),
                 getModItem(Thaumcraft.ID, "ItemChestplateVoid", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemChestplateRobe", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemChestplateRobe", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "ARMORVOIDFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemLeggingsVoidFortress", 1, 0, missing),
                 8,
@@ -5568,52 +5571,52 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 28).add(Aspect.getAspect("vacuos"), 28)
                         .add(Aspect.getAspect("praecantatio"), 28),
                 getModItem(Thaumcraft.ID, "ItemLeggingsVoid", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemLeggingsRobe", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemLeggingsRobe", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "SANITYCHECK",
                 getModItem(Thaumcraft.ID, "ItemSanityChecker", 1, 0, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("cognitio"), 32)
                         .add(Aspect.getAspect("sensus"), 24).add(Aspect.getAspect("sano"), 16),
                 getModItem(Thaumcraft.ID, "ItemThaumometer", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockMirror", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L), });
+                getModItem(Thaumcraft.ID, "blockMirror", 1, 0, missing),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                OrePrefixes.screw.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "SANITYCHECK",
                 new AspectList().add(Aspect.getAspect("sensus"), 12).add(Aspect.getAspect("cognitio"), 12)
                         .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("praecantatio"), 9)
                         .add(Aspect.getAspect("sano"), 6).add(Aspect.getAspect("victus"), 3));
         TCHelper.setResearchComplexity("SANITYCHECK", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "OCULUS",
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
                 7,
                 new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("iter"), 32)
                         .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("vacuos"), 32),
                 getModItem(StevesCarts2.ID, "ModuleComponents", 1, 45, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing), });
+                getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing));
         TCHelper.setResearchAspects(
                 "OCULUS",
                 new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("cognitio"), 12)
@@ -5621,7 +5624,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("vitium"), 6)
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("OCULUS", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PRIMALCRUSHER",
                 getModItem(Thaumcraft.ID, "ItemPrimalCrusher", 1, 0, missing),
                 10,
@@ -5630,12 +5633,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("perfodio"), 24).add(Aspect.getAspect("telum"), 24)
                         .add(Aspect.getAspect("vacuos"), 24),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemPickVoid", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShovelVoid", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemPickVoid", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShovelVoid", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "PRIMALCRUSHER",
                 new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("alienis"), 12)
@@ -5689,29 +5692,29 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .setConcealed().setPages(new ResearchPage("tc.research_page.CRIMSONRITES"))
                         .registerResearchItem();
         ThaumcraftApi.addWarpToResearch("CRIMSONRITES", 10);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CRIMSONRITES",
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 1, missing),
                 10,
                 new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("praecantatio"), 64)
                         .add(Aspect.getAspect("infernus"), 16),
                 getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
-                new ItemStack[] { getModItem(TaintedMagic.ID, "ItemCrystalDagger", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(Minecraft.ID, "ender_eye", 21, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 16, missing),
-                        getModItem(Minecraft.ID, "ender_eye", 21, 0, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing) });
+                getModItem(TaintedMagic.ID, "ItemCrystalDagger", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(Minecraft.ID, "ender_eye", 21, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 16, missing),
+                getModItem(Minecraft.ID, "ender_eye", 21, 0, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing));
         TCHelper.addResearchPage(
                 "CRIMSONRITES",
                 new ResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicBases.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicBases.java
@@ -20,7 +20,6 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 
 import com.dreammaster.gthandler.CustomItemList;
@@ -32,7 +31,6 @@ import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GTModHandler;
-import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
@@ -335,7 +333,7 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "plateInfusedAir",
                 'i',
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6, missing));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.AdvAlc",
                 getModItem(ThaumicBases.ID, "advAlchFurnace", 1, 0, missing),
                 6,
@@ -343,13 +341,13 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("machina"), 16).add(Aspect.getAspect("metallum"), 16)
                         .add(Aspect.getAspect("praecantatio"), 24),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 0, missing),
-                new ItemStack[] { getModItem(Railcraft.ID, "machine.beta", 1, 4, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Steel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Steel, 1L), });
+                getModItem(Railcraft.ID, "machine.beta", 1, 4, missing),
+                OrePrefixes.plateDense.get(Materials.Steel),
+                OrePrefixes.block.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing),
+                OrePrefixes.block.get(Materials.Thaumium),
+                OrePrefixes.plateDense.get(Materials.Steel));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.ThaumicAnvil",
                 getModItem(ThaumicBases.ID, "thaumicAnvil", 1, 0, missing),
@@ -377,26 +375,26 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "blockThaumium",
                 'i',
                 "plateThaumium");
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_tbthaumium",
                 getModItem(ThaumicBases.ID, "resource", 1, 3, missing),
                 6,
                 new AspectList().add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("auram"), 16)
                         .add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("vitreus"), 16)
                         .add(Aspect.getAspect("instrumentum"), 32),
-                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Thaumium, 1L),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Thaumium, 1L), });
+                OrePrefixes.stick.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Thaumium));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.BloodyRobes",
                 getModItem(ThaumicBases.ID, "bloodyChest", 1, 0, missing),
@@ -517,7 +515,7 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "blockThaumium",
                 'i',
                 "ingotThaumium");
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.Spike.Void",
                 getModItem(ThaumicBases.ID, "spike", 1, 4, missing),
                 5,
@@ -525,28 +523,22 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("alienis"), 16)
                         .add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("mortuus"), 16),
                 getModItem(ThaumicBases.ID, "spike", 1, 2, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        createItemStack(
-                                TinkersGregworks.ID,
-                                "tGregToolPartArrowHead",
-                                1,
-                                1520,
-                                "{material:\"Titanium\"}",
-                                missing),
-                        getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0, missing),
-                        createItemStack(
-                                TinkersGregworks.ID,
-                                "tGregToolPartArrowHead",
-                                1,
-                                1583,
-                                "{material:\"Void\"}",
-                                missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                OrePrefixes.plate.get(Materials.Void),
+                createItemStack(
+                        TinkersGregworks.ID,
+                        "tGregToolPartArrowHead",
+                        1,
+                        1520,
+                        "{material:\"Titanium\"}",
+                        missing),
+                getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0, missing),
+                createItemStack(TinkersGregworks.ID, "tGregToolPartArrowHead", 1, 1583, "{material:\"Void\"}", missing),
+                OrePrefixes.plate.get(Materials.Void));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.VoidAnvil",
                 getModItem(ThaumicBases.ID, "voidAnvil", 1, 0, missing),
                 9,
@@ -555,16 +547,16 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("vacuos"), 16)
                         .add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("praecantatio"), 16),
                 getModItem(ThaumicBases.ID, "thaumicAnvil", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.VoidSeed",
                 getModItem(ThaumicBases.ID, "voidSeed", 1, 0, missing),
                 10,
@@ -574,19 +566,19 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("desidia"), 8)
                         .add(Aspect.getAspect("nebrisum"), 8),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 17, missing),
-                new ItemStack[] { getModItem(ThaumicBases.ID, "lazulliaSeeds", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "lucriteSeeds", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "redlonSeeds", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "rainbowCactus", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "metalleatSeeds", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "plaxSeed", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "briar", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "aurelia", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "ashroom", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "knoseSeed", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "flaxium", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "glieoniaSeed", 1, 0, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(ThaumicBases.ID, "lazulliaSeeds", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "lucriteSeeds", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "redlonSeeds", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "rainbowCactus", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "metalleatSeeds", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "plaxSeed", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "briar", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "aurelia", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "ashroom", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "knoseSeed", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "flaxium", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "glieoniaSeed", 1, 0, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_thauminite",
                 getModItem(ThaumicBases.ID, "resource", 1, 2, missing),
                 6,
@@ -594,109 +586,111 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("vitreus"), 16)
                         .add(Aspect.getAspect("instrumentum"), 32),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 2, missing),
-                new ItemStack[] { getModItem(ThaumicBases.ID, "resource", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ThaumicBases.ID, "resource", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ThaumicBases.ID, "resource", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(ThaumicBases.ID, "resource", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ThaumicBases.ID, "resource", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ThaumicBases.ID, "resource", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.Foci.Experience",
                 getModItem(ThaumicBases.ID, "fociExperience", 1, 0, missing),
                 6,
                 new AspectList().add(Aspect.getAspect("lucrum"), 32).add(Aspect.getAspect("vitreus"), 32)
                         .add(Aspect.getAspect("cognitio"), 16).add(Aspect.getAspect("permutatio"), 16),
-                GTOreDictUnificator.get(OrePrefixes.lens, Materials.Emerald, 1L),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Emerald, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Emerald, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                OrePrefixes.lens.get(Materials.Emerald),
+                getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                OrePrefixes.gemFlawless.get(Materials.Emerald),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                OrePrefixes.gemFlawless.get(Materials.Emerald),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.Foci.Activation",
                 getModItem(ThaumicBases.ID, "fociActivation", 1, 0, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("motus"), 32).add(Aspect.getAspect("vitreus"), 32)
                         .add(Aspect.getAspect("iter"), 16).add(Aspect.getAspect("sensus"), 16),
-                GTOreDictUnificator.get(OrePrefixes.lens, Materials.InfusedOrder, 1L),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing), ItemList.Emitter_LV.get(1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing), ItemList.Sensor_LV.get(1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                OrePrefixes.lens.get(Materials.InfusedOrder),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                ItemList.Emitter_LV.get(1L),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                ItemList.Sensor_LV.get(1L),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.Foci.Drain",
                 getModItem(ThaumicBases.ID, "fociDrain", 1, 0, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("perditio"), 32)
                         .add(Aspect.getAspect("aqua"), 16),
-                GTOreDictUnificator.get(OrePrefixes.lens, Materials.InfusedWater, 1L),
-                new ItemStack[] { getModItem(Minecraft.ID, "bucket", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(IronTanks.ID, "ironTank", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(ExtraUtilities.ID, "trashcan", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                OrePrefixes.lens.get(Materials.InfusedWater),
+                getModItem(Minecraft.ID, "bucket", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(IronTanks.ID, "ironTank", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(ExtraUtilities.ID, "trashcan", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.Foci.Flux",
                 getModItem(ThaumicBases.ID, "fociFlux", 1, 0, missing),
                 7,
                 new AspectList().add(Aspect.getAspect("vitium"), 32).add(Aspect.getAspect("perditio"), 32)
                         .add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("sano"), 16),
-                GTOreDictUnificator.get(OrePrefixes.lens, Materials.EnderEye, 1L),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                OrePrefixes.lens.get(Materials.EnderEye),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.CryingObs",
                 getModItem(ThaumicBases.ID, "cryingObsidian", 1, 0, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("iter"), 32).add(Aspect.getAspect("vinculum"), 32)
                         .add(Aspect.getAspect("desidia"), 16).add(Aspect.getAspect("sensus"), 16),
                 GregtechItemList.DoubleCompressedObsidian.get(1),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemDensePlates", 1, 8, missing),
-                        getModItem(CarpentersBlocks.ID, "itemCarpentersBed", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.Thaumium, 1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(IndustrialCraft2.ID, "itemDensePlates", 1, 8, missing),
+                getModItem(CarpentersBlocks.ID, "itemCarpentersBed", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                OrePrefixes.plateDense.get(Materials.Thaumium));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.TaintFlask",
                 getModItem(ThaumicBases.ID, "concentratedTaint", 1, 0, missing),
                 10,
                 new AspectList().add(Aspect.getAspect("vitium"), 64).add(Aspect.getAspect("venenum"), 32)
                         .add(Aspect.getAspect("perditio"), 16),
                 getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0, missing),
-                new ItemStack[] { getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.EntityDec",
                 getModItem(ThaumicBases.ID, "entityDeconstructor", 1, 0, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("cognitio"), 32).add(Aspect.getAspect("spiritus"), 24)
                         .add(Aspect.getAspect("mortuus"), 16).add(Aspect.getAspect("praecantatio"), 16),
                 getModItem(Thaumcraft.ID, "blockTable", 1, 14, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "light_weighted_pressure_plate", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.InfusedAir, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.InfusedFire, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.InfusedWater, 1L),
-                        getModItem(Minecraft.ID, "light_weighted_pressure_plate", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.InfusedEarth, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.InfusedEntropy, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.InfusedOrder, 1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Minecraft.ID, "light_weighted_pressure_plate", 1, 0, missing),
+                OrePrefixes.lens.get(Materials.InfusedAir),
+                OrePrefixes.lens.get(Materials.InfusedFire),
+                OrePrefixes.lens.get(Materials.InfusedWater),
+                getModItem(Minecraft.ID, "light_weighted_pressure_plate", 1, 0, missing),
+                OrePrefixes.lens.get(Materials.InfusedEarth),
+                OrePrefixes.lens.get(Materials.InfusedEntropy),
+                OrePrefixes.lens.get(Materials.InfusedOrder));
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_tbvoid",
                 getModItem(ThaumicBases.ID, "resource", 1, 4, missing),
                 8,
@@ -704,16 +698,16 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("vitreus"), 16).add(Aspect.getAspect("instrumentum"), 32)
                         .add(Aspect.getAspect("potentia"), 40).add(Aspect.getAspect("vacuos"), 24),
                 getModItem(ThaumicBases.ID, "resource", 1, 3, missing),
-                new ItemStack[] { getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "knoseFragment", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Void));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeMan",
                 getModItem(ThaumicBases.ID, "nodeManipulator", 1, 0, missing),
                 9,
@@ -721,17 +715,19 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 40).add(Aspect.getAspect("potentia"), 32)
                         .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("tenebrae"), 24),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11, missing),
-                new ItemStack[] { getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
-                        ItemList.Emitter_EV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Knightmetal, 1L),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing), ItemList.Sensor_EV.get(1L),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 14, missing), ItemList.Sensor_EV.get(1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Knightmetal, 1L),
-                        ItemList.Emitter_EV.get(1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
+                ItemList.Emitter_EV.get(1L),
+                OrePrefixes.plate.get(Materials.Knightmetal),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
+                ItemList.Sensor_EV.get(1L),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 14, missing),
+                ItemList.Sensor_EV.get(1L),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10, missing),
+                OrePrefixes.plate.get(Materials.Knightmetal),
+                ItemList.Emitter_EV.get(1L));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeLinker",
                 getModItem(ThaumicBases.ID, "nodeLinker", 1, 0, missing),
                 5,
@@ -739,14 +735,16 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("instrumentum"), 40).add(Aspect.getAspect("ordo"), 32)
                         .add(Aspect.getAspect("electrum"), 32),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 14, missing),
-                        ItemList.Emitter_MV.get(1L), CustomItemList.ReinforcedGlassLense.get(1L),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        CustomItemList.ReinforcedGlassLense.get(1L), ItemList.Emitter_MV.get(1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 14, missing),
+                ItemList.Emitter_MV.get(1L),
+                CustomItemList.ReinforcedGlassLense.get(1L),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                CustomItemList.ReinforcedGlassLense.get(1L),
+                ItemList.Emitter_MV.get(1L));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.Overchanter",
                 getModItem(ThaumicBases.ID, "overchanter", 1, 0, missing),
                 15,
@@ -756,17 +754,17 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("machina"), 32)
                         .add(Aspect.getAspect("cognitio"), 32),
                 getModItem(Minecraft.ID, "enchanting_table", 1, 0, missing),
-                new ItemStack[] { getModItem(ThaumicBases.ID, "crystalBlock", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 2, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 3, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 4, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 5, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing),
-                        getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.block, Materials.Thaumium, 1L), });
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 2, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 3, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 4, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 5, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing),
+                getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
+                OrePrefixes.block.get(Materials.Thaumium),
+                OrePrefixes.block.get(Materials.Thaumium));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Iron",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 0, missing),
@@ -1091,7 +1089,7 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "craftingToolScrewdriver",
                 'i',
                 "boltVoid");
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.Bracelet.Primal",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 12, missing),
                 10,
@@ -1100,19 +1098,19 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("ordo"), 64).add(Aspect.getAspect("perditio"), 64)
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("alienis"), 32),
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 4, missing),
-                new ItemStack[] { getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 4, missing),
-                        CustomItemList.SnowQueenBlood.get(1L),
-                        getModItem(ThaumicBases.ID, "castingBracelet", 1, 5, missing),
-                        getModItem(ThaumicBases.ID, "castingBracelet", 1, 6, missing),
-                        getModItem(ThaumicBases.ID, "castingBracelet", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Iridium, 1L),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 4, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Iridium, 1L),
-                        getModItem(ThaumicBases.ID, "castingBracelet", 1, 8, missing),
-                        getModItem(ThaumicBases.ID, "castingBracelet", 1, 9, missing),
-                        getModItem(ThaumicBases.ID, "castingBracelet", 1, 10, missing),
-                        CustomItemList.SnowQueenBlood.get(1L), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 4, missing),
+                CustomItemList.SnowQueenBlood.get(1L),
+                getModItem(ThaumicBases.ID, "castingBracelet", 1, 5, missing),
+                getModItem(ThaumicBases.ID, "castingBracelet", 1, 6, missing),
+                getModItem(ThaumicBases.ID, "castingBracelet", 1, 7, missing),
+                OrePrefixes.screw.get(Materials.Iridium),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 4, missing),
+                OrePrefixes.screw.get(Materials.Iridium),
+                getModItem(ThaumicBases.ID, "castingBracelet", 1, 8, missing),
+                getModItem(ThaumicBases.ID, "castingBracelet", 1, 9, missing),
+                getModItem(ThaumicBases.ID, "castingBracelet", 1, 10, missing),
+                CustomItemList.SnowQueenBlood.get(1L));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeFoci.Bright",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 0, missing),
                 10,
@@ -1120,45 +1118,45 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 128).add(Aspect.getAspect("superbia"), 64)
                         .add(Aspect.getAspect("nebrisum"), 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
-                        getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
+                getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeFoci.Destr",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 1, missing),
                 8,
                 new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("perditio"), 96)
                         .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("mortuus"), 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 5, missing),
-                        GregtechItemList.DoubleCompressedObsidian.get(1),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 5, missing),
-                        GregtechItemList.DoubleCompressedObsidian.get(1),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 5, missing),
-                        GregtechItemList.DoubleCompressedObsidian.get(1),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 5, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 5, missing),
+                GregtechItemList.DoubleCompressedObsidian.get(1),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 5, missing),
+                GregtechItemList.DoubleCompressedObsidian.get(1),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 5, missing),
+                GregtechItemList.DoubleCompressedObsidian.get(1),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 5, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeFoci.Efficiency",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 2, missing),
                 7,
                 new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("potentia"), 96)
                         .add(Aspect.getAspect("electrum"), 64).add(Aspect.getAspect("machina"), 64),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 1, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeFoci.Hunger",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 3, missing),
                 10,
@@ -1166,90 +1164,90 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 128).add(Aspect.getAspect("vacuos"), 96)
                         .add(Aspect.getAspect("gula"), 64),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11, missing),
-                        getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11, missing),
-                        getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11, missing),
-                        getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11, missing),
+                getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11, missing),
+                getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11, missing),
+                getModItem(ThaumicBases.ID, "voidBlock", 1, 0, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeFoci.Unstable",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 4, missing),
                 8,
                 new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("alienis"), 96)
                         .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("perditio"), 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "ender_pearl", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 2, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Minecraft.ID, "ender_pearl", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 2, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeFoci.Purity",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 5, missing),
                 8,
                 new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("sano"), 96)
                         .add(Aspect.getAspect("victus"), 64).add(Aspect.getAspect("vitreus"), 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 1, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 1, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 1, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 1, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 1, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 1, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 6, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeFoci.Sinister",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 6, missing),
                 9,
                 new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("tenebrae"), 96)
                         .add(Aspect.getAspect("exanimis"), 64).add(Aspect.getAspect("spiritus"), 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemCompassStone", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
-                        getModItem(Minecraft.ID, "skull", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemCompassStone", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
+                getModItem(Minecraft.ID, "skull", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
+                getModItem(Minecraft.ID, "skull", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing),
+                getModItem(Minecraft.ID, "skull", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeFoci.Speed",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 7, missing),
                 8,
                 new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("potentia"), 96)
                         .add(Aspect.getAspect("motus"), 64).add(Aspect.getAspect("aer"), 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "sugar", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 2, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 2, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 2, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 0, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Minecraft.ID, "sugar", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 2, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 2, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 2, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 0, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeFoci.Stability",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 8, missing),
                 7,
                 new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("cognitio"), 96)
                         .add(Aspect.getAspect("instrumentum"), 64).add(Aspect.getAspect("ordo"), 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 4, missing),
-                        getModItem(ThaumicBases.ID, "thauminiteBlock", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 4, missing),
-                        getModItem(ThaumicBases.ID, "thauminiteBlock", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 4, missing),
-                        getModItem(ThaumicBases.ID, "thauminiteBlock", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 4, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 4, missing),
+                getModItem(ThaumicBases.ID, "thauminiteBlock", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 4, missing),
+                getModItem(ThaumicBases.ID, "thauminiteBlock", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 4, missing),
+                getModItem(ThaumicBases.ID, "thauminiteBlock", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 4, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "TB.NodeFoci.Taint",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 9, missing),
                 10,
@@ -1257,14 +1255,14 @@ public class ScriptThaumicBases implements IScriptLoader {
                         .add(Aspect.getAspect("venenum"), 128).add(Aspect.getAspect("perditio"), 64)
                         .add(Aspect.getAspect("strontio"), 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "concentratedTaint", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "concentratedTaint", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing),
-                        getModItem(ThaumicBases.ID, "concentratedTaint", 1, 0, missing),
-                        getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "concentratedTaint", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "concentratedTaint", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing),
+                getModItem(ThaumicBases.ID, "concentratedTaint", 1, 0, missing),
+                getModItem(ThaumicBases.ID, "crystalBlock", 1, 7, missing));
         ThaumcraftApi.addCrucibleRecipe(
                 "TB.SM",
                 getModItem(Thaumcraft.ID, "ItemResource", 2, 14, missing),

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
@@ -99,7 +99,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 Materials.SolderingAlloy.getMolten(72) };
 
         // Creates ItemStack for CEC craft input
-        ItemStack[] CECInfusionItems = { ItemList.Field_Generator_UIV.get(1),
+        Object[] CECInfusionItems = { ItemList.Field_Generator_UIV.get(1),
                 getModItem(TaintedMagic.ID, "ItemFocusEldritch", 1),
                 getModItem(Gadomancy.ID, "BlockNodeManipulator", 1, 5),
                 getModItem(Gadomancy.ID, "BlockEssentiaCompressor", 1), ItemList.Field_Generator_UIV.get(1),
@@ -118,7 +118,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         // Creative Essentia Cell
         ItemStack CEC = EssentialCellCreative;
 
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 CEC,
                 10,
@@ -273,7 +273,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                         1,
                         0,
                         missing));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "thaumicenergistics.TEESSPROV",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.essentia.provider", 1, 0, missing),
                 8,
@@ -282,14 +282,16 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                         .add(Aspect.getAspect("aqua"), 16).add(Aspect.getAspect("cognitio"), 8)
                         .add(Aspect.getAspect("lucrum"), 4),
                 getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockTube", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L), DiffusionCore,
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "blockTube", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing), CoalescenceCore,
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing), });
+                getModItem(Thaumcraft.ID, "blockTube", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                DiffusionCore,
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "blockTube", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                CoalescenceCore,
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEESSPROV",
                 new AspectList().add(Aspect.getAspect("sensus"), 21).add(Aspect.getAspect("praecantatio"), 18)
@@ -1473,7 +1475,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                         .add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("praecantatio"), 6)
                         .add(Aspect.getAspect("permutatio"), 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TETHAUMGBOX", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "thaumicenergistics.TEARCANEASSEMBLER",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.arcane.assembler", 1, 0, missing),
                 16,
@@ -1482,19 +1484,20 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 16).add(Aspect.getAspect("praecantatio"), 48)
                         .add(Aspect.getAspect("vitreus"), 16),
                 getModItem(AppliedEnergistics2.ID, "tile.BlockMolecularAssembler", 1, 0, missing),
-                new ItemStack[] { createItemStack(
+                createItemStack(
                         Thaumcraft.ID,
                         "WandCasting",
                         1,
                         wildcard,
                         "{aqua:15000,ignis:15000,terra:15000,cap:\"thaumium\",rod:\"silverwood\",ordo:15000,sceptre:1b,perditio:15000,aer:15000}",
-                        missing), getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing), });
+                        missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEARCANEASSEMBLER",
                 new AspectList().add(Aspect.getAspect("lucrum"), 24).add(Aspect.getAspect("fabrico"), 21)
@@ -1561,7 +1564,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                         .add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("permutatio"), 9)
                         .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEKNOWLEDGEINSCRIBER", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "thaumicenergistics.TEINFPROV",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.infusion.provider", 1, 0, missing),
                 10,
@@ -1569,14 +1572,16 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                         .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("alienis"), 24).add(Aspect.getAspect("spiritus"), 8),
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.essentia.provider", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockMirror", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(ThaumicEnergistics.ID, "part.base", 1, 0, missing), DiffusionCore,
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "blockMirror", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing), CoalescenceCore,
-                        getModItem(ThaumicEnergistics.ID, "part.base", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "blockMirror", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(ThaumicEnergistics.ID, "part.base", 1, 0, missing),
+                DiffusionCore,
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "blockMirror", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                CoalescenceCore,
+                getModItem(ThaumicEnergistics.ID, "part.base", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEINFPROV",
                 new AspectList().add(Aspect.getAspect("permutatio"), 21).add(Aspect.getAspect("motus"), 18)
@@ -1585,15 +1590,25 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                         .add(Aspect.getAspect("spiritus"), 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEINFPROV", 3);
 
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "thaumicenergistics.TEADVINFPROV",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.advanced.infusion.provider", 1, 0, missing),
                 30,
                 new AspectList().add(Aspect.MECHANISM, 64).add(Aspect.MAGIC, 64).add(Aspect.EXCHANGE, 64)
                         .add(Aspect.MIND, 64).add(Aspect.GREED, 64),
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.infusion.provider", 1, 0, missing),
-                new ItemStack[] { InfusionIntercepter, PrimalCharm, DiffusionCore, ZPMEmitter, DiffusionCore,
-                        PrimalCharm, CraftingUnit, PrimalCharm, EngProcessor, ZPMSensor, EngProcessor, PrimalCharm });
+                InfusionIntercepter,
+                PrimalCharm,
+                DiffusionCore,
+                ZPMEmitter,
+                DiffusionCore,
+                PrimalCharm,
+                CraftingUnit,
+                PrimalCharm,
+                EngProcessor,
+                ZPMSensor,
+                EngProcessor,
+                PrimalCharm);
 
         TCHelper.refreshResearchPages("thaumicenergistics.TEESSPROV");
         TCHelper.refreshResearchPages("thaumicenergistics.TEIRONGEARBOX");

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicExploration.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicExploration.java
@@ -16,15 +16,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import net.minecraft.item.ItemStack;
-
 import com.dreammaster.thaumcraft.TCHelper;
 
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
 import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -1374,7 +1371,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .setParents("DISTILESSENTIA", "TXINFUSION", "TXDISTILESSENTIA", "THAUMIUM").setConcealed()
                         .setPages(new ResearchPage("te.text.REPLICATOR.1"), new ResearchPage("te.text.REPLICATOR.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ReplicatorGTNH",
                 getModItem(ThaumicExploration.ID, "replicator", 1, 0, missing),
                 12,
@@ -1382,16 +1379,16 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("machina"), 48).add(Aspect.getAspect("ordo"), 32)
                         .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("lucrum"), 16),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 2, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockTable", 1, 15, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Amber, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L), });
+                getModItem(Thaumcraft.ID, "blockTable", 1, 15, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Amber),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold));
         TCHelper.addResearchPage(
                 "ReplicatorGTNH",
                 new ResearchPage(
@@ -1412,7 +1409,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .setParents("TXJARVOID", "TXINFUSION", "WARDEDARCANA", "HUNGRYCHEST").setConcealed()
                         .setPages(new ResearchPage("te.text.TRASHJAR.1"), new ResearchPage("te.text.TRASHJAR.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TrashjarGTNH",
                 getModItem(ThaumicExploration.ID, "trashJar", 1, 0, missing),
                 9,
@@ -1420,18 +1417,18 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("perditio"), 24).add(Aspect.getAspect("vacuos"), 32)
                         .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("tenebrae"), 8),
                 getModItem(Thaumcraft.ID, "blockJar", 1, 3, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockChestHungry", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
-                        getModItem(ExtraUtilities.ID, "trashcan", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing), });
+                getModItem(Thaumcraft.ID, "blockChestHungry", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
+                getModItem(ExtraUtilities.ID, "trashcan", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2, missing));
         TCHelper.addResearchPage(
                 "TrashjarGTNH",
                 new ResearchPage(
@@ -1451,7 +1448,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 getModItem(ThaumicExploration.ID, "bootsMeteor", 1, 0, missing))
                         .setParents("TXBOOTSTRAVELLER", "FOCUSFIRE", "INFUSION").setConcealed()
                         .setPages(new ResearchPage("te.text.METEORBOOTS.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "MeteorbootsGTNH",
                 getModItem(ThaumicExploration.ID, "bootsMeteor", 1, 0, missing),
                 6,
@@ -1459,14 +1456,14 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("volatus"), 32)
                         .add(Aspect.getAspect("praecantatio"), 16),
                 getModItem(Thaumcraft.ID, "BootsTraveller", 1, wildcard, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "FocusFire", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Firestone, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Firestone, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Firestone, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Firestone, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Firestone, 1L), });
+                getModItem(Thaumcraft.ID, "FocusFire", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Firestone),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Firestone),
+                OrePrefixes.plate.get(Materials.Firestone),
+                OrePrefixes.plate.get(Materials.Firestone),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                OrePrefixes.plate.get(Materials.Firestone));
         TCHelper.addResearchPage(
                 "MeteorbootsGTNH",
                 new ResearchPage(
@@ -1485,7 +1482,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 getModItem(ThaumicExploration.ID, "bootsComet", 1, 0, missing))
                         .setParents("TXBOOTSTRAVELLER", "FOCUSFROST", "INFUSION").setConcealed()
                         .setPages(new ResearchPage("te.text.COMETBOOTS.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CometsbootsGTNH",
                 getModItem(ThaumicExploration.ID, "bootsComet", 1, 0, missing),
                 6,
@@ -1493,14 +1490,14 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("motus"), 32)
                         .add(Aspect.getAspect("praecantatio"), 16),
                 getModItem(Thaumcraft.ID, "BootsTraveller", 1, wildcard, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "FocusFrost", 1, 0, missing),
-                        getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing),
-                        getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing),
-                        getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "FocusFrost", 1, 0, missing),
+                getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing),
+                getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing),
+                getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing));
         TCHelper.addResearchPage(
                 "CometsbootsGTNH",
                 new ResearchPage(
@@ -1519,7 +1516,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 getModItem(ThaumicExploration.ID, "soulBrazier", 1, 0, missing))
                         .setParents("TXTALLOW", "ELDRITCHMINOR", "VOIDMETAL", "INFUSION", "SANESOAP").setConcealed()
                         .setPages(new ResearchPage("te.text.SOULBRAZIER.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SoulbraizerGTNH",
                 getModItem(ThaumicExploration.ID, "soulBrazier", 1, 0, missing),
                 16,
@@ -1527,16 +1524,16 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 48).add(Aspect.getAspect("alienis"), 32)
                         .add(Aspect.getAspect("praecantatio"), 16),
                 getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemSanitySoap", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Void, 1),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Void, 1),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Void, 1),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
-                        getModItem(Thaumcraft.ID, "ItemSanitySoap", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemSanitySoap", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                OrePrefixes.ingot.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                OrePrefixes.ingot.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                OrePrefixes.ingot.get(Materials.Void),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7, missing),
+                getModItem(Thaumcraft.ID, "ItemSanitySoap", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SoulbraizerGTNH",
                 new ResearchPage(
@@ -1554,7 +1551,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 3,
                 getModItem(ThaumicExploration.ID, "everfullUrn", 1, 0, missing)).setParents("TXINFUSION", "ARCANEEAR")
                         .setConcealed().setPages(new ResearchPage("tc.research_page.UrnGTNH")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "UrnGTNH",
                 getModItem(ThaumicExploration.ID, "everfullUrn", 1, 0, missing),
                 9,
@@ -1562,18 +1559,18 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("alienis"), 32)
                         .add(Aspect.getAspect("lucrum"), 16),
                 getModItem(Minecraft.ID, "flower_pot", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "netherbrick", 1, 0, missing),
-                        getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L),
-                        getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "netherbrick", 1, 0, missing),
-                        getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "brick", 1, 0, missing),
-                        getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L),
-                        getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "brick", 1, 0, missing), });
+                getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "netherbrick", 1, 0, missing),
+                getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Titanium),
+                getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "netherbrick", 1, 0, missing),
+                getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "brick", 1, 0, missing),
+                getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Titanium),
+                getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "brick", 1, 0, missing));
         TCHelper.addResearchPage(
                 "UrnGTNH",
                 new ResearchPage(
@@ -1591,7 +1588,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 3,
                 getModItem(ThaumicExploration.ID, "everburnUrn", 1, 0, missing)).setParents("UrnGTNH").setConcealed()
                         .setPages(new ResearchPage("te.text.BURN.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "BurnGTNH",
                 getModItem(ThaumicExploration.ID, "everburnUrn", 1, 0, missing),
                 9,
@@ -1599,22 +1596,22 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("alienis"), 32)
                         .add(Aspect.getAspect("lucrum"), 16),
                 getModItem(Minecraft.ID, "flower_pot", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "netherbrick", 1, 0, missing),
-                        getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
-                        ItemList.Casing_Coil_TungstenSteel.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L),
-                        ItemList.Casing_Coil_TungstenSteel.get(1L),
-                        getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "netherbrick", 1, 0, missing),
-                        getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "brick", 1, 0, missing),
-                        getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
-                        ItemList.Casing_Coil_TungstenSteel.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Titanium, 1L),
-                        ItemList.Casing_Coil_TungstenSteel.get(1L),
-                        getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
-                        getModItem(Minecraft.ID, "brick", 1, 0, missing), });
+                getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "netherbrick", 1, 0, missing),
+                getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
+                ItemList.Casing_Coil_TungstenSteel.get(1L),
+                OrePrefixes.plate.get(Materials.Titanium),
+                ItemList.Casing_Coil_TungstenSteel.get(1L),
+                getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "netherbrick", 1, 0, missing),
+                getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "brick", 1, 0, missing),
+                getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
+                ItemList.Casing_Coil_TungstenSteel.get(1L),
+                OrePrefixes.plate.get(Materials.Titanium),
+                ItemList.Casing_Coil_TungstenSteel.get(1L),
+                getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing),
+                getModItem(Minecraft.ID, "brick", 1, 0, missing));
         TCHelper.addResearchPage(
                 "BurnGTNH",
                 new ResearchPage(
@@ -1664,7 +1661,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 new ResearchPage(
                         TCHelper.findArcaneRecipe(
                                 getModItem(ThaumicExploration.ID, "sojournerCapUncharged", 1, 0, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_SOJOURNER",
                 getModItem(ThaumicExploration.ID, "sojournerCap", 1, 0, missing),
                 6,
@@ -1672,12 +1669,12 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("permutatio"), 24).add(Aspect.getAspect("potentia"), 32)
                         .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("ordo"), 16),
                 getModItem(ThaumicExploration.ID, "sojournerCapUncharged", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Diamond, 1L), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.dust.get(Materials.Diamond));
         TCHelper.addResearchPage(
                 "CAP_SOJOURNER",
                 new ResearchPage(
@@ -1727,7 +1724,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 new ResearchPage(
                         TCHelper.findArcaneRecipe(
                                 getModItem(ThaumicExploration.ID, "mechanistCapUncharged", 1, 0, missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAP_MECHANIST",
                 getModItem(ThaumicExploration.ID, "mechanistCap", 1, 0, missing),
                 6,
@@ -1735,12 +1732,12 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("machina"), 24).add(Aspect.getAspect("potentia"), 32)
                         .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("ordo"), 16),
                 getModItem(ThaumicExploration.ID, "mechanistCapUncharged", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Minecraft.ID, "redstone", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Minecraft.ID, "redstone", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Minecraft.ID, "redstone", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Minecraft.ID, "redstone", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Minecraft.ID, "redstone", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Minecraft.ID, "redstone", 1, 0, missing));
         TCHelper.addResearchPage(
                 "CAP_MECHANIST",
                 new ResearchPage(
@@ -1759,7 +1756,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 getModItem(ThaumicExploration.ID, "stabilizerBelt", 1, 0, missing))
                         .setParents("TXHOVERHARNESS", "TXINFUSION").setConcealed()
                         .setPages(new ResearchPage("te.text.STABILIZERBELT.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "StabilizerbeltGTNH",
                 getModItem(ThaumicExploration.ID, "stabilizerBelt", 1, 0, missing),
                 4,
@@ -1767,14 +1764,14 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("iter"), 12).add(Aspect.getAspect("superbia"), 24)
                         .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 16),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2, missing),
-                new ItemStack[] { ItemList.Electric_Piston_LV.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.Thaumium, 1L), });
+                ItemList.Electric_Piston_LV.get(1L),
+                OrePrefixes.springSmall.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.springSmall.get(Materials.Thaumium),
+                OrePrefixes.lens.get(Materials.Diamond),
+                OrePrefixes.springSmall.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.springSmall.get(Materials.Thaumium));
         TCHelper.addResearchPage(
                 "StabilizerbeltGTNH",
                 new ResearchPage(
@@ -1837,7 +1834,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 getModItem(ThaumicExploration.ID, "pureZombieBrain", 1, 0, missing))
                         .setParents("TXINFUSION", "JARBRAIN", "FleshcureGTNH").setConcealed()
                         .setPages(new ResearchPage("te.text.BRAINCURE.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "BraincureGTNH",
                 getModItem(ThaumicExploration.ID, "pureZombieBrain", 1, 0, missing),
                 5,
@@ -1845,12 +1842,12 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("humanus"), 12).add(Aspect.getAspect("alienis"), 24)
                         .add(Aspect.getAspect("cognitio"), 16).add(Aspect.getAspect("praecantatio"), 8),
                 getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Minecraft.ID, "potion", 1, 8264, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Minecraft.ID, "golden_apple", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing), });
+                getModItem(Minecraft.ID, "water_bucket", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Minecraft.ID, "potion", 1, 8264, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Minecraft.ID, "golden_apple", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing));
         TCHelper.addResearchPage(
                 "BraincureGTNH",
                 new ResearchPage(
@@ -1870,7 +1867,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 getModItem(ThaumicExploration.ID, "talismanFood", 1, 0, missing))
                         .setParents("FleshcureGTNH", "TXINFUSION").setConcealed()
                         .setPages(new ResearchPage("tc.research_page.TalismanfoodtGTNH")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "TalismanfoodtGTNH",
                 getModItem(ThaumicExploration.ID, "talismanFood", 1, 0, missing),
                 6,
@@ -1878,15 +1875,15 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("messis"), 24).add(Aspect.getAspect("sano"), 24)
                         .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("ordo"), 16),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Ruby, 1L),
-                        getModItem(PamsHarvestCraft.ID, "heartybreakfastItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "rainbowcurryItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "supremepizzaItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "sausageinbreadItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "beefwellingtonItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "epicbaconItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "meatfeastpizzaItem", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "delightedmealItem", 1, 0, missing), });
+                OrePrefixes.gemExquisite.get(Materials.Ruby),
+                getModItem(PamsHarvestCraft.ID, "heartybreakfastItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "rainbowcurryItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "supremepizzaItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "sausageinbreadItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "beefwellingtonItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "epicbaconItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "meatfeastpizzaItem", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "delightedmealItem", 1, 0, missing));
         TCHelper.addResearchPage(
                 "TalismanfoodtGTNH",
                 new ResearchPage(
@@ -1970,7 +1967,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ResearchCategories.getResearch("CrucsoulGTNH").setConcealed();
         TCHelper.addResearchPage("CrucsoulGTNH", new ResearchPage("te.text.CRUCSOULS.1"));
         TCHelper.addResearchPage("CrucsoulGTNH", new ResearchPage("te.text.CRUCSOULS.2"));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CrucsoulGTNH",
                 getModItem(ThaumicExploration.ID, "crucibleSouls", 1, 0, missing),
                 8,
@@ -1979,18 +1976,18 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 24).add(Aspect.getAspect("vinculum"), 16)
                         .add(Aspect.getAspect("alienis"), 8),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 0, missing),
-                        getModItem(Minecraft.ID, "rotten_flesh", 1, 0, missing),
-                        getModItem(Minecraft.ID, "soul_sand", 1, 0, missing),
-                        getModItem(Minecraft.ID, "slime_ball", 1, 0, missing),
-                        getModItem(Minecraft.ID, "soul_sand", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 1, missing),
-                        getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                        getModItem(Minecraft.ID, "soul_sand", 1, 0, missing),
-                        getModItem(Minecraft.ID, "magma_cream", 1, 0, missing),
-                        getModItem(Minecraft.ID, "soul_sand", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bone", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 0, missing),
+                getModItem(Minecraft.ID, "rotten_flesh", 1, 0, missing),
+                getModItem(Minecraft.ID, "soul_sand", 1, 0, missing),
+                getModItem(Minecraft.ID, "slime_ball", 1, 0, missing),
+                getModItem(Minecraft.ID, "soul_sand", 1, 0, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 1, missing),
+                getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
+                getModItem(Minecraft.ID, "soul_sand", 1, 0, missing),
+                getModItem(Minecraft.ID, "magma_cream", 1, 0, missing),
+                getModItem(Minecraft.ID, "soul_sand", 1, 0, missing),
+                getModItem(Minecraft.ID, "bone", 1, 0, missing));
         TCHelper.addResearchPage(
                 "CrucsoulGTNH",
                 new ResearchPage(
@@ -1999,7 +1996,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addWarpToResearch("CrucsoulGTNH", 4);
         // SPAWNER
 
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CrucsoulGTNH",
                 getModItem(EnderIO.ID, "itemBrokenSpawner", 1, 0, missing),
                 8,
@@ -2008,18 +2005,18 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 24).add(Aspect.getAspect("vinculum"), 46)
                         .add(Aspect.getAspect("alienis"), 28),
                 getModItem(ThaumicExploration.ID, "crucibleSouls", 1, 0, missing),
-                new ItemStack[] { getModItem(Botania.ID, "cocoon", 1, 0, missing),
-                        getModItem(EnderIO.ID, "itemMaterial", 1, 9, missing),
-                        getModItem(EnderIO.ID, "itemMaterial", 1, 17, missing),
-                        GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Shadow, 1L),
-                        getModItem(EnderIO.ID, "itemFrankenSkull", 1, 4, missing),
-                        getModItem(EnderIO.ID, "itemMaterial", 1, 9, missing),
-                        getModItem(Botania.ID, "cocoon", 1, 0, missing),
-                        getModItem(EnderIO.ID, "itemMaterial", 1, 9, missing),
-                        getModItem(EnderIO.ID, "itemMaterial", 1, 16, missing),
-                        GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Shadow, 1L),
-                        getModItem(EnderIO.ID, "itemFrankenSkull", 1, 4, missing),
-                        getModItem(EnderIO.ID, "itemMaterial", 1, 9, missing), });
+                getModItem(Botania.ID, "cocoon", 1, 0, missing),
+                getModItem(EnderIO.ID, "itemMaterial", 1, 9, missing),
+                getModItem(EnderIO.ID, "itemMaterial", 1, 17, missing),
+                OrePrefixes.frameGt.get(Materials.Shadow),
+                getModItem(EnderIO.ID, "itemFrankenSkull", 1, 4, missing),
+                getModItem(EnderIO.ID, "itemMaterial", 1, 9, missing),
+                getModItem(Botania.ID, "cocoon", 1, 0, missing),
+                getModItem(EnderIO.ID, "itemMaterial", 1, 9, missing),
+                getModItem(EnderIO.ID, "itemMaterial", 1, 16, missing),
+                OrePrefixes.frameGt.get(Materials.Shadow),
+                getModItem(EnderIO.ID, "itemFrankenSkull", 1, 4, missing),
+                getModItem(EnderIO.ID, "itemMaterial", 1, 9, missing));
         TCHelper.addResearchPage(
                 "CrucsoulGTNH",
                 new ResearchPage(
@@ -2049,7 +2046,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 getModItem(ThaumicExploration.ID, "transmutationCore", 1, 0, missing))
                         .setParents("TXROD_greatwood", "TXBASICARTIFACE").setParentsHidden("TXINFUSION").setConcealed()
                         .setPages(new ResearchPage("te.text.ROD_TRANSMUTATION.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_TRANSMUTATION",
                 getModItem(ThaumicExploration.ID, "transmutationCore", 1, 0, missing),
                 8,
@@ -2057,14 +2054,14 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("auram"), 24).add(Aspect.getAspect("terra"), 16)
                         .add(Aspect.getAspect("arbor"), 8).add(Aspect.getAspect("alienis"), 8),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 6, missing));
         TCHelper.addResearchPage(
                 "ROD_TRANSMUTATION",
                 new ResearchPage(
@@ -2129,26 +2126,26 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 3,
                 getModItem(ThaumicExploration.ID, "amberCore", 1, 0, missing)).setParents("TXROD_greatwood")
                         .setConcealed().setPages(new ResearchPage("te.text.ROD_AMBER.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_AMBER",
                 getModItem(ThaumicExploration.ID, "amberCore", 1, 0, missing),
                 8,
                 new AspectList().add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("vinculum"), 32)
                         .add(Aspect.getAspect("auram"), 24).add(Aspect.getAspect("vitreus"), 16)
                         .add(Aspect.getAspect("arbor"), 8).add(Aspect.getAspect("alienis"), 8),
-                GTOreDictUnificator.get(OrePrefixes.stick, Materials.Amber, 1L),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing), });
+                OrePrefixes.stick.get(Materials.Amber),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 6, missing));
         TCHelper.addResearchPage(
                 "ROD_AMBER",
                 new ResearchPage(
@@ -2213,7 +2210,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 getModItem(ThaumicExploration.ID, "necroStaffCore", 1, 0, missing)).setParents("TXROD_greatwood_staff")
                         .setParentsHidden("BraincureGTNH").setConcealed()
                         .setPages(new ResearchPage("te.text.ROD_NECROMANCER_staff.1")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_NECROMANCER_staff",
                 getModItem(ThaumicExploration.ID, "necroStaffCore", 1, 0, missing),
                 12,
@@ -2222,14 +2219,14 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         .add(Aspect.getAspect("spiritus"), 32).add(Aspect.getAspect("exanimis"), 16)
                         .add(Aspect.getAspect("cognitio"), 16),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 57, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "skull", 1, 1, missing),
-                        getModItem(ThaumicExploration.ID, "pureZombieBrain", 1, 0, missing),
-                        getModItem(Minecraft.ID, "rotten_flesh", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bone", 1, 0, missing),
-                        getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(ThaumicExploration.ID, "pureZombieBrain", 1, 0, missing),
-                        getModItem(Minecraft.ID, "rotten_flesh", 1, 0, missing),
-                        getModItem(Minecraft.ID, "bone", 1, 0, missing), });
+                getModItem(Minecraft.ID, "skull", 1, 1, missing),
+                getModItem(ThaumicExploration.ID, "pureZombieBrain", 1, 0, missing),
+                getModItem(Minecraft.ID, "rotten_flesh", 1, 0, missing),
+                getModItem(Minecraft.ID, "bone", 1, 0, missing),
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(ThaumicExploration.ID, "pureZombieBrain", 1, 0, missing),
+                getModItem(Minecraft.ID, "rotten_flesh", 1, 0, missing),
+                getModItem(Minecraft.ID, "bone", 1, 0, missing));
         TCHelper.addResearchPage(
                 "ROD_NECROMANCER_staff",
                 new ResearchPage(

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicHorizons.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicHorizons.java
@@ -11,15 +11,12 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.item.ItemStack;
-
 import com.dreammaster.thaumcraft.TCHelper;
 
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
 import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -144,7 +141,7 @@ public class ScriptThaumicHorizons implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 12).add(Aspect.getAspect("alienis"), 9));
         TCHelper.setResearchComplexity("transductionAmplifier", 4);
         ThaumcraftApi.addWarpToResearch("transductionAmplifier", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "vortexStabilizer",
                 getModItem(ThaumicHorizons.ID, "vortexStabilizer", 1, 0, missing),
                 7,
@@ -152,14 +149,14 @@ public class ScriptThaumicHorizons implements IScriptLoader {
                         .add(Aspect.getAspect("machina"), 48).add(Aspect.getAspect("ordo"), 32)
                         .add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("vinculum"), 32),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10, missing),
-                new ItemStack[] { getModItem(ThaumicHorizons.ID, "planarConduit", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Amber, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.Olivine, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Void, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.Olivine, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Amber, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L), });
+                getModItem(ThaumicHorizons.ID, "planarConduit", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.gemExquisite.get(Materials.Amber),
+                OrePrefixes.lens.get(Materials.Olivine),
+                OrePrefixes.plate.get(Materials.Void),
+                OrePrefixes.lens.get(Materials.Olivine),
+                OrePrefixes.gemExquisite.get(Materials.Amber),
+                OrePrefixes.plate.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "vortexStabilizer",
                 new AspectList().add(Aspect.getAspect("auram"), 21).add(Aspect.getAspect("fames"), 18)
@@ -167,7 +164,7 @@ public class ScriptThaumicHorizons implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("vinculum"), 6));
         TCHelper.setResearchComplexity("vortexStabilizer", 4);
         ThaumcraftApi.addWarpToResearch("vortexStabilizer", 2);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "recombinator",
                 getModItem(ThaumicHorizons.ID, "recombinator", 1, 0, missing),
                 10,
@@ -175,18 +172,18 @@ public class ScriptThaumicHorizons implements IScriptLoader {
                         .add(Aspect.getAspect("fabrico"), 32).add(Aspect.getAspect("potentia"), 32)
                         .add(Aspect.getAspect("sensus"), 16).add(Aspect.getAspect("praecantatio"), 24),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Amber, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
-                        getModItem(ThaumicHorizons.ID, "planarConduit", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Amber, 1L),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Amber, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
-                        getModItem(ThaumicHorizons.ID, "planarConduit", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Amber, 1L), });
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11, missing),
+                OrePrefixes.gemExquisite.get(Materials.Amber),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
+                getModItem(ThaumicHorizons.ID, "planarConduit", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
+                OrePrefixes.gemExquisite.get(Materials.Amber),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10, missing),
+                OrePrefixes.gemExquisite.get(Materials.Amber),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
+                getModItem(ThaumicHorizons.ID, "planarConduit", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
+                OrePrefixes.gemExquisite.get(Materials.Amber));
         TCHelper.setResearchAspects(
                 "recombinator",
                 new AspectList().add(Aspect.getAspect("auram"), 21).add(Aspect.getAspect("permutatio"), 18)

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
@@ -21,7 +21,6 @@ import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 
 import com.dreammaster.thaumcraft.TCHelper;
@@ -211,18 +210,18 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 3,
                 getModItem(ThaumicTinkerer.ID, "shareBook", 1, 0, missing)).setParents("INFUSION")
                         .setPages(new ResearchPage("ttresearch.page.SHARE_TOME.0")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "SHARETOME",
                 getModItem(ThaumicTinkerer.ID, "shareBook", 1, 0, missing),
                 6,
                 new AspectList().add(Aspect.getAspect("cognitio"), 32).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("pannus"), 16),
                 getModItem(Minecraft.ID, "skull", 1, 3, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                        getModItem(Minecraft.ID, "paper", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemInkwell", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
-                        getModItem(Minecraft.ID, "paper", 1, 0, missing), });
+                getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
+                getModItem(Minecraft.ID, "paper", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemInkwell", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
+                getModItem(Minecraft.ID, "paper", 1, 0, missing));
         TCHelper.addResearchPage(
                 "SHARETOME",
                 new ResearchPage(
@@ -474,17 +473,17 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "fireFire", 1, 0, missing))
                         .setParents("INFUSION", "BRIGHT_NITOR", "ELDRITCHMINOR").setConcealed()
                         .setPages(new ResearchPage("ttresearch.page.FIRE_IGNIS.0")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FIREIGNIS",
                 getModItem(ThaumicTinkerer.ID, "fireFire", 1, 0, missing),
                 16,
                 new AspectList().add(Aspect.getAspect("ignis"), 10).add(Aspect.getAspect("lux"), 10)
                         .add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("praecantatio"), 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"ignis\"}]}", missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Minecraft.ID, "redstone", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing), });
+                getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Minecraft.ID, "redstone", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing));
         TCHelper.addResearchPage(
                 "FIREIGNIS",
                 new ResearchPage(
@@ -503,17 +502,17 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "fireWater", 1, 0, missing))
                         .setParents("INFUSION", "BRIGHT_NITOR", "ELDRITCHMINOR").setConcealed()
                         .setPages(new ResearchPage("ttresearch.page.FIRE_AQUA.0")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FIREAQUA",
                 getModItem(ThaumicTinkerer.ID, "fireWater", 1, 0, missing),
                 16,
                 new AspectList().add(Aspect.getAspect("aqua"), 10).add(Aspect.getAspect("lux"), 10)
                         .add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("praecantatio"), 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"aqua\"}]}", missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Minecraft.ID, "redstone", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing), });
+                getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Minecraft.ID, "redstone", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing));
         TCHelper.addResearchPage(
                 "FIREAQUA",
                 new ResearchPage(
@@ -532,17 +531,17 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "fireEarth", 1, 0, missing))
                         .setParents("INFUSION", "BRIGHT_NITOR", "ELDRITCHMINOR").setConcealed()
                         .setPages(new ResearchPage("ttresearch.page.FIRE_TERRA.0")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FIRETERRA",
                 getModItem(ThaumicTinkerer.ID, "fireEarth", 1, 0, missing),
                 16,
                 new AspectList().add(Aspect.getAspect("terra"), 10).add(Aspect.getAspect("lux"), 10)
                         .add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("praecantatio"), 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"terra\"}]}", missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Minecraft.ID, "redstone", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing), });
+                getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Minecraft.ID, "redstone", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing));
         TCHelper.addResearchPage(
                 "FIRETERRA",
                 new ResearchPage(
@@ -561,17 +560,17 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "fireOrder", 1, 0, missing))
                         .setParents("INFUSION", "BRIGHT_NITOR", "ELDRITCHMINOR").setConcealed()
                         .setPages(new ResearchPage("ttresearch.page.FIRE_ORDO.0")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FIREORDO",
                 getModItem(ThaumicTinkerer.ID, "fireOrder", 1, 0, missing),
                 16,
                 new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("lux"), 10)
                         .add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("praecantatio"), 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"ordo\"}]}", missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Minecraft.ID, "redstone", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing), });
+                getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Minecraft.ID, "redstone", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing));
         TCHelper.addResearchPage(
                 "FIREORDO",
                 new ResearchPage(
@@ -590,17 +589,17 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "fireAir", 1, 0, missing))
                         .setParents("INFUSION", "BRIGHT_NITOR", "ELDRITCHMINOR").setConcealed()
                         .setPages(new ResearchPage("ttresearch.page.FIRE_AER.0")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FIREAER",
                 getModItem(ThaumicTinkerer.ID, "fireAir", 1, 0, missing),
                 16,
                 new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("lux"), 10)
                         .add(Aspect.getAspect("motus"), 10).add(Aspect.getAspect("praecantatio"), 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"aer\"}]}", missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Minecraft.ID, "redstone", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing), });
+                getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Minecraft.ID, "redstone", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing));
         TCHelper.addResearchPage(
                 "FIREAER",
                 new ResearchPage(
@@ -619,7 +618,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "fireChaos", 1, 0, missing))
                         .setParents("INFUSION", "BRIGHT_NITOR", "ELDRITCHMINOR").setConcealed()
                         .setPages(new ResearchPage("ttresearch.page.FIRE_PERDITIO.0")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FIREPERDITIO",
                 getModItem(ThaumicTinkerer.ID, "fireChaos", 1, 0, missing),
                 16,
@@ -632,10 +631,10 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         1,
                         "{Aspects:[0:{amount:8,key:\"perditio\"}]}",
                         missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Minecraft.ID, "redstone", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing), });
+                getModItem(Minecraft.ID, "glowstone_dust", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Minecraft.ID, "redstone", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing));
         TCHelper.addResearchPage(
                 "FIREPERDITIO",
                 new ResearchPage(
@@ -673,7 +672,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                                         new ResearchPage("ttresearch.page.INFUSED_POTIONS.2"),
                                         new ResearchPage("ttresearch.page.INFUSED_POTIONS.3"))
                                 .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "INFUSEDSEED",
                 createItemStack(
                         ThaumicTinkerer.ID,
@@ -686,10 +685,10 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("messis"), 32).add(Aspect.getAspect("meto"), 32)
                         .add(Aspect.getAspect("aer"), 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing));
         TCHelper.addResearchPage(
                 "INFUSEDSEED",
                 new ResearchPage(
@@ -701,7 +700,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                                         0,
                                         "{mainAspect:{Aspects:[0:{amount:1,key:\"aer\"}]},aspectTendencies:{Aspects:[]}}",
                                         missing))));
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "INFUSEDSEED",
                 createItemStack(
                         ThaumicTinkerer.ID,
@@ -714,11 +713,11 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("messis"), 32).add(Aspect.getAspect("meto"), 32)
                         .add(Aspect.getAspect("ignis"), 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "INFUSEDSEED",
                 createItemStack(
                         ThaumicTinkerer.ID,
@@ -731,11 +730,11 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("messis"), 32).add(Aspect.getAspect("meto"), 32)
                         .add(Aspect.getAspect("aqua"), 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 2, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "INFUSEDSEED",
                 createItemStack(
                         ThaumicTinkerer.ID,
@@ -748,11 +747,11 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("messis"), 32).add(Aspect.getAspect("meto"), 32)
                         .add(Aspect.getAspect("terra"), 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "INFUSEDSEED",
                 createItemStack(
                         ThaumicTinkerer.ID,
@@ -765,11 +764,11 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("messis"), 32).add(Aspect.getAspect("meto"), 32)
                         .add(Aspect.getAspect("ordo"), 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "INFUSEDSEED",
                 createItemStack(
                         ThaumicTinkerer.ID,
@@ -782,10 +781,10 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("messis"), 32).add(Aspect.getAspect("meto"), 32)
                         .add(Aspect.getAspect("perditio"), 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing), });
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing));
         TCHelper.addResearchPage("INFUSEDSEED", new ResearchPage("tt.research.page.INFUSEDSEED.3"));
         ThaumcraftApi.addWarpToResearch("INFUSEDSEED", 2);
         new ResearchItem(
@@ -872,22 +871,22 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("FUNNEL", 3);
         TCHelper.addResearchPrereq("REPAIRER", "INFUSION", false);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "REPAIRER",
                 getModItem(ThaumicTinkerer.ID, "repairer", 1, 0, missing),
                 8,
                 new AspectList().add(Aspect.getAspect("fabrico"), 32).add(Aspect.getAspect("instrumentum"), 32)
                         .add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("praecantatio"), 16)
                         .add(Aspect.getAspect("potentia"), 8),
-                GTOreDictUnificator.get(OrePrefixes.block, Materials.Thaumium, 1L),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Iron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.ReinforceGlass, 1),
-                        getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.ReinforceGlass, 1),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L), });
+                OrePrefixes.block.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Iron),
+                OrePrefixes.plate.get(Materials.ReinforceGlass),
+                getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 7, missing),
+                OrePrefixes.plate.get(Materials.Diamond),
+                OrePrefixes.plate.get(Materials.ReinforceGlass),
+                OrePrefixes.plate.get(Materials.Gold));
         TCHelper.setResearchAspects(
                 "REPAIRER",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("fabrico"), 12)
@@ -994,7 +993,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         TCHelper.setResearchComplexity("ANIMATION_TABLET", 4);
         ThaumcraftApi.addWarpToResearch("ANIMATION_TABLET", 3);
         ResearchCategories.getResearch("LEVITATOR_LOCOMOTIVE").setConcealed();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "LEVITATOR_LOCOMOTIVE",
                 getModItem(ThaumicTinkerer.ID, "Levitational Locomotive", 1, 0, missing),
                 4,
@@ -1002,14 +1001,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("aer"), 25)
                         .add(Aspect.getAspect("potentia"), 10),
                 getModItem(Thaumcraft.ID, "blockLifter", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Iron, 1L),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Iron, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Obsidian, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Iron, 1L),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Iron, 1L), });
+                OrePrefixes.plate.get(Materials.Obsidian),
+                OrePrefixes.screw.get(Materials.Iron),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
+                OrePrefixes.screw.get(Materials.Iron),
+                OrePrefixes.plate.get(Materials.Obsidian),
+                OrePrefixes.screw.get(Materials.Iron),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
+                OrePrefixes.screw.get(Materials.Iron));
         TCHelper.setResearchAspects(
                 "LEVITATOR_LOCOMOTIVE",
                 new AspectList().add(Aspect.getAspect("motus"), 15).add(Aspect.getAspect("ordo"), 15)
@@ -1046,21 +1045,21 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         TCHelper.addResearchPrereq("CLEANSING_TALISMAN", "INFUSION", false);
         TCHelper.addResearchPrereq("CLEANSING_TALISMAN", "RUNICARMOR", false);
         ResearchCategories.getResearch("INFUSEDPOTIONS").setConcealed();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CLEANSING_TALISMAN",
                 getModItem(ThaumicTinkerer.ID, "cleansingTalisman", 1, 0, missing),
                 4,
                 new AspectList().add(Aspect.getAspect("humanus"), 32).add(Aspect.getAspect("instrumentum"), 24)
                         .add(Aspect.getAspect("sano"), 16).add(Aspect.getAspect("victus"), 16),
                 getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
-                new ItemStack[] { getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
-                        getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing), });
+                getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing),
+                getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 1, missing));
         TCHelper.setResearchAspects(
                 "CLEANSING_TALISMAN",
                 new AspectList().add(Aspect.getAspect("sano"), 15).add(Aspect.getAspect("ordo"), 12)
@@ -1094,7 +1093,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 3));
         TCHelper.setResearchComplexity("PLATFORM", 3);
         ResearchCategories.getResearch("BLOOD_SWORD").setConcealed();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "BLOOD_SWORD",
                 getModItem(ThaumicTinkerer.ID, "bloodSword", 1, 0, missing),
                 8,
@@ -1102,18 +1101,18 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("spiritus"), 16).add(Aspect.getAspect("tenebrae"), 24)
                         .add(Aspect.getAspect("telum"), 16),
                 getModItem(Thaumcraft.ID, "ItemSwordThaumium", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(Minecraft.ID, "rotten_flesh", 1, 0, missing),
-                        getModItem(Minecraft.ID, "porkchop", 1, 0, missing),
-                        getModItem(Minecraft.ID, "fish", 1, 0, missing),
-                        getModItem(Minecraft.ID, "nether_wart", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Minecraft.ID, "bone", 1, 0, missing),
-                        getModItem(Minecraft.ID, "beef", 1, 0, missing),
-                        getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
-                        getModItem(Minecraft.ID, "spider_eye", 1, 0, missing),
-                        getModItem(Minecraft.ID, "chicken", 1, 0, missing), });
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(Minecraft.ID, "rotten_flesh", 1, 0, missing),
+                getModItem(Minecraft.ID, "porkchop", 1, 0, missing),
+                getModItem(Minecraft.ID, "fish", 1, 0, missing),
+                getModItem(Minecraft.ID, "nether_wart", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Minecraft.ID, "bone", 1, 0, missing),
+                getModItem(Minecraft.ID, "beef", 1, 0, missing),
+                getModItem(Minecraft.ID, "blaze_powder", 1, 0, missing),
+                getModItem(Minecraft.ID, "spider_eye", 1, 0, missing),
+                getModItem(Minecraft.ID, "chicken", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "BLOOD_SWORD",
                 new AspectList().add(Aspect.getAspect("fames"), 15).add(Aspect.getAspect("telum"), 12)
@@ -1188,19 +1187,19 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 3));
         TCHelper.setResearchComplexity("FOCUS_SMELT", 3);
         TCHelper.addResearchPrereq("FOCUS_FLIGHT", "FOCUSFIRE", false);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_FLIGHT",
                 getModItem(ThaumicTinkerer.ID, "focusFlight", 1, 0, missing),
                 6,
                 new AspectList().add(Aspect.getAspect("aer"), 48).add(Aspect.getAspect("iter"), 24)
                         .add(Aspect.getAspect("motus"), 32).add(Aspect.getAspect("volatus"), 24),
                 getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Thaumium, 1L),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.EnderPearl, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Thaumium, 1L),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.EnderPearl, 1L), });
+                OrePrefixes.rotor.get(Materials.Thaumium),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
+                OrePrefixes.dust.get(Materials.EnderPearl),
+                OrePrefixes.rotor.get(Materials.Thaumium),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
+                OrePrefixes.dust.get(Materials.EnderPearl));
         TCHelper.setResearchAspects(
                 "FOCUS_FLIGHT",
                 new AspectList().add(Aspect.getAspect("motus"), 15).add(Aspect.getAspect("aer"), 12)
@@ -1208,7 +1207,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("iter"), 3));
         TCHelper.setResearchComplexity("FOCUS_FLIGHT", 4);
         TCHelper.addResearchPrereq("FOCUS_DEFLECT", "FOCUS_FLIGHT", false);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_DEFLECT",
                 getModItem(ThaumicTinkerer.ID, "focusDeflect", 1, 0, missing),
                 6,
@@ -1216,12 +1215,12 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("auram"), 24)
                         .add(Aspect.getAspect("alienis"), 16),
                 getModItem(ThaumicTinkerer.ID, "focusFlight", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing), });
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 10, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing));
         TCHelper.setResearchAspects(
                 "FOCUS_DEFLECT",
                 new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("praecantatio"), 12)
@@ -1261,7 +1260,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 3));
         TCHelper.setResearchComplexity("FOCUS_ENDER_CHEST", 4);
         ThaumcraftApi.addWarpToResearch("ANIMATION_TABLET", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_TELEKINESIS",
                 getModItem(ThaumicTinkerer.ID, "focusTelekinesis", 1, 0, missing),
                 10,
@@ -1269,14 +1268,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("motus"), 32).add(Aspect.getAspect("perditio"), 24)
                         .add(Aspect.getAspect("lucrum"), 16),
                 getModItem(ThaumicTinkerer.ID, "focusFlight", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.SteelMagnetic, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                        getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.SteelMagnetic, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L), });
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.NetherQuartz),
+                OrePrefixes.plate.get(Materials.SteelMagnetic),
+                OrePrefixes.plate.get(Materials.NetherQuartz),
+                getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.NetherQuartz),
+                OrePrefixes.plate.get(Materials.SteelMagnetic),
+                OrePrefixes.plate.get(Materials.NetherQuartz));
         TCHelper.setResearchAspects(
                 "FOCUS_TELEKINESIS",
                 new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("motus"), 15)
@@ -1284,7 +1283,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 6));
         TCHelper.setResearchComplexity("FOCUS_TELEKINESIS", 4);
         TCHelper.addResearchPrereq("FOCUS_DISLOCATION", "FOCUSTRADE", false);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_DISLOCATION",
                 getModItem(ThaumicTinkerer.ID, "focusDislocation", 1, 0, missing),
                 10,
@@ -1292,14 +1291,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("vacuos"), 32)
                         .add(Aspect.getAspect("vitium"), 16).add(Aspect.getAspect("permutatio"), 16),
                 getModItem(Thaumcraft.ID, "FocusTrade", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Amber, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Amber, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L), });
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                OrePrefixes.plate.get(Materials.NetherQuartz),
+                OrePrefixes.gemFlawless.get(Materials.Amber),
+                OrePrefixes.plate.get(Materials.NetherQuartz),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                OrePrefixes.plate.get(Materials.NetherQuartz),
+                OrePrefixes.gemFlawless.get(Materials.Amber),
+                OrePrefixes.plate.get(Materials.NetherQuartz));
         TCHelper.setResearchAspects(
                 "FOCUS_DISLOCATION",
                 new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("permutatio"), 15)
@@ -1307,21 +1306,21 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 6).add(Aspect.getAspect("vitium"), 3));
         TCHelper.setResearchComplexity("FOCUS_DISLOCATION", 4);
         ThaumcraftApi.addWarpToResearch("FOCUS_DISLOCATION", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_HEAL",
                 getModItem(ThaumicTinkerer.ID, "focusHeal", 1, 0, missing),
                 10,
                 new AspectList().add(Aspect.getAspect("sano"), 24).add(Aspect.getAspect("spiritus"), 32)
                         .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("victus"), 24),
                 getModItem(Thaumcraft.ID, "FocusPech", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "golden_apple", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Minecraft.ID, "golden_carrot", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.RoseGold, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing), });
+                getModItem(Minecraft.ID, "golden_apple", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.plate.get(Materials.RoseGold),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Minecraft.ID, "golden_carrot", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.plate.get(Materials.RoseGold),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing));
         TCHelper.setResearchAspects(
                 "FOCUS_HEAL",
                 new AspectList().add(Aspect.getAspect("sano"), 15).add(Aspect.getAspect("victus"), 15)
@@ -1331,7 +1330,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         TCHelper.addResearchPrereq("ENCHANTER", "ENCHANTINGTABLE", false);
         TCHelper.addResearchPrereq("ENCHANTER", "INFUSION", false);
         ResearchCategories.getResearch("ENCHANTER").setConcealed();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ENCHANTER",
                 getModItem(ThaumicTinkerer.ID, "enchanter", 1, 0, missing),
                 12,
@@ -1339,18 +1338,18 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("praecantatio"), 64)
                         .add(Aspect.getAspect("auram"), 64).add(Aspect.getAspect("vacuos"), 64),
                 getModItem(Minecraft.ID, "enchanting_table", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(ThaumicTinkerer.ID, "spellCloth", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "spellCloth", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(ThaumicTinkerer.ID, "spellCloth", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "spellCloth", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Thaumium, 1L),
-                        getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing), });
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(ThaumicTinkerer.ID, "spellCloth", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "spellCloth", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(ThaumicTinkerer.ID, "spellCloth", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "spellCloth", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Thaumium),
+                getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ENCHANTER",
                 new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("praecantatio"), 15)
@@ -1372,7 +1371,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("pannus"), 9)
                         .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("SPELL_CLOTH", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "XP_TALISMAN",
                 getModItem(ThaumicTinkerer.ID, "xpTalisman", 1, 0, missing),
                 8,
@@ -1380,14 +1379,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("machina"), 16).add(Aspect.getAspect("permutatio"), 16)
                         .add(Aspect.getAspect("humanus"), 8),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.NetherQuartz, 1L),
-                        getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Diamond, 1L), });
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.NetherQuartz),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.NetherQuartz),
+                getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0, missing),
+                OrePrefixes.plate.get(Materials.Diamond));
         TCHelper.setResearchAspects(
                 "XP_TALISMAN",
                 new AspectList().add(Aspect.getAspect("lucrum"), 15).add(Aspect.getAspect("praecantatio"), 12)
@@ -1609,7 +1608,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 3,
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing)).setParents("INFUSION")
                         .setPages(new ResearchPage("tt.research.page.DIMENSIONSHARDS")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "DIMENSIONSHARDS",
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing),
                 8,
@@ -1620,22 +1619,22 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("desidia"), 8).add(Aspect.getAspect("ira"), 8)
                         .add(Aspect.getAspect("alienis"), 8),
                 getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                new ItemStack[] { getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 6, missing),
-                        getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 6, missing),
+                getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "DIMENSIONSHARDS",
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing),
                 8,
@@ -1646,21 +1645,21 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("desidia"), 8).add(Aspect.getAspect("ira"), 8)
                         .add(Aspect.getAspect("alienis"), 8),
                 getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
-                new ItemStack[] { getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing),
-                        getModItem(ForbiddenMagic.ID, "NetherShard", 1, 6, missing),
-                        getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 2, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 3, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 4, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 5, missing),
-                        getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing), });
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 5, missing),
+                getModItem(ForbiddenMagic.ID, "NetherShard", 1, 6, missing),
+                getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 2, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 3, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 4, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 5, missing),
+                getModItem(Thaumcraft.ID, "ItemShard", 1, 6, missing));
         TCHelper.addResearchPage(
                 "DIMENSIONSHARDS",
                 new ResearchPage(
@@ -1670,7 +1669,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 new ResearchPage(
                         TCHelper.findInfusionRecipe(getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing))));
         TCHelper.addResearchPrereq("ICHOR", "DIMENSIONSHARDS", false);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHOR",
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 2, 0, missing),
                 10,
@@ -1678,10 +1677,10 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("spiritus"), 64).add(Aspect.getAspect("alienis"), 16)
                         .add(Aspect.getAspect("ordo"), 16),
                 getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing),
-                        getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing), });
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing),
+                getModItem(Minecraft.ID, "ender_eye", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing));
         TCHelper.setResearchAspects(
                 "ICHOR",
                 new AspectList().add(Aspect.getAspect("humanus"), 15).add(Aspect.getAspect("spiritus"), 15)
@@ -1809,27 +1808,28 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("CAP_ICHOR", 4);
         ThaumcraftApi.addWarpToResearch("CAP_ICHOR", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "CAT_AMULET",
                 getModItem(ThaumicTinkerer.ID, "catAmulet", 1, 0, missing),
                 8,
                 new AspectList().add(Aspect.getAspect("cognitio"), 16).add(Aspect.getAspect("ordo"), 32)
                         .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("mortuus"), 16),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
-                new ItemStack[] { getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 10, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Gold, 1L),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        getModItem(Minecraft.ID, "fish", 1, 0, missing), getModItem(Minecraft.ID, "dye", 1, 3, missing),
-                        getModItem(Minecraft.ID, "leaves", 1, 3, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ring, Materials.Gold, 1L), });
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 10, missing),
+                OrePrefixes.ring.get(Materials.Gold),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                getModItem(Minecraft.ID, "fish", 1, 0, missing),
+                getModItem(Minecraft.ID, "dye", 1, 3, missing),
+                getModItem(Minecraft.ID, "leaves", 1, 3, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                OrePrefixes.ring.get(Materials.Gold));
         TCHelper.setResearchAspects(
                 "CAT_AMULET",
                 new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("ordo"), 15)
                         .add(Aspect.getAspect("tenebrae"), 12).add(Aspect.getAspect("mortuus"), 9)
                         .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("CAT_AMULET", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHOR_POUCH",
                 getModItem(ThaumicTinkerer.ID, "ichorPouch", 1, 0, missing),
                 10,
@@ -1837,14 +1837,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("pannus"), 48).add(Aspect.getAspect("alienis"), 48)
                         .add(Aspect.getAspect("aer"), 64),
                 getModItem(Thaumcraft.ID, "FocusPouch", 1, 0, missing),
-                new ItemStack[] { getModItem(Thaumcraft.ID, "blockJar", 1, 3, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "TrunkSpawner", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L), });
+                getModItem(Thaumcraft.ID, "blockJar", 1, 3, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "TrunkSpawner", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond));
         TCHelper.setResearchAspects(
                 "ICHOR_POUCH",
                 new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("pannus"), 15)
@@ -1953,7 +1953,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("ICHORCLOTH_ARMOR", 4);
         ThaumcraftApi.addWarpToResearch("ICHORCLOTH_ARMOR", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ROD_ICHORCLOTH",
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 5, missing),
                 10,
@@ -1961,14 +1961,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("instrumentum"), 100).add(Aspect.getAspect("arbor"), 75)
                         .add(Aspect.getAspect("alienis"), 50),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2, missing),
-                new ItemStack[] { getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing), });
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ROD_ICHORCLOTH",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("pannus"), 15)
@@ -1976,7 +1976,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("arbor"), 6).add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("ROD_ICHORCLOTH", 4);
         ThaumcraftApi.addWarpToResearch("ROD_ICHORCLOTH", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_SHADOWBEAM",
                 getModItem(ThaumicTinkerer.ID, "focusShadowbeam", 1, 0, missing),
                 12,
@@ -1984,13 +1984,13 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("telum"), 64).add(Aspect.getAspect("tenebrae"), 64)
                         .add(Aspect.getAspect("tempestas"), 32),
                 getModItem(Thaumcraft.ID, "FocusShock", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ring, Materials.Ichorium, 1),
-                        getModItem(ThaumicTinkerer.ID, "focusDeflect", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Emerald, 1L),
-                        getModItem(Thaumcraft.ID, "PrimalArrow", 1, 2, missing), // Water arrow
-                        getModItem(Thaumcraft.ID, "PrimalArrow", 1, 2, missing), // Water arrow
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing), });
+                OrePrefixes.ring.get(Materials.Ichorium),
+                getModItem(ThaumicTinkerer.ID, "focusDeflect", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Emerald),
+                getModItem(Thaumcraft.ID, "PrimalArrow", 1, 2, missing), // Water arrow
+                getModItem(Thaumcraft.ID, "PrimalArrow", 1, 2, missing), // Water arrow
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "FOCUS_SHADOWBEAM",
                 new AspectList().add(Aspect.getAspect("tenebrae"), 15).add(Aspect.getAspect("praecantatio"), 15)
@@ -1998,19 +1998,19 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("tempestas"), 6).add(Aspect.getAspect("motus"), 3));
         TCHelper.setResearchComplexity("FOCUS_SHADOWBEAM", 4);
         ThaumcraftApi.addWarpToResearch("FOCUS_SHADOWBEAM", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_XP_DRAIN",
                 getModItem(ThaumicTinkerer.ID, "focusXPDrain", 1, 0, missing),
                 12,
                 new AspectList().add(Aspect.getAspect("auram"), 64).add(Aspect.getAspect("cognitio"), 64)
                         .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("vitium"), 32),
                 getModItem(Minecraft.ID, "experience_bottle", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(ThaumicTinkerer.ID, "enchanter", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.EnderPearl, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Emerald, 1L),
-                        getModItem(ThaumicTinkerer.ID, "xpTalisman", 1, 0, missing), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(ThaumicTinkerer.ID, "enchanter", 1, 0, missing),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                OrePrefixes.lens.get(Materials.EnderPearl),
+                OrePrefixes.gemFlawless.get(Materials.Emerald),
+                getModItem(ThaumicTinkerer.ID, "xpTalisman", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "FOCUS_XP_DRAIN",
                 new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("praecantatio"), 15)
@@ -2018,7 +2018,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("FOCUS_XP_DRAIN", 4);
         ThaumcraftApi.addWarpToResearch("FOCUS_XP_DRAIN", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHORCLOTH_HELM_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorclothHelmGem", 1, 0, missing),
                 16,
@@ -2027,18 +2027,18 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("fames"), 64).add(Aspect.getAspect("lux"), 64)
                         .add(Aspect.getAspect("tutamen"), 64),
                 getModItem(ThaumicTinkerer.ID, "ichorclothHelm", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemHelmetThaumium", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.EnderEye, 1L),
-                        getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
-                        getModItem(Minecraft.ID, "potion", 1, 8262, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(Minecraft.ID, "fish", 1, wildcard, missing),
-                        getModItem(Minecraft.ID, "cake", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemGoggles", 1, 0, missing), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "ItemHelmetThaumium", 1, 0, missing),
+                OrePrefixes.lens.get(Materials.EnderEye),
+                getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
+                getModItem(Minecraft.ID, "potion", 1, 8262, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(Minecraft.ID, "fish", 1, wildcard, missing),
+                getModItem(Minecraft.ID, "cake", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemGoggles", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ICHORCLOTH_HELM_GEM",
                 new AspectList().add(Aspect.getAspect("aqua"), 24).add(Aspect.getAspect("sano"), 21)
@@ -2047,7 +2047,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("tutamen"), 3));
         TCHelper.setResearchComplexity("ICHORCLOTH_HELM_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHORCLOTH_HELM_GEM", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHORCLOTH_CHEST_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorclothChestGem", 1, 0, missing),
                 16,
@@ -2056,18 +2056,18 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("sensus"), 64).add(Aspect.getAspect("tutamen"), 64)
                         .add(Aspect.getAspect("volatus"), 64),
                 getModItem(ThaumicTinkerer.ID, "ichorclothChest", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.plate, Materials.Ichorium, 1),
-                        getModItem(Thaumcraft.ID, "ItemChestplateThaumium", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "focusFlight", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "PrimalArrow", 1, 0, missing), // Air Arrow
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Ichorium, 1),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "PrimalArrow", 1, 0, missing), // Air Arrow
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
-                        getModItem(ThaumicTinkerer.ID, "focusDeflect", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "HoverHarness", 1, 0, missing), });
+                OrePrefixes.plate.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "ItemChestplateThaumium", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "focusFlight", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "PrimalArrow", 1, 0, missing), // Air Arrow
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                OrePrefixes.plate.get(Materials.Ichorium),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "PrimalArrow", 1, 0, missing), // Air Arrow
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
+                getModItem(ThaumicTinkerer.ID, "focusDeflect", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "HoverHarness", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ICHORCLOTH_CHEST_GEM",
                 new AspectList().add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("motus"), 21)
@@ -2076,7 +2076,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("tutamen"), 3));
         TCHelper.setResearchComplexity("ICHORCLOTH_CHEST_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHORCLOTH_CHEST_GEM", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHORCLOTH_LEGS_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorclothLegsGem", 1, 0, missing),
                 16,
@@ -2085,18 +2085,18 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("sano"), 64)
                         .add(Aspect.getAspect("tutamen"), 64),
                 getModItem(ThaumicTinkerer.ID, "ichorclothLegs", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemLeggingsThaumium", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "focusSmelt", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
-                        getModItem(Minecraft.ID, "potion", 1, 8259, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(ThaumicTinkerer.ID, "brightNitor", 1, 0, missing),
-                        getModItem(Minecraft.ID, "fire_charge", 1, 0, missing),
-                        getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
-                        getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "ItemLeggingsThaumium", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "focusSmelt", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
+                getModItem(Minecraft.ID, "potion", 1, 8259, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(ThaumicTinkerer.ID, "brightNitor", 1, 0, missing),
+                getModItem(Minecraft.ID, "fire_charge", 1, 0, missing),
+                getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
+                getModItem(Minecraft.ID, "lava_bucket", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ICHORCLOTH_LEGS_GEM",
                 new AspectList().add(Aspect.getAspect("ignis"), 24).add(Aspect.getAspect("sano"), 21)
@@ -2105,7 +2105,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("tutamen"), 3));
         TCHelper.setResearchComplexity("ICHORCLOTH_LEGS_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHORCLOTH_LEGS_GEM", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHORCLOTH_BOOTS_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorclothBootsGem", 1, 0, missing),
                 16,
@@ -2114,24 +2114,24 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("perfodio"), 64).add(Aspect.getAspect("terra"), 64)
                         .add(Aspect.getAspect("tutamen"), 64),
                 getModItem(ThaumicTinkerer.ID, "ichorclothBoots", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemBootsThaumium", 1, 0, missing),
-                        createItemStack(
-                                ThaumicTinkerer.ID,
-                                "infusedSeeds",
-                                1,
-                                0,
-                                "{mainAspect:{Aspects:[0:{amount:1,key:\"terra\"}]}}",
-                                missing),
-                        getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
-                        getModItem(PamsHarvestCraft.ID, "wovencottonItem", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 8, missing),
-                        getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 5, missing),
-                        getModItem(Minecraft.ID, "lead", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
-                        getModItem(Minecraft.ID, "grass", 1, 0, missing), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "ItemBootsThaumium", 1, 0, missing),
+                createItemStack(
+                        ThaumicTinkerer.ID,
+                        "infusedSeeds",
+                        1,
+                        0,
+                        "{mainAspect:{Aspects:[0:{amount:1,key:\"terra\"}]}}",
+                        missing),
+                getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0, missing),
+                getModItem(PamsHarvestCraft.ID, "wovencottonItem", 1, 0, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 8, missing),
+                getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 5, missing),
+                getModItem(Minecraft.ID, "lead", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0, missing),
+                getModItem(Minecraft.ID, "grass", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ICHORCLOTH_BOOTS_GEM",
                 new AspectList().add(Aspect.getAspect("terra"), 24).add(Aspect.getAspect("iter"), 21)
@@ -2140,7 +2140,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("tutamen"), 3));
         TCHelper.setResearchComplexity("ICHORCLOTH_BOOTS_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHORCLOTH_BOOTS_GEM", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WARP_GATE",
                 getModItem(ThaumicTinkerer.ID, "warpGate", 1, 0, missing),
                 10,
@@ -2148,14 +2148,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("volatus"), 64).add(Aspect.getAspect("terra"), 32)
                         .add(Aspect.getAspect("aer"), 32),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 2, missing),
-                new ItemStack[] { getModItem(ThaumicTinkerer.ID, "dislocator", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing), });
-        ThaumcraftApi.addInfusionCraftingRecipe(
+                getModItem(ThaumicTinkerer.ID, "dislocator", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing));
+        TCHelper.addInfusionCraftingRecipe(
                 "WARP_GATE",
                 getModItem(ThaumicTinkerer.ID, "skyPearl", 1, 0, missing),
                 10,
@@ -2163,12 +2163,12 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("volatus"), 32).add(Aspect.getAspect("iter"), 32)
                         .add(Aspect.getAspect("vitreus"), 24),
                 getModItem(Minecraft.ID, "ender_pearl", 1, 0, missing),
-                new ItemStack[] { getModItem(IndustrialCraft2.ID, "itemDensePlates", 1, 8, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing),
-                        getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing), });
+                getModItem(IndustrialCraft2.ID, "itemDensePlates", 1, 8, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing),
+                getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing));
         TCHelper.setResearchAspects(
                 "WARP_GATE",
                 new AspectList().add(Aspect.getAspect("iter"), 18).add(Aspect.getAspect("volatus"), 15)
@@ -2176,7 +2176,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("vitreus"), 6).add(Aspect.getAspect("aer"), 3));
         TCHelper.setResearchComplexity("WARP_GATE", 4);
         ThaumcraftApi.addWarpToResearch("WARP_GATE", 4);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_RECALL",
                 getModItem(ThaumicTinkerer.ID, "focusRecall", 1, 0, missing),
                 14,
@@ -2184,10 +2184,10 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 96).add(Aspect.getAspect("volatus"), 48)
                         .add(Aspect.getAspect("aer"), 32),
                 getModItem(ThaumicTinkerer.ID, "focusEnderChest", 1, 0, missing),
-                new ItemStack[] { getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "skyPearl", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(ThaumicTinkerer.ID, "skyPearl", 1, 0, missing), });
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "skyPearl", 1, 0, missing),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(ThaumicTinkerer.ID, "skyPearl", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "FOCUS_RECALL",
                 new AspectList().add(Aspect.getAspect("iter"), 18).add(Aspect.getAspect("alienis"), 15)
@@ -2298,7 +2298,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3));
         TCHelper.setResearchComplexity("ICHOR_TOOLS", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_TOOLS", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHOR_PICK_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorPickGem", 1, 0, missing),
                 18,
@@ -2307,18 +2307,18 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("messis"), 64).add(Aspect.getAspect("perfodio"), 64)
                         .add(Aspect.getAspect("terra"), 64).add(Aspect.getAspect("sensus"), 64),
                 getModItem(ThaumicTinkerer.ID, "ichorPick", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "FocusFire", 1, 0, missing),
-                        getModItem(StevesCarts2.ID, "CartModule", 1, 9, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
-                        getModItem(StevesCarts2.ID, "CartModule", 1, 9, missing),
-                        getModItem(Thaumcraft.ID, "FocusFire", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "FocusFire", 1, 0, missing),
+                getModItem(StevesCarts2.ID, "CartModule", 1, 9, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
+                getModItem(StevesCarts2.ID, "CartModule", 1, 9, missing),
+                getModItem(Thaumcraft.ID, "FocusFire", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ICHOR_PICK_GEM",
                 new AspectList().add(Aspect.getAspect("ignis"), 24).add(Aspect.getAspect("lucrum"), 21)
@@ -2327,7 +2327,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("sensus"), 3));
         TCHelper.setResearchComplexity("ICHOR_PICK_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_PICK_GEM", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHOR_SHOVEL_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorShovelGem", 1, 0, missing),
                 18,
@@ -2336,18 +2336,18 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 64).add(Aspect.getAspect("vinculum"), 64)
                         .add(Aspect.getAspect("ordo"), 64),
                 getModItem(ThaumicTinkerer.ID, "ichorShovel", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing),
-                        ItemList.Electric_Piston_HV.get(1L),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
-                        ItemList.Electric_Piston_HV.get(1L),
-                        getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing),
+                ItemList.Electric_Piston_HV.get(1L),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
+                ItemList.Electric_Piston_HV.get(1L),
+                getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ICHOR_SHOVEL_GEM",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 21).add(Aspect.getAspect("meto"), 18)
@@ -2356,7 +2356,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("ordo"), 3));
         TCHelper.setResearchComplexity("ICHOR_SHOVEL_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_SHOVEL_GEM", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHOR_AXE_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorAxeGem", 1, 0, missing),
                 18,
@@ -2365,18 +2365,18 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("meto"), 64).add(Aspect.getAspect("perfodio"), 64)
                         .add(Aspect.getAspect("sensus"), 64),
                 getModItem(ThaumicTinkerer.ID, "ichorAxe", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing),
-                        ItemList.Component_Sawblade_Diamond.get(1L),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
-                        ItemList.Component_Sawblade_Diamond.get(1L),
-                        getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing),
+                ItemList.Component_Sawblade_Diamond.get(1L),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
+                ItemList.Component_Sawblade_Diamond.get(1L),
+                getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ICHOR_AXE_GEM",
                 new AspectList().add(Aspect.getAspect("aqua"), 21).add(Aspect.getAspect("arbor"), 18)
@@ -2385,7 +2385,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("sensus"), 3));
         TCHelper.setResearchComplexity("ICHOR_AXE_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_AXE_GEM", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "ICHOR_SWORD_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorSwordGem", 1, 0, missing),
                 18,
@@ -2394,18 +2394,18 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("spiritus"), 64).add(Aspect.getAspect("telum"), 64)
                         .add(Aspect.getAspect("vitreus"), 64),
                 getModItem(ThaumicTinkerer.ID, "ichorSword", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "FocusFrost", 1, 0, missing),
-                        getModItem(ExtraUtilities.ID, "spike_base_diamond", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
-                        getModItem(ExtraUtilities.ID, "spike_base_diamond", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "FocusFrost", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "FocusFrost", 1, 0, missing),
+                getModItem(ExtraUtilities.ID, "spike_base_diamond", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                OrePrefixes.gemExquisite.get(Materials.Emerald),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0, missing),
+                getModItem(ExtraUtilities.ID, "spike_base_diamond", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "FocusFrost", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "ICHOR_SWORD_GEM",
                 new AspectList().add(Aspect.getAspect("aer"), 21).add(Aspect.getAspect("fames"), 18)
@@ -2414,21 +2414,21 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("vitreus"), 3));
         TCHelper.setResearchComplexity("ICHOR_SWORD_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_SWORD_GEM", 3);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PROTOCLAY",
                 getModItem(ThaumicTinkerer.ID, "protoclay", 1, 0, missing),
                 5,
                 new AspectList().add(Aspect.getAspect("instrumentum"), 32).add(Aspect.getAspect("perfodio"), 32)
                         .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("aer"), 16),
                 getModItem(Minecraft.ID, "clay_ball", 1, 0, missing),
-                new ItemStack[] { getModItem(Minecraft.ID, "stone", 1, 0, missing),
-                        getModItem(Minecraft.ID, "dirt", 1, 0, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing),
-                        getModItem(Minecraft.ID, "sand", 1, wildcard, missing),
-                        getModItem(Minecraft.ID, "cobblestone", 1, 0, missing),
-                        getModItem(Minecraft.ID, "log", 1, wildcard, missing),
-                        getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing),
-                        getModItem(Minecraft.ID, "grass", 1, 0, missing), });
+                getModItem(Minecraft.ID, "stone", 1, 0, missing),
+                getModItem(Minecraft.ID, "dirt", 1, 0, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7, missing),
+                getModItem(Minecraft.ID, "sand", 1, wildcard, missing),
+                getModItem(Minecraft.ID, "cobblestone", 1, 0, missing),
+                getModItem(Minecraft.ID, "log", 1, wildcard, missing),
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6, missing),
+                getModItem(Minecraft.ID, "grass", 1, 0, missing));
         TCHelper.setResearchAspects(
                 "PROTOCLAY",
                 new AspectList().add(Aspect.getAspect("instrumentum"), 18).add(Aspect.getAspect("humanus"), 15)
@@ -2436,7 +2436,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("aer"), 3));
         TCHelper.setResearchComplexity("PROTOCLAY", 4);
         ThaumcraftApi.addWarpToResearch("PROTOCLAY", 1);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "BLOCK_TALISMAN",
                 getModItem(ThaumicTinkerer.ID, "blockTalisman", 1, 0, missing),
                 10,
@@ -2444,14 +2444,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("vacuos"), 72).add(Aspect.getAspect("tenebrae"), 48)
                         .add(Aspect.getAspect("spiritus"), 32),
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(EnderStorage.ID, "enderChest", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
-                        getModItem(Thaumcraft.ID, "blockJar", 1, 3, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(EnderStorage.ID, "enderChest", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 11, missing),
+                getModItem(Thaumcraft.ID, "blockJar", 1, 3, missing),
+                OrePrefixes.gemExquisite.get(Materials.Emerald));
         TCHelper.setResearchAspects(
                 "BLOCK_TALISMAN",
                 new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("tenebrae"), 12)
@@ -2459,7 +2459,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("spiritus"), 3));
         TCHelper.setResearchComplexity("BLOCK_TALISMAN", 4);
         ThaumcraftApi.addWarpToResearch("BLOCK_TALISMAN", 6);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PLACEMENT_MIRROR",
                 getModItem(ThaumicTinkerer.ID, "placementMirror", 1, 0, missing),
                 16,
@@ -2467,14 +2467,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("vitreus"), 48)
                         .add(Aspect.getAspect("alienis"), 32),
                 getModItem(ThaumicTinkerer.ID, "blockTalisman", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Diamond, 1L),
-                        getModItem(Minecraft.ID, "dropper", 1, 0, missing),
-                        getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "blockMirror", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.gemExquisite, Materials.Emerald, 1L), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                OrePrefixes.gemExquisite.get(Materials.Diamond),
+                getModItem(Minecraft.ID, "dropper", 1, 0, missing),
+                getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Minecraft.ID, "blaze_rod", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "blockMirror", 1, 0, missing),
+                OrePrefixes.gemExquisite.get(Materials.Emerald));
         TCHelper.setResearchAspects(
                 "PLACEMENT_MIRROR",
                 new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("fabrico"), 12)

--- a/src/main/java/com/dreammaster/scripts/ScriptWarpTheory.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptWarpTheory.java
@@ -16,14 +16,11 @@ import static gregtech.api.util.GTModHandler.getModItem;
 import java.util.Arrays;
 import java.util.List;
 
-import net.minecraft.item.ItemStack;
-
 import com.dreammaster.thaumcraft.TCHelper;
 
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
-import gregtech.api.util.GTOreDictUnificator;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -114,7 +111,7 @@ public class ScriptWarpTheory implements IScriptLoader {
                 getModItem(WarpTheory.ID, "item.warptheory.cleanserminor", 1, 0, missing))
                         .setParents("ELDRITCHMINOR", "warptheory.paper")
                         .setPages(new ResearchPage("research.warptheory.warpcleanserminor")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PURETEARMINOR",
                 getModItem(WarpTheory.ID, "item.warptheory.cleanserminor", 1, 0, missing),
                 10,
@@ -123,17 +120,18 @@ public class ScriptWarpTheory implements IScriptLoader {
                         .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("praecantatio"), 32)
                         .add(Aspect.getAspect("venenum"), 32),
                 getModItem(BiomesOPlenty.ID, "hardIce", 1, 0, missing),
-                new ItemStack[] { getModItem(ThaumicBases.ID, "resource", 1, 5, missing),
-                        ItemList.Crop_Drop_MTomato.get(1L),
-                        getModItem(ThaumicBases.ID, "quicksilverBlock", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.cell, Materials.LifeEssence, 1L),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 36, missing),
-                        getModItem(ThaumicBases.ID, "resource", 1, 5, missing), ItemList.Crop_Drop_MTomato.get(1L),
-                        getModItem(ThaumicBases.ID, "quicksilverBlock", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.cell, Materials.LifeEssence, 1L),
-                        getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 36, missing), });
+                getModItem(ThaumicBases.ID, "resource", 1, 5, missing),
+                ItemList.Crop_Drop_MTomato.get(1L),
+                getModItem(ThaumicBases.ID, "quicksilverBlock", 1, 0, missing),
+                OrePrefixes.cell.get(Materials.LifeEssence),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 36, missing),
+                getModItem(ThaumicBases.ID, "resource", 1, 5, missing),
+                ItemList.Crop_Drop_MTomato.get(1L),
+                getModItem(ThaumicBases.ID, "quicksilverBlock", 1, 0, missing),
+                OrePrefixes.cell.get(Materials.LifeEssence),
+                getModItem(BloodMagic.ID, "magicales", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 36, missing));
         TCHelper.addResearchPage(
                 "PURETEARMINOR",
                 new ResearchPage(
@@ -153,23 +151,23 @@ public class ScriptWarpTheory implements IScriptLoader {
                 getModItem(WarpTheory.ID, "item.warptheory.cleanser", 1, 0, missing))
                         .setParents("ELDRITCHMAJOR", "warptheory.paper", "ICHORIUM")
                         .setPages(new ResearchPage("research.warptheory.warpcleanser")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "PURETEAR",
                 getModItem(WarpTheory.ID, "item.warptheory.cleanser", 1, 0, missing),
                 10,
                 new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("permutatio"), 32)
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("sano"), 16),
                 getModItem(Minecraft.ID, "nether_star", 1, 0, missing),
-                new ItemStack[] { GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 10, missing),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 1L),
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 11, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 11, missing),
-                        GTOreDictUnificator.get(OrePrefixes.lens, Materials.Diamond, 1L),
-                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 10, missing), });
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 10, missing),
+                OrePrefixes.lens.get(Materials.Diamond),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 11, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                getModItem(Minecraft.ID, "ghast_tear", 1, 0, missing),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 11, missing),
+                OrePrefixes.lens.get(Materials.Diamond),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 10, missing));
         TCHelper.addResearchPage(
                 "PURETEAR",
                 new ResearchPage(
@@ -178,7 +176,7 @@ public class ScriptWarpTheory implements IScriptLoader {
         TCHelper.orphanResearch("warptheory.amulet");
         TCHelper.clearPrereq("warptheory.amulet");
         TCHelper.addResearchPrereq("warptheory.amulet", "PURETEAR", false);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "warptheory.amulet",
                 getModItem(WarpTheory.ID, "item.warptheory.amulet", 1, 0, missing),
                 16,
@@ -186,20 +184,20 @@ public class ScriptWarpTheory implements IScriptLoader {
                         .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("praecantatio"), 64)
                         .add(Aspect.getAspect("permutatio"), 32),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 0, missing),
-                new ItemStack[] { getModItem(WarpTheory.ID, "item.warptheory.cleanser", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        getModItem(WarpTheory.ID, "item.warptheory.cleanser", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.gemFlawless, Materials.Diamond, 1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
-                        GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Gold, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Thaumium, 1L), });
+                getModItem(WarpTheory.ID, "item.warptheory.cleanser", 1, 0, missing),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                getModItem(WarpTheory.ID, "item.warptheory.cleanser", 1, 0, missing),
+                OrePrefixes.screw.get(Materials.Thaumium),
+                OrePrefixes.gemFlawless.get(Materials.Diamond),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 14, missing),
+                OrePrefixes.ingot.get(Materials.Ichorium),
+                OrePrefixes.plate.get(Materials.Gold),
+                OrePrefixes.screw.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "warptheory.amulet",
                 new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("auram"), 15)
@@ -210,7 +208,7 @@ public class ScriptWarpTheory implements IScriptLoader {
         TCHelper.orphanResearch("warptheory.portableshower");
         TCHelper.clearPrereq("warptheory.portableshower");
         TCHelper.addResearchPrereq("warptheory.portableshower", "PURETEAR", false);
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "warptheory.portableshower",
                 getModItem(WarpTheory.ID, "item.warptheory.portableshower", 1, 0, missing),
                 64,
@@ -220,15 +218,15 @@ public class ScriptWarpTheory implements IScriptLoader {
                         .add(Aspect.getAspect("cognitio"), 256).add(Aspect.getAspect("tutamen"), 256)
                         .add(Aspect.getAspect("sano"), 1024),
                 getModItem(WarpTheory.ID, "item.warptheory.amulet", 1, 0, missing),
-                new ItemStack[] { getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
-                        getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 12, missing),
-                        getModItem(ThaumicExploration.ID, "everfullUrn", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 0, missing),
-                        getModItem(OpenBlocks.ID, "sprinkler", 1, 0, missing),
-                        GTOreDictUnificator.get(OrePrefixes.pipeTiny, Materials.Neutronium, 1L),
-                        getModItem(OpenBlocks.ID, "xpshower", 1, 0, missing),
-                        getModItem(Thaumcraft.ID, "ItemEldritchObject", 1L, 3),
-                        GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.Ichorium, 1L) });
+                getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1, missing),
+                getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 12, missing),
+                getModItem(ThaumicExploration.ID, "everfullUrn", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 0, missing),
+                getModItem(OpenBlocks.ID, "sprinkler", 1, 0, missing),
+                OrePrefixes.pipeTiny.get(Materials.Neutronium),
+                getModItem(OpenBlocks.ID, "xpshower", 1, 0, missing),
+                getModItem(Thaumcraft.ID, "ItemEldritchObject", 1L, 3),
+                OrePrefixes.plateSuperdense.get(Materials.Ichorium));
         TCHelper.setResearchAspects(
                 "warptheory.portableshower",
                 new AspectList().add(Aspect.getAspect("custom1"), 5).add(Aspect.getAspect("custom3"), 5)

--- a/src/main/java/com/dreammaster/scripts/ScriptWitchery.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptWitchery.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidRegistry;
 
@@ -563,7 +562,7 @@ public class ScriptWitchery implements IScriptLoader {
                                 new ResearchPage("Witchery.research_page.RUBYSLIPPERS.1"),
                                 new ResearchPage("Witchery.research_page.RUBYSLIPPERS.2"))
                         .registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "RUBYSLIPPERS",
                 getModItem(Witchery.ID, "rubyslippers", 1, 0, missing),
                 5,
@@ -571,14 +570,16 @@ public class ScriptWitchery implements IScriptLoader {
                         .add(Aspect.getAspect("lucrum"), 32).add(Aspect.getAspect("potentia"), 16)
                         .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("fames"), 32),
                 getModItem(Witchery.ID, "seepingshoes", 1, 0, missing),
-                new ItemStack[] { getModItem(Witchery.ID, "ingredient", 1, 80, missing),
-                        CustomItemList.ManyullynCrystal.get(1L), getModItem(Witchery.ID, "ingredient", 1, 34, missing),
-                        getModItem(BloodArsenal.ID, "blood_burned_string", 1, 0, missing),
-                        CustomItemList.ManyullynCrystal.get(1L), getModItem(Witchery.ID, "ingredient", 1, 80, missing),
-                        CustomItemList.ManyullynCrystal.get(1L),
-                        getModItem(BloodArsenal.ID, "blood_burned_string", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 34, missing),
-                        CustomItemList.ManyullynCrystal.get(1L), });
+                getModItem(Witchery.ID, "ingredient", 1, 80, missing),
+                CustomItemList.ManyullynCrystal.get(1L),
+                getModItem(Witchery.ID, "ingredient", 1, 34, missing),
+                getModItem(BloodArsenal.ID, "blood_burned_string", 1, 0, missing),
+                CustomItemList.ManyullynCrystal.get(1L),
+                getModItem(Witchery.ID, "ingredient", 1, 80, missing),
+                CustomItemList.ManyullynCrystal.get(1L),
+                getModItem(BloodArsenal.ID, "blood_burned_string", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 34, missing),
+                CustomItemList.ManyullynCrystal.get(1L));
         TCHelper.addResearchPage(
                 "RUBYSLIPPERS",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Witchery.ID, "rubyslippers", 1, 0, missing))));
@@ -951,17 +952,19 @@ public class ScriptWitchery implements IScriptLoader {
                 3,
                 getModItem(Witchery.ID, "filteredfumefunnel", 1, 0, missing)).setParents("FUMEFILTER").setConcealed()
                         .setPages(new ResearchPage("Witchery.research_page.FILTEREDFUMEFUNNEL")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "FILTEREDFUMEFUNNEL",
                 getModItem(Witchery.ID, "filteredfumefunnel", 1, 0, missing),
                 3,
                 new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("vitreus"), 8)
                         .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("lux"), 16),
                 getModItem(Witchery.ID, "fumefunnel", 1, 0, missing),
-                new ItemStack[] { CustomItemList.SteelBars.get(1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing), CustomItemList.SteelBars.get(1L),
-                        getModItem(Witchery.ID, "ingredient", 1, 73, missing), CustomItemList.SteelBars.get(1L),
-                        getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing), });
+                CustomItemList.SteelBars.get(1L),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing),
+                CustomItemList.SteelBars.get(1L),
+                getModItem(Witchery.ID, "ingredient", 1, 73, missing),
+                CustomItemList.SteelBars.get(1L),
+                getModItem(Thaumcraft.ID, "ItemResource", 1, 8, missing));
         TCHelper.addResearchPage(
                 "FILTEREDFUMEFUNNEL",
                 new ResearchPage(
@@ -977,7 +980,7 @@ public class ScriptWitchery implements IScriptLoader {
                 3,
                 getModItem(Witchery.ID, "ingredient", 1, 12, missing)).setParents("RITUALCHALK").setConcealed()
                         .setPages(new ResearchPage("Witchery.research_page.WAYSTONE")).registerResearchItem();
-        ThaumcraftApi.addInfusionCraftingRecipe(
+        TCHelper.addInfusionCraftingRecipe(
                 "WAYSTONE",
                 getModItem(Witchery.ID, "ingredient", 1, 12, missing),
                 5,
@@ -985,14 +988,14 @@ public class ScriptWitchery implements IScriptLoader {
                         .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("tenebrae"), 32)
                         .add(Aspect.getAspect("aer"), 64),
                 getModItem(Minecraft.ID, "flint", 1, 0, missing),
-                new ItemStack[] { getModItem(Witchery.ID, "chalkritual", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 7, missing),
-                        getModItem(Witchery.ID, "chalkotherwhere", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 7, missing),
-                        getModItem(Witchery.ID, "chalkritual", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 7, missing),
-                        getModItem(Witchery.ID, "chalkotherwhere", 1, 0, missing),
-                        getModItem(Witchery.ID, "ingredient", 1, 7, missing), });
+                getModItem(Witchery.ID, "chalkritual", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 7, missing),
+                getModItem(Witchery.ID, "chalkotherwhere", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 7, missing),
+                getModItem(Witchery.ID, "chalkritual", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 7, missing),
+                getModItem(Witchery.ID, "chalkotherwhere", 1, 0, missing),
+                getModItem(Witchery.ID, "ingredient", 1, 7, missing));
         TCHelper.addResearchPage(
                 "WAYSTONE",
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Witchery.ID, "ingredient", 1, 12, missing))));

--- a/src/main/java/com/dreammaster/thaumcraft/TCHelper.java
+++ b/src/main/java/com/dreammaster/thaumcraft/TCHelper.java
@@ -5,12 +5,14 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
+import net.glease.tc4tweak.api.infusionrecipe.InfusionRecipeExt;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
 
 import org.apache.commons.lang3.ArrayUtils;
 
+import gregtech.api.objects.ItemData;
 import gregtech.api.util.GTUtility;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.AspectList;
@@ -299,5 +301,14 @@ public class TCHelper {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static InfusionRecipe addInfusionCraftingRecipe(String research, ItemStack result, int instability,
+            AspectList aspects, Object input, Object... recipe) {
+        if (input instanceof ItemData) input = input.toString();
+        for (int i = 0; i < recipe.length; i++) {
+            if (recipe[i] instanceof ItemData) recipe[i] = recipe[i].toString();
+        }
+        return InfusionRecipeExt.get().addInfusionCraftingRecipe(research, result, instability, aspects, input, recipe);
     }
 }


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14631 and maybe some other instances.

In case there are other cases where implicit oredict can be problematic, I did an semi-automatic refactor to refactor all infusion recipes defined by this mod to
1. If it's clear that the ingredient is something from oredict, i.e. GTOreDictUnificator.get(), it's now specified to use that oredict name explicitly.
2. Otherwise, the new recipe will accept the original item passed in **only**, and its oredict substitutes (if any) will be rejected.

I did not look at every recipe modified and there might be cases where oredict would have been desired and I'm ready to correct them as soon as possible.

This changes all infusion recipes defined by coremod to use the new InfusionRecipe subclass from [TC4RecipeLib](https://github.com/Glease/TC4RecipeLib).
Quoting its README,

> This library provides an InfusionRecipe subclass with enhanced oredict handling capabilities.
>
> The basic InfusionRecipe class offered by thaumcraft itself uses a broken oredict handling algorithm.
It is broken in these ways:
> 1. Unconditionally and implicitly do oredict on all inputs. For instance, If your recipe require a specific type of wood (such as warpwood from Tainted Magic), thaumcraft will automatically allow any other kind of wood as well.
> 2. Only considers the first oredict name of the specified stack, and only check if any oredict name of player supplied ingredient is that first oredict name. This is problematic when items have more than one oredict name.
>
> This library, on the other hand, require mod author to give explicit instruction on whether oredict is needed.
It unifies various kinds of input under one interface RecipeIngredient.
Library itself provides a few implementation to handle common use cases and you should not need to implement your own subclass.

For more information, please refer to its complete README.

Related to https://github.com/GTNewHorizons/TCNEIAdditions/pull/32 and these 2 should be merged together.

@Dream-Master if this is to be merged, please be sure to upgrade TC4Tweaks to 1.5.37