### PR TITLE
Restore overwritten recipes for Warding, Portable Hole, Nine Hells foci

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
@@ -1333,11 +1333,11 @@ public class ScriptThaumcraft implements IScriptLoader {
                 OrePrefixes.lens.get(Materials.NetherStar),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                getModItem(Minecraft.ID, "quartz", 1, 1, missing),
+                getModItem(Botania.ID, "quartz", 1, 1, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 3, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
-                getModItem(Minecraft.ID, "quartz", 1, 1, missing),
+                getModItem(Botania.ID, "quartz", 1, 1, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4, missing));
         TCHelper.setResearchAspects(
                 "FOCUSWARDING",
@@ -1353,11 +1353,11 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("perditio"), 20).add(Aspect.getAspect("permutatio"), 10)
                         .add(Aspect.getAspect("praecantatio"), 5),
                 OrePrefixes.lens.get(Materials.EnderPearl),
-                getModItem(Minecraft.ID, "quartz", 1, 1, missing),
+                getModItem(Botania.ID, "quartz", 1, 1, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
-                getModItem(Minecraft.ID, "quartz", 1, 1, missing),
+                getModItem(Botania.ID, "quartz", 1, 1, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3, missing));
@@ -1376,11 +1376,11 @@ public class ScriptThaumcraft implements IScriptLoader {
                         .add(Aspect.getAspect("bestia"), 20).add(Aspect.getAspect("perditio"), 10)
                         .add(Aspect.getAspect("praecantatio"), 5),
                 OrePrefixes.lens.get(Materials.Firestone),
-                getModItem(Minecraft.ID, "quartz", 1, 4, missing),
+                getModItem(Botania.ID, "quartz", 1, 4, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
-                getModItem(Minecraft.ID, "quartz", 1, 4, missing),
+                getModItem(Botania.ID, "quartz", 1, 4, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1, missing),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0, missing));


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21114

https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1324 changed the recipes for the three foci. They were accidentally overwritten which also caused the linked issue. This PR restores them to the intended Botania quartz variants.

Recipes now:
<img width="509" height="455" alt="image" src="https://github.com/user-attachments/assets/92dec31b-65a1-4281-a2cf-5aaf591349a5" />
<img width="510" height="453" alt="image" src="https://github.com/user-attachments/assets/d80fbbdb-1657-4a11-951a-8855cc1422b2" />
<img width="511" height="452" alt="image" src="https://github.com/user-attachments/assets/e707a170-107b-4ef1-98c8-ae92ab049ac1" />
