### PR TITLE
fix: relocate lang files to correct paths for Paratranz CI detection

### DIFF
--- a/src/main/resources/assets/customtooltips/en_US.lang
+++ b/src/main/resources/assets/customtooltips/en_US.lang
@@ -1,0 +1,68 @@
+## Misc
+customtooltip.quest_reset_warning=§4This block will RESET ALL YOUR QUESTS, starting over from Tier 0. Do NOT build or use unless you really mean it!
+customtooltip.blast_resistance_warning=§4Blast resistance is now %s. DOES NOT PROTECT AGAINST NUKES!
+customtooltip.cooldown_seconds=Cooldown %s seconds
+customtooltip.infinite_energy=§dInfinite Energy
+customtooltip.expensive_device=§3Now: Quite Expensive Device
+customtooltip.riches_imagination=§3Riches beyond your imagination
+customtooltip.ender_collector_warning=§4Warning: When broken, the powerful ender collector may vanish in an attempt to collect itself!...and take nearby items with it!
+customtooltip.max_voltage_eu=§4Maximum voltage in: %s EU/t
+customtooltip.need_gloves=§4You need Gloves for it?
+customtooltip.prolonged_use_warning=§4Prolonged use is not recommended...
+customtooltip.perpetual_locomotion=§dPerpetual Locomotion
+
+customtooltip.disabled_item=§4Disabled Item; No recipe
+customtooltip.personal_use=§3Only For Personal Use
+customtooltip.left_click_disabled=§4left click disabled
+customtooltip.recharge_tier_machine=Recharge in a %s-tier §7Machine
+
+## Bags
+customtooltip.backpack_slots=%s Slots
+customtooltip.crafting_backpack_slots=Crafting Backpack with %s Inventory Slots
+
+## Chisel
+customtooltip.chisel_mod=§5Chisel from Chisel Mod
+
+## Core Mod
+customtooltip.oven_gloves_slot=§3Put both Gloves in the Baubles Ring Slot
+customtooltip.cannot_wear=§4Don't try to wear this, you can't
+customtooltip.very_toxic=§4Very toxic
+customtooltip.blood_altar_pillar=§5Used for Blood Altar Tier %s Pillars
+customtooltip.reinforced_stone_stats=§3Hardness %s §4Blast Resistance %s
+customtooltip.chunkloader_coin=%s%sH Chunkloader Coin, %sH in Passive Chunkloader, %sH in Personal Chunkloader
+customtooltip.chunkloader_ender_fragment=§11H Use in Personal Chunkloader
+customtooltip.ender_pearl_chunkloader=§81H Chunkloader Use in Passive and 4H in Personal Chunkloader
+customtooltip.donation_servers=§4Can be used for Donation on Servers only
+
+## Draconic Evolution
+customtooltip.slush_warning=§2I hope you are not going to eat this later.
+customtooltip.slush_cooking=§4Heating up makes food better?
+customtooltip.marshmallow_glow=§5Is it me or it just gained pixels from all that heat.
+customtooltip.marshmallow_wired=§6I have a very wired feeling.
+
+## Gregtech
+customtooltip.deprecated_furnace=§4This furnace is deprecated use bricked blast furnace
+customtooltip.coolant_steam_5x=§4Hot coolant steam output is increased by 5x
+customtooltip.black_gold_rip=§bMay you have all the black gold you want, RIP Cerulean
+customtooltip.crystallized_shards=§b§lCrystallized shards stabilized by a maximized Godforge
+
+## IC2
+customtooltip.battery_tier=%s-tier
+
+## OMT
+customtooltip.omt_hardness_resistance=Hardness: %s - Blast Resistance: %s
+
+## Tinkers Construct
+customtooltip.smeltery_purity_warning=§3Some metals processed in smeltery don't meet the purity requirement for GregTech processing.
+customtooltip.ic2_crop_berries=Can be placed on an empty IC2 Crop.\nRequires low light to be placed.
+
+## GG
+customtooltip.check_ebf_recipe=§3Check Flawed Crystal recipe in EBF
+customtooltip.check_press_recipe=§3Check Plate recipe in Forming Press
+
+## Bee Housings
+customtooltip.bee_apiary=Effective production chance as a percent is\n2.8 * b^0.52 * (p + t)^0.52 * s^0.37\nwhere b is the base production chance as a percent,\np is the production modifier (additive, starts at -0.9 for the apiary),\nt is 1 for the apiary, and\ns is the speed value for the bee\nOutputs are generated at the end of every bee tick (27.5 seconds)\nPrimary outputs are rolled once with base chance, once with half base
+customtooltip.bee_house=Effective production chance as a percent is\n2.8 * b^0.52 * (p + t)^0.52 * s^0.37\nwhere b is the base production chance as a percent,\np is the production modifier (always -0.75 for the bee house),\nt is 1 for the bee house, and\ns is the speed value for the bee\nOutputs are generated at the end of every bee tick (27.5 seconds)\nPrimary outputs are rolled once with base chance, once with half\nBees cannot mutate in the bee house
+customtooltip.bee_alveary=Effective production chance as a percent is\n2.8 * b^0.52 * (p + t)^0.52 * s^0.37\nwhere b is the base production chance as a percent,\np is the production modifier (additive, starts at 0 for the alveary),\nt is 1 for the alveary, and\ns is the speed value for the bee\nOutputs are generated at the end of every bee tick (27.5 seconds)\nPrimary outputs are rolled once with base chance, once with half
+customtooltip.bee_magic_apiary=Effective production chance as a percent is\n2.8 * b^0.52 * (p + t)^0.52 * s^0.37\nwhere b is the base production chance as a percent,\np is the production modifier (additive, starts at -0.1 for the magic apiary),\nt is 1 for the magic apiary, and\ns is the speed value for the bee\nOutputs are generated at the end of every bee tick (27.5 seconds)\nPrimary outputs are rolled once with base chance, once with half\nWhen boosted, base p becomes 0.8, Mutation: 2x, Lifespan: 0.5x
+customtooltip.magic_aura_range=Must be within 6 blocks of magic apiary

