### PR TITLE
Removes Duplicate Recipes for Compressed Glowstone

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -43,7 +43,6 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.recipe.metadata.CompressionTierKey;
 import gregtech.api.util.GTOreDictUnificator;
-import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
 
 public class CompressorRecipes implements Runnable {
@@ -57,7 +56,6 @@ public class CompressorRecipes implements Runnable {
         makeBiomesOPlentyRecipes();
         makeBloodMagicRecipes();
         makeExtraUtilitiesRecipes();
-        makeGTPlusPlusRecipes();
         makeHardcoreEnderExpansionRecipes();
         makePamsHarvestCraftRecipes();
         makeRailcraftRecipes();
@@ -305,18 +303,6 @@ public class CompressorRecipes implements Runnable {
         GTValues.RA.stdBuilder().itemInputs(getModItem(ExtraUtilities.ID, "unstableingot", 9, 0, missing))
                 .itemOutputs(getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 5, missing)).duration(15 * SECONDS)
                 .eut(2).addTo(compressorRecipes);
-    }
-
-    private void makeGTPlusPlusRecipes() {
-        // Compressed Glowstone
-        GTValues.RA.stdBuilder().itemInputs(new ItemStack(Blocks.glowstone, 9))
-                .itemOutputs(GregtechItemList.CompressedGlowstone.get(1)).duration(15 * SECONDS).eut(2)
-                .addTo(compressorRecipes);
-
-        // Double Compressed Glowstone
-        GTValues.RA.stdBuilder().itemInputs(GregtechItemList.CompressedGlowstone.get(9))
-                .itemOutputs(GregtechItemList.DoubleCompressedGlowstone.get(1)).duration(15 * SECONDS).eut(2)
-                .addTo(compressorRecipes);
     }
 
     private void makeHardcoreEnderExpansionRecipes() {


### PR DESCRIPTION
### Changes:
- As title states, recipes were added to GT5u in a much more complete way in https://github.com/GTNewHorizons/GT5-Unofficial/pull/4634 they don't belong here any longer.