### PR TITLE
Recipes for new power ICs

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,21 +1,21 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.428:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.437:dev")
     api("com.github.GTNewHorizons:Yamcl:0.7.4:dev")
     api("com.github.GTNewHorizons:Baubles-Expanded:2.2.11-GTNH:dev")
 
-    implementation("com.github.GTNewHorizons:GTNHLib:0.9.50:dev")
+    implementation("com.github.GTNewHorizons:GTNHLib:0.9.52:dev")
 
     implementation("net.glease:tc4recipelib:1.5.37:dev")
 
     compileOnly("com.github.GTNewHorizons:AkashicTome:1.2.6:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Avaritia:1.93:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Avaritia:1.96:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Irontanks:1.4.5:dev") { transitive = false }
     compileOnly("secondderivative.irontankminecarts:IronTankMinecarts:1.0.5:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:twilightforest:2.7.27:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:twilightforest:2.7.28:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Mantle:0.5.1:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.52-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.54-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:WitcheryExtras:1.4.11:dev") { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:witchery-69673:2234410")
@@ -25,20 +25,20 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:extra-utilities-225561:2264384")
     compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.26:deobf") { transitive = false }
     compileOnly("com.github.GTNewHorizons:amunra:0.8.9:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Galacticraft:3.4.21-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Galacticraft:3.4.22-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:ForestryMC:4.11.13:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:MatterManipulator:0.1.23-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:MatterManipulator:0.1.24-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:IguanaTweaksTConstruct:2.7.1:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.5.10-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:Backhand:1.8.8:dev") { transitive = false }
     compileOnly("com.cubefury.vendingmachine:VendingMachine:0.4.2:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:BetterQuesting:3.8.33-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:BetterQuesting:3.8.35-GTNH:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")
     //compileOnly("com.github.Roadhog360:Et-Futurum-Requiem:2.6.2:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev") { transitive = false }
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:WailaHarvestability:1.3.4-GTNH:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.21-GTNH:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.22-GTNH:dev")
 
     //uncomment to test RC and Forestry recipes
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Railcraft:9.17.26:dev")

--- a/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_MachineRecipeLoader.java
@@ -5,6 +5,7 @@ import com.dreammaster.gthandler.recipes.ArcFurnaceRecipes;
 import com.dreammaster.gthandler.recipes.AssemblerRecipes;
 import com.dreammaster.gthandler.recipes.AssemblingLineRecipes;
 import com.dreammaster.gthandler.recipes.AutoclaveRecipes;
+import com.dreammaster.gthandler.recipes.BeamcraftingRecipes;
 import com.dreammaster.gthandler.recipes.BendingMachineRecipes;
 import com.dreammaster.gthandler.recipes.BlastFurnaceRecipes;
 import com.dreammaster.gthandler.recipes.BrewingMachineRecipes;
@@ -88,6 +89,7 @@ public class GT_MachineRecipeLoader implements Runnable {
         new VacuumFurnaceRecipes().run();
         new PolarizerRecipes().run();
         new PreciseAssemblerRecipes().run();
+        new BeamcraftingRecipes().run();
     }
 
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/AutoclaveRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AutoclaveRecipes.java
@@ -108,7 +108,7 @@ public class AutoclaveRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(ItemList.Circuit_Silicon_Wafer6.get(1L), MaterialsElements.STANDALONE.HYPOGEN.getDust(1))
                 .itemOutputs(ItemList.Circuit_Wafer_Bioware.get(1L)).outputChances(10000)
-                .fluidInputs(Materials.BioMediumSterilized.getFluid(8_000L)).duration(60 * SECONDS)
+                .fluidInputs(Materials.BioMediumSterilized.getFluid(8_000L)).duration(15 * SECONDS)
                 .eut(TierEU.RECIPE_UHV).addTo(autoclaveRecipes);
 
     }

