### PR TITLE
Allow for usage of MetaID range (MetaStart and MetaEnd) to specify the custom tooltip

### DIFF
--- a/src/main/java/com/dreammaster/modctt/CustomToolTips.java
+++ b/src/main/java/com/dreammaster/modctt/CustomToolTips.java
@@ -42,9 +42,19 @@ public class CustomToolTips {
             }
 
             for (ItemToolTip itt : mToolTips) {
-                if (itt.mUnlocalizedName.equalsIgnoreCase(tCompareName)
-                        && (itt.mNBT.isEmpty() || JsonToNBT.func_150315_a(itt.mNBT).equals(pItem.stackTagCompound))) {
-                    return itt;
+                if (itt.mMetaStart == null || itt.mMetaEnd == null) {
+                    if (itt.mUnlocalizedName.equalsIgnoreCase(tCompareName) && (itt.mNBT.isEmpty()
+                            || JsonToNBT.func_150315_a(itt.mNBT).equals(pItem.stackTagCompound))) {
+                        return itt;
+                    }
+                } else {
+                    if (tCompareName.startsWith(itt.mUnlocalizedName)
+                            && (pItem.getItemDamage() >= Integer.parseInt(itt.mMetaStart)
+                                    && pItem.getItemDamage() <= Integer.parseInt(itt.mMetaEnd))
+                            && (itt.mNBT.isEmpty()
+                                    || JsonToNBT.func_150315_a(itt.mNBT).equals(pItem.stackTagCompound))) {
+                        return itt;
+                    }
                 }
             }
 
@@ -73,6 +83,12 @@ public class CustomToolTips {
         @XmlAttribute(name = "NBT")
         protected String mNBT;
 
+        @XmlAttribute(name = "MetaStart")
+        protected String mMetaStart;
+
+        @XmlAttribute(name = "MetaEnd")
+        protected String mMetaEnd;
+
         public String getUnlocalizedName() {
             return mUnlocalizedName;
         }
@@ -83,6 +99,14 @@ public class CustomToolTips {
 
         public String getNBT() {
             return mNBT;
+        }
+
+        public String getMetaStart() {
+            return mMetaStart;
+        }
+
+        public String getMetaEnd() {
+            return mMetaEnd;
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21405
As shown in the issue, extra tooltip lines with charging info gets thanos snapped as the items get charged or used because Meta ID changes.

This change allows to specify Meta ID range for such items by specifying it in the XML file (MetaStart and MetaEnd). If they are not specified, they are set as null and ignored in the FindItemToolTip and uses only old values/comparisons.

The affected items (from [linked](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/21431) config change PR): Oreberries, Backpacks, ETM, Thaumic Boots, Gravisuit, IC2

After:

https://github.com/user-attachments/assets/90f2104e-1d48-4c6a-8fcb-257ab315839f

Other vids can be found here with before, after, and side comparison: https://discord.com/channels/181078474394566657/401118216228831252/1420451825555083334 (too big for 10 MB limit)

Extra, it can work with items that have no MetaID by setting MetaStart as 0 (can be seen with oreberries example)