### PR TITLE
Fix Potassium Hydroxide Dupe/Exploit

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalReactorRecipes.java
@@ -54,8 +54,8 @@ public class ChemicalReactorRecipes implements Runnable {
                 .duration(40 * SECONDS).eut(TierEU.RECIPE_LV).addTo(UniversalChemical);
         // Rock Salt
 
-        GTValues.RA.stdBuilder().itemInputs(Materials.PotassiumHydroxide.getDust(1)).circuit(2)
-                .itemOutputs(Materials.RockSalt.getDust(1)).fluidInputs(Materials.HydrochloricAcid.getFluid(1000))
+        GTValues.RA.stdBuilder().itemInputs(Materials.PotassiumHydroxide.getDust(3)).circuit(2)
+                .itemOutputs(Materials.RockSalt.getDust(2)).fluidInputs(Materials.HydrochloricAcid.getFluid(1000))
                 .fluidOutputs(Materials.Water.getFluid(1000)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
                 .addTo(UniversalChemical);
 


### PR DESCRIPTION
This PR fixes a dupe where an LCR recipe from potassium hydroxide to rock salt was chemically imbalanced, causing an increase in potassium and loss in chlorine. Note that it is different from the proposed change in the PR since existing recipes of potassium hydroxide and rock salt are balanced around 3 KOH = 1 potassium + other stuff = 2 KCl, and it would be more consistent with how other chemical dusts are composed.

Testing in dev environment:
<img width="1002" height="672" alt="Screenshot 2026-05-07 at 8 23 20 PM" src="https://github.com/user-attachments/assets/3f1f8a21-bb09-4b45-b814-7532b4aacc73" />

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24594