### PR TITLE
Add Chisel recipe for EFR Concrete and Concrete Powder

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptEFR.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEFR.java
@@ -2034,6 +2034,17 @@ public class ScriptEFR implements IScriptLoader {
         addOxidizedCopperDoors();
         addOxidizedCopperTrapdoors();
         addOxidizedCopperBlocks();
+
+        // Concrete
+        for (int i = 0; i < 16; i++) {
+            ItemStack efrConcrete = getModItem(EtFuturumRequiem.ID, "concrete", 1L, i);
+            if (efrConcrete == null) continue;
+            ChiselHelper.addVariationFromStack("hempcrete", efrConcrete);
+
+            ItemStack efrConcretePowder = getModItem(EtFuturumRequiem.ID, "concrete_powder", 1L, i);
+            if (efrConcretePowder == null) continue;
+            ChiselHelper.addVariationFromStack("hempcretesand", efrConcretePowder);
+        }
     }
 
     // Oxidation Functions


### PR DESCRIPTION
Adds EFR concrete variants to the hempcrete and hempcrete powder chisel groups
This PR does not change anything by itself, it should be approved along with https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/21105, which enables concrete in the EFR configs

Block color comparison, rows 1 and 3 from the the are Hempcrete, rows 2 and 4 are concrete:
<img width="2560" height="1421" alt="image" src="https://github.com/user-attachments/assets/49e153c9-0870-4ac9-b7d9-3e0164d20708" />

Hempcrete chisel group:
<img width="598" height="553" alt="image" src="https://github.com/user-attachments/assets/424fe401-e976-40a7-b4ed-8f0feaca73f9" />

Hempcrete Powder chisel group:
<img width="603" height="558" alt="image" src="https://github.com/user-attachments/assets/022cfa85-5208-414b-9581-54967b49f701" />