### PR TITLE
Remove the rest of the gear smelting and several metals

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
@@ -1859,6 +1859,11 @@ public class ScriptTinkersConstruct implements IScriptLoader {
         TConstructHelper.removeTableRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Enderium, 1L));
         TConstructHelper.removeTableRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Ardite, 1L));
         TConstructHelper.removeTableRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Manyullyn, 1L));
+        TConstructHelper.removeMeltingRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Invar, 1L));
+        TConstructHelper.removeMeltingRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Electrum, 1L));
+        TConstructHelper.removeMeltingRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Platinum, 1L));
+        TConstructHelper.removeMeltingRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Nickel, 1L));
+        TConstructHelper.removeMeltingRecipe(GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Enderium, 1L));
         TConstructHelper.removeTableRecipe(getModItem(TinkerConstruct.ID, "materials", 1, 29, missing));
         TConstructHelper.removeTableRecipe(getModItem(TinkerConstruct.ID, "materials", 1, 30, missing));
         TConstructHelper.removeTableRecipe(getModItem(TinkerConstruct.ID, "materials", 1, 4, missing));
@@ -1869,6 +1874,7 @@ public class ScriptTinkersConstruct implements IScriptLoader {
         TConstructHelper.removeMeltingRecipe(getModItem(ExtraUtilities.ID, "cobblestone_compressed", 1, 14, missing));
         TConstructHelper.removeMeltingRecipe(getModItem(ExtraUtilities.ID, "cobblestone_compressed", 1, 15, missing));
         TConstructHelper.removeBasinRecipe(getModItem(IndustrialCraft2.ID, "blockMetal", 1, 5, missing));
+        TConstructHelper.removeMeltingRecipe(getModItem(Thaumcraft.ID, "ItemNugget", 1, 19, missing));
         TConstructHelper
                 .getMeltingAdder(
                         GameRegistry.findBlock("gregtech", "gt.blockmachines"),
@@ -2065,23 +2071,6 @@ public class ScriptTinkersConstruct implements IScriptLoader {
                 GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Aluminium, 1L),
                 GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Aluminium, 1L),
                 GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Aluminium, 1L));
-        TConstructHelper
-                .getMeltingAdder(GameRegistry.findBlock("gregtech", "gt.blockores"), 34, 400, "nickel.molten", 144).add(
-                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Nickel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Nickel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Nickel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Nickel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Nickel, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Nickel, 1L));
-        TConstructHelper
-                .getMeltingAdder(GameRegistry.findBlock("gregtech", "gt.blockores"), 85, 800, "platinum.molten", 144)
-                .add(
-                        GTOreDictUnificator.get(OrePrefixes.ore, Materials.Platinum, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Platinum, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreNetherrack, Materials.Platinum, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreEndstone, Materials.Platinum, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreBlackgranite, Materials.Platinum, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.oreRedgranite, Materials.Platinum, 1L));
         TConstructHelper.getMeltingAdder(FluidType.getFluidType("Emerald"), 225, 640).add(
                 new ItemStack(GregTechAPI.sBlockOres1, 1, 501),
                 GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.Emerald, 1L),

--- a/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
@@ -1896,6 +1896,12 @@ public class ScriptTinkersConstruct implements IScriptLoader {
                 0,
                 800,
                 FluidRegistry.getFluidStack("glass.molten", 1000));
+        Smeltery.addMelting(
+                GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Electrum, 1L),
+                GameRegistry.findBlock("TConstruct", "MetalBlock"),
+                7,
+                400,
+                FluidRegistry.getFluidStack("electrum.molten", 144));
         TConstructRegistry.getTableCasting().addCastingRecipe(
                 GTOreDictUnificator.get(OrePrefixes.nugget, Materials.Copper, 1L),
                 FluidRegistry.getFluidStack("copper.molten", 16),


### PR DESCRIPTION
istg I hope this is it. This removes the nickel and platinum ores that have smelting added for some reason, removes gear melting for a few alloys and nickel, and finally fucking removes the damned silver cluster recipe. Also adds electrum ingot melting for the purpose of making brownstone. 

Also! Those cluster recipes are added by witching gadgets, which adds iron, gold, copper, tin, silver, but not lead for some reason. idk if we want to remove the recipes from there directly, but yeah.

tested in full pack since apparently neither the scripts nor thaumcraft are in the dev env, and its 4am and I cant be assed to figure it out rn