### PR TITLE
Fix prototype MM power core recipe not using oredict for circuit

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptMatterManipulator.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMatterManipulator.java
@@ -77,7 +77,7 @@ public class ScriptMatterManipulator implements IScriptLoader {
                         GTOreDictUnificator.get(OrePrefixes.itemCasing, Materials.StainlessSteel, 8),
                         getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, WILDCARD), // energy crystal
                         GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.SuperconductorHV, 12),
-                        new Object[] { OrePrefixes.circuit.get(Materials.HV), 2 },
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.HV, 2),
                         GTOreDictUnificator.get(OrePrefixes.screw, Materials.StainlessSteel, 16))
                 .fluidInputs(Materials.SolderingAlloy.getMolten(L * 4)).itemOutputs(MMItemList.PowerCore0.get(1))
                 .eut((int) TierEU.RECIPE_HV).duration(20 * SECONDS).addTo(RecipeMaps.assemblerRecipes);


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20942

The recipe previously was only accepting the advanced circuit from IC2.