--- a/src/main/java/com/dreammaster/gthandler/recipes/BeamcraftingRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BeamcraftingRecipes.java
@@ -1,0 +1,34 @@
+package com.dreammaster.gthandler.recipes;
+
+import static gregtech.api.recipe.RecipeMaps.BEAMCRAFTER_METADATA;
+import static gregtech.api.recipe.RecipeMaps.beamcrafterRecipes;
+import static gregtech.api.util.GTRecipeBuilder.SECONDS;
+import static gtnhlanth.common.beamline.Particle.GRAVITON;
+
+import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
+import gregtech.api.enums.Materials;
+import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TierEU;
+import gregtech.api.util.GTOreDictUnificator;
+import gregtech.loaders.postload.recipes.beamcrafter.BeamCrafterMetadata;
+
+public class BeamcraftingRecipes implements Runnable {
+
+    @Override
+    public void run() {
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Wafer_APIC.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.SpaceTime, 1))
+                .fluidInputs(Materials.Creon.getMolten(576L), Materials.Mellion.getMolten(576L))
+                .itemOutputs(ItemList.Circuit_Wafer_ZPIC.get(1))
+                .metadata(
+                        BEAMCRAFTER_METADATA,
+                        BeamCrafterMetadata.builder().particleID_A(GRAVITON.getId()).particleID_B(GRAVITON.getId())
+                                .amount_A(20).amount_B(20).energy_A(1).energy_B(1).build())
+                .eut(TierEU.RECIPE_UIV).duration(2 * SECONDS).addTo(beamcrafterRecipes);
+
+    }
+}

--- a/src/main/java/com/dreammaster/gthandler/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BlastFurnaceRecipes.java
@@ -20,6 +20,7 @@ import net.minecraft.item.ItemStack;
 
 import com.dreammaster.item.NHItemList;
 
+import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -799,6 +800,14 @@ public class BlastFurnaceRecipes implements Runnable {
                 .itemOutputs(Materials.Aluminiumoxide.getDust(1), Materials.AshDark.getDust(1))
                 .outputChances(10000, 1111).duration(30 * SECONDS).eut(TierEU.RECIPE_MV).metadata(COIL_HEAT, 1200)
                 .addTo(blastFurnaceRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Silicon_Wafer7.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Eternity, 4L),
+                        GGMaterial.shirabon.get(OrePrefixes.dust, 4))
+                .fluidInputs(Materials.Infinity.getPlasma(576L)).itemOutputs(ItemList.Circuit_Silicon_Wafer8.get(1))
+                .duration(30 * SECONDS).eut(TierEU.RECIPE_UXV).metadata(COIL_HEAT, 33500).addTo(blastFurnaceRecipes);
 
         if (TinkerConstruct.isModLoaded()) {
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
@@ -270,15 +270,6 @@ public class ChemicalReactorRecipes implements Runnable {
                 .eut(TierEU.RECIPE_UHV).addTo(UniversalChemical);
 
         GTValues.RA.stdBuilder()
-                .itemInputs(
-                        ItemList.Circuit_Wafer_Bioware.get(1L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Tartarite, 2),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.RadoxPolymer, 1),
-                        NHItemList.TCetiESeaweedExtract.get(1))
-                .itemOutputs(ItemList.Circuit_Wafer_APIC.get(1L)).fluidInputs(Materials.DTR.getFluid(1000L))
-                .requiresCleanRoom().duration(60 * SECONDS).eut(TierEU.RECIPE_UEV).addTo(UniversalChemical);
-
-        GTValues.RA.stdBuilder()
                 .itemInputs(ItemList.Circuit_Wafer_CPU.get(1L), GTUtility.copyAmount(16, Ic2Items.carbonFiber))
                 .itemOutputs(ItemList.Circuit_Wafer_NanoCPU.get(1L)).fluidInputs(Materials.Glowstone.getMolten(576L))
                 .requiresCleanRoom().duration(60 * SECONDS).eut(TierEU.RECIPE_EV).addTo(UniversalChemical);
@@ -534,6 +525,16 @@ public class ChemicalReactorRecipes implements Runnable {
                 .fluidInputs(FluidRegistry.getFluidStack("blood", 1000), FluidRegistry.getFluidStack("netherair", 100))
                 .fluidOutputs(FluidRegistry.getFluidStack("hell_blood", 1000)).duration(20 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(multiblockChemicalReactorRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Wafer_Bioware.get(1L),
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Tartarite, 2),
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.RadoxPolymer, 1),
+                        NHItemList.TCetiESeaweedExtract.get(1))
+                .itemOutputs(ItemList.Circuit_Wafer_APIC.get(1L)).fluidInputs(Materials.DTR.getFluid(1000L))
+                .requiresCleanRoom().duration(60 * SECONDS).eut(TierEU.RECIPE_UEV)
+                .addTo(multiblockChemicalReactorRecipes);
 
         if (Forestry.isModLoaded()) {
             GTValues.RA.stdBuilder()

--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
@@ -19,6 +19,7 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeBuilder.WILDCARD;
 import static gregtech.api.util.GTRecipeConstants.UniversalChemical;
+import static gtnhlanth.common.register.WerkstoffMaterialPool.Iodine;
 
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -262,6 +263,20 @@ public class ChemicalReactorRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.IndiumGalliumPhosphide, 64))
                 .itemOutputs(ItemList.Circuit_Wafer_PPIC.get(1L)).fluidInputs(Materials.Sunnarium.getMolten(1440L))
                 .requiresCleanRoom().duration(60 * SECONDS).eut(TierEU.RECIPE_ZPM).addTo(UniversalChemical);
