### PR TITLE
Fix supreme pizza gloves not preventing fire hazard item damage

### DIFF
--- a/src/main/java/com/dreammaster/modhazardousitems/HazardousItems.java
+++ b/src/main/java/com/dreammaster/modhazardousitems/HazardousItems.java
@@ -437,7 +437,11 @@ public class HazardousItems {
         protected void apply(HazardCause cause, EntityPlayer player) {
             Function<HazardCause, DamageSource> sourceFactory = HazardDamageSources
                     .getDamageSourceFactoryOrFail(getDamageSource());
-            player.attackEntityFrom(sourceFactory.apply(cause), getAmount());
+
+            DamageSource source = sourceFactory.apply(cause);
+            if (source.isFireDamage() && player.isImmuneToFire()) return;
+
+            player.attackEntityFrom(source, getAmount());
         }
     }
 


### PR DESCRIPTION
Adds a check to `ItmDamageEffect::apply` to see if the player has fire immunity and the damage effect is fire damage. Now the player can hold a lava bucket without taking damage with the supreme pizza gloves.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/22235