### PR TITLE
Add chisel recipes for BoP Tanzanite and Topaz blocks

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptBiomesOPlenty.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBiomesOPlenty.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import net.minecraftforge.fluids.FluidRegistry;
 
+import com.dreammaster.chisel.ChiselHelper;
 import com.dreammaster.item.NHItemList;
 
 import gregtech.api.enums.GTValues;
@@ -540,5 +541,12 @@ public class ScriptBiomesOPlenty implements IScriptLoader {
                 .itemOutputs(getModItem(BiomesOPlenty.ID, "foliage", 1, 7, missing)).eut(TierEU.RECIPE_HV).duration(10)
                 .metadata(DISSOLUTION_TANK_RATIO, 1).addTo(dissolutionTankRecipes);
 
+        ChiselHelper.addVariationFromStack("topaz", GTOreDictUnificator.get(OrePrefixes.block, Materials.Topaz, 1L));
+        ChiselHelper.addVariationFromStack("topaz", getModItem(BiomesOPlenty.ID, "gemOre", 1, 7, missing));
+
+        ChiselHelper.addVariationFromStack(
+                "tanzanite",
+                GTOreDictUnificator.get(OrePrefixes.block, Materials.Tanzanite, 1L));
+        ChiselHelper.addVariationFromStack("tanzanite", getModItem(BiomesOPlenty.ID, "gemOre", 1, 9, missing));
     }
 }


### PR DESCRIPTION
Noticed these blocks were uncraftable, which was a shame since they look quite good. This PR makes them obtainable via chiseling their GT equivalents.

<img width="500" height="258" alt="image" src="https://github.com/user-attachments/assets/6b36f02a-6c16-4368-8436-62ae1bbf9a37" />
<img width="497" height="256" alt="image" src="https://github.com/user-attachments/assets/3f146e67-a290-492c-8d70-9ec1010210b2" />
