### PR TITLE
fix(ZincGravel): extends GravelOre(TConstruct) for Waila Effective Tool

### DIFF
--- a/src/main/java/com/dreammaster/tinkersConstruct/worldgen/ZincGravelOre.java
+++ b/src/main/java/com/dreammaster/tinkersConstruct/worldgen/ZincGravelOre.java
@@ -12,7 +12,6 @@ import net.minecraft.world.World;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-
 import tconstruct.world.blocks.GravelOre;
 
 public class ZincGravelOre extends GravelOre {


### PR DESCRIPTION
[Modpack Issue#21176](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21176)

Zinc Gravel Ore shows Effective Tool: Pickaxe in Waila, because:

- IguanaTweaksTConstruct overrides harvestTool to pickaxe, but shovel for Instance of GravelOre (Tconstruct) ([source](https://github.com/GTNewHorizons/IguanaTweaksTConstruct/blob/master/src/main/java/iguanaman/iguanatweakstconstruct/harvestlevels/HarvestLevelTweaks.java#L107-L108))
- ZincGravelOre class here extends BlockSand, not GravelOre

So Iguana set Pickaxe has harvesting tool

Result:
<img width="1920" height="1009" alt="487387604-305b3fd6-46de-4830-8187-a7cde765802e" src="https://github.com/user-attachments/assets/332a243a-4efa-4d13-8e66-5e546f90ed19" />
