### PR TITLE
Change T2 and T3 air filter recipes.

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -633,7 +633,7 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
                 new Object[] { "RPR", "MBM", "CGC", 'B', ItemList.Hull_HV, 'R',
                         OrePrefixes.rotor.get(Materials.Titanium), 'P', ItemList.Electric_Pump_HV, 'M',
                         ItemList.Electric_Motor_HV, 'C', OrePrefixes.cableGt01.get(Materials.Gold), 'G',
-                        ItemList.Casing_Turbine2 });
+                        ItemList.Casing_AirFilter_Turbine_T2 });
         GTModHandler.addCraftingRecipe(
                 ItemList.Casing_AirFilter_Vent_T3.get(1L),
                 bits,
@@ -652,7 +652,7 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
                 new Object[] { "RPR", "MBM", "CGC", 'B', ItemList.Hull_IV, 'R',
                         OrePrefixes.rotor.get(Materials.TungstenSteel), 'P', ItemList.Electric_Pump_IV, 'M',
                         ItemList.Electric_Motor_IV, 'C', OrePrefixes.cableGt01.get(Materials.Tungsten), 'G',
-                        ItemList.Casing_Turbine3 });
+                        ItemList.Casing_AirFilter_Turbine_T3 });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Casing_Pyrolyse.get(1L),

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -4740,7 +4740,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Hull_HV.get(1L),
-                        ItemList.Casing_Turbine2.get(1L),
+                        ItemList.Casing_AirFilter_Turbine_T2.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Titanium, 1L),
                         ItemList.Electric_Motor_HV.get(2L),
                         ItemList.Electric_Pump_HV.get(1L),
@@ -4753,7 +4753,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Hull_HV.get(1L),
-                        ItemList.Casing_Turbine2.get(1L),
+                        ItemList.Casing_AirFilter_Turbine_T2.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Titanium, 1L),
                         ItemList.Electric_Motor_HV.get(2L),
                         ItemList.Electric_Pump_HV.get(1L),
@@ -4765,7 +4765,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Hull_HV.get(1L),
-                        ItemList.Casing_Turbine2.get(1L),
+                        ItemList.Casing_AirFilter_Turbine_T2.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.rotor, Materials.Titanium, 1L),
                         ItemList.Electric_Motor_HV.get(2L),
                         ItemList.Electric_Pump_HV.get(1L),
@@ -4830,7 +4830,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Hull_IV.get(1L),
-                        ItemList.Casing_Turbine3.get(1L),
+                        ItemList.Casing_AirFilter_Turbine_T3.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.rotor, Materials.TungstenSteel, 1L),
                         ItemList.Electric_Motor_IV.get(2L),
                         ItemList.Electric_Pump_IV.get(1L),
@@ -4843,7 +4843,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Hull_IV.get(1L),
-                        ItemList.Casing_Turbine3.get(1L),
+                        ItemList.Casing_AirFilter_Turbine_T3.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.rotor, Materials.TungstenSteel, 1L),
                         ItemList.Electric_Motor_IV.get(2L),
                         ItemList.Electric_Pump_IV.get(1L),
@@ -4855,7 +4855,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Hull_IV.get(1L),
-                        ItemList.Casing_Turbine3.get(1L),
+                        ItemList.Casing_AirFilter_Turbine_T3.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.rotor, Materials.TungstenSteel, 1L),
                         ItemList.Electric_Motor_IV.get(2L),
                         ItemList.Electric_Pump_IV.get(1L),


### PR DESCRIPTION
As this comment mentioned the change in PR https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1278#issuecomment-2910951502, T2 and T3 got their controller recipes changed to use their respective Air Filter casings
<img width="532" height="188" alt="image" src="https://github.com/user-attachments/assets/6f63a182-8115-4495-aeda-d2c706f0d694" />
<img width="526" height="230" alt="image" src="https://github.com/user-attachments/assets/5b374240-209a-474b-a635-282b7f45e767" />
<img width="498" height="184" alt="image" src="https://github.com/user-attachments/assets/f0003cef-87b0-4dae-a9ec-870d6d1575ea" />
<img width="468" height="159" alt="image" src="https://github.com/user-attachments/assets/d8557169-6f33-4842-868a-0524d2d03b4d" />
Ignore this if the change is too much (like, i just make a PR so all tiers follow the same logic
The difference in tungsten price for a controller:
1. previous one (just default turbine casing)
2. done in assembler (cheaper cost)
3. done in crafting table (the most expensive)
<img width="290" height="739" alt="image" src="https://github.com/user-attachments/assets/3c0efcbf-d230-4cab-86ac-d221af19b487" />
The same costs follow other tiers, just motor tier and metal changes (lv and steel, hv and titanium, iv and tungsten)