### PR TITLE
Fix Dirty Portal Generator Recipe to Use OreDict Diamond

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -912,7 +912,7 @@ public class AssemblerRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        new ItemStack(Items.diamond, 1, 0),
+                        GTOreDictUnificator.get(OrePrefixes.gem, Materials.Diamond, 1L),
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.LV, 4L))
                 .itemOutputs(NHItemList.TwilightCrystal.get()).duration(30 * SECONDS).eut(TierEU.RECIPE_LV / 2)
                 .addTo(assemblerRecipes);


### PR DESCRIPTION
Fixes #24101

This PR changes the Twilight Crystal assembler recipe to use a unified diamond input instead of a hardcoded vanilla diamond.

Previously, the recipe used `new ItemStack(Items.diamond, 1, 0)`, which allowed vanilla diamonds to trigger the recipe lookup but did not allow Industrial Diamonds to trigger the recipe initially. However, once the recipe had been matched once and cached by the assembler, Industrial Diamonds could be consumed correctly through GT unification / ore dictionary matching.

By using `GTOreDictUnificator.get(OrePrefixes.gem, Materials.Diamond, 1L)`, the initial recipe lookup becomes consistent with the later validation and consumption behavior.