### PR TITLE
Adds Recipe for Super Stock Replenisher & Makes Void Cell Recipe Consistent

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -5149,7 +5149,7 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.screw, Materials.CertusQuartz, 2L),
                         GTOreDictUnificator.get(OrePrefixes.plate, Materials.CertusQuartz, 1L),
                         GTOreDictUnificator.get(OrePrefixes.plate, Materials.Tungsten, 3L),
-                        GTOreDictUnificator.get(OrePrefixes.gem, Materials.EnderEye, 1),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 47),
                         GTUtility.getIntegratedCircuit(2))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "item.ItemVoidStorageCell", 1)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -11,7 +11,6 @@ import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.GalacticraftAmunRa;
 import static gregtech.api.enums.Mods.GraviSuite;
-import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.SGCraft;
 import static gregtech.api.util.GTModHandler.getModItem;
@@ -1803,11 +1802,11 @@ public class AssemblingLineRecipes implements Runnable {
 
         if (AE2FluidCraft.isModLoaded()) {
             // Super Stock Replenisher
-            GTValues.RA.stdBuilder().metadata(RESEARCH_ITEM, getModItem(GregTech.ID, "gt.blockmachines", 1, 2717))
+            GTValues.RA.stdBuilder().metadata(RESEARCH_ITEM, ItemList.Hatch_Input_ME.get(1))
                     .metadata(SCANNING, new Scanning(2 * MINUTES, TierEU.RECIPE_UV))
                     .itemInputs(
-                            getModItem(GregTech.ID, "gt.blockmachines", 1, 2718),
-                            getModItem(GregTech.ID, "gt.blockmachines", 1, 2717),
+                            ItemList.Hatch_Input_Bus_ME.get(1L),
+                            ItemList.Hatch_Input_ME.get(1),
                             getModItem(AppliedEnergistics2.ID, "tile.BlockController", 1, 0),
                             getModItem(AppliedEnergistics2.ID, "tile.BlockChest", 1, 0),
                             getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4, 27),

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -3,6 +3,7 @@ package com.dreammaster.gthandler.recipes;
 import static bartworks.system.material.WerkstoffLoader.Californium;
 import static com.dreammaster.scripts.IScriptLoader.missing;
 import static gregtech.api.enums.GTValues.L;
+import static gregtech.api.enums.Mods.AE2FluidCraft;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.Computronics;
@@ -10,6 +11,7 @@ import static gregtech.api.enums.Mods.EtFuturumRequiem;
 import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.GalacticraftAmunRa;
 import static gregtech.api.enums.Mods.GraviSuite;
+import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.SGCraft;
 import static gregtech.api.util.GTModHandler.getModItem;
@@ -1798,6 +1800,25 @@ public class AssemblingLineRecipes implements Runnable {
                 ItemRefer.AntimatterAnnihilationMatrix.get(4),
                 60 * SECONDS,
                 (int) TierEU.RECIPE_UIV);
+
+        if (AE2FluidCraft.isModLoaded()) {
+            // Super Stock Replenisher
+            GTValues.RA.stdBuilder().metadata(RESEARCH_ITEM, getModItem(GregTech.ID, "gt.blockmachines", 1, 2717))
+                    .metadata(SCANNING, new Scanning(2 * MINUTES, TierEU.RECIPE_UV))
+                    .itemInputs(
+                            getModItem(GregTech.ID, "gt.blockmachines", 1, 2718),
+                            getModItem(GregTech.ID, "gt.blockmachines", 1, 2717),
+                            getModItem(AppliedEnergistics2.ID, "tile.BlockController", 1, 0),
+                            getModItem(AppliedEnergistics2.ID, "tile.BlockChest", 1, 0),
+                            getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4, 27),
+                            getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 4, 56))
+                    .fluidInputs(
+                            Materials.Naquadria.getMolten(1_152L),
+                            MaterialsAlloy.INDALLOY_140.getFluidStack(1152),
+                            FluidRegistry.getFluidStack("lubricant", 2000))
+                    .itemOutputs(getModItem(AE2FluidCraft.ID, "super_stock_replenisher", 1, 0)).duration(30 * SECONDS)
+                    .eut((int) TierEU.RECIPE_UV).addTo(AssemblyLine);
+        }
 
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
@@ -590,7 +590,7 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
                 "plateCertusQuartz",
                 "screwCertusQuartz",
                 "plateTungsten",
-                "gemEnderEye",
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 47),
                 "plateTungsten",
                 "screwCertusQuartz",
                 "plateTungsten",


### PR DESCRIPTION
### Changes:
- Adds in recipe for super stock replenisher, UV gated since it performs UV gated actions (stocks fluids)
- Changes void cell recipe to more closely mimic the fluid void cell recipe (replaced ender eye with ae2 singularity)

(There will also be a quest for SSR it's coming in a sweep probably tomorrow)

### Super Stock Replenisher Recipe:
<img width="508" height="434" alt="image" src="https://github.com/user-attachments/assets/b75ee44f-58d4-4171-b60c-2c60de4a7b3e" />
<img width="514" height="437" alt="image" src="https://github.com/user-attachments/assets/22543476-d31b-4fa4-bb27-db3a49720328" />

### Void Cell Change: (Void Cell on Left, Fluid on Right)
<img width="341" height="291" alt="image" src="https://github.com/user-attachments/assets/4e69f737-dbfa-4633-95d0-b56737ece79f" />
<img width="342" height="292" alt="image" src="https://github.com/user-attachments/assets/9b53147b-8ea4-424a-bc81-7eae7f4316d5" />
