### PR TITLE
Fix: Remove direct Macerator Recipe which causes issue with nei-custom-diagrams

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -1909,9 +1909,6 @@ public class ScriptGalacticraft implements IScriptLoader {
     }
 
     private void maceratorRecipes() {
-        GTValues.RA.stdBuilder().itemInputs(getModItem(GalacticraftMars.ID, "item.null", 1, 0, missing))
-                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.Desh, 1L)).outputChances(10000)
-                .duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);
         GTValues.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "tile.fallenMeteor", 1, 0, missing))
                 .itemOutputs(getModItem(GalacticraftCore.ID, "item.meteoricIronRaw", 2, 0, missing))
                 .outputChances(10000).duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);


### PR DESCRIPTION
# Currently:
<img width="419" height="823" alt="desh" src="https://github.com/user-attachments/assets/a0f9fa24-ab29-44ec-9dcc-426884f71345" />

# With this fix:
<img width="419" height="823" alt="desh_fixed" src="https://github.com/user-attachments/assets/e05f6425-9fbf-4a80-96a7-dd465fccb58f" />

# Issue

In [NeiCustomDiagram we remove](https://github.com/GTNewHorizons/nei-custom-diagram/blob/master/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/RecipeHandler.java#L218) recipes from the output if there is more than one.

With this [PR](https://github.com/GTNewHorizons/GT5-Unofficial/pull/4540) in GT5U Desh became an ore-dict which causes it now to have two macerator recipes.

# Solution
Remove the now clashing of the Macerator Recipe for Desh Ore since its now handled via the oredict


