### PR TITLE
Adds Alternate Rubber Recipes for EIO Conduit Binder

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalBathRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalBathRecipes.java
@@ -258,6 +258,20 @@ public class ChemicalBathRecipes implements Runnable {
                             getModItem(EnderIO.ID, "itemMaterial", 1, 1, missing))
                     .outputChances(10000, 9000, 5000).fluidInputs(Materials.Rubber.getMolten(144L))
                     .duration(10 * SECONDS).eut(2).addTo(chemicalBathRecipes);
+            GTValues.RA.stdBuilder().itemInputs(getModItem(EnderIO.ID, "itemMaterial", 1, 2, missing))
+                    .itemOutputs(
+                            getModItem(EnderIO.ID, "itemMaterial", 2, 1, missing),
+                            getModItem(EnderIO.ID, "itemMaterial", 2, 1, missing),
+                            getModItem(EnderIO.ID, "itemMaterial", 2, 1, missing))
+                    .outputChances(10000, 10000, 10000).fluidInputs(Materials.Silicone.getMolten(144L))
+                    .duration(10 * SECONDS).eut(2).addTo(chemicalBathRecipes);
+            GTValues.RA.stdBuilder().itemInputs(getModItem(EnderIO.ID, "itemMaterial", 1, 2, missing))
+                    .itemOutputs(
+                            getModItem(EnderIO.ID, "itemMaterial", 2, 1, missing),
+                            getModItem(EnderIO.ID, "itemMaterial", 2, 1, missing),
+                            getModItem(EnderIO.ID, "itemMaterial", 2, 1, missing))
+                    .outputChances(10000, 10000, 10000).fluidInputs(Materials.StyreneButadieneRubber.getMolten(144L))
+                    .duration(10 * SECONDS).eut(2).addTo(chemicalBathRecipes);
         }
 
         if (PamsHarvestCraft.isModLoaded()) {


### PR DESCRIPTION
### Changes:
- Simple change, adds extra recipes using more expensive HV rubbers for guaranteed EIO conduit binder out of chemical bath.

The regular recipe takes normal rubber and makes it a percent chance output, which is messy for AE2 recipes. The more expensive later tier rubber giving access to slightly more of this relatively insignificant resource should not create any balance problem and would only serve as QoL. 

(There's no issue to reference on this, it's just a feature I've seen requested by a lot of players)

### Current Solo Recipe:
<img width="520" height="436" alt="image" src="https://github.com/user-attachments/assets/729d63a5-f228-49f2-a051-61354c1faedb" />


### New Recipes:
<img width="515" height="330" alt="image" src="https://github.com/user-attachments/assets/14e84ccf-cc9a-48f6-9e29-1c1cb71528dd" />
<img width="517" height="437" alt="image" src="https://github.com/user-attachments/assets/21a4fbb7-5e7e-4613-b2f6-51ad24ae5712" />
