### PR TITLE
fix: add a missing torch craft using the new clay creosote bucket

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMinecraft.java
@@ -1918,6 +1918,14 @@ public class ScriptMinecraft implements IScriptLoader {
                 getModItem(Railcraft.ID, "fluid.creosote.bucket", 1, 0, missing),
                 "stickWood",
                 null);
+        if (IguanaTweaksTinkerConstruct.isModLoaded()) {
+            addShapedRecipe(
+                    getModItem(Minecraft.ID, "torch", 5, 0, missing),
+                    "blockWool",
+                    getModItem(IguanaTweaksTinkerConstruct.ID, "clayBucketCreosote", 1, 0, missing),
+                    "stickWood",
+                    null);
+        }
         addShapedRecipe(
                 getModItem(Minecraft.ID, "torch", 4, 0, missing),
                 getModItem(TwilightForest.ID, "item.torchberries", 1, 0, missing),


### PR DESCRIPTION
Questbook states that you can use creosote to make torches, but since Creosote Clay buckets were added in https://github.com/GTNewHorizons/IguanaTweaksTConstruct/pull/19, the torch recipe using that bucket is missing

<img width="598" height="524" alt="image" src="https://github.com/user-attachments/assets/c369be33-558d-4aee-bc92-83611cc6ee1e" />
