### PR TITLE
Add recipe for crushed obsidian

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/ForgeHammerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ForgeHammerRecipes.java
@@ -138,6 +138,11 @@ public class ForgeHammerRecipes implements Runnable {
                     .itemOutputs(GTModHandler.getModItem(Botania.ID, "manaResource", 9L, 8)).duration(16 * TICKS)
                     .eut(TierEU.RECIPE_LV).addTo(hammerRecipes);
         }
+        if (Railcraft.isModLoaded()) {
+            GTValues.RA.stdBuilder().itemInputs(new ItemStack(Blocks.obsidian, 1))
+                    .itemOutputs(getModItem(Railcraft.ID, "cube", 1, 4, missing)).duration(2 * SECONDS)
+                    .eut(TierEU.RECIPE_LV).addTo(hammerRecipes);
+        }
 
         // Raw optical chip
         int chip_duration_ticks = 10 * SECONDS;


### PR DESCRIPTION
<img width="346" height="331" alt="grafik" src="https://github.com/user-attachments/assets/082bd79d-9d10-40a6-94bc-32210e78bd44" />

As crushed obsidian only has a blast resistance of 27 and isn't used in any recipes, I tiered it to LV.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19369