### PR TITLE
Use wireGt01 for RedAlloy input

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
@@ -1800,7 +1800,7 @@ public class ScriptProjectRed implements IScriptLoader {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 1),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt02, Materials.RedAlloy, 1L))
+                        GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.RedAlloy, 1L))
                 .itemOutputs(getModItem(ProjectRedCore.ID, "projectred.core.part", 1, 2)).duration(15 * SECONDS)
                 .eut(TierEU.RECIPE_LV).requireMods(ProjectRedCore).addTo(assemblerRecipes);
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
Fix assembler recipe in ScriptProjectRed: replace OrePrefixes.wireGt02 with wireGt01 for Materials.RedAlloy input so the recipe uses the correct wire prefix for the ProjectRed core part. Affected file: src/main/java/com/dreammaster/scripts/ScriptProjectRed.java.

|Before|After|
|-|-|
|<img width="423" height="688" alt="image" src="https://github.com/user-attachments/assets/9fc8a112-b73d-4b10-ad31-d41a634baa75" />|<img width="415" height="686" alt="image" src="https://github.com/user-attachments/assets/67c31664-1028-40ef-a462-8c3b1374f64c" />| 