### PR TITLE
Fix Barnarda C plank recipes

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -47,6 +47,7 @@ import com.dreammaster.recipes.Recipe;
 
 import bartworks.common.loaders.ItemRegistry;
 import bartworks.system.material.WerkstoffLoader;
+import cpw.mods.fml.common.registry.GameRegistry;
 import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.Dyes;
 import gregtech.api.enums.GTValues;
@@ -1374,6 +1375,12 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
                     new Object[] { "LLL", "PBP", "PVP", 'L', CustomItemList.BlackPlutoniumCompressedPlate.get(1), 'P',
                             CustomItemList.HeavyDutyPlateTier7.get(1), 'B', CustomItemList.Tier3Booster.get(1), 'V',
                             GTModHandler.getModItem(GalaxySpace.ID, "item.CompressedSDHD120", 1L, 0) });
+
+            // Barnarda C Wood
+            // GT replaces this recipe automatically
+            GameRegistry.addShapelessRecipe(
+                    GTModHandler.getModItem(GalaxySpace.ID, "barnardaCplanks", 4, 0),
+                    GTModHandler.getModItem(GalaxySpace.ID, "barnardaClog", 1, 0));
 
         }
 

--- a/src/main/java/com/dreammaster/scripts/ScriptGalaxySpace.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalaxySpace.java
@@ -533,10 +533,6 @@ public class ScriptGalaxySpace implements IScriptLoader {
                 's',
                 ItemList.Sensor_MV.get(1));
 
-        // todo move somewhere else not in a script
-        // GT replaces this recipe automatically
-        addShapelessRecipe(getGSItem("barnardaClog", 1, 0), getGSItem("barnardaCplanks", 4, 0));
-
         addShapedRecipe(
                 getGSItem("item.spacesuit_boots", 1, 0),
                 "ABA",


### PR DESCRIPTION
basically just moves the barnarda C base wood recipe. That is enough to fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21564

There must have been some problem with load order or the recipe adder or something, I don't actually know the cause of the bug.

now it works:
<img width="482" height="364" alt="image" src="https://github.com/user-attachments/assets/fc10de2a-dcaf-4433-a695-814ca255dfc3" />
<img width="485" height="263" alt="image" src="https://github.com/user-attachments/assets/b384f7f2-fbab-49fe-9946-a46c0333bea0" />
