### PR TITLE
Remove Crop-Matron Recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptIndustrialCraft.java
@@ -755,17 +755,6 @@ public class ScriptIndustrialCraft implements IScriptLoader {
                 getModItem(IndustrialCraft2.ID, "itemBatREDischarged", 1, 0, missing),
                 "craftingToolScrewdriver");
         addShapedRecipe(
-                getModItem(IndustrialCraft2.ID, "blockMachine2", 1, 2, missing),
-                getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0, missing),
-                "chestIron",
-                getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0, missing),
-                "itemCasingSteel",
-                ItemList.Casing_LV.get(1L),
-                "itemCasingSteel",
-                "circuitBasic",
-                ItemList.Electric_Motor_LV.get(1L),
-                "circuitBasic");
-        addShapedRecipe(
                 getModItem(IndustrialCraft2.ID, "blockMachine3", 1, 6, missing),
                 "itemCasingAnyIron",
                 "itemCasingAnyIron",


### PR DESCRIPTION
### Changes:
- Removes IC2 crop matron recipe. 

The Crop-Matron only works reliably with some crops, and it's associated with a few glitches as it stands (including transforming into a teleporter when broken) We have a wonderful, feature packed, fully working block intended for usage; the Crop Manager. (alongside other farming options of course) 

It's partner in crime, the harvester is the same story but worse. (It already doesn't have a recipe)

I am sparingly labeling this as 'affects balance' because in some way it does, but there are alternate automatic farming options cheaper & slightly more expensive (and far less buggy) than this machine so the effects on balance would be minimal.

See this for more detail: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/20904
Only Merge this if this passes ^^^ I will close this PR in the event that it doesn't.