+
+        GTValues.RA.stdBuilder().itemInputs(ItemList.Circuit_Wafer_QPIC.get(1L), Iodine.get(OrePrefixes.dust, 64))
+                .itemOutputs(ItemList.Circuit_Wafer_FPIC.get(1L))
+                .fluidInputs(Materials.InfinityCatalyst.getMolten(576L)).requiresCleanRoom().duration(60 * SECONDS)
+                .eut(TierEU.RECIPE_UHV).addTo(UniversalChemical);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Wafer_Bioware.get(1L),
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Tartarite, 2),
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.RadoxPolymer, 1),
+                        NHItemList.TCetiESeaweedExtract.get(1))
+                .itemOutputs(ItemList.Circuit_Wafer_APIC.get(1L)).fluidInputs(Materials.DTR.getFluid(1000L))
+                .requiresCleanRoom().duration(60 * SECONDS).eut(TierEU.RECIPE_UEV).addTo(UniversalChemical);
 
         GTValues.RA.stdBuilder()
                 .itemInputs(ItemList.Circuit_Wafer_CPU.get(1L), GTUtility.copyAmount(16, Ic2Items.carbonFiber))

--- a/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CompressorRecipes.java
@@ -35,12 +35,14 @@ import com.dreammaster.block.BlockList;
 import com.dreammaster.item.NHItemList;
 
 import gregtech.api.enums.GTValues;
+import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.recipe.metadata.CompressionTierKey;
 import gregtech.api.util.GTOreDictUnificator;
 import gtnhlanth.common.register.WerkstoffMaterialPool;