--- a/src/main/resources/assets/customtooltips/ru_RU.lang
+++ b/src/main/resources/assets/customtooltips/ru_RU.lang
@@ -1,0 +1,68 @@
+## Misc
+customtooltip.quest_reset_warning=§4Этот блок СБРОСИТ ВСЕ ВАШИ КВЕСТЫ, начав заново с Tier 0. Не создавайте и не используйте его, если вы действительно этого не хотите!
+customtooltip.blast_resistance_warning=§4Взрывоустойчивость теперь %s. НЕ ЗАЩИЩАЕТ ОТ ЯДЕРНЫХ ВЗРЫВОВ!
+customtooltip.cooldown_seconds=Перезарядка %s секунд
+customtooltip.infinite_energy=§dБесконечная энергия
+customtooltip.expensive_device=§3Теперь: довольно дорогой механизм
+customtooltip.riches_imagination=§3Богатства, превосходящие ваше воображение
+customtooltip.ender_collector_warning=§4Внимание: при разрушении мощный эндер-сборщик может исчезнуть, пытаясь собрать самого себя!... и утащить с собой ближайшие предметы!
+customtooltip.max_voltage_eu=§4Максимальное входное напряжение: %s EU/t
+customtooltip.need_gloves=§4Тебе нужны перчатки для этого?
+customtooltip.prolonged_use_warning=§4Длительное использование не рекомендуется...
+customtooltip.perpetual_locomotion=§dВечное движение
+
+customtooltip.disabled_item=§4Предмет отключён; рецепта нет
+customtooltip.personal_use=§3Только для личного использования
+customtooltip.left_click_disabled=§4ЛКМ отключена
+customtooltip.recharge_tier_machine=Перезарядка в машине уровня %s
+
+## Bags
+customtooltip.backpack_slots=%s слотов
+customtooltip.crafting_backpack_slots=Рюкзак для крафта с %s слотами инвентаря
+
+## Chisel
+customtooltip.chisel_mod=§5Долото из мода Chisel
+
+## Core Mod
+customtooltip.oven_gloves_slot=§3Поместите обе перчатки в слот кольца Baubles
+customtooltip.cannot_wear=§4Не пытайтесь это надеть, нельзя
+customtooltip.very_toxic=§4Очень токсично
+customtooltip.blood_altar_pillar=§5Используется для столбов алтаря крови уровня %s
+customtooltip.reinforced_stone_stats=§3Твёрдость %s §4Взрывоустойчивость %s
+customtooltip.chunkloader_coin=%s%s ч чанклодер-монета, %s ч в пассивном чанклодере, %s ч в персональном чанклодере
+customtooltip.chunkloader_ender_fragment=§11 ч использования в персональном чанклодере
+customtooltip.ender_pearl_chunkloader=§81 ч использования в пассивном и 4 ч в персональном чанклодере
+customtooltip.donation_servers=§4Можно использовать только для доната на серверах
+
+## Draconic Evolution
+customtooltip.slush_warning=§2Надеюсь, ты не собираешься это потом есть.
+customtooltip.slush_cooking=§4Нагрев делает еду лучше?
+customtooltip.marshmallow_glow=§5Мне кажется или он получил пиксели от этого жара.
+customtooltip.marshmallow_wired=§6У меня очень странное чувство.
+
+## Gregtech
+customtooltip.deprecated_furnace=§4Эта печь устарела, используйте кирпичную доменную печь
+customtooltip.coolant_steam_5x=§4Выход горячего парового хладагента увеличен в 5 раз
+customtooltip.black_gold_rip=§bПусть у тебя будет всё чёрное золото, RIP Cerulean
+customtooltip.crystallized_shards=§b§lКристаллизованные осколки, стабилизированные максимизированной Godforge
+
+## IC2
+customtooltip.battery_tier=%s уровень
+
+## OMT
+customtooltip.omt_hardness_resistance=Твёрдость: %s - Взрывоустойчивость: %s
+
+## Tinkers Construct
+customtooltip.smeltery_purity_warning=§3Некоторые металлы, обработанные в плавильне, не соответствуют требованиям чистоты для обработки в GregTech.
+customtooltip.ic2_crop_berries=Можно разместить на пустом IC2 Crop.\nТребуется низкий уровень освещения для установки.
+
+## GG
+customtooltip.check_ebf_recipe=§3Проверь рецепт Flawed Crystal в EBF
+customtooltip.check_press_recipe=§3Проверь рецепт пластины в Forming Press
+
+## Bee Housings
+customtooltip.bee_apiary=Эффективный шанс производства (в процентах):\n2.8 * b^0.52 * (p + t)^0.52 * s^0.37\nгде b — базовый шанс производства (в процентах),\np — модификатор производства (аддитивный, начинается с -0.9 для пасеки),\nt — 1 для пасеки,\ns — скорость пчелы\nВыходы генерируются в конце каждого тика пчелы (27.5 секунд)\nОсновные выходы рассчитываются один раз с базовым шансом и один раз с половинным
+customtooltip.bee_house=Эффективный шанс производства (в процентах):\n2.8 * b^0.52 * (p + t)^0.52 * s^0.37\nгде b — базовый шанс производства (в процентах),\np — модификатор производства (всегда -0.75 для улья),\nt — 1 для улья,\ns — скорость пчелы\nВыходы генерируются в конце каждого тика пчелы (27.5 секунд)\nОсновные выходы рассчитываются один раз с базовым шансом и один раз с половинным\nПчёлы не могут мутировать в улье
+customtooltip.bee_alveary=Эффективный шанс производства (в процентах):\n2.8 * b^0.52 * (p + t)^0.52 * s^0.37\nгде b — базовый шанс производства (в процентах),\np — модификатор производства (аддитивный, начинается с 0 для альвеария),\nt — 1 для альвеария,\ns — скорость пчелы\nВыходы генерируются в конце каждого тика пчелы (27.5 секунд)\nОсновные выходы рассчитываются один раз с базовым шансом и один раз с половинным
+customtooltip.bee_magic_apiary=Эффективный шанс производства (в процентах):\n2.8 * b^0.52 * (p + t)^0.52 * s^0.37\nгде b — базовый шанс производства (в процентах),\np — модификатор производства (аддитивный, начинается с -0.1 для магической пасеки),\nt — 1 для магической пасеки,\ns — скорость пчелы\nВыходы генерируются в конце каждого тика пчелы (27.5 секунд)\nОсновные выходы рассчитываются один раз с базовым шансом и один раз с половинным\nПри усилении: базовый p становится 0.8, мутация: x2, длительность жизни: 0.5x
+customtooltip.magic_aura_range=Должно находиться в пределах 6 блоков от магической пасеки


### PR DESCRIPTION
Several mods had additional tooltip strings added in English only. Lang files were created for these strings but placed in incorrect directories, causing the Paratranz CI pipeline to skip them entirely.

Move lang files to the expected paths so CI can pick them up and the strings become available for translation.