### PR TITLE
Add a Machine Recipe for Coated Circuit Boards

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -3753,17 +3753,6 @@ public class AssemblerRecipes implements Runnable {
 
     private void makeCircuitPartRecipes() {
         // Circuits and Boards
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 8),
-                        new OreDictItemStack("slimeball", 8))
-                .circuit(5).itemOutputs(ItemList.Circuit_Board_Basic.get(8)).duration(20 * SECONDS).eut(8)
-                .addTo(assemblerRecipes);
-
-        GTValues.RA.stdBuilder()
-                .itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 8), ItemList.IC2_Resin.get(8))
-                .circuit(5).itemOutputs(ItemList.Circuit_Board_Basic.get(8)).duration(20 * SECONDS).eut(8)
-                .addTo(assemblerRecipes);
 
         GTValues.RA.stdBuilder()
                 .itemInputs(

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -84,6 +84,7 @@ import static tectech.thing.CustomItemList.Machine_Multi_Transformer;
 import java.util.HashMap;
 import java.util.Map;
 
+import gregtech.api.enums.Materials;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -3753,6 +3754,17 @@ public class AssemblerRecipes implements Runnable {
 
     private void makeCircuitPartRecipes() {
         // Circuits and Boards
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 4),
+                        new OreDictItemStack("slimeball", 8))
+                .circuit(5).itemOutputs(ItemList.Circuit_Board_Basic.get(4)).duration(10 * SECONDS).eut(8)
+                .addTo(assemblerRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 4), ItemList.IC2_Resin.get(8))
+                .circuit(5).itemOutputs(ItemList.Circuit_Board_Basic.get(4)).duration(10 * SECONDS).eut(8)
+                .addTo(assemblerRecipes);
 
         GTValues.RA.stdBuilder()
                 .itemInputs(

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -3755,14 +3755,14 @@ public class AssemblerRecipes implements Runnable {
         // Circuits and Boards
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 4),
+                        GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 8),
                         new OreDictItemStack("slimeball", 8))
-                .circuit(5).itemOutputs(ItemList.Circuit_Board_Basic.get(4)).duration(10 * SECONDS).eut(8)
+                .circuit(5).itemOutputs(ItemList.Circuit_Board_Basic.get(8)).duration(20 * SECONDS).eut(8)
                 .addTo(assemblerRecipes);
 
         GTValues.RA.stdBuilder()
-                .itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 4), ItemList.IC2_Resin.get(8))
-                .circuit(5).itemOutputs(ItemList.Circuit_Board_Basic.get(4)).duration(10 * SECONDS).eut(8)
+                .itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 8), ItemList.IC2_Resin.get(8))
+                .circuit(5).itemOutputs(ItemList.Circuit_Board_Basic.get(8)).duration(20 * SECONDS).eut(8)
                 .addTo(assemblerRecipes);
 
         GTValues.RA.stdBuilder()

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -84,7 +84,6 @@ import static tectech.thing.CustomItemList.Machine_Multi_Transformer;
 import java.util.HashMap;
 import java.util.Map;
 
-import gregtech.api.enums.Materials;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalBathRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalBathRecipes.java
@@ -37,6 +37,7 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
+import gtPlusPlus.core.material.MaterialMisc;
 
 public class ChemicalBathRecipes implements Runnable {
 
@@ -59,6 +60,23 @@ public class ChemicalBathRecipes implements Runnable {
         GTValues.RA.stdBuilder().itemInputs(new ItemStack(Blocks.sticky_piston, 1, 0))
                 .itemOutputs(new ItemStack(Blocks.piston, 1, 0)).fluidInputs(Materials.Chlorine.getGas(10L))
                 .duration(1 * SECONDS + 10 * TICKS).eut(TierEU.RECIPE_LV).addTo(chemicalBathRecipes);
+
+        // Coated Circuit Board
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1))
+                .itemOutputs(ItemList.Circuit_Board_Basic.get(1)).duration(100 * TICKS).eut(8)
+                .fluidInputs(FluidRegistry.getFluidStack("glue", 144)).addTo(chemicalBathRecipes);
+
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1))
+                .itemOutputs(ItemList.Circuit_Board_Basic.get(1)).duration(50 * TICKS).eut(8)
+                .fluidInputs(Materials.Glue.getFluid(72)).addTo(chemicalBathRecipes);
+
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 2))
+                .itemOutputs(ItemList.Circuit_Board_Basic.get(2)).duration(25 * TICKS).eut(8)
+                .fluidInputs(Materials.GlueAdvanced.getFluid(36)).addTo(chemicalBathRecipes);
+
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 8))
+                .itemOutputs(ItemList.Circuit_Board_Basic.get(8)).duration(25 * TICKS).eut(8)
+                .fluidInputs(MaterialMisc.ETHYL_CYANOACRYLATE.getFluidStack(18)).addTo(chemicalBathRecipes);
 
         // Cooling Hot Netherrack Bricks
         GTValues.RA.stdBuilder().itemInputs(NHItemList.HotNetherrackBrick.get())

