### PR TITLE
Set Melodic alloy recipe to 3840 eu/t to leave cable headroom when using MVF

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/VacuumFreezerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/VacuumFreezerRecipes.java
@@ -51,7 +51,7 @@ public class VacuumFreezerRecipes implements Runnable {
 
         GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.ingotHot, Materials.MelodicAlloy, 1L))
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.MelodicAlloy, 1L))
-                .duration(36 * SECONDS + 19 * TICKS).eut(4096).addTo(vacuumFreezerRecipes);
+                .duration(36 * SECONDS + 19 * TICKS).eut(3840).addTo(vacuumFreezerRecipes);
 
         GTValues.RA.stdBuilder()
                 .itemInputs(GTOreDictUnificator.get(OrePrefixes.ingotHot, Materials.CrystallinePinkSlime, 1L))


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20859

The MVF will run 32 parallels of Melodic alloy at the current 4096 EU/t which is exactly 4A of LuV and will eventually power fail after a couple of blocks of cable unless using superconductor.

Changing the cost to 3840 EU/t addresses this and makes the MVF do 34 parallels in 130,560 EU/t instead.