### PR TITLE
Remove Silver melting since there isn't any silver casting

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
@@ -1829,6 +1829,7 @@ public class ScriptTinkersConstruct implements IScriptLoader {
         TConstructHelper.removeTableRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Platinum, 1L));
         TConstructHelper.removeTableRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Nickel, 1L));
         TConstructHelper.removeTableRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Silver, 1L));
+        TConstructHelper.removeMeltingRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Silver, 1L));
         TConstructHelper.removeTableRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Electrum, 1L));
         TConstructHelper.removeTableRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Invar, 1L));
         TConstructHelper.removeTableRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Lead, 1L));
@@ -2072,14 +2073,6 @@ public class ScriptTinkersConstruct implements IScriptLoader {
                         GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Nickel, 1L),
                         GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Nickel, 1L),
                         GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Nickel, 1L));
-        TConstructHelper
-                .getMeltingAdder(GameRegistry.findBlock("gregtech", "gt.blockores"), 54, 500, "silver.molten", 144).add(
-                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Silver, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Silver, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Silver, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Silver, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Silver, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Silver, 1L));
         TConstructHelper
                 .getMeltingAdder(GameRegistry.findBlock("gregtech", "gt.blockores"), 85, 800, "platinum.molten", 144)
                 .add(


### PR DESCRIPTION
The issue comes back out every once in a while, but nothing happened, so here you go. Lead doesn't have casting, and the same issue was fixed by removing its melting.

fixes [#20480](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20840)
fixes [#16044](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16044)