### PR TITLE
Add missing source meta value to alu gravel transformer

### DIFF
--- a/src/main/java/com/dreammaster/tinkersConstruct/TiCoLoader.java
+++ b/src/main/java/com/dreammaster/tinkersConstruct/TiCoLoader.java
@@ -96,6 +96,7 @@ public class TiCoLoader {
     private static void registerGravelOrePosteaTransformers() {
         ItemStackReplacementManager.addSimpleReplacement(
                 "TConstruct:GravelOre",
+                4,
                 Item.getItemFromBlock(BlockList.ZincGravelOre.block),
                 0,
                 false);


### PR DESCRIPTION
The transformer was configured to perform a transformation on any meta, but it should have been set to transform only meta 4. 

This caused some unusual bugs when ore dicts are being used to query for specific ore types and then rendered in NEI, for example.