### PR TITLE
bring tantalum freeze time to a reasonable level

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/VacuumFreezerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/VacuumFreezerRecipes.java
@@ -81,7 +81,7 @@ public class VacuumFreezerRecipes implements Runnable {
 
         GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.ingotHot, Materials.Tantalum, 1L))
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Tantalum, 1L))
-                .duration(26 * SECONDS + 1 * TICKS).eut(TierEU.RECIPE_HV).addTo(vacuumFreezerRecipes);
+                .duration(12 * SECONDS + 10 * TICKS).eut(TierEU.RECIPE_HV).addTo(vacuumFreezerRecipes);
 
         GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.ingotHot, Materials.EnderiumBase, 1L))
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.EnderiumBase, 1L))


### PR DESCRIPTION
Tantalum was a major outlier in freezing time (longer to cool than HSSG or TungstenSteel ingots), this PR brings more in line. MV chembatch recipe untouched