### PR TITLE
Aligns Air Filter T1 crafting table recipe with assembler

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -615,7 +615,7 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
                 bits,
                 new Object[] { "RPR", "MBM", "CGC", 'B', ItemList.Hull_LV, 'R', OrePrefixes.rotor.get(Materials.Steel),
                         'P', ItemList.Electric_Pump_LV, 'M', ItemList.Electric_Motor_LV, 'C',
-                        OrePrefixes.cableGt01.get(Materials.Copper), 'G', ItemList.Casing_Turbine });
+                        OrePrefixes.cableGt01.get(Materials.Copper), 'G', ItemList.Casing_AirFilter_Turbine_T1 });
         GTModHandler.addCraftingRecipe(
                 ItemList.Casing_AirFilter_Vent_T2.get(1L),
                 bits,


### PR DESCRIPTION
This PR https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1278 changed assembler recipes, but didn't touch crafting table one. This PR fixes it.
<img width="436" height="231" alt="image" src="https://github.com/user-attachments/assets/5b8264bd-398f-4242-8e6e-3c4c2ec0a2f3" />
before
<img width="452" height="193" alt="image" src="https://github.com/user-attachments/assets/e8b4997f-42c1-4ca6-9aa3-fa0f3d415899" />
after
<img width="439" height="270" alt="image" src="https://github.com/user-attachments/assets/2f7472ff-921d-4b76-b0f0-b437f431c7c0" />
