### PR TITLE
EFR Copper Singleblock CR Recipe Fix

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptEFR.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEFR.java
@@ -2028,13 +2028,14 @@ public class ScriptEFR implements IScriptLoader {
 
         // x20 to keep the same ratio as the LCR
         ItemStack singleBlockInput = GTUtility.copyAmount(20, lessOxidized);
+        ItemStack singleBlockOutput = GTUtility.copyAmount(20, moreOxidized);
 
         GTValues.RA.stdBuilder().itemInputs(singleBlockInput, Materials.CarbonDioxide.getCells(2))
-                .itemOutputs(moreOxidized, getModItem(IndustrialCraft2.ID, "itemCellEmpty", 2L, 0))
+                .itemOutputs(singleBlockOutput, getModItem(IndustrialCraft2.ID, "itemCellEmpty", 2L, 0))
                 .fluidInputs(Materials.Oxygen.getGas(1000L)).duration(20 * SECONDS).eut(30)
                 .addTo(chemicalReactorRecipes);
         GTValues.RA.stdBuilder().itemInputs(singleBlockInput, Materials.Oxygen.getCells(1))
-                .itemOutputs(moreOxidized, getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1L, 0))
+                .itemOutputs(singleBlockOutput, getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1L, 0))
                 .fluidInputs(Materials.CarbonDioxide.getGas(2000L)).duration(20 * SECONDS).eut(30)
                 .addTo(chemicalReactorRecipes);
         GTValues.RA.stdBuilder().itemInputs(moreOxidized).itemOutputs(lessOxidized)


### PR DESCRIPTION
### Changes:
- Gives correct amount of outputs for a load of singleblock CR copper recipes, was 1, is now 20. This was an oversight before.

### Pre-Fix:
<img width="450" height="361" alt="image" src="https://github.com/user-attachments/assets/da542e05-dd78-4d26-8e7b-1a0879b44f50" />

### Post-Fix::
<img width="352" height="270" alt="image" src="https://github.com/user-attachments/assets/8af4ec3e-7630-4879-b12e-c7cc5ea250c3" />