--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalBathRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalBathRecipes.java
@@ -37,7 +37,6 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
-import gtPlusPlus.core.material.MaterialMisc;
 
 public class ChemicalBathRecipes implements Runnable {
 
@@ -67,16 +66,24 @@ public class ChemicalBathRecipes implements Runnable {
                 .fluidInputs(FluidRegistry.getFluidStack("glue", 144)).addTo(chemicalBathRecipes);
 
         GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1))
-                .itemOutputs(ItemList.Circuit_Board_Basic.get(1)).duration(50 * TICKS).eut(8)
+                .itemOutputs(ItemList.Circuit_Board_Basic.get(1)).duration(100 * TICKS).eut(8)
                 .fluidInputs(Materials.Glue.getFluid(72)).addTo(chemicalBathRecipes);
 
-        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 2))
-                .itemOutputs(ItemList.Circuit_Board_Basic.get(2)).duration(25 * TICKS).eut(8)
-                .fluidInputs(Materials.GlueAdvanced.getFluid(36)).addTo(chemicalBathRecipes);
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1))
+                .itemOutputs(ItemList.Circuit_Board_Basic.get(2)).duration(100 * TICKS).eut(8)
+                .fluidInputs(Materials.Polyethylene.getMolten(36)).addTo(chemicalBathRecipes);
 
-        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 8))
-                .itemOutputs(ItemList.Circuit_Board_Basic.get(8)).duration(25 * TICKS).eut(8)
-                .fluidInputs(MaterialMisc.ETHYL_CYANOACRYLATE.getFluidStack(18)).addTo(chemicalBathRecipes);
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1))
+                .itemOutputs(ItemList.Circuit_Board_Basic.get(2)).duration(100 * TICKS).eut(8)
+                .fluidInputs(Materials.Polytetrafluoroethylene.getMolten(18)).addTo(chemicalBathRecipes);
+
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1))
+                .itemOutputs(ItemList.Circuit_Board_Basic.get(3)).duration(100 * TICKS).eut(8)
+                .fluidInputs(Materials.Epoxid.getMolten(18)).addTo(chemicalBathRecipes);
+
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Wood, 1))
+                .itemOutputs(ItemList.Circuit_Board_Basic.get(4)).duration(100 * TICKS).eut(8)
+                .fluidInputs(Materials.Polybenzimidazole.getMolten(9)).addTo(chemicalBathRecipes);
 
         // Cooling Hot Netherrack Bricks
         GTValues.RA.stdBuilder().itemInputs(NHItemList.HotNetherrackBrick.get())


### PR DESCRIPTION
Coated circuit boards are used for 1k ae2 cells, so it would useful to have a machine recipe for them. 
Was mentioned in [#beta-testing](https://discord.com/channels/181078474394566657/522098956491030558/1491149903206944882).
Currently the recipe cost is identical to the crafting table recipe. I think the assembler recipe should be a bit cheaper to motivate players to use it pre-ae2, but there should be some more discussion about what that would look like first.
Here's the recipe (both have the same eu/t and time)
<img width="512" height="931" alt="image" src="https://github.com/user-attachments/assets/2e4cdeef-e90b-4921-9b39-36c766bbc3e6" />