+import tectech.thing.block.BlockGodforgeGlass;
 
 public class CompressorRecipes implements Runnable {
 
@@ -168,6 +170,11 @@ public class CompressorRecipes implements Runnable {
 
         GTValues.RA.stdBuilder().itemInputs(getModItem(Minecraft.ID, "reeds", 8, 0))
                 .itemOutputs(getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0)).duration(15 * SECONDS).eut(2)
+                .addTo(compressorRecipes);
+
+        GTValues.RA.stdBuilder().itemInputs(new ItemStack(BlockGodforgeGlass.INSTANCE, 1))
+                .itemOutputs(ItemList.Gravitational_Lens.get(1)).fluidInputs(Materials.Space.getMolten(5760L))
+                .duration(2 * MINUTES).metadata(CompressionTierKey.INSTANCE, 2).eut(TierEU.RECIPE_UMV)
                 .addTo(compressorRecipes);
 
         if (StevesCarts2.isModLoaded()) {

--- a/src/main/java/com/dreammaster/gthandler/recipes/CuttingMachineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CuttingMachineRecipes.java
@@ -120,7 +120,7 @@ public class CuttingMachineRecipes implements Runnable {
         GTValues.RA.stdBuilder().itemInputs(ItemList.Circuit_Wafer_FPIC.get(1))
                 .itemOutputs(ItemList.Circuit_Chip_FPIC.get(2))
                 .fluidInputs(Materials.DimensionallyShiftedSuperfluid.getFluid(10L)).requiresCleanRoom()
-                .duration(45 * SECONDS).eut(TierEU.RECIPE_UEV).addTo(cutterRecipes);
+                .duration(18 * SECONDS).eut(TierEU.RECIPE_UEV).addTo(cutterRecipes);
 
         if (ZTones.isModLoaded() && ProjectRedCore.isModLoaded()) {
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/CuttingMachineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CuttingMachineRecipes.java
@@ -113,6 +113,15 @@ public class CuttingMachineRecipes implements Runnable {
                 .itemOutputs(ItemList.NandChip.get(8)).requiresCleanRoom().duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(cutterRecipes);
 
+        GTValues.RA.stdBuilder().itemInputs(ItemList.Circuit_Wafer_FPIC.get(1))
+                .itemOutputs(ItemList.Circuit_Chip_FPIC.get(2)).fluidInputs(Materials.Lubricant.getFluid(250L))
+                .requiresCleanRoom().duration(45 * SECONDS).eut(TierEU.RECIPE_UEV).addTo(cutterRecipes);
+
+        GTValues.RA.stdBuilder().itemInputs(ItemList.Circuit_Wafer_FPIC.get(1))
+                .itemOutputs(ItemList.Circuit_Chip_FPIC.get(2))
+                .fluidInputs(Materials.DimensionallyShiftedSuperfluid.getFluid(10L)).requiresCleanRoom()
+                .duration(45 * SECONDS).eut(TierEU.RECIPE_UEV).addTo(cutterRecipes);
+
         if (ZTones.isModLoaded() && ProjectRedCore.isModLoaded()) {
 
             GTValues.RA.stdBuilder()

--- a/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
@@ -428,9 +428,10 @@ public class FluidSolidifierRecipes implements Runnable {
                     .fluidInputs(new FluidStack(FluidRegistry.getFluid("molten.rhugnor"), 1152)).duration(20 * SECONDS)
                     .eut(TierEU.RECIPE_UIV).itemOutputs(ItemList.Hawking_Glass.get(1)).addTo(fluidSolidifierRecipes);
 
+            //TODO: move into exo-foundry when special uiv+ module is finished
             GTValues.RA.stdBuilder().itemInputs(ItemList.Circuit_Silicon_Wafer8.get(1))
                     .fluidInputs(Materials.QuarkGluonPlasma.getFluid(1500L))
-                    .itemOutputs(ItemList.Circuit_Wafer_YPIC.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_UXV)
+                    .itemOutputs(ItemList.Circuit_Wafer_YPIC.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_MAX)
                     .addTo(fluidSolidifierRecipes);
         }
     }

--- a/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
@@ -427,6 +427,11 @@ public class FluidSolidifierRecipes implements Runnable {
             GTValues.RA.stdBuilder().itemInputs(new ItemStack(ItemRegistry.bw_glasses[0], 1, 15))
                     .fluidInputs(new FluidStack(FluidRegistry.getFluid("molten.rhugnor"), 1152)).duration(20 * SECONDS)
                     .eut(TierEU.RECIPE_UIV).itemOutputs(ItemList.Hawking_Glass.get(1)).addTo(fluidSolidifierRecipes);
+
+            GTValues.RA.stdBuilder().itemInputs(ItemList.Circuit_Silicon_Wafer8.get(1))
+                    .fluidInputs(Materials.QuarkGluonPlasma.getFluid(1500L))
+                    .itemOutputs(ItemList.Circuit_Wafer_YPIC.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_UXV)
+                    .addTo(fluidSolidifierRecipes);
         }
     }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/FluidSolidifierRecipes.java
@@ -428,7 +428,7 @@ public class FluidSolidifierRecipes implements Runnable {
                     .fluidInputs(new FluidStack(FluidRegistry.getFluid("molten.rhugnor"), 1152)).duration(20 * SECONDS)
                     .eut(TierEU.RECIPE_UIV).itemOutputs(ItemList.Hawking_Glass.get(1)).addTo(fluidSolidifierRecipes);
 
-            //TODO: move into exo-foundry when special uiv+ module is finished
+            // TODO: move into exo-foundry when special uiv+ module is finished
             GTValues.RA.stdBuilder().itemInputs(ItemList.Circuit_Silicon_Wafer8.get(1))
                     .fluidInputs(Materials.QuarkGluonPlasma.getFluid(1500L))
                     .itemOutputs(ItemList.Circuit_Wafer_YPIC.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_MAX)

--- a/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
@@ -281,6 +281,31 @@ public class LaserEngraverRecipes implements Runnable {
                 .fluidInputs(Materials.Protomatter.getFluid(100L)).duration(10000 * SECONDS).eut(TierEU.RECIPE_UIV)
                 .fluidOutputs(Materials.Antimatter.getFluid(1L)).requiresCleanRoom().addTo(laserEngraverRecipes);
 
+        // APIC+ laser cutting recipes
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Wafer_APIC.get(1),
+                        GTUtility.copyAmount(0, ItemList.Gravitational_Lens.get(1)))
+                .fluidInputs(Materials.DimensionallyShiftedSuperfluid.getFluid(15L)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_UIV).itemOutputs(ItemList.Circuit_Chip_APIC.get(2)).requiresCleanRoom()
+                .addTo(laserEngraverRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Wafer_ZPIC.get(1),
+                        GTUtility.copyAmount(0, ItemList.Gravitational_Lens.get(1)))
+                .fluidInputs(Materials.DimensionallyShiftedSuperfluid.getFluid(20L)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_UMV).itemOutputs(ItemList.Circuit_Chip_ZPIC.get(2)).requiresCleanRoom()
+                .addTo(laserEngraverRecipes);
+
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Wafer_YPIC.get(1),
+                        GTUtility.copyAmount(0, ItemList.Gravitational_Lens.get(1)))
+                .fluidInputs(Materials.DimensionallyShiftedSuperfluid.getFluid(25L)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_UXV).itemOutputs(ItemList.Circuit_Chip_YPIC.get(2)).requiresCleanRoom()
+                .addTo(laserEngraverRecipes);
+
         if (OpenComputers.isModLoaded()) {
             // floppys w NBT
             makeFloppy("OpenOS (Operating System)", "openos", 2, 1);

--- a/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/LaserEngraverRecipes.java
@@ -27,6 +27,7 @@ import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
+import gtnhlanth.common.register.WerkstoffMaterialPool;
 
 public class LaserEngraverRecipes implements Runnable {
 
@@ -282,6 +283,18 @@ public class LaserEngraverRecipes implements Runnable {
                 .fluidOutputs(Materials.Antimatter.getFluid(1L)).requiresCleanRoom().addTo(laserEngraverRecipes);
 
         // APIC+ laser cutting recipes
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Circuit_Wafer_APIC.get(1),
+                        ItemList.EnergisedTesseract.get(1),
+                        NHItemList.ChromaticLens.get(0))
+                .fluidInputs(Materials.DimensionallyShiftedSuperfluid.getFluid(30L)).duration(20 * SECONDS)
+                .eut(TierEU.RECIPE_UIV)
+                .itemOutputs(
+                        ItemList.Circuit_Chip_APIC.get(1),
+                        WerkstoffMaterialPool.SeaweedAsh.get(OrePrefixes.dust, 2))
+                .outputChances(10000, 6700).requiresCleanRoom().addTo(laserEngraverRecipes);
+
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         ItemList.Circuit_Wafer_APIC.get(1),

--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -1438,7 +1438,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addAssemblyMatrixRecipe(
                 Arrays.asList(
                         new CircuitComponentStack(CircuitComponent.ProcessedPicoCircuitCasing, 1),
-                        new CircuitComponentStack(CircuitComponent.ProcessedChipPico, 4),
+                        new CircuitComponentStack(CircuitComponent.ProcessedChipAttoPIC, 4),
                         new CircuitComponentStack(CircuitComponent.OpticalMainframe, 2),
                         new CircuitComponentStack(CircuitComponent.ProcessedChipPikoPIC, 64),
                         new CircuitComponentStack(CircuitComponent.ProcessedOpticalSMDInductor, 48),

--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -628,9 +628,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
 
         // Pico
         addSimpleProcessingRecipe(
-                CircuitComponent.WaferPico,
+                CircuitComponent.ChipAttoPIC,
                 Materials.DimensionallyShiftedSuperfluid.getFluid(10),
-                CircuitComponent.ProcessedChipPico,
+                CircuitComponent.ProcessedChipAttoPIC,
                 ModuleRecipeInfo.ExtremeTier,
                 20 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);


### PR DESCRIPTION
This PR adds recipes for the new power ICs, wafer and lens added in <https://github.com/GTNewHorizons/GT5-Unofficial/pull/6396>. 
The UIV power IC (APIC) is meant to replace the current pico wafer in recipes, with the recipe using the bio wafer used in bio SoCs, which is why the recipe time for those got buffed as well (60s -> 15s UHV autoclave).
The cutting recipes for all the UIV+ wafers (APIC+) are moved from cutting machine to HILE (using the new lens), reason being to lower the load on cutting machines, since those are one of the most spammed multis currently and HILEs perform far better due to having multiamp support. The higher tier power IC chips also have faster recipe times and will be used in lower amounts than QPICs currently.
The new lens is made in the BHC, which is why the UIV cutting recipe also has a worse alternative pre-bhc.

<details>
<summary>FPIC (UEV)</summary>

QPIC, Iodine dust, molten inf cat
<img width="518" height="434" alt="image" src="https://github.com/user-attachments/assets/0082f036-b518-4174-817e-95cac9b31a5e" />
Cutting as usual
<img width="528" height="452" alt="image" src="https://github.com/user-attachments/assets/5b97f646-cf90-4432-a0d1-f8e5e1f78688" />

</details>

<details>
<summary>APIC (UIV)</summary>

Bio wafer, tartarite dust, radox dust, seaweed extract, dtpf residue
<img width="515" height="456" alt="image" src="https://github.com/user-attachments/assets/ce67a0f1-9937-432d-bde8-94b25ef4063c" />
Bad cutting
<img width="524" height="452" alt="image" src="https://github.com/user-attachments/assets/3ba23ec5-3a1e-4357-9fe0-be8b7c32e081" />
Good cutting
<img width="519" height="459" alt="image" src="https://github.com/user-attachments/assets/7fb4faa8-e526-45d5-ad90-51486b0f664c" />

</details>
<details>
<summary>ZPIC (UMV)</summary>

APIC, spacetime dust, molten creon, molten mellion
<img width="532" height="483" alt="image" src="https://github.com/user-attachments/assets/c763f9ac-0ef8-48ba-9804-faf4204fe5b4" />
Cutting
<img width="518" height="459" alt="image" src="https://github.com/user-attachments/assets/dcc98999-dd12-4e3f-b8d8-b130720c743f" />

</details>
<details>
<summary>YPIC (UXV)</summary>

Infinite wafer: Photonically enhanced wafer, eternity dust, shirabon dust, inf plasma
<img width="542" height="462" alt="image" src="https://github.com/user-attachments/assets/69c29875-13e0-42c2-b110-49ad16c48c23" />
Infinite wafer, qgp
<img width="526" height="426" alt="image" src="https://github.com/user-attachments/assets/034a1b44-e083-413f-9138-872c6793166b" />
Cutting
<img width="518" height="455" alt="image" src="https://github.com/user-attachments/assets/11df9f2c-2254-41e8-956f-460fde108637" />

</details>

<details>
<summary>Gravitational Lens</summary>

Gravitational Lens Block, spatially enlarged fluid
<img width="528" height="455" alt="image" src="https://github.com/user-attachments/assets/c8dad93c-e135-4d78-8072-d417f195f8a3" />
Note: spatially enlarged fluid can be obtained with a uiv lasered spinmatron to reach the uxv voltage required, making this fluid obtainable pre umv hatch

</details>

This PR has to be merged after<https://github.com/GTNewHorizons/GT5-Unofficial/pull/6396>, and requires a version bump in gt (which then has to be added here) 
Recipe integration will follow in a separate PR.