### PR TITLE
Rotated Blood Channel recipe 90 degrees

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTinkersConstruct.java
@@ -974,13 +974,13 @@ public class ScriptTinkersConstruct implements IScriptLoader {
         addShapedRecipe(
                 getModItem(TinkerConstruct.ID, "blood.channel", 1, 0),
                 getModItem(TinkerConstruct.ID, "strangeFood", 1, 1),
-                getModItem(TinkerConstruct.ID, "strangeFood", 1, 1),
-                getModItem(TinkerConstruct.ID, "strangeFood", 1, 1),
                 "dustRedstone",
+                getModItem(TinkerConstruct.ID, "strangeFood", 1, 1),
+                getModItem(TinkerConstruct.ID, "strangeFood", 1, 1),
                 getModItem(Minecraft.ID, "water_bucket", 1, 0),
+                getModItem(TinkerConstruct.ID, "strangeFood", 1, 1),
+                getModItem(TinkerConstruct.ID, "strangeFood", 1, 1),
                 "dustRedstone",
-                getModItem(TinkerConstruct.ID, "strangeFood", 1, 1),
-                getModItem(TinkerConstruct.ID, "strangeFood", 1, 1),
                 getModItem(TinkerConstruct.ID, "strangeFood", 1, 1));
         Recipe.of(
                 getModItem(TinkerConstruct.ID, "slime.pad", 1, 0),


### PR DESCRIPTION
Fixes issue: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24587
Implemented changes suggested by Dream to rotate the recipe for the blood channel by 90°.
Works as intended in SP