### PR TITLE
Replace Aspect.getAspect with direct references to aspect objects for thaum aspects

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,6 +37,8 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")
     //compileOnly("com.github.Roadhog360:Et-Futurum-Requiem:2.6.2:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForbiddenMagic:0.9.15-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:MagicBees:2.10.9-GTNH:dev") { transitive = false }
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:WailaHarvestability:1.3.4-GTNH:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.23-GTNH:dev")

--- a/src/main/java/com/dreammaster/scripts/ScriptAutomagy.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAutomagy.java
@@ -105,7 +105,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "REDSTONETHEORY",
                 getModItem(Automagy.ID, "blockTorchInversion", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.ORDER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -126,7 +126,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "REDSTONETHEORY",
                 getModItem(Automagy.ID, "blockHourglass", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -154,25 +154,22 @@ public class ScriptAutomagy implements IScriptLoader {
         TCHelper.addResearchPage("REDSTONETHEORY", new ResearchPage("Automagy.research_page.REDSTONETHEORY.5"));
         TCHelper.setResearchAspects(
                 "REDCRYSTAL",
-                new AspectList().add(Aspect.getAspect("machina"), 2).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("vitreus"), 12));
+                new AspectList().add(Aspect.MECHANISM, 2).add(Aspect.MAGIC, 6).add(Aspect.CRYSTAL, 12));
         TCHelper.setResearchComplexity("REDCRYSTAL", 3);
         ThaumcraftApi.addCrucibleRecipe(
                 "REDCRYSTAL",
                 getModItem(Automagy.ID, "blockRedcrystal", 9, 0),
                 getModItem(Minecraft.ID, "redstone_block", 1, 0),
-                new AspectList().add(Aspect.getAspect("machina"), 3).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("vitreus"), 18));
+                new AspectList().add(Aspect.MECHANISM, 3).add(Aspect.MAGIC, 9).add(Aspect.CRYSTAL, 18));
         TCHelper.setResearchAspects(
                 "REDCRYSTAL",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("machina"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("vitreus"), 6)
-                        .add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.MECHANISM, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.CRYSTAL, 6).add(Aspect.FIRE, 3));
         TCHelper.setResearchComplexity("REDCRYSTAL", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "REDCRYSTAL_AMP",
                 getModItem(Automagy.ID, "blockRedcrystalAmp", 2, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 10),
+                new AspectList().add(Aspect.FIRE, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -196,14 +193,13 @@ public class ScriptAutomagy implements IScriptLoader {
                 getModItem(Automagy.ID, "shardSliver", 1, 1));
         TCHelper.setResearchAspects(
                 "REDCRYSTAL",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("machina"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("vitreus"), 6)
-                        .add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.MECHANISM, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.CRYSTAL, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("REDCRYSTAL", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "REDCRYSTAL_AMP",
                 getModItem(Automagy.ID, "blockRedcrystalDense", 2, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 10),
+                new AspectList().add(Aspect.EARTH, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -223,14 +219,13 @@ public class ScriptAutomagy implements IScriptLoader {
                 getModItem(Automagy.ID, "blockRedcrystal", 1, 0));
         TCHelper.setResearchAspects(
                 "REDCRYSTAL",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("machina"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("vitreus"), 6)
-                        .add(Aspect.getAspect("perditio"), 3));
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.MECHANISM, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.CRYSTAL, 6).add(Aspect.ENTROPY, 3));
         TCHelper.setResearchComplexity("REDCRYSTAL", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "REDCRYSTAL_AMP",
                 getModItem(Automagy.ID, "blockRedcrystalDim", 2, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.ENTROPY, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -257,7 +252,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Automagy.ID, "shardSliver", 4, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 10).add(Aspect.getAspect("aer"), 5),
+                new AspectList().add(Aspect.ENTROPY, 10).add(Aspect.AIR, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -271,7 +266,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Automagy.ID, "shardSliver", 4, 1),
-                new AspectList().add(Aspect.getAspect("perditio"), 10).add(Aspect.getAspect("ignis"), 5),
+                new AspectList().add(Aspect.ENTROPY, 10).add(Aspect.FIRE, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -285,7 +280,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Automagy.ID, "shardSliver", 4, 2),
-                new AspectList().add(Aspect.getAspect("perditio"), 10).add(Aspect.getAspect("aqua"), 5),
+                new AspectList().add(Aspect.ENTROPY, 10).add(Aspect.WATER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -299,7 +294,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Automagy.ID, "shardSliver", 4, 3),
-                new AspectList().add(Aspect.getAspect("perditio"), 10).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.ENTROPY, 10).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -313,7 +308,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Automagy.ID, "shardSliver", 4, 4),
-                new AspectList().add(Aspect.getAspect("perditio"), 10).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.ENTROPY, 10).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -327,7 +322,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Automagy.ID, "shardSliver", 4, 5),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.ENTROPY, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -341,7 +336,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("aer"), 5),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.AIR, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -361,7 +356,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 1),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("ignis"), 5),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.FIRE, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -381,7 +376,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 2),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("aqua"), 5),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.WATER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -401,7 +396,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 3),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -421,7 +416,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 4),
-                new AspectList().add(Aspect.getAspect("perditio"), 10).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.ENTROPY, 10).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -441,7 +436,7 @@ public class ScriptAutomagy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SLIVERS",
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 5),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.ENTROPY, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -464,15 +459,13 @@ public class ScriptAutomagy implements IScriptLoader {
         TCHelper.removeResearch("SLIVERS_WARDING");
         TCHelper.setResearchAspects(
                 "REMOTECOMPARATOR",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("machina"), 12)
-                        .add(Aspect.getAspect("sensus"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.MECHANISM, 12).add(Aspect.SENSES, 9)
+                        .add(Aspect.AIR, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("REMOTECOMPARATOR", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "REMOTECOMPARATOR",
                 getModItem(Automagy.ID, "blockRemoteComparator", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -494,18 +487,16 @@ public class ScriptAutomagy implements IScriptLoader {
                 "REMOTECOMPARATOR",
                 getModItem(Automagy.ID, "crystalEye", 1, 0),
                 getModItem(Minecraft.ID, "spider_eye", 1, 0),
-                new AspectList().add(Aspect.getAspect("vitreus"), 15).add(Aspect.getAspect("sensus"), 10)
-                        .add(Aspect.getAspect("praecantatio"), 5));
+                new AspectList().add(Aspect.CRYSTAL, 15).add(Aspect.SENSES, 10).add(Aspect.MAGIC, 5));
         TCHelper.setResearchAspects(
                 "REDCRYSTAL_RES",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("machina"), 12)
-                        .add(Aspect.getAspect("vitreus"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.MECHANISM, 12).add(Aspect.CRYSTAL, 9)
+                        .add(Aspect.AIR, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("REDCRYSTAL_RES", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "REDCRYSTAL_RES",
                 getModItem(Automagy.ID, "blockRedcrystalRes", 2, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -529,16 +520,14 @@ public class ScriptAutomagy implements IScriptLoader {
                 getModItem(Automagy.ID, "shardSliver", 1, 0));
         TCHelper.setResearchAspects(
                 "REDCRYSTAL_MIRRORBOUND",
-                new AspectList().add(Aspect.getAspect("iter"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TRAVEL, 15).add(Aspect.ENERGY, 12).add(Aspect.DARKNESS, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("REDCRYSTAL_MIRRORBOUND", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "REDCRYSTAL_MIRRORBOUND",
                 getModItem(Automagy.ID, "blockRedcrystalMerc", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("aer"), 20)
-                        .add(Aspect.getAspect("perditio"), 10).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("terra"), 15),
+                new AspectList().add(Aspect.ORDER, 25).add(Aspect.AIR, 20).add(Aspect.ENTROPY, 10).add(Aspect.FIRE, 20)
+                        .add(Aspect.EARTH, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -562,15 +551,13 @@ public class ScriptAutomagy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6));
         TCHelper.setResearchAspects(
                 "FOCUSCRAFTING",
-                new AspectList().add(Aspect.getAspect("fabrico"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("terra"), 6));
+                new AspectList().add(Aspect.CRAFT, 15).add(Aspect.MAGIC, 12).add(Aspect.TOOL, 9).add(Aspect.EARTH, 6));
         TCHelper.setResearchComplexity("FOCUSCRAFTING", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCUSCRAFTING",
                 getModItem(Automagy.ID, "focusCrafting", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("terra"), 40)
-                        .add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("aer"), 20)
-                        .add(Aspect.getAspect("aqua"), 10),
+                new AspectList().add(Aspect.ORDER, 50).add(Aspect.EARTH, 40).add(Aspect.ENTROPY, 30).add(Aspect.AIR, 20)
+                        .add(Aspect.WATER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -595,8 +582,7 @@ public class ScriptAutomagy implements IScriptLoader {
         new ResearchItem(
                 "InfusedGoldGTNH",
                 "AUTOMAGY",
-                new AspectList().add(Aspect.getAspect("lucrum"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("metallum"), 3),
+                new AspectList().add(Aspect.GREED, 12).add(Aspect.MAGIC, 9).add(Aspect.AIR, 6).add(Aspect.METAL, 3),
                 -5,
                 -2,
                 3,
@@ -607,9 +593,8 @@ public class ScriptAutomagy implements IScriptLoader {
                 "InfusedGoldGTNH",
                 GTOreDictUnificator.get(OrePrefixes.ingot, Materials.InfusedGold, 1L),
                 2,
-                new AspectList().add(Aspect.getAspect("lucrum"), 16).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("praecantatio"), 4)
-                        .add(Aspect.getAspect("aer"), 4),
+                new AspectList().add(Aspect.GREED, 16).add(Aspect.METAL, 12).add(Aspect.ORDER, 8).add(Aspect.MAGIC, 4)
+                        .add(Aspect.AIR, 4),
                 getModItem(Minecraft.ID, "gold_ingot", 1, 0),
                 OrePrefixes.dust.get(Materials.Thaumium),
                 OrePrefixes.dust.get(Materials.Thaumium),
@@ -626,15 +611,13 @@ public class ScriptAutomagy implements IScriptLoader {
         TCHelper.addResearchPrereq("MAGICHOURGLASS", "REDCRYSTAL", false);
         TCHelper.setResearchAspects(
                 "MAGICHOURGLASS",
-                new AspectList().add(Aspect.getAspect("machina"), 15).add(Aspect.getAspect("motus"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.MECHANISM, 15).add(Aspect.MOTION, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.AIR, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("MAGICHOURGLASS", 4);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MAGICHOURGLASS",
                 getModItem(Automagy.ID, "blockHourglassMagic", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("perditio"), 15)
-                        .add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.ORDER, 20).add(Aspect.ENTROPY, 15).add(Aspect.AIR, 10).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -660,14 +643,12 @@ public class ScriptAutomagy implements IScriptLoader {
         TCHelper.addResearchPage("NITORLIGHT", new ResearchPage("Automagy.research_page.NITORLIGHT.1"));
         TCHelper.setResearchAspects(
                 "NITORLIGHT",
-                new AspectList().add(Aspect.getAspect("lux"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("aer"), 6));
+                new AspectList().add(Aspect.LIGHT, 12).add(Aspect.FIRE, 9).add(Aspect.AIR, 6));
         TCHelper.setResearchComplexity("NITORLIGHT", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NITORLIGHT",
                 getModItem(Automagy.ID, "blockTranslucent", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 10).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.FIRE, 10).add(Aspect.WATER, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -690,9 +671,8 @@ public class ScriptAutomagy implements IScriptLoader {
                 "ENCHANT_FISHING",
                 Enchantment.enchantmentsList[61],
                 3,
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("bestia"), 15)
-                        .add(Aspect.getAspect("fames"), 10).add(Aspect.getAspect("meto"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 10),
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.BEAST, 15).add(Aspect.HUNGER, 10)
+                        .add(Aspect.HARVEST, 15).add(Aspect.MAGIC, 10),
                 new ItemStack[] { getModItem(Minecraft.ID, "carrot_on_a_stick", 1, 0),
                         getModItem(Thaumcraft.ID, "ItemResource", 1, 14), getModItem(Minecraft.ID, "sugar", 1, 0),
                         getModItem(Thaumcraft.ID, "ItemResource", 1, 14), });
@@ -700,9 +680,8 @@ public class ScriptAutomagy implements IScriptLoader {
                 "ENCHANT_FISHING",
                 Enchantment.enchantmentsList[62],
                 4,
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("bestia"), 15)
-                        .add(Aspect.getAspect("meto"), 15).add(Aspect.getAspect("lucrum"), 10)
-                        .add(Aspect.getAspect("praecantatio"), 10),
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.BEAST, 15).add(Aspect.HARVEST, 15)
+                        .add(Aspect.GREED, 10).add(Aspect.MAGIC, 10),
                 new ItemStack[] { getModItem(Minecraft.ID, "golden_carrot", 1, 0),
                         getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                         getModItem(Minecraft.ID, "tripwire_hook", 1, 0),

--- a/src/main/java/com/dreammaster/scripts/ScriptAvaritia.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAvaritia.java
@@ -52,9 +52,11 @@ import com.dreammaster.block.BlockList;
 import com.dreammaster.thaumcraft.TCHelper;
 import com.rwtema.extrautils.ExtraUtils;
 
+import fox.spiteful.avaritia.compat.thaumcraft.Lucrum;
 import fox.spiteful.avaritia.compat.ticon.Tonkers;
 import fox.spiteful.avaritia.crafting.CompressorManager;
 import fox.spiteful.avaritia.crafting.ExtremeCraftingManager;
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -62,6 +64,7 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.recipe.RecipeCategories;
 import gregtech.api.util.GTOreDictUnificator;
+import magicbees.api.MagicBeesAPI;
 import tconstruct.smeltery.TinkerSmeltery;
 import tconstruct.tools.TinkerTools;
 import tconstruct.tools.items.Pattern;
@@ -929,9 +932,9 @@ public class ScriptAvaritia implements IScriptLoader {
                 "AKASHIC",
                 getModItem(Avaritia.ID, "Akashic_Record", 1, 0),
                 24,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 512).add(Aspect.getAspect("cognitio"), 128)
-                        .add(Aspect.getAspect("sensus"), 96).add(Aspect.getAspect("luxuria"), 96)
-                        .add(Aspect.getAspect("tempus"), 64).add(Aspect.getAspect("terminus"), 128),
+                new AspectList().add(Aspect.MAGIC, 512).add(Aspect.MIND, 128).add(Aspect.SENSES, 96)
+                        .add(DarkAspects.LUST, 96).add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 64)
+                        .add(Lucrum.ULTRA_DEATH, 128),
                 OrePrefixes.plate.get(Materials.Infinity),
                 getModItem(TaintedMagic.ID, "ItemFocusTime", 1, 0),
                 getModItem(ThaumicBases.ID, "knoseFragment", 1, 6),

--- a/src/main/java/com/dreammaster/scripts/ScriptAvaritia.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAvaritia.java
@@ -16,6 +16,7 @@ import static gregtech.api.enums.Mods.Gadomancy;
 import static gregtech.api.enums.Mods.GalaxySpace;
 import static gregtech.api.enums.Mods.GraviSuite;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
+import static gregtech.api.enums.Mods.MagicBees;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.TaintedMagic;
 import static gregtech.api.enums.Mods.Thaumcraft;
@@ -99,6 +100,7 @@ public class ScriptAvaritia implements IScriptLoader {
                 GalaxySpace.ID,
                 GraviSuite.ID,
                 IndustrialCraft2.ID,
+                MagicBees.ID,
                 TaintedMagic.ID,
                 Thaumcraft.ID,
                 ThaumicBases.ID,

--- a/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
@@ -20,6 +20,7 @@ import static gregtech.api.enums.Mods.Genetics;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.IronChests;
 import static gregtech.api.enums.Mods.IronTanks;
+import static gregtech.api.enums.Mods.MagicBees;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Natura;
 import static gregtech.api.enums.Mods.Railcraft;
@@ -99,6 +100,7 @@ public class ScriptBloodMagic implements IScriptLoader {
                 IndustrialCraft2.ID,
                 IronChests.ID,
                 IronTanks.ID,
+                MagicBees.ID,
                 Railcraft.ID,
                 StevesCarts2.ID,
                 Thaumcraft.ID,

--- a/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptBloodMagic.java
@@ -54,12 +54,16 @@ import WayofTime.alchemicalWizardry.api.bindingRegistry.BindingRegistry;
 import WayofTime.alchemicalWizardry.api.bindingRegistry.UnbindingRegistry;
 import WayofTime.alchemicalWizardry.api.items.ShapedBloodOrbRecipe;
 import cpw.mods.fml.common.registry.GameRegistry;
+import fox.spiteful.avaritia.compat.thaumcraft.Lucrum;
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TCAspects;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
+import magicbees.api.MagicBeesAPI;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -428,9 +432,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "BLOODALTAR",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("fames"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.MAGIC, 12).add(Aspect.AURA, 9)
+                        .add(Aspect.HUNGER, 6).add(Aspect.EARTH, 3),
                 0,
                 0,
                 3,
@@ -443,9 +446,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BLOODALTAR",
                 getModItem(BloodMagic.ID, "Altar", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("terra"), 20).add(Aspect.getAspect("aqua"), 20)
-                        .add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("perditio"), 20),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.FIRE, 20).add(Aspect.EARTH, 20).add(Aspect.WATER, 20)
+                        .add(Aspect.ORDER, 20).add(Aspect.ENTROPY, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -475,9 +477,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "LIFEINFUSER",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("victus"), 18).add(Aspect.getAspect("alienis"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("fames"), 6).add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.LIFE, 18).add(Aspect.ELDRITCH, 15).add(Aspect.MAGIC, 12).add(Aspect.AURA, 9)
+                        .add(Aspect.HUNGER, 6).add(Aspect.EARTH, 3),
                 -2,
                 2,
                 3,
@@ -491,9 +492,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "LIFEINFUSER",
                 getModItem(BloodArsenal.ID, "life_infuser", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("victus"), 32).add(Aspect.getAspect("alienis"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("auram"), 16)
-                        .add(Aspect.getAspect("fames"), 8).add(Aspect.getAspect("terra"), 8),
+                new AspectList().add(Aspect.LIFE, 32).add(Aspect.ELDRITCH, 32).add(Aspect.MAGIC, 24)
+                        .add(Aspect.AURA, 16).add(Aspect.HUNGER, 8).add(Aspect.EARTH, 8),
                 getModItem(BloodMagic.ID, "Altar", 1, 0),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 OrePrefixes.stickLong.get(Materials.BloodInfusedIron),
@@ -511,8 +511,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "LIFEINFUSER",
                 getModItem(BloodArsenal.ID, "lp_materializer", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 50).add(Aspect.getAspect("terra"), 50)
-                        .add(Aspect.getAspect("aqua"), 50).add(Aspect.getAspect("ordo"), 50),
+                new AspectList().add(Aspect.FIRE, 50).add(Aspect.EARTH, 50).add(Aspect.WATER, 50).add(Aspect.ORDER, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -540,9 +539,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SOULCOMPACTER",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("spiritus"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("lucrum"), 9)
-                        .add(Aspect.getAspect("vacuos"), 6).add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.SOUL, 18).add(Aspect.MAGIC, 15).add(Aspect.ELDRITCH, 12)
+                        .add(Aspect.GREED, 9).add(Aspect.VOID, 6).add(Aspect.MIND, 3),
                 0,
                 -6,
                 3,
@@ -551,9 +549,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SOULCOMPACTER",
                 getModItem(BloodArsenal.ID, "compacter", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("ignis"), 75)
-                        .add(Aspect.getAspect("terra"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.FIRE, 75).add(Aspect.EARTH, 75).add(Aspect.WATER, 75)
+                        .add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -582,9 +579,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SACRIFICIALKNIFE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("telum"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("fames"), 6)
-                        .add(Aspect.getAspect("fabrico"), 3),
+                new AspectList().add(Aspect.WEAPON, 15).add(Aspect.GREED, 12).add(Aspect.TOOL, 9).add(Aspect.HUNGER, 6)
+                        .add(Aspect.CRAFT, 3),
                 2,
                 -2,
                 3,
@@ -597,8 +593,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SACRIFICIALKNIFE",
                 getModItem(BloodMagic.ID, "sacrificialKnife", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 20),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.EARTH, 20).add(Aspect.ORDER, 10)
+                        .add(Aspect.ENTROPY, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -626,9 +622,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ALCHEMICCHEMSTRYSET",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("fabrico"), 15).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("victus"), 3),
+                new AspectList().add(Aspect.CRAFT, 15).add(Aspect.FIRE, 12).add(Aspect.TOOL, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.LIFE, 3),
                 4,
                 -4,
                 3,
@@ -642,9 +637,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "ALCHEMICCHEMSTRYSET",
                 getModItem(BloodMagic.ID, "blockWritingTable", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("fabrico"), 24).add(Aspect.getAspect("instrumentum"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("victus"), 12)
-                        .add(Aspect.getAspect("ignis"), 12),
+                new AspectList().add(Aspect.CRAFT, 24).add(Aspect.TOOL, 24).add(Aspect.MAGIC, 18).add(Aspect.LIFE, 12)
+                        .add(Aspect.FIRE, 12),
                 getModItem(Minecraft.ID, "brewing_stand", 1, 0),
                 Materials.LifeEssence.getCells(1),
                 getModItem(BloodMagic.ID, "blankSlate", 1, 0),
@@ -665,9 +659,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "AMORPHICCATALYST",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("aqua"), 18).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("terra"), 12).add(Aspect.getAspect("aer"), 9)
-                        .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("perditio"), 3),
+                new AspectList().add(Aspect.WATER, 18).add(Aspect.FIRE, 15).add(Aspect.EARTH, 12).add(Aspect.AIR, 9)
+                        .add(Aspect.ORDER, 6).add(Aspect.ENTROPY, 3),
                 6,
                 -4,
                 3,
@@ -678,9 +671,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "AMORPHICCATALYST",
                 getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("aqua"), 16).add(Aspect.getAspect("ignis"), 16)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("aer"), 16)
-                        .add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("perditio"), 16),
+                new AspectList().add(Aspect.WATER, 16).add(Aspect.FIRE, 16).add(Aspect.EARTH, 16).add(Aspect.AIR, 16)
+                        .add(Aspect.ORDER, 16).add(Aspect.ENTROPY, 16),
                 getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0),
                 getModItem(BloodMagic.ID, "simpleCatalyst", 1, 0),
                 getModItem(BloodMagic.ID, "aether", 1, 0),
@@ -699,9 +691,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "BIDIAMONDBLOCK",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("aqua"), 18).add(Aspect.getAspect("ignis"), 24)
-                        .add(Aspect.getAspect("victus"), 12).add(Aspect.getAspect("ira"), 6)
-                        .add(Aspect.getAspect("perditio"), 3),
+                new AspectList().add(Aspect.WATER, 18).add(Aspect.FIRE, 24).add(Aspect.LIFE, 12)
+                        .add(DarkAspects.WRATH, 6).add(Aspect.ENTROPY, 3),
                 8,
                 -4,
                 3,
@@ -712,9 +703,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "BIDIAMONDBLOCK",
                 getModItem(BloodArsenal.ID, "blood_infused_diamond_block", 1, 0),
                 7,
-                new AspectList().add(Aspect.getAspect("ira"), 32).add(Aspect.getAspect("alienis"), 16)
-                        .add(Aspect.getAspect("victus"), 24).add(Aspect.getAspect("ignis"), 48)
-                        .add(Aspect.getAspect("aqua"), 64).add(Aspect.getAspect("perditio"), 16),
+                new AspectList().add(DarkAspects.WRATH, 32).add(Aspect.ELDRITCH, 16).add(Aspect.LIFE, 24)
+                        .add(Aspect.FIRE, 48).add(Aspect.WATER, 64).add(Aspect.ENTROPY, 16),
                 getModItem(Botania.ID, "storage", 1, 3),
                 getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0),
                 getModItem(BloodArsenal.ID, "blood_infused_diamond_bound", 1, 0),
@@ -733,9 +723,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "DIVINATIONSIGIL",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("metallum"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 15).add(Aspect.EARTH, 12).add(Aspect.TOOL, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.METAL, 3),
                 0,
                 2,
                 3,
@@ -749,9 +738,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "DIVINATIONSIGIL",
                 getModItem(BloodMagic.ID, "divinationSigil", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("vitreus"), 24).add(Aspect.getAspect("terra"), 18)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("instrumentum"), 6)
-                        .add(Aspect.getAspect("metallum"), 4),
+                new AspectList().add(Aspect.CRYSTAL, 24).add(Aspect.EARTH, 18).add(Aspect.MAGIC, 12).add(Aspect.TOOL, 6)
+                        .add(Aspect.METAL, 4),
                 getModItem(BloodMagic.ID, "blankSlate", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 1),
                 getModItem(TinkerConstruct.ID, "GlassPane", 1, 0),
@@ -767,9 +755,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SPEEDRUNE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("motus"), 15).add(Aspect.getAspect("volatus"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("fames"), 3),
+                new AspectList().add(Aspect.MOTION, 15).add(Aspect.FLIGHT, 12).add(Aspect.ENERGY, 9).add(Aspect.AIR, 6)
+                        .add(Aspect.HUNGER, 3),
                 -2,
                 0,
                 3,
@@ -783,9 +770,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SPEEDRUNE",
                 getModItem(BloodMagic.ID, "speedRune", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("motus"), 24).add(Aspect.getAspect("volatus"), 24)
-                        .add(Aspect.getAspect("potentia"), 18).add(Aspect.getAspect("aer"), 12)
-                        .add(Aspect.getAspect("fames"), 4),
+                new AspectList().add(Aspect.MOTION, 24).add(Aspect.FLIGHT, 24).add(Aspect.ENERGY, 18)
+                        .add(Aspect.AIR, 12).add(Aspect.HUNGER, 4),
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 0),
                 getModItem(BloodMagic.ID, "aether", 1, 0),
                 getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0),
@@ -799,8 +785,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "IMPERFECTRITUALSTONE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("tenebrae"), 3),
+                new AspectList().add(Aspect.AURA, 12).add(Aspect.MAGIC, 9).add(Aspect.EARTH, 6).add(Aspect.DARKNESS, 3),
                 -2,
                 -2,
                 3,
@@ -813,8 +798,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "IMPERFECTRITUALSTONE",
                 getModItem(BloodMagic.ID, "imperfectRitualStone", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 1).add(Aspect.getAspect("ignis"), 6)
-                        .add(Aspect.getAspect("terra"), 8),
+                new AspectList().add(Aspect.AIR, 1).add(Aspect.FIRE, 6).add(Aspect.EARTH, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -839,8 +823,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "IMPERFECTRITUALSTONE",
                 getModItem(BloodMagic.ID, "imperfectRitualStone", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 2).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("terra"), 16),
+                new AspectList().add(Aspect.AIR, 2).add(Aspect.FIRE, 12).add(Aspect.EARTH, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -860,9 +843,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "RITUALSTONE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("aer"), 3),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.FIRE, 12).add(Aspect.DARKNESS, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.AIR, 3),
                 -2,
                 -4,
                 3,
@@ -873,9 +855,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RITUALSTONE",
                 getModItem(BloodMagic.ID, "ritualStone", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("terra"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("praecantatio"), 3)
-                        .add(Aspect.getAspect("aer"), 2),
+                new AspectList().add(Aspect.EARTH, 12).add(Aspect.FIRE, 9).add(Aspect.DARKNESS, 6).add(Aspect.MAGIC, 3)
+                        .add(Aspect.AIR, 2),
                 getModItem(BloodMagic.ID, "imperfectRitualStone", 1, 0),
                 getModItem(BloodMagic.ID, "terrae", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1),
@@ -886,8 +867,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "RITUALSTONE",
                 getModItem(BloodMagic.ID, "ritualStone", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 3).add(Aspect.getAspect("ignis"), 18)
-                        .add(Aspect.getAspect("terra"), 24),
+                new AspectList().add(Aspect.AIR, 3).add(Aspect.FIRE, 18).add(Aspect.EARTH, 24),
                 "abc",
                 "def",
                 "ghi",
@@ -916,9 +896,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SPELLTABLE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("terra"), 18).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("tenebrae"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("infernus"), 3),
+                new AspectList().add(Aspect.EARTH, 18).add(Aspect.FIRE, 15).add(Aspect.DARKNESS, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.AIR, 6).add(DarkAspects.NETHER, 3),
                 -4,
                 -4,
                 3,
@@ -927,9 +906,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SPELLTABLE",
                 getModItem(BloodMagic.ID, "blockHomHeart", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 40).add(Aspect.getAspect("ignis"), 40)
-                        .add(Aspect.getAspect("terra"), 40).add(Aspect.getAspect("aqua"), 40)
-                        .add(Aspect.getAspect("ordo"), 40).add(Aspect.getAspect("perditio"), 40),
+                new AspectList().add(Aspect.AIR, 40).add(Aspect.FIRE, 40).add(Aspect.EARTH, 40).add(Aspect.WATER, 40)
+                        .add(Aspect.ORDER, 40).add(Aspect.ENTROPY, 40),
                 "abc",
                 "def",
                 "ghi",
@@ -958,9 +936,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "MASTERRITUALSTONE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("terra"), 18).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("tenebrae"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("aer"), 6),
+                new AspectList().add(Aspect.EARTH, 18).add(Aspect.FIRE, 15).add(Aspect.DARKNESS, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.AIR, 6),
                 -2,
                 -6,
                 3,
@@ -970,9 +947,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "MASTERRITUALSTONE",
                 getModItem(BloodMagic.ID, "masterStone", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("terra"), 36).add(Aspect.getAspect("ignis"), 24)
-                        .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("cognitio"), 8),
+                new AspectList().add(Aspect.EARTH, 36).add(Aspect.FIRE, 24).add(Aspect.DARKNESS, 16)
+                        .add(Aspect.MAGIC, 16).add(Aspect.AIR, 8).add(Aspect.MIND, 8),
                 getModItem(BloodMagic.ID, "ritualStone", 1, 0),
                 getModItem(BloodMagic.ID, "terrae", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0),
@@ -991,9 +967,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "WATERSIGIL",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("metallum"), 3),
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.EARTH, 12).add(Aspect.TOOL, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.METAL, 3),
                 0,
                 4,
                 3,
@@ -1003,9 +978,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "WATERSIGIL",
                 getModItem(BloodMagic.ID, "waterSigil", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("aqua"), 40).add(Aspect.getAspect("terra"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("instrumentum"), 16)
-                        .add(Aspect.getAspect("metallum"), 8),
+                new AspectList().add(Aspect.WATER, 40).add(Aspect.EARTH, 32).add(Aspect.MAGIC, 24).add(Aspect.TOOL, 16)
+                        .add(Aspect.METAL, 8),
                 getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0),
                 getModItem(Witchery.ID, "divinerwater", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 1),
@@ -1023,9 +997,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "LAVASIGIL",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("metallum"), 3),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.EARTH, 12).add(Aspect.TOOL, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.METAL, 3),
                 0,
                 8,
                 3,
@@ -1035,9 +1008,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "LAVASIGIL",
                 getModItem(BloodMagic.ID, "lavaSigil", 1, 0),
                 7,
-                new AspectList().add(Aspect.getAspect("ignis"), 64).add(Aspect.getAspect("terra"), 40)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("instrumentum"), 24)
-                        .add(Aspect.getAspect("metallum"), 16),
+                new AspectList().add(Aspect.FIRE, 64).add(Aspect.EARTH, 40).add(Aspect.MAGIC, 32).add(Aspect.TOOL, 24)
+                        .add(Aspect.METAL, 16),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0),
                 getModItem(Witchery.ID, "divinerlava", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 2),
@@ -1056,9 +1028,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "EMPTYCORE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("metallum"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 15).add(Aspect.EARTH, 12).add(Aspect.GREED, 9).add(Aspect.METAL, 6)
+                        .add(Aspect.MAGIC, 3),
                 0,
                 -2,
                 3,
@@ -1067,9 +1038,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "EMPTYCORE",
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1097,9 +1067,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "BMLAVACRYSTAL",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("infernus"), 12)
-                        .add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("aer"), 3),
+                new AspectList().add(Aspect.FIRE, 15).add(DarkAspects.NETHER, 12).add(Aspect.EARTH, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.AIR, 3),
                 0,
                 -4,
                 3,
@@ -1110,9 +1079,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "BMLAVACRYSTAL",
                 getModItem(BloodMagic.ID, "lavaCrystal", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("ignis"), 24).add(Aspect.getAspect("terra"), 18)
-                        .add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("infernus"), 6)
-                        .add(Aspect.getAspect("aer"), 6),
+                new AspectList().add(Aspect.FIRE, 24).add(Aspect.EARTH, 18).add(Aspect.MAGIC, 18)
+                        .add(DarkAspects.NETHER, 6).add(Aspect.AIR, 6),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 1),
                 getModItem(TinkerConstruct.ID, "materials", 1, 7),
                 getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2),
@@ -1124,9 +1092,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "RUNESACRIFICE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("fames"), 15).add(Aspect.getAspect("infernus"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.HUNGER, 15).add(DarkAspects.NETHER, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.EARTH, 3),
                 -4,
                 0,
                 3,
@@ -1136,9 +1103,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RUNESACRIFICE",
                 getModItem(BloodMagic.ID, "runeOfSacrifice", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("fames"), 24).add(Aspect.getAspect("infernus"), 24)
-                        .add(Aspect.getAspect("potentia"), 18).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("terra"), 4),
+                new AspectList().add(Aspect.HUNGER, 24).add(DarkAspects.NETHER, 24).add(Aspect.ENERGY, 18)
+                        .add(Aspect.MAGIC, 12).add(Aspect.EARTH, 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 1),
                 getModItem(BloodMagic.ID, "tennebrae", 1, 0),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0),
@@ -1154,9 +1120,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "RUNESELFSACRIFICE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("fames"), 15).add(Aspect.getAspect("infernus"), 12)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.HUNGER, 15).add(DarkAspects.NETHER, 12).add(Aspect.GREED, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.EARTH, 3),
                 -4,
                 2,
                 3,
@@ -1167,9 +1132,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RUNESELFSACRIFICE",
                 getModItem(BloodMagic.ID, "runeOfSelfSacrifice", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("fames"), 24).add(Aspect.getAspect("infernus"), 24)
-                        .add(Aspect.getAspect("lucrum"), 18).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("terra"), 4),
+                new AspectList().add(Aspect.HUNGER, 24).add(DarkAspects.NETHER, 24).add(Aspect.GREED, 18)
+                        .add(Aspect.MAGIC, 12).add(Aspect.EARTH, 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 1),
                 getModItem(BloodMagic.ID, "tennebrae", 1, 0),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0),
@@ -1185,10 +1149,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "AIRSIGIL",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("volatus"), 21).add(Aspect.getAspect("aer"), 18)
-                        .add(Aspect.getAspect("motus"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("iter"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.FLIGHT, 21).add(Aspect.AIR, 18).add(Aspect.MOTION, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.TRAVEL, 9).add(Aspect.ENERGY, 6).add(Aspect.MIND, 3),
                 0,
                 10,
                 3,
@@ -1198,10 +1160,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "AIRSIGIL",
                 getModItem(BloodMagic.ID, "airSigil", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("volatus"), 64).add(Aspect.getAspect("aer"), 48)
-                        .add(Aspect.getAspect("motus"), 32).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("iter"), 18).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("cognitio"), 6),
+                new AspectList().add(Aspect.FLIGHT, 64).add(Aspect.AIR, 48).add(Aspect.MOTION, 32).add(Aspect.MAGIC, 24)
+                        .add(Aspect.TRAVEL, 18).add(Aspect.ENERGY, 12).add(Aspect.MIND, 6),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
                 getModItem(Minecraft.ID, "ghast_tear", 1, 0),
                 getModItem(BloodMagic.ID, "aether", 1, 0),
@@ -1222,9 +1182,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "FASTERMINING",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("perfodio"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("metallum"), 6)
-                        .add(Aspect.getAspect("motus"), 3),
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.MINE, 12).add(Aspect.MAGIC, 9).add(Aspect.METAL, 6)
+                        .add(Aspect.MOTION, 3),
                 -2,
                 4,
                 3,
@@ -1235,9 +1194,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "FASTERMINING",
                 getModItem(BloodMagic.ID, "sigilOfTheFastMiner", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 36).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("perfodio"), 12)
-                        .add(Aspect.getAspect("motus"), 8),
+                new AspectList().add(Aspect.TOOL, 36).add(Aspect.MAGIC, 24).add(Aspect.METAL, 18).add(Aspect.MINE, 12)
+                        .add(Aspect.MOTION, 8),
                 getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7),
                 getModItem(Thaumcraft.ID, "ItemPickThaumium", 1, 0),
@@ -1255,9 +1213,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "GREENGROW",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("herba"), 9).add(Aspect.getAspect("arbor"), 6)
-                        .add(Aspect.getAspect("victus"), 3),
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.EARTH, 12).add(Aspect.PLANT, 9).add(Aspect.TREE, 6)
+                        .add(Aspect.LIFE, 3),
                 2,
                 4,
                 3,
@@ -1267,9 +1224,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "GREENGROW",
                 getModItem(BloodMagic.ID, "growthSigil", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 36).add(Aspect.getAspect("terra"), 24)
-                        .add(Aspect.getAspect("herba"), 18).add(Aspect.getAspect("arbor"), 12)
-                        .add(Aspect.getAspect("victus"), 8),
+                new AspectList().add(Aspect.TOOL, 36).add(Aspect.EARTH, 24).add(Aspect.PLANT, 18).add(Aspect.TREE, 12)
+                        .add(Aspect.LIFE, 8),
                 getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0),
                 getModItem(Witchery.ID, "witchsapling", 1, 0),
                 getModItem(BloodMagic.ID, "terrae", 1, 0),
@@ -1288,9 +1244,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "VOIDSIGIL",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("metallum"), 3),
+                new AspectList().add(Aspect.VOID, 15).add(Aspect.EARTH, 12).add(Aspect.AURA, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.METAL, 3),
                 -2,
                 6,
                 3,
@@ -1300,9 +1255,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "VOIDSIGIL",
                 getModItem(BloodMagic.ID, "voidSigil", 1, 0),
                 7,
-                new AspectList().add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("terra"), 40)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("auram"), 24)
-                        .add(Aspect.getAspect("metallum"), 16),
+                new AspectList().add(Aspect.VOID, 64).add(Aspect.EARTH, 40).add(Aspect.MAGIC, 32).add(Aspect.AURA, 24)
+                        .add(Aspect.METAL, 16),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0),
                 getModItem(BloodArsenal.ID, "blood_burned_string", 1, 0),
                 OrePrefixes.plate.get(Materials.Void),
@@ -1323,10 +1277,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFSWIMMING",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("aer"), 21).add(Aspect.getAspect("aqua"), 18)
-                        .add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("metallum"), 3),
+                new AspectList().add(Aspect.AIR, 21).add(Aspect.WATER, 18).add(Aspect.VOID, 15).add(Aspect.EARTH, 12)
+                        .add(Aspect.AURA, 9).add(Aspect.MAGIC, 6).add(Aspect.METAL, 3),
                 -4,
                 8,
                 3,
@@ -1337,10 +1289,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFSWIMMING",
                 getModItem(BloodArsenal.ID, "sigil_of_swimming", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("aqua"), 64)
-                        .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("terra"), 48)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("auram"), 24)
-                        .add(Aspect.getAspect("metallum"), 16),
+                new AspectList().add(Aspect.AIR, 64).add(Aspect.WATER, 64).add(Aspect.VOID, 64).add(Aspect.EARTH, 48)
+                        .add(Aspect.MAGIC, 32).add(Aspect.AURA, 24).add(Aspect.METAL, 16),
                 getModItem(BloodMagic.ID, "voidSigil", 1, 0),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
                 Materials.FishOil.getCells(1),
@@ -1359,9 +1309,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "BLOODLETTERSPACK",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("telum"), 15).add(Aspect.getAspect("sano"), 12)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("tutamen"), 6)
-                        .add(Aspect.getAspect("pannus"), 3),
+                new AspectList().add(Aspect.WEAPON, 15).add(Aspect.HEAL, 12).add(Aspect.GREED, 9).add(Aspect.ARMOR, 6)
+                        .add(Aspect.CLOTH, 3),
                 2,
                 -4,
                 3,
@@ -1374,9 +1323,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BLOODLETTERSPACK",
                 getModItem(BloodMagic.ID, "itemBloodPack", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("aqua"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("perditio"), 30),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 30).add(Aspect.WATER, 30)
+                        .add(Aspect.ORDER, 30).add(Aspect.ENTROPY, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -1404,9 +1352,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "IMBUEARMOR",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("sano"), 15).add(Aspect.getAspect("tutamen"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("metallum"), 6)
-                        .add(Aspect.getAspect("potentia"), 3),
+                new AspectList().add(Aspect.HEAL, 15).add(Aspect.ARMOR, 12).add(Aspect.MAGIC, 9).add(Aspect.METAL, 6)
+                        .add(Aspect.ENERGY, 3),
                 4,
                 -6,
                 3,
@@ -1416,8 +1363,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "IMBUEARMOR",
                 createItemStack(BloodArsenal.ID, "life_imbued_helmet", 1, 0, "{LPStored:0}"),
-                new AspectList().add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("perditio"), 30),
+                new AspectList().add(Aspect.EARTH, 30).add(Aspect.FIRE, 30).add(Aspect.ORDER, 30)
+                        .add(Aspect.ENTROPY, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -1444,8 +1391,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "IMBUEARMOR",
                 createItemStack(BloodArsenal.ID, "life_imbued_chestplate", 1, 0, "{LPStored:0}"),
-                new AspectList().add(Aspect.getAspect("terra"), 60).add(Aspect.getAspect("ignis"), 60)
-                        .add(Aspect.getAspect("ordo"), 60).add(Aspect.getAspect("perditio"), 60),
+                new AspectList().add(Aspect.EARTH, 60).add(Aspect.FIRE, 60).add(Aspect.ORDER, 60)
+                        .add(Aspect.ENTROPY, 60),
                 "abc",
                 "def",
                 "ghi",
@@ -1475,8 +1422,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "IMBUEARMOR",
                 createItemStack(BloodArsenal.ID, "life_imbued_leggings", 1, 0, "{LPStored:0}"),
-                new AspectList().add(Aspect.getAspect("terra"), 45).add(Aspect.getAspect("ignis"), 45)
-                        .add(Aspect.getAspect("ordo"), 45).add(Aspect.getAspect("perditio"), 45),
+                new AspectList().add(Aspect.EARTH, 45).add(Aspect.FIRE, 45).add(Aspect.ORDER, 45)
+                        .add(Aspect.ENTROPY, 45),
                 "abc",
                 "def",
                 "ghi",
@@ -1506,8 +1453,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "IMBUEARMOR",
                 createItemStack(BloodArsenal.ID, "life_imbued_boots", 1, 0, "{LPStored:0}"),
-                new AspectList().add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("perditio"), 30),
+                new AspectList().add(Aspect.EARTH, 30).add(Aspect.FIRE, 30).add(Aspect.ORDER, 30)
+                        .add(Aspect.ENTROPY, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -1531,8 +1478,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "WEAKORB",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 9).add(Aspect.ENERGY, 6).add(Aspect.MAGIC, 3),
                 2,
                 0,
                 2,
@@ -1545,9 +1491,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "WEAKORB",
                 NHItemList.WeakOrb.get(),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("aqua"), 20)
-                        .add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("perditio"), 20).add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.WATER, 20).add(Aspect.FIRE, 20).add(Aspect.EARTH, 20)
+                        .add(Aspect.ENTROPY, 20).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -1566,8 +1511,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "APPRENTICEORB",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 12).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 12).add(Aspect.ENERGY, 9).add(Aspect.MAGIC, 6).add(Aspect.MIND, 3),
                 4,
                 0,
                 3,
@@ -1580,9 +1524,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "APPRENTICEORB",
                 NHItemList.ApprenticeOrb.get(),
-                new AspectList().add(Aspect.getAspect("aer"), 40).add(Aspect.getAspect("aqua"), 40)
-                        .add(Aspect.getAspect("ignis"), 40).add(Aspect.getAspect("terra"), 40)
-                        .add(Aspect.getAspect("perditio"), 40).add(Aspect.getAspect("ordo"), 40),
+                new AspectList().add(Aspect.AIR, 40).add(Aspect.WATER, 40).add(Aspect.FIRE, 40).add(Aspect.EARTH, 40)
+                        .add(Aspect.ENTROPY, 40).add(Aspect.ORDER, 40),
                 "abc",
                 "def",
                 "ghi",
@@ -1603,9 +1546,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "MAGICANORB",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("cognitio"), 6)
-                        .add(Aspect.getAspect("sano"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 15).add(Aspect.ENERGY, 12).add(Aspect.MAGIC, 9).add(Aspect.MIND, 6)
+                        .add(Aspect.HEAL, 3),
                 6,
                 0,
                 3,
@@ -1618,9 +1560,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MAGICANORB",
                 NHItemList.MagicianOrb.get(),
-                new AspectList().add(Aspect.getAspect("aer"), 60).add(Aspect.getAspect("aqua"), 60)
-                        .add(Aspect.getAspect("ignis"), 60).add(Aspect.getAspect("terra"), 60)
-                        .add(Aspect.getAspect("perditio"), 60).add(Aspect.getAspect("ordo"), 60),
+                new AspectList().add(Aspect.AIR, 60).add(Aspect.WATER, 60).add(Aspect.FIRE, 60).add(Aspect.EARTH, 60)
+                        .add(Aspect.ENTROPY, 60).add(Aspect.ORDER, 60),
                 "abc",
                 "def",
                 "ghi",
@@ -1641,9 +1582,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "MASTERORB",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 18).add(Aspect.getAspect("potentia"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("cognitio"), 9)
-                        .add(Aspect.getAspect("sano"), 6).add(Aspect.getAspect("aqua"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 18).add(Aspect.ENERGY, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.MIND, 9).add(Aspect.HEAL, 6).add(Aspect.WATER, 3),
                 8,
                 0,
                 3,
@@ -1652,9 +1592,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MASTERORB",
                 NHItemList.MasterOrb.get(),
-                new AspectList().add(Aspect.getAspect("aer"), 80).add(Aspect.getAspect("aqua"), 80)
-                        .add(Aspect.getAspect("ignis"), 80).add(Aspect.getAspect("terra"), 80)
-                        .add(Aspect.getAspect("perditio"), 80).add(Aspect.getAspect("ordo"), 80),
+                new AspectList().add(Aspect.AIR, 80).add(Aspect.WATER, 80).add(Aspect.FIRE, 80).add(Aspect.EARTH, 80)
+                        .add(Aspect.ENTROPY, 80).add(Aspect.ORDER, 80),
                 "abc",
                 "def",
                 "ghi",
@@ -1673,10 +1612,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ARCHMAGEORB",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 21).add(Aspect.getAspect("potentia"), 18)
-                        .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("cognitio"), 12)
-                        .add(Aspect.getAspect("sano"), 9).add(Aspect.getAspect("aqua"), 6)
-                        .add(Aspect.getAspect("infernus"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 21).add(Aspect.ENERGY, 18).add(Aspect.MAGIC, 15)
+                        .add(Aspect.MIND, 12).add(Aspect.HEAL, 9).add(Aspect.WATER, 6).add(DarkAspects.NETHER, 3),
                 10,
                 0,
                 3,
@@ -1689,9 +1626,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ARCHMAGEORB",
                 NHItemList.ArchmageOrb.get(),
-                new AspectList().add(Aspect.getAspect("aer"), 100).add(Aspect.getAspect("aqua"), 100)
-                        .add(Aspect.getAspect("ignis"), 100).add(Aspect.getAspect("terra"), 100)
-                        .add(Aspect.getAspect("perditio"), 100).add(Aspect.getAspect("ordo"), 100),
+                new AspectList().add(Aspect.AIR, 100).add(Aspect.WATER, 100).add(Aspect.FIRE, 100)
+                        .add(Aspect.EARTH, 100).add(Aspect.ENTROPY, 100).add(Aspect.ORDER, 100),
                 "abc",
                 "def",
                 "ghi",
@@ -1712,10 +1648,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "TRANSCENDENTORB",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 24).add(Aspect.getAspect("potentia"), 21)
-                        .add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("cognitio"), 15)
-                        .add(Aspect.getAspect("sano"), 12).add(Aspect.getAspect("aqua"), 9)
-                        .add(Aspect.getAspect("infernus"), 6).add(Aspect.getAspect("electrum"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 24).add(Aspect.ENERGY, 21).add(Aspect.MAGIC, 18)
+                        .add(Aspect.MIND, 15).add(Aspect.HEAL, 12).add(Aspect.WATER, 9).add(DarkAspects.NETHER, 6)
+                        .add(TCAspects.ELECTRUM.getAspect(), 3),
                 12,
                 0,
                 3,
@@ -1728,9 +1663,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TRANSCENDENTORB",
                 NHItemList.TranscendentOrb.get(),
-                new AspectList().add(Aspect.getAspect("aer"), 150).add(Aspect.getAspect("aqua"), 150)
-                        .add(Aspect.getAspect("ignis"), 150).add(Aspect.getAspect("terra"), 150)
-                        .add(Aspect.getAspect("perditio"), 150).add(Aspect.getAspect("ordo"), 150),
+                new AspectList().add(Aspect.AIR, 150).add(Aspect.WATER, 150).add(Aspect.FIRE, 150)
+                        .add(Aspect.EARTH, 150).add(Aspect.ENTROPY, 150).add(Aspect.ORDER, 150),
                 "abc",
                 "def",
                 "ghi",
@@ -1751,11 +1685,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "TRANSPARENTORB",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 27).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 21).add(Aspect.getAspect("cognitio"), 18)
-                        .add(Aspect.getAspect("sano"), 15).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("infernus"), 9).add(Aspect.getAspect("electrum"), 6)
-                        .add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 27).add(Aspect.ENERGY, 24).add(Aspect.MAGIC, 21)
+                        .add(Aspect.MIND, 18).add(Aspect.HEAL, 15).add(Aspect.WATER, 12).add(DarkAspects.NETHER, 9)
+                        .add(TCAspects.ELECTRUM.getAspect(), 6).add(Aspect.ELDRITCH, 3),
                 14,
                 0,
                 3,
@@ -1764,9 +1696,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TRANSPARENTORB",
                 getModItem(BloodArsenal.ID, "transparent_orb", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 175).add(Aspect.getAspect("aqua"), 175)
-                        .add(Aspect.getAspect("ignis"), 175).add(Aspect.getAspect("terra"), 175)
-                        .add(Aspect.getAspect("perditio"), 175).add(Aspect.getAspect("ordo"), 175),
+                new AspectList().add(Aspect.AIR, 175).add(Aspect.WATER, 175).add(Aspect.FIRE, 175)
+                        .add(Aspect.EARTH, 175).add(Aspect.ENTROPY, 175).add(Aspect.ORDER, 175),
                 "abc",
                 "def",
                 "ghi",
@@ -1795,9 +1726,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "EMPTYSOCKET",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("tutamen"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("tenebrae"), 6)
-                        .add(Aspect.getAspect("sano"), 3),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.ARMOR, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.DARKNESS, 6).add(Aspect.HEAL, 3),
                 2,
                 -6,
                 3,
@@ -1806,9 +1736,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "EMPTYSOCKET",
                 getModItem(BloodMagic.ID, "emptySocket", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ignis"), 50).add(Aspect.getAspect("terra"), 50)
-                        .add(Aspect.getAspect("perditio"), 50).add(Aspect.getAspect("ordo"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.WATER, 50).add(Aspect.FIRE, 50).add(Aspect.EARTH, 50)
+                        .add(Aspect.ENTROPY, 50).add(Aspect.ORDER, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -1837,9 +1766,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SOULARMORFORGE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("tutamen"), 18).add(Aspect.getAspect("metallum"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 21).add(Aspect.getAspect("tenebrae"), 6)
-                        .add(Aspect.getAspect("exanimis"), 3),
+                new AspectList().add(Aspect.ARMOR, 18).add(Aspect.METAL, 15).add(Aspect.MAGIC, 21)
+                        .add(Aspect.DARKNESS, 6).add(Aspect.UNDEAD, 3),
                 2,
                 -8,
                 3,
@@ -1853,9 +1781,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SOULARMORFORGE",
                 getModItem(BloodMagic.ID, "armourForge", 1, 0),
                 7,
-                new AspectList().add(Aspect.getAspect("tutamen"), 64).add(Aspect.getAspect("metallum"), 40)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("auram"), 24)
-                        .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("exanimis"), 8),
+                new AspectList().add(Aspect.ARMOR, 64).add(Aspect.METAL, 40).add(Aspect.MAGIC, 32).add(Aspect.AURA, 24)
+                        .add(Aspect.DARKNESS, 16).add(Aspect.UNDEAD, 8),
                 getModItem(TinkerConstruct.ID, "ToolForgeBlock", 1, 6),
                 getModItem(BloodMagic.ID, "bloodSocket", 1, 0),
                 getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 3),
@@ -1876,9 +1803,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "RUNEOFARGUMENTEDCAPACITY",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("aqua"), 18).add(Aspect.getAspect("fames"), 15)
-                        .add(Aspect.getAspect("lucrum"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("vacuos"), 3),
+                new AspectList().add(Aspect.WATER, 18).add(Aspect.HUNGER, 15).add(Aspect.GREED, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.VOID, 3),
                 -6,
                 0,
                 3,
@@ -1889,9 +1815,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RUNEOFARGUMENTEDCAPACITY",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 1),
                 7,
-                new AspectList().add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("lucrum"), 24)
-                        .add(Aspect.getAspect("fames"), 18).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("terra"), 8).add(Aspect.getAspect("vacuos"), 4),
+                new AspectList().add(Aspect.WATER, 32).add(Aspect.GREED, 24).add(Aspect.HUNGER, 18)
+                        .add(Aspect.MAGIC, 12).add(Aspect.EARTH, 8).add(Aspect.VOID, 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 1),
                 getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0),
                 getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8),
@@ -1910,8 +1835,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "RUNEOFDISLOCATION",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("aqua"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.WATER, 18).add(Aspect.MAGIC, 15).add(Aspect.EARTH, 9).add(Aspect.MIND, 3),
                 -6,
                 2,
                 3,
@@ -1922,9 +1846,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RUNEOFDISLOCATION",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 2),
                 7,
-                new AspectList().add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("motus"), 18).add(Aspect.getAspect("tempus"), 12)
-                        .add(Aspect.getAspect("terra"), 8).add(Aspect.getAspect("cognitio"), 4),
+                new AspectList().add(Aspect.WATER, 32).add(Aspect.MAGIC, 24).add(Aspect.MOTION, 18)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 12).add(Aspect.EARTH, 8).add(Aspect.MIND, 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 1),
                 ItemList.Electric_Pump_EV.get(1L),
                 getModItem(BloodMagic.ID, "aquasalus", 1, 0),
@@ -1943,11 +1866,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFELEMENTALAFFINITY",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("volatus"), 27).add(Aspect.getAspect("ignis"), 24)
-                        .add(Aspect.getAspect("aqua"), 21).add(Aspect.getAspect("aer"), 18)
-                        .add(Aspect.getAspect("motus"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("iter"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.FLIGHT, 27).add(Aspect.FIRE, 24).add(Aspect.WATER, 21).add(Aspect.AIR, 18)
+                        .add(Aspect.MOTION, 15).add(Aspect.MAGIC, 12).add(Aspect.TRAVEL, 9).add(Aspect.ENERGY, 6)
+                        .add(Aspect.MIND, 3),
                 0,
                 12,
                 3,
@@ -1958,11 +1879,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFELEMENTALAFFINITY",
                 getModItem(BloodMagic.ID, "sigilOfElementalAffinity", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("volatus"), 64).add(Aspect.getAspect("aer"), 48)
-                        .add(Aspect.getAspect("aqua"), 48).add(Aspect.getAspect("ignis"), 48)
-                        .add(Aspect.getAspect("motus"), 32).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("iter"), 18).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("cognitio"), 6),
+                new AspectList().add(Aspect.FLIGHT, 64).add(Aspect.AIR, 48).add(Aspect.WATER, 48).add(Aspect.FIRE, 48)
+                        .add(Aspect.MOTION, 32).add(Aspect.MAGIC, 24).add(Aspect.TRAVEL, 18).add(Aspect.ENERGY, 12)
+                        .add(Aspect.MIND, 6),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
                 getModItem(BloodMagic.ID, "earthScribeTool", 1, 0),
                 getModItem(BloodMagic.ID, "weakBloodShard", 1, 0),
@@ -1984,10 +1903,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFLIGHTNING",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("tempestas"), 24).add(Aspect.getAspect("aer"), 21)
-                        .add(Aspect.getAspect("aqua"), 18).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("tenebrae"), 9)
-                        .add(Aspect.getAspect("ira"), 6).add(Aspect.getAspect("electrum"), 3),
+                new AspectList().add(Aspect.WEATHER, 24).add(Aspect.AIR, 21).add(Aspect.WATER, 18).add(Aspect.EARTH, 15)
+                        .add(Aspect.ENERGY, 12).add(Aspect.DARKNESS, 9).add(DarkAspects.WRATH, 6)
+                        .add(TCAspects.ELECTRUM.getAspect(), 3),
                 2,
                 14,
                 3,
@@ -2001,10 +1919,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFLIGHTNING",
                 getModItem(BloodArsenal.ID, "sigil_of_lightning", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("tempestas"), 32).add(Aspect.getAspect("aer"), 72)
-                        .add(Aspect.getAspect("aqua"), 72).add(Aspect.getAspect("terra"), 64)
-                        .add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("tenebrae"), 8)
-                        .add(Aspect.getAspect("ira"), 8).add(Aspect.getAspect("electrum"), 16),
+                new AspectList().add(Aspect.WEATHER, 32).add(Aspect.AIR, 72).add(Aspect.WATER, 72).add(Aspect.EARTH, 64)
+                        .add(Aspect.ENERGY, 48).add(Aspect.DARKNESS, 8).add(DarkAspects.WRATH, 8)
+                        .add(TCAspects.ELECTRUM.getAspect(), 16),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27),
                 getModItem(BloodMagic.ID, "airSigil", 1, 0),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 3),
@@ -2021,9 +1938,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFHOLDING",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("lucrum"), 18).add(Aspect.getAspect("cognitio"), 15)
-                        .add(Aspect.getAspect("gula"), 12).add(Aspect.getAspect("superbia"), 9)
-                        .add(Aspect.getAspect("limus"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.GREED, 18).add(Aspect.MIND, 15).add(DarkAspects.GLUTTONY, 12)
+                        .add(DarkAspects.PRIDE, 9).add(Aspect.SLIME, 6).add(Aspect.MAGIC, 3),
                 4,
                 6,
                 3,
@@ -2034,9 +1950,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFHOLDING",
                 getModItem(BloodMagic.ID, "sigilOfHolding", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("lucrum"), 32).add(Aspect.getAspect("cognitio"), 24)
-                        .add(Aspect.getAspect("gula"), 16).add(Aspect.getAspect("superbia"), 16)
-                        .add(Aspect.getAspect("limus"), 16).add(Aspect.getAspect("praecantatio"), 8),
+                new AspectList().add(Aspect.GREED, 32).add(Aspect.MIND, 24).add(DarkAspects.GLUTTONY, 16)
+                        .add(DarkAspects.PRIDE, 16).add(Aspect.SLIME, 16).add(Aspect.MAGIC, 8),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0),
                 getModItem(IronChests.ID, "BlockIronChest", 1, 0),
                 getModItem(BloodMagic.ID, "reinforcedSlate", 1, 0),
@@ -2055,10 +1970,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFAUGMENTETHOLDING",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vacuos"), 21).add(Aspect.getAspect("lucrum"), 18)
-                        .add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("gula"), 12)
-                        .add(Aspect.getAspect("superbia"), 9).add(Aspect.getAspect("limus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.VOID, 21).add(Aspect.GREED, 18).add(Aspect.MIND, 15)
+                        .add(DarkAspects.GLUTTONY, 12).add(DarkAspects.PRIDE, 9).add(Aspect.SLIME, 6)
+                        .add(Aspect.MAGIC, 3),
                 4,
                 8,
                 3,
@@ -2069,10 +1983,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFAUGMENTETHOLDING",
                 getModItem(BloodArsenal.ID, "sigil_of_augmented_holding", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("vacuos"), 48).add(Aspect.getAspect("lucrum"), 32)
-                        .add(Aspect.getAspect("cognitio"), 24).add(Aspect.getAspect("gula"), 16)
-                        .add(Aspect.getAspect("superbia"), 16).add(Aspect.getAspect("limus"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 8),
+                new AspectList().add(Aspect.VOID, 48).add(Aspect.GREED, 32).add(Aspect.MIND, 24)
+                        .add(DarkAspects.GLUTTONY, 16).add(DarkAspects.PRIDE, 16).add(Aspect.SLIME, 16)
+                        .add(Aspect.MAGIC, 8),
                 getModItem(BloodMagic.ID, "sigilOfHolding", 1, 0),
                 getModItem(IronChests.ID, "BlockIronChest", 1, 2),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
@@ -2094,9 +2007,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFPHANTOMBRIDGE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("terra"), 18).add(Aspect.getAspect("alienis"), 15)
-                        .add(Aspect.getAspect("iter"), 12).add(Aspect.getAspect("vitreus"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.EARTH, 18).add(Aspect.ELDRITCH, 15).add(Aspect.TRAVEL, 12)
+                        .add(Aspect.CRYSTAL, 9).add(Aspect.ENERGY, 6).add(Aspect.MAGIC, 3),
                 -4,
                 6,
                 3,
@@ -2106,9 +2018,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFPHANTOMBRIDGE",
                 getModItem(BloodMagic.ID, "sigilOfTheBridge", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("terra"), 48).add(Aspect.getAspect("alienis"), 32)
-                        .add(Aspect.getAspect("iter"), 24).add(Aspect.getAspect("vitreus"), 16)
-                        .add(Aspect.getAspect("potentia"), 8).add(Aspect.getAspect("praecantatio"), 8),
+                new AspectList().add(Aspect.EARTH, 48).add(Aspect.ELDRITCH, 32).add(Aspect.TRAVEL, 24)
+                        .add(Aspect.CRYSTAL, 16).add(Aspect.ENERGY, 8).add(Aspect.MAGIC, 8),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0),
                 getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 1),
@@ -2129,9 +2040,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFMAGNETISM",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("magneto"), 21).add(Aspect.getAspect("potentia"), 18)
-                        .add(Aspect.getAspect("electrum"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(TCAspects.MAGNETO.getAspect(), 21).add(Aspect.ENERGY, 18)
+                        .add(TCAspects.ELECTRUM.getAspect(), 15).add(Aspect.MAGIC, 12).add(Aspect.AURA, 6)
+                        .add(Aspect.MIND, 3),
                 2,
                 6,
                 3,
@@ -2141,9 +2052,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFMAGNETISM",
                 getModItem(BloodMagic.ID, "sigilOfMagnetism", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("magneto"), 24)
-                        .add(Aspect.getAspect("electrum"), 24).add(Aspect.getAspect("auram"), 16)
-                        .add(Aspect.getAspect("cognitio"), 12).add(Aspect.getAspect("praecantatio"), 6),
+                new AspectList().add(Aspect.ENERGY, 32).add(TCAspects.MAGNETO.getAspect(), 24)
+                        .add(TCAspects.ELECTRUM.getAspect(), 24).add(Aspect.AURA, 16).add(Aspect.MIND, 12)
+                        .add(Aspect.MAGIC, 6),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0),
                 OrePrefixes.block.get(Materials.NeodymiumMagnetic),
                 getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8),
@@ -2164,9 +2075,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFTHEBLOODLAMP",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("lux"), 18).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("sensus"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.LIGHT, 18).add(Aspect.FIRE, 15).add(Aspect.AIR, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.SENSES, 6).add(Aspect.MAGIC, 3),
                 0,
                 6,
                 3,
@@ -2177,9 +2087,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFTHEBLOODLAMP",
                 getModItem(BloodMagic.ID, "itemBloodLightSigil", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("lux"), 48).add(Aspect.getAspect("ignis"), 32)
-                        .add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("sensus"), 16).add(Aspect.getAspect("praecantatio"), 8),
+                new AspectList().add(Aspect.LIGHT, 48).add(Aspect.FIRE, 32).add(Aspect.AIR, 32).add(Aspect.ENERGY, 24)
+                        .add(Aspect.SENSES, 16).add(Aspect.MAGIC, 8),
                 getModItem(BloodMagic.ID, "imbuedSlate", 1, 0),
                 getModItem(ThaumicTinkerer.ID, "brightNitor", 1, 0),
                 getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 6),
@@ -2196,9 +2105,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFSIGHT",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("sensus"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("vitreus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.SENSES, 12).add(Aspect.MIND, 9).add(Aspect.CRYSTAL, 6)
+                        .add(Aspect.MAGIC, 3),
                 2,
                 2,
                 3,
@@ -2208,9 +2116,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFSIGHT",
                 getModItem(BloodMagic.ID, "seerSigil", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("ordo"), 24).add(Aspect.getAspect("sensus"), 18)
-                        .add(Aspect.getAspect("cognitio"), 12).add(Aspect.getAspect("vitreus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 4),
+                new AspectList().add(Aspect.ORDER, 24).add(Aspect.SENSES, 18).add(Aspect.MIND, 12)
+                        .add(Aspect.CRYSTAL, 6).add(Aspect.MAGIC, 4),
                 getModItem(BloodMagic.ID, "divinationSigil", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0),
                 getModItem(TinkerConstruct.ID, "GlassPane", 1, 0),
@@ -2226,9 +2133,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "RITUALDIVINER",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("aer"), 18).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("terra"), 12).add(Aspect.getAspect("aqua"), 9)
-                        .add(Aspect.getAspect("perditio"), 6).add(Aspect.getAspect("ordo"), 3),
+                new AspectList().add(Aspect.AIR, 18).add(Aspect.FIRE, 15).add(Aspect.EARTH, 12).add(Aspect.WATER, 9)
+                        .add(Aspect.ENTROPY, 6).add(Aspect.ORDER, 3),
                 -2,
                 -8,
                 3,
@@ -2239,9 +2145,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RITUALDIVINER",
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("ignis"), 32)
-                        .add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("aqua"), 32)
-                        .add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AIR, 32).add(Aspect.FIRE, 32).add(Aspect.EARTH, 32).add(Aspect.WATER, 32)
+                        .add(Aspect.ENTROPY, 16).add(Aspect.ORDER, 16),
                 getModItem(BloodMagic.ID, "seerSigil", 1, 0),
                 getModItem(Witchery.ID, "chalkritual", 1, 0),
                 getModItem(BloodMagic.ID, "waterScribeTool", 1, 0),
@@ -2261,9 +2166,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RITUALDIVINER",
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 1),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 48).add(Aspect.getAspect("ignis"), 48)
-                        .add(Aspect.getAspect("terra"), 48).add(Aspect.getAspect("aqua"), 48)
-                        .add(Aspect.getAspect("perditio"), 24).add(Aspect.getAspect("ordo"), 24),
+                new AspectList().add(Aspect.AIR, 48).add(Aspect.FIRE, 48).add(Aspect.EARTH, 48).add(Aspect.WATER, 48)
+                        .add(Aspect.ENTROPY, 24).add(Aspect.ORDER, 24),
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 0),
                 getModItem(BloodMagic.ID, "duskScribeTool", 1, 0),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
@@ -2280,9 +2184,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RITUALDIVINER",
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 2),
                 9,
-                new AspectList().add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("ignis"), 64)
-                        .add(Aspect.getAspect("terra"), 64).add(Aspect.getAspect("aqua"), 64)
-                        .add(Aspect.getAspect("perditio"), 32).add(Aspect.getAspect("ordo"), 32),
+                new AspectList().add(Aspect.AIR, 64).add(Aspect.FIRE, 64).add(Aspect.EARTH, 64).add(Aspect.WATER, 64)
+                        .add(Aspect.ENTROPY, 32).add(Aspect.ORDER, 32),
                 getModItem(BloodMagic.ID, "itemRitualDiviner", 1, 1),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27),
                 getModItem(BloodMagic.ID, "dawnScribeTool", 1, 0),
@@ -2298,9 +2201,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "RUNEOFTHEORB",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("victus"), 12)
-                        .add(Aspect.getAspect("motus"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.LIFE, 12).add(Aspect.MOTION, 9).add(Aspect.GREED, 6)
+                        .add(Aspect.MAGIC, 3),
                 -6,
                 -2,
                 3,
@@ -2311,9 +2213,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RUNEOFTHEORB",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 3),
                 6,
-                new AspectList().add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("victus"), 24)
-                        .add(Aspect.getAspect("motus"), 16).add(Aspect.getAspect("lucrum"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 4),
+                new AspectList().add(Aspect.ENERGY, 32).add(Aspect.LIFE, 24).add(Aspect.MOTION, 16).add(Aspect.GREED, 8)
+                        .add(Aspect.MAGIC, 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 3),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 3),
@@ -2332,9 +2233,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "RUNEOFSUPERIORCAPACITY",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("potentia"), 18).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("cognitio"), 12).add(Aspect.getAspect("lucrum"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.ENERGY, 18).add(Aspect.WATER, 15).add(Aspect.MIND, 12).add(Aspect.GREED, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.ELDRITCH, 3),
                 -8,
                 -2,
                 3,
@@ -2348,9 +2248,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RUNEOFSUPERIORCAPACITY",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 4),
                 8,
-                new AspectList().add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("aqua"), 32)
-                        .add(Aspect.getAspect("cognitio"), 24).add(Aspect.getAspect("lucrum"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 8).add(Aspect.getAspect("alienis"), 4),
+                new AspectList().add(Aspect.ENERGY, 48).add(Aspect.WATER, 32).add(Aspect.MIND, 24).add(Aspect.GREED, 16)
+                        .add(Aspect.MAGIC, 8).add(Aspect.ELDRITCH, 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 3),
                 getModItem(IronTanks.ID, "diamondTank", 1, 0),
                 getModItem(BloodMagic.ID, "magicales", 1, 0),
@@ -2371,10 +2270,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "RUNEOFACCELERATION",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("potentia"), 21).add(Aspect.getAspect("tempus"), 18)
-                        .add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("motus"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.ENERGY, 21).add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 18)
+                        .add(Aspect.MIND, 15).add(Aspect.WATER, 12).add(Aspect.MOTION, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.EARTH, 3),
                 -8,
                 0,
                 3,
@@ -2385,10 +2283,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RUNEOFACCELERATION",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 5),
                 10,
-                new AspectList().add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("aqua"), 48)
-                        .add(Aspect.getAspect("motus"), 32).add(Aspect.getAspect("cognitio"), 24)
-                        .add(Aspect.getAspect("tempus"), 16).add(Aspect.getAspect("praecantatio"), 8)
-                        .add(Aspect.getAspect("terra"), 4),
+                new AspectList().add(Aspect.ENERGY, 64).add(Aspect.WATER, 48).add(Aspect.MOTION, 32)
+                        .add(Aspect.MIND, 24).add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 16).add(Aspect.MAGIC, 8)
+                        .add(Aspect.EARTH, 4),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 4),
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 2),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 24),
@@ -2409,10 +2306,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "RUNEOFQUICKNESS",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("tempus"), 35)
-                        .add(Aspect.getAspect("cognitio"), 35).add(Aspect.getAspect("machina"), 23)
-                        .add(Aspect.getAspect("motus"), 27).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("terra"), 7),
+                new AspectList().add(Aspect.ENERGY, 48).add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 35)
+                        .add(Aspect.MIND, 35).add(Aspect.MECHANISM, 23).add(Aspect.MOTION, 27).add(Aspect.MAGIC, 15)
+                        .add(Aspect.EARTH, 7),
                 -10,
                 -2,
                 3,
@@ -2426,10 +2322,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "RUNEOFQUICKNESS",
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 6),
                 15,
-                new AspectList().add(Aspect.getAspect("potentia"), 96).add(Aspect.getAspect("machina"), 48)
-                        .add(Aspect.getAspect("motus"), 64).add(Aspect.getAspect("cognitio"), 32)
-                        .add(Aspect.getAspect("tempus"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("terra"), 8),
+                new AspectList().add(Aspect.ENERGY, 96).add(Aspect.MECHANISM, 48).add(Aspect.MOTION, 64)
+                        .add(Aspect.MIND, 32).add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 32)
+                        .add(Aspect.MAGIC, 16).add(Aspect.EARTH, 8),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 4),
                 getModItem(BloodMagic.ID, "AlchemicalWizardrybloodRune", 1, 5),
                 ItemList.AcceleratorLuV.get(1L, missing),
@@ -2450,9 +2345,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ARCANEPEDESTALANDPLINTH",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.EARTH, 12).add(Aspect.DARKNESS, 9)
+                        .add(Aspect.ELDRITCH, 6).add(Aspect.MAGIC, 3),
                 -4,
                 -6,
                 3,
@@ -2462,8 +2356,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ARCANEPEDESTALANDPLINTH",
                 getModItem(BloodMagic.ID, "blockPedestal", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 30).add(Aspect.getAspect("terra"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("perditio"), 30),
+                new AspectList().add(Aspect.FIRE, 30).add(Aspect.EARTH, 30).add(Aspect.ORDER, 30)
+                        .add(Aspect.ENTROPY, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -2495,9 +2389,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "ARCANEPEDESTALANDPLINTH",
                 getModItem(BloodMagic.ID, "blockPlinth", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("metallum"), 64).add(Aspect.getAspect("ignis"), 48)
-                        .add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("tenebrae"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("alienis"), 8),
+                new AspectList().add(Aspect.METAL, 64).add(Aspect.FIRE, 48).add(Aspect.EARTH, 32)
+                        .add(Aspect.DARKNESS, 24).add(Aspect.MAGIC, 16).add(Aspect.ELDRITCH, 8),
                 getModItem(BloodMagic.ID, "blockPedestal", 1, 0),
                 getModItem(BloodArsenal.ID, "blood_infused_iron_block", 1, 0),
                 getModItem(Witchery.ID, "ingredient", 1, 130),
@@ -2524,9 +2417,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ALCHEMICCALCINATOR",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("vitreus"), 15)
-                        .add(Aspect.getAspect("terra"), 12).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("aqua"), 6).add(Aspect.getAspect("ignis"), 3),
+                new AspectList().add(Aspect.MAGIC, 18).add(Aspect.CRYSTAL, 15).add(Aspect.EARTH, 12)
+                        .add(Aspect.ENTROPY, 9).add(Aspect.WATER, 6).add(Aspect.FIRE, 3),
                 -4,
                 -8,
                 3,
@@ -2536,9 +2428,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ALCHEMICCALCINATOR",
                 getModItem(BloodMagic.ID, "blockAlchemicCalcinator", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("aer"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.FIRE, 50).add(Aspect.WATER, 50).add(Aspect.EARTH, 50).add(Aspect.AIR, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -2568,9 +2459,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ALCHEMICTOOLS",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("aer"), 3),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.MAGIC, 12).add(Aspect.TOOL, 9).add(Aspect.ENERGY, 6)
+                        .add(Aspect.AIR, 3),
                 -4,
                 -12,
                 3,
@@ -2579,8 +2469,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ALCHEMICTOOLS",
                 getModItem(BloodMagic.ID, "itemAttunedCrystal", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.ORDER, 15).add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -2603,8 +2492,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ALCHEMICTOOLS",
                 getModItem(BloodMagic.ID, "itemDestinationClearer", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("aer"), 15)
-                        .add(Aspect.getAspect("perditio"), 15),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.AIR, 15).add(Aspect.ENTROPY, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -2631,8 +2519,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ALCHEMICTOOLS",
                 getModItem(BloodMagic.ID, "itemTankSegmenter", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("aer"), 15)
-                        .add(Aspect.getAspect("ignis"), 15),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.AIR, 15).add(Aspect.FIRE, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -2656,9 +2543,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "BELLJAR",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 18).add(Aspect.getAspect("aer"), 15)
-                        .add(Aspect.getAspect("terra"), 12).add(Aspect.getAspect("ordo"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("arbor"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 18).add(Aspect.AIR, 15).add(Aspect.EARTH, 12).add(Aspect.ORDER, 9)
+                        .add(Aspect.GREED, 6).add(Aspect.TREE, 3),
                 -6,
                 -12,
                 3,
@@ -2667,8 +2553,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BELLJAR",
                 getModItem(BloodMagic.ID, "blockCrystalBelljar", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.EARTH, 15).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -2696,9 +2581,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ALCHEMYRELAY",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("bestia"), 15)
-                        .add(Aspect.getAspect("pannus"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("potentia"), 3),
+                new AspectList().add(Aspect.METAL, 18).add(Aspect.BEAST, 15).add(Aspect.CLOTH, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.ELDRITCH, 6).add(Aspect.ENERGY, 3),
                 -2,
                 -12,
                 3,
@@ -2707,8 +2591,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ALCHEMYRELAY",
                 getModItem(BloodMagic.ID, "blockReagentConduit", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 25).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("ignis"), 10),
+                new AspectList().add(Aspect.AIR, 25).add(Aspect.EARTH, 15).add(Aspect.ORDER, 25).add(Aspect.FIRE, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -2736,10 +2619,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "CRYSTALCLUSTER",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("victus"), 21).add(Aspect.getAspect("spiritus"), 18)
-                        .add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("tenebrae"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.LIFE, 21).add(Aspect.SOUL, 18).add(Aspect.ELDRITCH, 15)
+                        .add(Aspect.ENERGY, 12).add(Aspect.MAGIC, 9).add(Aspect.DARKNESS, 6).add(Aspect.MIND, 3),
                 -10,
                 0,
                 3,
@@ -2750,10 +2631,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "CRYSTALCLUSTER",
                 getModItem(BloodMagic.ID, "blockCrystal", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("potentia"), 72).add(Aspect.getAspect("victus"), 64)
-                        .add(Aspect.getAspect("spiritus"), 64).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("alienis"), 16)
-                        .add(Aspect.getAspect("cognitio"), 16),
+                new AspectList().add(Aspect.ENERGY, 72).add(Aspect.LIFE, 64).add(Aspect.SOUL, 64).add(Aspect.MAGIC, 32)
+                        .add(Aspect.DARKNESS, 32).add(Aspect.ELDRITCH, 16).add(Aspect.MIND, 16),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 4),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 29),
@@ -2772,10 +2651,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ICHORIUMBLOCK",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("victus"), 21).add(Aspect.getAspect("fames"), 18)
-                        .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("infernus"), 12)
-                        .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("superbia"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.LIFE, 21).add(Aspect.HUNGER, 18).add(Aspect.MAGIC, 15)
+                        .add(DarkAspects.NETHER, 12).add(Aspect.ELDRITCH, 9).add(DarkAspects.PRIDE, 6)
+                        .add(Aspect.EARTH, 3),
                 -10,
                 2,
                 3,
@@ -2789,10 +2667,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "ICHORIUMBLOCK",
                 GTOreDictUnificator.get(OrePrefixes.block, Materials.Ichorium, 1L),
                 12,
-                new AspectList().add(Aspect.getAspect("victus"), 64).add(Aspect.getAspect("fames"), 48)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("infernus"), 24)
-                        .add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("superbia"), 16)
-                        .add(Aspect.getAspect("terra"), 8),
+                new AspectList().add(Aspect.LIFE, 64).add(Aspect.HUNGER, 48).add(Aspect.MAGIC, 32)
+                        .add(DarkAspects.NETHER, 24).add(Aspect.ELDRITCH, 16).add(DarkAspects.PRIDE, 16)
+                        .add(Aspect.EARTH, 8),
                 BlockList.Mytryl.get(),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 28),
@@ -2811,10 +2688,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "GLYPHSTONE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("terra"), 21).add(Aspect.getAspect("superbia"), 18)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("cognitio"), 12)
-                        .add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.EARTH, 21).add(DarkAspects.PRIDE, 18).add(Aspect.ORDER, 15)
+                        .add(Aspect.MIND, 12).add(Aspect.AURA, 9).add(Aspect.MAGIC, 6).add(Aspect.ELDRITCH, 3),
                 2,
                 -10,
                 3,
@@ -2827,9 +2702,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GLYPHSTONE",
                 getModItem(BloodMagic.ID, "blockStabilityGlyph", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("aqua"), 20).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("perditio"), 20),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.EARTH, 20).add(Aspect.WATER, 20).add(Aspect.FIRE, 20)
+                        .add(Aspect.ORDER, 20).add(Aspect.ENTROPY, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -2860,9 +2734,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GLYPHSTONE",
                 getModItem(BloodMagic.ID, "blockEnchantmentGlyph", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("terra"), 30)
-                        .add(Aspect.getAspect("aqua"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("perditio"), 30),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.EARTH, 30).add(Aspect.WATER, 30).add(Aspect.FIRE, 30)
+                        .add(Aspect.ORDER, 30).add(Aspect.ENTROPY, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -2890,9 +2763,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GLYPHSTONE",
                 getModItem(BloodMagic.ID, "blockEnchantmentGlyph", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("terra"), 30)
-                        .add(Aspect.getAspect("aqua"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("perditio"), 30),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.EARTH, 30).add(Aspect.WATER, 30).add(Aspect.FIRE, 30)
+                        .add(Aspect.ORDER, 30).add(Aspect.ENTROPY, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -2920,9 +2792,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "KEYOFBINDING",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vitreus"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 15).add(Aspect.GREED, 12).add(Aspect.METAL, 9).add(Aspect.EARTH, 6)
+                        .add(Aspect.MAGIC, 3),
                 4,
                 -2,
                 3,
@@ -2931,8 +2802,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "KEYOFBINDING",
                 getModItem(BloodMagic.ID, "itemKeyOfDiablo", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("ignis"), 15),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.ORDER, 15).add(Aspect.FIRE, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -2956,9 +2826,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ARMORINHIBITOR",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("spiritus"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.GREED, 12).add(Aspect.SOUL, 9).add(Aspect.ELDRITCH, 6)
+                        .add(Aspect.MAGIC, 3),
                 4,
                 -8,
                 3,
@@ -2967,8 +2836,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ARMORINHIBITOR",
                 getModItem(BloodMagic.ID, "armourInhibitor", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("aer"), 30)
-                        .add(Aspect.getAspect("aqua"), 30),
+                new AspectList().add(Aspect.ENTROPY, 30).add(Aspect.AIR, 30).add(Aspect.WATER, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -2992,10 +2860,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFHASTE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("iter"), 21).add(Aspect.getAspect("motus"), 18)
-                        .add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.TRAVEL, 21).add(Aspect.MOTION, 18).add(Aspect.AIR, 15)
+                        .add(Aspect.ENERGY, 12).add(Aspect.MAGIC, 9).add(Aspect.ELDRITCH, 6).add(Aspect.MIND, 3),
                 -2,
                 12,
                 3,
@@ -3005,10 +2871,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFHASTE",
                 getModItem(BloodMagic.ID, "sigilOfHaste", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("iter"), 64).add(Aspect.getAspect("motus"), 32)
-                        .add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("alienis"), 8)
-                        .add(Aspect.getAspect("cognitio"), 8),
+                new AspectList().add(Aspect.TRAVEL, 64).add(Aspect.MOTION, 32).add(Aspect.AIR, 24)
+                        .add(Aspect.ENERGY, 24).add(Aspect.MAGIC, 16).add(Aspect.ELDRITCH, 8).add(Aspect.MIND, 8),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
                 getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 8),
                 getModItem(Botania.ID, "manaCookie", 1, 0),
@@ -3027,10 +2891,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFWHIRLWIND",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("tutamen"), 21)
-                        .add(Aspect.getAspect("potentia"), 18).add(Aspect.getAspect("victus"), 15)
-                        .add(Aspect.getAspect("sano"), 12).add(Aspect.getAspect("cognitio"), 9)
-                        .add(Aspect.getAspect("superbia"), 6).add(Aspect.getAspect("nebrisum"), 3),
+                new AspectList().add(Aspect.AIR, 24).add(Aspect.ARMOR, 21).add(Aspect.ENERGY, 18).add(Aspect.LIFE, 15)
+                        .add(Aspect.HEAL, 12).add(Aspect.MIND, 9).add(DarkAspects.PRIDE, 6)
+                        .add(TCAspects.NEBRISUM.getAspect(), 3),
                 2,
                 12,
                 3,
@@ -3040,10 +2903,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFWHIRLWIND",
                 getModItem(BloodMagic.ID, "sigilOfWind", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("aer"), 72).add(Aspect.getAspect("tutamen"), 48)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("victus"), 32)
-                        .add(Aspect.getAspect("sano"), 16).add(Aspect.getAspect("cognitio"), 16)
-                        .add(Aspect.getAspect("superbia"), 8).add(Aspect.getAspect("nebrisum"), 8),
+                new AspectList().add(Aspect.AIR, 72).add(Aspect.ARMOR, 48).add(Aspect.ENERGY, 32).add(Aspect.LIFE, 32)
+                        .add(Aspect.HEAL, 16).add(Aspect.MIND, 16).add(DarkAspects.PRIDE, 8)
+                        .add(TCAspects.NEBRISUM.getAspect(), 8),
                 getModItem(BloodMagic.ID, "airSigil", 1, 0),
                 getModItem(TwilightForest.ID, "item.tfFeather", 1, 0),
                 getModItem(BloodMagic.ID, "aether", 1, 0),
@@ -3064,10 +2926,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFSUPRESSION",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vacuos"), 21).add(Aspect.getAspect("auram"), 18)
-                        .add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("motus"), 3),
+                new AspectList().add(Aspect.VOID, 21).add(Aspect.AURA, 18).add(Aspect.WATER, 15).add(Aspect.METAL, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.EARTH, 6).add(Aspect.MOTION, 3),
                 -2,
                 8,
                 3,
@@ -3077,10 +2937,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFSUPRESSION",
                 getModItem(BloodMagic.ID, "sigilOfSupression", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("vacuos"), 72).add(Aspect.getAspect("auram"), 16)
-                        .add(Aspect.getAspect("aqua"), 64).add(Aspect.getAspect("metallum"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("terra"), 32)
-                        .add(Aspect.getAspect("motus"), 16),
+                new AspectList().add(Aspect.VOID, 72).add(Aspect.AURA, 16).add(Aspect.WATER, 64).add(Aspect.METAL, 8)
+                        .add(Aspect.MAGIC, 32).add(Aspect.EARTH, 32).add(Aspect.MOTION, 16),
                 getModItem(BloodMagic.ID, "voidSigil", 1, 0),
                 getModItem(BloodMagic.ID, "blockTeleposer", 1, 0),
                 getModItem(Minecraft.ID, "bucket", 1, 0),
@@ -3101,10 +2959,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFENDERSEVERANCE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("alienis"), 21).add(Aspect.getAspect("cognitio"), 18)
-                        .add(Aspect.getAspect("humanus"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("vinculum"), 9).add(Aspect.getAspect("limus"), 6)
-                        .add(Aspect.getAspect("nebrisum"), 3),
+                new AspectList().add(Aspect.ELDRITCH, 21).add(Aspect.MIND, 18).add(Aspect.MAN, 15)
+                        .add(Aspect.ENERGY, 12).add(Aspect.TRAP, 9).add(Aspect.SLIME, 6)
+                        .add(TCAspects.NEBRISUM.getAspect(), 3),
                 0,
                 14,
                 3,
@@ -3115,10 +2972,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFENDERSEVERANCE",
                 getModItem(BloodMagic.ID, "sigilOfEnderSeverance", 1, 0),
                 17,
-                new AspectList().add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("cognitio"), 72)
-                        .add(Aspect.getAspect("humanus"), 16).add(Aspect.getAspect("potentia"), 64)
-                        .add(Aspect.getAspect("vinculum"), 48).add(Aspect.getAspect("limus"), 32)
-                        .add(Aspect.getAspect("nebrisum"), 8),
+                new AspectList().add(Aspect.ELDRITCH, 16).add(Aspect.MIND, 72).add(Aspect.MAN, 16)
+                        .add(Aspect.ENERGY, 64).add(Aspect.TRAP, 48).add(Aspect.SLIME, 32)
+                        .add(TCAspects.NEBRISUM.getAspect(), 8),
                 getModItem(BloodMagic.ID, "bloodMagicBaseItems", 1, 27),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
@@ -3138,10 +2994,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ENDERSIGIL",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("vacuos"), 24).add(Aspect.getAspect("alienis"), 21)
-                        .add(Aspect.getAspect("cognitio"), 18).add(Aspect.getAspect("humanus"), 15)
-                        .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("vinculum"), 9)
-                        .add(Aspect.getAspect("limus"), 6).add(Aspect.getAspect("nebrisum"), 3),
+                new AspectList().add(Aspect.VOID, 24).add(Aspect.ELDRITCH, 21).add(Aspect.MIND, 18).add(Aspect.MAN, 15)
+                        .add(Aspect.ENERGY, 12).add(Aspect.TRAP, 9).add(Aspect.SLIME, 6)
+                        .add(TCAspects.NEBRISUM.getAspect(), 3),
                 -2,
                 16,
                 3,
@@ -3152,10 +3007,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "ENDERSIGIL",
                 getModItem(BloodArsenal.ID, "sigil_of_ender", 1, 0),
                 20,
-                new AspectList().add(Aspect.getAspect("vacuos"), 16).add(Aspect.getAspect("alienis"), 16)
-                        .add(Aspect.getAspect("cognitio"), 72).add(Aspect.getAspect("humanus"), 16)
-                        .add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("vinculum"), 48)
-                        .add(Aspect.getAspect("limus"), 32).add(Aspect.getAspect("nebrisum"), 8),
+                new AspectList().add(Aspect.VOID, 16).add(Aspect.ELDRITCH, 16).add(Aspect.MIND, 72).add(Aspect.MAN, 16)
+                        .add(Aspect.ENERGY, 64).add(Aspect.TRAP, 48).add(Aspect.SLIME, 32)
+                        .add(TCAspects.NEBRISUM.getAspect(), 8),
                 getModItem(BloodMagic.ID, "sigilOfEnderSeverance", 1, 0),
                 getModItem(EnderStorage.ID, "enderChest", 1, 0),
                 ItemList.Gravistar.get(1L),
@@ -3173,10 +3027,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFDIVINITY",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("tutamen"), 24).add(Aspect.getAspect("aer"), 21)
-                        .add(Aspect.getAspect("ignis"), 18).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("terra"), 12).add(Aspect.getAspect("ordo"), 9)
-                        .add(Aspect.getAspect("perditio"), 6).add(Aspect.getAspect("sano"), 3),
+                new AspectList().add(Aspect.ARMOR, 24).add(Aspect.AIR, 21).add(Aspect.FIRE, 18).add(Aspect.WATER, 15)
+                        .add(Aspect.EARTH, 12).add(Aspect.ORDER, 9).add(Aspect.ENTROPY, 6).add(Aspect.HEAL, 3),
                 2,
                 16,
                 3,
@@ -3187,10 +3039,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFDIVINITY",
                 getModItem(BloodArsenal.ID, "sigil_of_divinity", 1, 0),
                 25,
-                new AspectList().add(Aspect.getAspect("tutamen"), 64).add(Aspect.getAspect("aer"), 72)
-                        .add(Aspect.getAspect("ignis"), 64).add(Aspect.getAspect("aqua"), 48)
-                        .add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("ordo"), 32)
-                        .add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("sano"), 8),
+                new AspectList().add(Aspect.ARMOR, 64).add(Aspect.AIR, 72).add(Aspect.FIRE, 64).add(Aspect.WATER, 48)
+                        .add(Aspect.EARTH, 32).add(Aspect.ORDER, 32).add(Aspect.ENTROPY, 16).add(Aspect.HEAL, 8),
                 getModItem(BloodMagic.ID, "sigilOfElementalAffinity", 1, 0),
                 getModItem(BloodArsenal.ID, "blood_stone", 1, 4),
                 getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0),
@@ -3211,10 +3061,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "HARVESTGODDESSSIGIL",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("herba"), 21).add(Aspect.getAspect("arbor"), 18)
-                        .add(Aspect.getAspect("meto"), 15).add(Aspect.getAspect("messis"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.PLANT, 21).add(Aspect.TREE, 18).add(Aspect.HARVEST, 15).add(Aspect.CROP, 12)
+                        .add(Aspect.MIND, 9).add(Aspect.MAGIC, 6).add(Aspect.ELDRITCH, 3),
                 0,
                 16,
                 3,
@@ -3225,10 +3073,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "HARVESTGODDESSSIGIL",
                 getModItem(BloodMagic.ID, "itemHarvestSigil", 1, 0),
                 20,
-                new AspectList().add(Aspect.getAspect("herba"), 72).add(Aspect.getAspect("arbor"), 64)
-                        .add(Aspect.getAspect("meto"), 8).add(Aspect.getAspect("messis"), 16)
-                        .add(Aspect.getAspect("cognitio"), 24).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("alienis"), 16),
+                new AspectList().add(Aspect.PLANT, 72).add(Aspect.TREE, 64).add(Aspect.HARVEST, 8).add(Aspect.CROP, 16)
+                        .add(Aspect.MIND, 24).add(Aspect.MAGIC, 32).add(Aspect.ELDRITCH, 16),
                 getModItem(BloodMagic.ID, "growthSigil", 1, 0),
                 getModItem(BloodArsenal.ID, "bound_sickle", 1, 0),
                 getModItem(BloodMagic.ID, "bloodMagicBaseAlchemyItems", 1, 2),
@@ -3245,9 +3091,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "SIGILOFCOMPRESSION",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("superbia"), 3),
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.ENERGY, 12).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.GREED, 6).add(DarkAspects.PRIDE, 3),
                 2,
                 8,
                 3,
@@ -3258,9 +3103,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "SIGILOFCOMPRESSION",
                 getModItem(BloodMagic.ID, "itemCompressionSigil", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("machina"), 16).add(Aspect.getAspect("lucrum"), 16)
-                        .add(Aspect.getAspect("superbia"), 8),
+                new AspectList().add(Aspect.METAL, 32).add(Aspect.ENERGY, 24).add(Aspect.MECHANISM, 16)
+                        .add(Aspect.GREED, 16).add(DarkAspects.PRIDE, 8),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
                 ItemList.Electric_Piston_IV.get(1L),
@@ -3277,10 +3121,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ENERGYBAZOOKAI",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("potentia"), 21).add(Aspect.getAspect("instrumentum"), 18)
-                        .add(Aspect.getAspect("telum"), 15).add(Aspect.getAspect("superbia"), 12)
-                        .add(Aspect.getAspect("fames"), 9).add(Aspect.getAspect("nebrisum"), 6)
-                        .add(Aspect.getAspect("ira"), 3),
+                new AspectList().add(Aspect.ENERGY, 21).add(Aspect.TOOL, 18).add(Aspect.WEAPON, 15)
+                        .add(DarkAspects.PRIDE, 12).add(Aspect.HUNGER, 9).add(TCAspects.NEBRISUM.getAspect(), 6)
+                        .add(DarkAspects.WRATH, 3),
                 -12,
                 0,
                 3,
@@ -3290,9 +3133,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ENERGYBAZOOKAI",
                 getModItem(BloodMagic.ID, "energyBazooka", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 150).add(Aspect.getAspect("ignis"), 150)
-                        .add(Aspect.getAspect("terra"), 150).add(Aspect.getAspect("aer"), 150)
-                        .add(Aspect.getAspect("perditio"), 150).add(Aspect.getAspect("ordo"), 150),
+                new AspectList().add(Aspect.WATER, 150).add(Aspect.FIRE, 150).add(Aspect.EARTH, 150)
+                        .add(Aspect.AIR, 150).add(Aspect.ENTROPY, 150).add(Aspect.ORDER, 150),
                 "abc",
                 "def",
                 "ghi",
@@ -3321,10 +3163,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ENERGYBAZOOKAII",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("potentia"), 24).add(Aspect.getAspect("instrumentum"), 21)
-                        .add(Aspect.getAspect("telum"), 18).add(Aspect.getAspect("infernus"), 15)
-                        .add(Aspect.getAspect("superbia"), 12).add(Aspect.getAspect("fames"), 9)
-                        .add(Aspect.getAspect("nebrisum"), 6).add(Aspect.getAspect("ira"), 3),
+                new AspectList().add(Aspect.ENERGY, 24).add(Aspect.TOOL, 21).add(Aspect.WEAPON, 18)
+                        .add(DarkAspects.NETHER, 15).add(DarkAspects.PRIDE, 12).add(Aspect.HUNGER, 9)
+                        .add(TCAspects.NEBRISUM.getAspect(), 6).add(DarkAspects.WRATH, 3),
                 -14,
                 0,
                 3,
@@ -3335,10 +3176,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "ENERGYBAZOOKAII",
                 getModItem(BloodMagic.ID, "energyBazookaSecondTier", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("potentia"), 96).add(Aspect.getAspect("instrumentum"), 72)
-                        .add(Aspect.getAspect("telum"), 64).add(Aspect.getAspect("infernus"), 64)
-                        .add(Aspect.getAspect("superbia"), 32).add(Aspect.getAspect("fames"), 32)
-                        .add(Aspect.getAspect("nebrisum"), 16).add(Aspect.getAspect("ira"), 8),
+                new AspectList().add(Aspect.ENERGY, 96).add(Aspect.TOOL, 72).add(Aspect.WEAPON, 64)
+                        .add(DarkAspects.NETHER, 64).add(DarkAspects.PRIDE, 32).add(Aspect.HUNGER, 32)
+                        .add(TCAspects.NEBRISUM.getAspect(), 16).add(DarkAspects.WRATH, 8),
                 getModItem(BloodMagic.ID, "energyBazooka", 1, 0),
                 getModItem(DraconicEvolution.ID, "draconium", 1, 2),
                 getModItem(DraconicEvolution.ID, "draconicCore", 1, 0),
@@ -3358,11 +3198,9 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ENERGYBAZOOKAIII",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("potentia"), 27).add(Aspect.getAspect("instrumentum"), 24)
-                        .add(Aspect.getAspect("telum"), 21).add(Aspect.getAspect("terminus"), 18)
-                        .add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("superbia"), 12)
-                        .add(Aspect.getAspect("fames"), 9).add(Aspect.getAspect("nebrisum"), 6)
-                        .add(Aspect.getAspect("ira"), 3),
+                new AspectList().add(Aspect.ENERGY, 27).add(Aspect.TOOL, 24).add(Aspect.WEAPON, 21)
+                        .add(Lucrum.ULTRA_DEATH, 18).add(DarkAspects.NETHER, 15).add(DarkAspects.PRIDE, 12)
+                        .add(Aspect.HUNGER, 9).add(TCAspects.NEBRISUM.getAspect(), 6).add(DarkAspects.WRATH, 3),
                 -16,
                 0,
                 3,
@@ -3373,11 +3211,9 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "ENERGYBAZOOKAIII",
                 getModItem(BloodMagic.ID, "energyBazookaThirdTier", 1, 0),
                 20,
-                new AspectList().add(Aspect.getAspect("potentia"), 128).add(Aspect.getAspect("instrumentum"), 96)
-                        .add(Aspect.getAspect("telum"), 72).add(Aspect.getAspect("terminus"), 64)
-                        .add(Aspect.getAspect("infernus"), 72).add(Aspect.getAspect("superbia"), 48)
-                        .add(Aspect.getAspect("fames"), 32).add(Aspect.getAspect("nebrisum"), 16)
-                        .add(Aspect.getAspect("ira"), 8),
+                new AspectList().add(Aspect.ENERGY, 128).add(Aspect.TOOL, 96).add(Aspect.WEAPON, 72)
+                        .add(Lucrum.ULTRA_DEATH, 64).add(DarkAspects.NETHER, 72).add(DarkAspects.PRIDE, 48)
+                        .add(Aspect.HUNGER, 32).add(TCAspects.NEBRISUM.getAspect(), 16).add(DarkAspects.WRATH, 8),
                 getModItem(BloodMagic.ID, "energyBazookaSecondTier", 1, 0),
                 getModItem(Avaritia.ID, "big_pearl", 1, 0),
                 getModItem(Avaritia.ID, "Resource", 1, 6),
@@ -3399,9 +3235,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "CAP_blood_iron",
                 getModItem(BloodArsenal.ID, "wand_caps", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("victus"), 24).add(Aspect.getAspect("metallum"), 16)
-                        .add(Aspect.getAspect("ignis"), 8),
+                new AspectList().add(Aspect.WATER, 32).add(Aspect.MAGIC, 24).add(Aspect.LIFE, 24).add(Aspect.METAL, 16)
+                        .add(Aspect.FIRE, 8),
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 0),
                 getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0),
                 getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0),
@@ -3420,9 +3255,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodArsenal.ID, "wand_caps", 1, 0))));
         TCHelper.setResearchAspects(
                 "CAP_blood_iron",
-                new AspectList().add(Aspect.getAspect("victus"), 18).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("metallum"), 6));
+                new AspectList().add(Aspect.LIFE, 18).add(Aspect.WATER, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.DARKNESS, 12).add(Aspect.METAL, 6));
         TCHelper.setResearchComplexity("CAP_blood_iron", 3);
         ThaumcraftApi.addWarpToResearch("CAP_blood_iron", 3);
         TCHelper.clearPages("ROD_blood_wood");
@@ -3432,9 +3266,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "ROD_blood_wood",
                 getModItem(BloodArsenal.ID, "wand_cores", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("instrumentum"), 24)
-                        .add(Aspect.getAspect("victus"), 32).add(Aspect.getAspect("arbor"), 16)
-                        .add(Aspect.getAspect("potentia"), 8),
+                new AspectList().add(Aspect.MAGIC, 32).add(Aspect.TOOL, 24).add(Aspect.LIFE, 32).add(Aspect.TREE, 16)
+                        .add(Aspect.ENERGY, 8),
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 3),
                 getModItem(BloodArsenal.ID, "amorphic_catalyst", 1, 0),
                 getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0),
@@ -3451,9 +3284,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(BloodArsenal.ID, "wand_cores", 1, 0))));
         TCHelper.setResearchAspects(
                 "ROD_blood_wood",
-                new AspectList().add(Aspect.getAspect("victus"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("aqua"), 12).add(Aspect.getAspect("tenebrae"), 9)
-                        .add(Aspect.getAspect("instrumentum"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.LIFE, 18).add(Aspect.MAGIC, 15).add(Aspect.WATER, 12)
+                        .add(Aspect.DARKNESS, 9).add(Aspect.TOOL, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ROD_blood_wood", 3);
         ThaumcraftApi.addWarpToResearch("ROD_blood_wood", 5);
         TCHelper.orphanResearch("ROD_blood_wood_staff");
@@ -3461,9 +3293,8 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "ROD_blood_wood_staff",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("victus"), 18).add(Aspect.getAspect("instrumentum"), 15)
-                        .add(Aspect.getAspect("aqua"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("tenebrae"), 3),
+                new AspectList().add(Aspect.LIFE, 18).add(Aspect.TOOL, 15).add(Aspect.WATER, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.ENERGY, 6).add(Aspect.DARKNESS, 3),
                 7,
                 -5,
                 3,
@@ -3475,10 +3306,8 @@ public class ScriptBloodMagic implements IScriptLoader {
                 "ROD_blood_wood_staff",
                 getModItem(BloodArsenal.ID, "wand_cores", 1, 1),
                 12,
-                new AspectList().add(Aspect.getAspect("victus"), 64).add(Aspect.getAspect("aqua"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("instrumentum"), 48)
-                        .add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("ignis"), 16)
-                        .add(Aspect.getAspect("infernus"), 8).add(Aspect.getAspect("arbor"), 32),
+                new AspectList().add(Aspect.LIFE, 64).add(Aspect.WATER, 64).add(Aspect.MAGIC, 64).add(Aspect.TOOL, 48)
+                        .add(Aspect.METAL, 16).add(Aspect.FIRE, 16).add(DarkAspects.NETHER, 8).add(Aspect.TREE, 32),
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 9),
                 getModItem(BloodArsenal.ID, "wand_cores", 1, 0),
                 getModItem(BloodArsenal.ID, "blood_infused_glowstone_dust", 1, 0),
@@ -3503,8 +3332,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         new ResearchItem(
                 "INCENSECRUCIBLE",
                 "BLOODMAGIC",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("victus"), 18)
-                        .add(Aspect.getAspect("potentia"), 6),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.LIFE, 18).add(Aspect.ENERGY, 6),
                 6,
                 -2,
                 3,
@@ -3513,8 +3341,7 @@ public class ScriptBloodMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "INCENSECRUCIBLE",
                 getModItem(BloodMagic.ID, "blockCrucible", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("aer"), 15)
-                        .add(Aspect.getAspect("ordo"), 15),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.AIR, 15).add(Aspect.ORDER, 15),
                 "abc",
                 "def",
                 "ghi",

--- a/src/main/java/com/dreammaster/scripts/ScriptEFR.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEFR.java
@@ -58,7 +58,6 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gregtech.api.util.GTRecipeConstants.UniversalChemical;
 import static gtPlusPlus.api.recipe.GTPPRecipeMaps.chemicalDehydratorRecipes;
-import static thaumcraft.api.aspects.Aspect.getAspect;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -91,6 +90,7 @@ import bartworks.system.material.WerkstoffLoader;
 import cpw.mods.fml.common.registry.GameRegistry;
 import forestry.api.recipes.RecipeManagers;
 import forestry.core.fluids.Fluids;
+import fox.spiteful.forbidden.DarkAspects;
 import ganymedes01.etfuturum.recipes.SmokerRecipes;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
@@ -1288,9 +1288,8 @@ public class ScriptEFR implements IScriptLoader {
         new ResearchItem(
                 "UNDYINGTOTEM",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("spiritus"), 9)
-                        .add(Aspect.getAspect("fames"), 6).add(Aspect.getAspect("corpus"), 3),
+                new AspectList().add(DarkAspects.NETHER, 15).add(Aspect.GREED, 12).add(Aspect.MAGIC, 12)
+                        .add(Aspect.SOUL, 9).add(Aspect.HUNGER, 6).add(Aspect.FLESH, 3),
                 -6,
                 -7,
                 3,
@@ -1301,9 +1300,8 @@ public class ScriptEFR implements IScriptLoader {
                 "UNDYINGTOTEM",
                 getModItem(EtFuturumRequiem.ID, "totem_of_undying", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("exanimis"), 100).add(Aspect.getAspect("ignis"), 150)
-                        .add(Aspect.getAspect("lucrum"), 150).add(Aspect.getAspect("sano"), 200)
-                        .add(Aspect.getAspect("praecantatio"), 200),
+                new AspectList().add(Aspect.UNDEAD, 100).add(Aspect.FIRE, 150).add(Aspect.GREED, 150)
+                        .add(Aspect.HEAL, 200).add(Aspect.MAGIC, 200),
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 1),
                 OrePrefixes.plate.get(Materials.InfusedGold),
                 OrePrefixes.gemExquisite.get(Materials.Emerald),
@@ -1348,9 +1346,8 @@ public class ScriptEFR implements IScriptLoader {
         new ResearchItem(
                 "SHULKER",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("spiritus"), 9)
-                        .add(Aspect.getAspect("fames"), 6).add(Aspect.getAspect("corpus"), 3),
+                new AspectList().add(DarkAspects.NETHER, 15).add(Aspect.GREED, 12).add(Aspect.MAGIC, 12)
+                        .add(Aspect.SOUL, 9).add(Aspect.HUNGER, 6).add(Aspect.FLESH, 3),
                 -6,
                 6,
                 3,
@@ -1361,9 +1358,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getShulkerBox(0, 0), // Regular
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 "aba",
                 "cdc",
                 "aba",
@@ -1378,9 +1374,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getShulkerBox(0, 1), // Iron
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "abe",
                 "cdc",
                 "eba",
@@ -1397,9 +1392,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getShulkerBox(0, 2), // Gold
-                new AspectList().add(Aspect.getAspect("aer"), 25).add(Aspect.getAspect("ignis"), 25)
-                        .add(Aspect.getAspect("terra"), 25).add(Aspect.getAspect("aqua"), 25)
-                        .add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("perditio"), 25),
+                new AspectList().add(Aspect.AIR, 25).add(Aspect.FIRE, 25).add(Aspect.EARTH, 25).add(Aspect.WATER, 25)
+                        .add(Aspect.ORDER, 25).add(Aspect.ENTROPY, 25),
                 "abe",
                 "cdc",
                 "eba",
@@ -1416,9 +1410,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getShulkerBox(0, 3), // Diamond
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.FIRE, 50).add(Aspect.EARTH, 50).add(Aspect.WATER, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abe",
                 "cdc",
                 "eba",
@@ -1435,9 +1428,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getShulkerBox(0, 4), // Copper
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("terra"), 10).add(Aspect.getAspect("aqua"), 10)
-                        .add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.FIRE, 10).add(Aspect.EARTH, 10).add(Aspect.WATER, 10)
+                        .add(Aspect.ORDER, 10).add(Aspect.ENTROPY, 10),
                 "abe",
                 "cdc",
                 "eba",
@@ -1454,9 +1446,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getShulkerBox(0, 5), // Silver
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("terra"), 20).add(Aspect.getAspect("aqua"), 20)
-                        .add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("perditio"), 20),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.FIRE, 20).add(Aspect.EARTH, 20).add(Aspect.WATER, 20)
+                        .add(Aspect.ORDER, 20).add(Aspect.ENTROPY, 20),
                 "abe",
                 "cdc",
                 "eba",
@@ -1473,9 +1464,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getShulkerBox(0, 6), // Crystal
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.FIRE, 50).add(Aspect.EARTH, 50).add(Aspect.WATER, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abe",
                 "cdc",
                 "eba",
@@ -1492,9 +1482,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getShulkerBox(0, 7), // Obsidian
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.FIRE, 50).add(Aspect.EARTH, 50).add(Aspect.WATER, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abe",
                 "cdc",
                 "eba",
@@ -1514,9 +1503,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getModItem(EtFuturumRequiem.ID, "shulker_box_upgrade", 1, 1), // Vanilla to Copper
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 " a ",
                 "bab",
                 " a ",
@@ -1527,9 +1515,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getModItem(EtFuturumRequiem.ID, "shulker_box_upgrade", 1, 0), // Vanilla to Iron
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("terra"), 10).add(Aspect.getAspect("aqua"), 10)
-                        .add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.FIRE, 10).add(Aspect.EARTH, 10).add(Aspect.WATER, 10)
+                        .add(Aspect.ORDER, 10).add(Aspect.ENTROPY, 10),
                 " a ",
                 "bab",
                 " a ",
@@ -1540,9 +1527,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getModItem(EtFuturumRequiem.ID, "shulker_box_upgrade", 1, 6), // Copper to Iron
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 " a ",
                 "bcb",
                 " a ",
@@ -1555,9 +1541,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getModItem(EtFuturumRequiem.ID, "shulker_box_upgrade", 1, 7), // Copper to Silver
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("terra"), 10).add(Aspect.getAspect("aqua"), 10)
-                        .add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.FIRE, 10).add(Aspect.EARTH, 10).add(Aspect.WATER, 10)
+                        .add(Aspect.ORDER, 10).add(Aspect.ENTROPY, 10),
                 " a ",
                 "bcb",
                 " a ",
@@ -1570,9 +1555,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getModItem(EtFuturumRequiem.ID, "shulker_box_upgrade", 1, 2), // Iron to Gold
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("terra"), 10).add(Aspect.getAspect("aqua"), 10)
-                        .add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.FIRE, 10).add(Aspect.EARTH, 10).add(Aspect.WATER, 10)
+                        .add(Aspect.ORDER, 10).add(Aspect.ENTROPY, 10),
                 " a ",
                 "bcb",
                 " a ",
@@ -1585,9 +1569,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getModItem(EtFuturumRequiem.ID, "shulker_box_upgrade", 1, 8), // Silver to Gold
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 " a ",
                 "bcb",
                 " a ",
@@ -1600,9 +1583,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getModItem(EtFuturumRequiem.ID, "shulker_box_upgrade", 1, 3), // Gold to Diamond
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.FIRE, 50).add(Aspect.EARTH, 50).add(Aspect.WATER, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 " a ",
                 "bcb",
                 " a ",
@@ -1615,9 +1597,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getModItem(EtFuturumRequiem.ID, "shulker_box_upgrade", 1, 5), // Diamond to Crystal
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 " a ",
                 "bcb",
                 " a ",
@@ -1630,9 +1611,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SHULKER",
                 getModItem(EtFuturumRequiem.ID, "shulker_box_upgrade", 1, 4), // Diamond to Obsidian
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 " a ",
                 "bcb",
                 " a ",
@@ -1691,9 +1671,8 @@ public class ScriptEFR implements IScriptLoader {
         new ResearchItem(
                 "NetheriteArmour",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("spiritus"), 9)
-                        .add(Aspect.getAspect("fames"), 6).add(Aspect.getAspect("ignis"), 3),
+                new AspectList().add(DarkAspects.NETHER, 15).add(Aspect.GREED, 12).add(Aspect.MAGIC, 12)
+                        .add(Aspect.SOUL, 9).add(Aspect.HUNGER, 6).add(Aspect.FIRE, 3),
                 6,
                 6,
                 3,
@@ -1704,8 +1683,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NetheriteArmour",
                 getModItem(EtFuturumRequiem.ID, "netherite_helmet", 1, 0),
-                new AspectList().add(getAspect("aer"), 15).add(getAspect("ignis"), 15).add(getAspect("terra"), 15)
-                        .add(getAspect("aqua"), 15).add(getAspect("ordo"), 15).add(getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "aba",
                 "cdc",
                 "aea",
@@ -1723,8 +1702,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NetheriteArmour",
                 getModItem(EtFuturumRequiem.ID, "netherite_chestplate", 1, 0),
-                new AspectList().add(getAspect("aer"), 15).add(getAspect("ignis"), 15).add(getAspect("terra"), 15)
-                        .add(getAspect("aqua"), 15).add(getAspect("ordo"), 15).add(getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "aba",
                 "cdc",
                 "aea",
@@ -1742,8 +1721,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NetheriteArmour",
                 getModItem(EtFuturumRequiem.ID, "netherite_leggings", 1, 0),
-                new AspectList().add(getAspect("aer"), 15).add(getAspect("ignis"), 15).add(getAspect("terra"), 15)
-                        .add(getAspect("aqua"), 15).add(getAspect("ordo"), 15).add(getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "aba",
                 "cdc",
                 "aea",
@@ -1761,8 +1740,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NetheriteArmour",
                 getModItem(EtFuturumRequiem.ID, "netherite_boots", 1, 0),
-                new AspectList().add(getAspect("aer"), 15).add(getAspect("ignis"), 15).add(getAspect("terra"), 15)
-                        .add(getAspect("aqua"), 15).add(getAspect("ordo"), 15).add(getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "aba",
                 "cdc",
                 "aea",
@@ -1780,8 +1759,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NetheriteArmour",
                 getModItem(EtFuturumRequiem.ID, "netherite_pickaxe", 1, 0),
-                new AspectList().add(getAspect("aer"), 15).add(getAspect("ignis"), 15).add(getAspect("terra"), 15)
-                        .add(getAspect("aqua"), 15).add(getAspect("ordo"), 15).add(getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "aba",
                 "cdc",
                 "aea",
@@ -1799,8 +1778,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NetheriteArmour",
                 getModItem(EtFuturumRequiem.ID, "netherite_hoe", 1, 0),
-                new AspectList().add(getAspect("aer"), 15).add(getAspect("ignis"), 15).add(getAspect("terra"), 15)
-                        .add(getAspect("aqua"), 15).add(getAspect("ordo"), 15).add(getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "aba",
                 "cdc",
                 "aea",
@@ -1818,8 +1797,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NetheriteArmour",
                 getModItem(EtFuturumRequiem.ID, "netherite_spade", 1, 0),
-                new AspectList().add(getAspect("aer"), 15).add(getAspect("ignis"), 15).add(getAspect("terra"), 15)
-                        .add(getAspect("aqua"), 15).add(getAspect("ordo"), 15).add(getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "aba",
                 "cdc",
                 "aea",
@@ -1837,8 +1816,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NetheriteArmour",
                 getModItem(EtFuturumRequiem.ID, "netherite_sword", 1, 0),
-                new AspectList().add(getAspect("aer"), 15).add(getAspect("ignis"), 15).add(getAspect("terra"), 15)
-                        .add(getAspect("aqua"), 15).add(getAspect("ordo"), 15).add(getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "aba",
                 "cdc",
                 "aea",
@@ -1856,8 +1835,8 @@ public class ScriptEFR implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NetheriteArmour",
                 getModItem(EtFuturumRequiem.ID, "netherite_axe", 1, 0),
-                new AspectList().add(getAspect("aer"), 15).add(getAspect("ignis"), 15).add(getAspect("terra"), 15)
-                        .add(getAspect("aqua"), 15).add(getAspect("ordo"), 15).add(getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "aba",
                 "cdc",
                 "aea",
@@ -1924,9 +1903,8 @@ public class ScriptEFR implements IScriptLoader {
         new ResearchItem(
                 "ELYTRA",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("spiritus"), 9)
-                        .add(Aspect.getAspect("motus"), 12).add(Aspect.getAspect("tempestas"), 3),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.GREED, 12).add(Aspect.MAGIC, 12).add(Aspect.SOUL, 9)
+                        .add(Aspect.MOTION, 12).add(Aspect.WEATHER, 3),
                 -4,
                 6,
                 3,
@@ -1936,9 +1914,8 @@ public class ScriptEFR implements IScriptLoader {
                 "ELYTRA",
                 getModItem(EtFuturumRequiem.ID, "elytra", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("aer"), 100).add(Aspect.getAspect("praecantatio"), 150)
-                        .add(Aspect.getAspect("motus"), 150).add(Aspect.getAspect("tempestas"), 200)
-                        .add(Aspect.getAspect("praecantatio"), 200),
+                new AspectList().add(Aspect.AIR, 100).add(Aspect.MAGIC, 150).add(Aspect.MOTION, 150)
+                        .add(Aspect.WEATHER, 200).add(Aspect.MAGIC, 200),
                 getModItem(WitchingGadgets.ID, "item.WG_Kama", 1, 4),
                 getModItem(EnderIO.ID, "itemGliderWing", 1, 1),
                 GregtechItemList.MagicFeather.get(1),

--- a/src/main/java/com/dreammaster/scripts/ScriptEMT.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEMT.java
@@ -40,10 +40,12 @@ import net.minecraftforge.fluids.FluidRegistry;
 import com.dreammaster.item.NHItemList;
 import com.dreammaster.thaumcraft.TCHelper;
 
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TCAspects;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
@@ -217,7 +219,7 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ElectricMagicTools",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("terra"), 0),
+                new AspectList().add(Aspect.EARTH, 0),
                 0,
                 0,
                 1,
@@ -227,8 +229,7 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "DiamondChainsaw",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("lucrum"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.GREED, 12).add(Aspect.FIRE, 9).add(Aspect.METAL, 6).add(Aspect.EARTH, 3),
                 0,
                 -2,
                 2,
@@ -237,9 +238,8 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DiamondChainsaw",
                 getModItem(ElectroMagicTools.ID, "DiamondChainsaw", 1, 27),
-                new AspectList().add(Aspect.getAspect("aer"), 35).add(Aspect.getAspect("terra"), 35)
-                        .add(Aspect.getAspect("ignis"), 35).add(Aspect.getAspect("aqua"), 35)
-                        .add(Aspect.getAspect("ordo"), 35).add(Aspect.getAspect("perditio"), 35),
+                new AspectList().add(Aspect.AIR, 35).add(Aspect.EARTH, 35).add(Aspect.FIRE, 35).add(Aspect.WATER, 35)
+                        .add(Aspect.ORDER, 35).add(Aspect.ENTROPY, 35),
                 "abc",
                 "def",
                 "ghi",
@@ -295,9 +295,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "FeatherWings",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("volatus"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.ENERGY, 12).add(Aspect.MAGIC, 9).add(Aspect.FLIGHT, 6)
+                        .add(Aspect.EARTH, 3),
                 0,
                 2,
                 3,
@@ -306,8 +305,7 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FeatherWings",
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("terra"), 5)
-                        .add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.EARTH, 5).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -332,7 +330,7 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FeatherWings",
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 11),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -350,7 +348,7 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FeatherWings",
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 12),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.ORDER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -378,9 +376,8 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FeatherWings",
                 getModItem(ElectroMagicTools.ID, "FeatherWing", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("terra"), 24)
-                        .add(Aspect.getAspect("ignis"), 24).add(Aspect.getAspect("aqua"), 24)
-                        .add(Aspect.getAspect("ordo"), 24).add(Aspect.getAspect("perditio"), 24),
+                new AspectList().add(Aspect.AIR, 24).add(Aspect.EARTH, 24).add(Aspect.FIRE, 24).add(Aspect.WATER, 24)
+                        .add(Aspect.ORDER, 24).add(Aspect.ENTROPY, 24),
                 "abc",
                 "def",
                 "ghi",
@@ -410,10 +407,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ThaumiumReinforcedWings",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("aer"), 21).add(Aspect.getAspect("potentia"), 18)
-                        .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("volatus"), 12)
-                        .add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("vitium"), 6)
-                        .add(Aspect.getAspect("machina"), 3),
+                new AspectList().add(Aspect.AIR, 21).add(Aspect.ENERGY, 18).add(Aspect.MAGIC, 15).add(Aspect.FLIGHT, 12)
+                        .add(Aspect.METAL, 9).add(Aspect.TAINT, 6).add(Aspect.MECHANISM, 3),
                 0,
                 4,
                 3,
@@ -424,17 +419,15 @@ public class ScriptEMT implements IScriptLoader {
                 "ThaumiumReinforcedWings",
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 13),
                 getModItem(Minecraft.ID, "feather", 1, 0),
-                new AspectList().add(Aspect.getAspect("vitium"), 6).add(Aspect.getAspect("lucrum"), 4)
-                        .add(Aspect.getAspect("fames"), 4));
+                new AspectList().add(Aspect.TAINT, 6).add(Aspect.GREED, 4).add(Aspect.HUNGER, 4));
         TCHelper.addResearchPage(
                 "ThaumiumReinforcedWings",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTItems", 1, 13))));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ThaumiumReinforcedWings",
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 14),
-                new AspectList().add(Aspect.getAspect("aer"), 48).add(Aspect.getAspect("terra"), 48)
-                        .add(Aspect.getAspect("ignis"), 48).add(Aspect.getAspect("aqua"), 48)
-                        .add(Aspect.getAspect("ordo"), 48).add(Aspect.getAspect("perditio"), 48),
+                new AspectList().add(Aspect.AIR, 48).add(Aspect.EARTH, 48).add(Aspect.FIRE, 48).add(Aspect.WATER, 48)
+                        .add(Aspect.ORDER, 48).add(Aspect.ENTROPY, 48),
                 "abc",
                 "def",
                 "ghi",
@@ -462,9 +455,8 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ThaumiumReinforcedWings",
                 getModItem(ElectroMagicTools.ID, "ThaumiumWing", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 48).add(Aspect.getAspect("terra"), 48)
-                        .add(Aspect.getAspect("ignis"), 48).add(Aspect.getAspect("aqua"), 48)
-                        .add(Aspect.getAspect("ordo"), 48).add(Aspect.getAspect("perditio"), 48),
+                new AspectList().add(Aspect.AIR, 48).add(Aspect.EARTH, 48).add(Aspect.FIRE, 48).add(Aspect.WATER, 48)
+                        .add(Aspect.ORDER, 48).add(Aspect.ENTROPY, 48),
                 "abc",
                 "def",
                 "ghi",
@@ -489,10 +481,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "NanosuitWings",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("potentia"), 21)
-                        .add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("volatus"), 15)
-                        .add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("vitium"), 9)
-                        .add(Aspect.getAspect("machina"), 6).add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.AIR, 24).add(Aspect.ENERGY, 21).add(Aspect.MAGIC, 18).add(Aspect.FLIGHT, 15)
+                        .add(Aspect.METAL, 12).add(Aspect.TAINT, 9).add(Aspect.MECHANISM, 6).add(Aspect.EARTH, 3),
                 0,
                 6,
                 3,
@@ -503,10 +493,8 @@ public class ScriptEMT implements IScriptLoader {
                 "NanosuitWings",
                 getModItem(ElectroMagicTools.ID, "NanosuitWing", 1, 27),
                 5,
-                new AspectList().add(Aspect.getAspect("aer"), 48).add(Aspect.getAspect("machina"), 48)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("volatus"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("vitium"), 8)
-                        .add(Aspect.getAspect("terra"), 8),
+                new AspectList().add(Aspect.AIR, 48).add(Aspect.MECHANISM, 48).add(Aspect.ENERGY, 32)
+                        .add(Aspect.FLIGHT, 32).add(Aspect.MAGIC, 16).add(Aspect.TAINT, 8).add(Aspect.EARTH, 8),
                 getModItem(ElectroMagicTools.ID, "ThaumiumWing", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemArmorNanoChestplate", 1, wildcard),
                 OrePrefixes.wireFine.get(Materials.Titanium),
@@ -527,11 +515,9 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "QuantumWings",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("aer"), 27).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 21).add(Aspect.getAspect("volatus"), 18)
-                        .add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("vitium"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.AIR, 27).add(Aspect.ENERGY, 24).add(Aspect.MAGIC, 21).add(Aspect.FLIGHT, 18)
+                        .add(Aspect.METAL, 15).add(Aspect.TAINT, 12).add(Aspect.MECHANISM, 9).add(Aspect.EARTH, 6)
+                        .add(Aspect.GREED, 3),
                 0,
                 8,
                 3,
@@ -541,10 +527,9 @@ public class ScriptEMT implements IScriptLoader {
                 "QuantumWings",
                 getModItem(ElectroMagicTools.ID, "QuantumWing", 1, 27),
                 10,
-                new AspectList().add(Aspect.getAspect("tutamen"), 64).add(Aspect.getAspect("aer"), 64)
-                        .add(Aspect.getAspect("machina"), 64).add(Aspect.getAspect("potentia"), 48)
-                        .add(Aspect.getAspect("volatus"), 48).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("vitium"), 16).add(Aspect.getAspect("terra"), 16),
+                new AspectList().add(Aspect.ARMOR, 64).add(Aspect.AIR, 64).add(Aspect.MECHANISM, 64)
+                        .add(Aspect.ENERGY, 48).add(Aspect.FLIGHT, 48).add(Aspect.MAGIC, 32).add(Aspect.TAINT, 16)
+                        .add(Aspect.EARTH, 16),
                 getModItem(ElectroMagicTools.ID, "NanosuitWing", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorQuantumChestplate", 1, wildcard),
                 OrePrefixes.wireFine.get(Materials.Osmium),
@@ -565,11 +550,9 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "InfusedQuantumArmor",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("potentia"), 27)
-                        .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("volatus"), 21)
-                        .add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("vitium"), 15)
-                        .add(Aspect.getAspect("machina"), 12).add(Aspect.getAspect("terra"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("superbia"), 3),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.ENERGY, 27).add(Aspect.MAGIC, 24).add(Aspect.FLIGHT, 21)
+                        .add(Aspect.METAL, 18).add(Aspect.TAINT, 15).add(Aspect.MECHANISM, 12).add(Aspect.EARTH, 9)
+                        .add(Aspect.GREED, 6).add(DarkAspects.PRIDE, 3),
                 0,
                 10,
                 3,
@@ -580,11 +563,9 @@ public class ScriptEMT implements IScriptLoader {
                 "InfusedQuantumArmor",
                 getModItem(ElectroMagicTools.ID, "itemArmorQuantumChestplate", 1, 27),
                 15,
-                new AspectList().add(Aspect.getAspect("tutamen"), 72).add(Aspect.getAspect("aer"), 64)
-                        .add(Aspect.getAspect("machina"), 64).add(Aspect.getAspect("potentia"), 48)
-                        .add(Aspect.getAspect("volatus"), 48).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("vitium"), 16).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("lucrum"), 8),
+                new AspectList().add(Aspect.ARMOR, 72).add(Aspect.AIR, 64).add(Aspect.MECHANISM, 64)
+                        .add(Aspect.ENERGY, 48).add(Aspect.FLIGHT, 48).add(Aspect.MAGIC, 32).add(Aspect.TAINT, 16)
+                        .add(Aspect.EARTH, 16).add(Aspect.GREED, 8),
                 getModItem(IndustrialCraft2.ID, "itemArmorQuantumChestplate", 1, wildcard),
                 getModItem(ElectroMagicTools.ID, "ShieldBlock", 1, 0),
                 OrePrefixes.wireFine.get(Materials.Naquadah),
@@ -609,8 +590,7 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "IronOmnitool",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("instrumentum"), 9)
-                        .add(Aspect.getAspect("perfodio"), 6).add(Aspect.getAspect("telum"), 3),
+                new AspectList().add(Aspect.ENERGY, 12).add(Aspect.TOOL, 9).add(Aspect.MINE, 6).add(Aspect.WEAPON, 3),
                 -2,
                 0,
                 2,
@@ -619,9 +599,8 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "IronOmnitool",
                 getModItem(ElectroMagicTools.ID, "Omnitool", 1, 27),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.EARTH, 15).add(Aspect.FIRE, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -651,9 +630,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "DiamondOmnitool",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("instrumentum"), 12)
-                        .add(Aspect.getAspect("perfodio"), 9).add(Aspect.getAspect("telum"), 6)
-                        .add(Aspect.getAspect("vitreus"), 3),
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.TOOL, 12).add(Aspect.MINE, 9).add(Aspect.WEAPON, 6)
+                        .add(Aspect.CRYSTAL, 3),
                 -4,
                 0,
                 3,
@@ -664,9 +642,8 @@ public class ScriptEMT implements IScriptLoader {
                 "DiamondOmnitool",
                 getModItem(ElectroMagicTools.ID, "Diamond Omnitool", 1, 27),
                 6,
-                new AspectList().add(getAspect("instrumentum"), 32).add(getAspect("perfodio"), 24)
-                        .add(getAspect("potentia"), 24).add(getAspect("metallum"), 16).add(getAspect("telum"), 16)
-                        .add(getAspect("terra"), 8),
+                new AspectList().add(Aspect.TOOL, 32).add(Aspect.MINE, 24).add(Aspect.ENERGY, 24).add(Aspect.METAL, 16)
+                        .add(Aspect.WEAPON, 16).add(Aspect.EARTH, 8),
                 createItemStack(
                         GregTech.ID,
                         "gt.metatool.01",
@@ -692,9 +669,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ThaumiumOmnitool",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("instrumentum"), 12)
-                        .add(Aspect.getAspect("perfodio"), 9).add(Aspect.getAspect("telum"), 6)
-                        .add(Aspect.getAspect("vitreus"), 3),
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.TOOL, 12).add(Aspect.MINE, 9).add(Aspect.WEAPON, 6)
+                        .add(Aspect.CRYSTAL, 3),
                 -6,
                 0,
                 3,
@@ -705,10 +681,8 @@ public class ScriptEMT implements IScriptLoader {
                 "ThaumiumOmnitool",
                 getModItem(ElectroMagicTools.ID, "ThaumiumOmnitool", 1, 27),
                 8,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 48).add(Aspect.getAspect("perfodio"), 24)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("metallum"), 24)
-                        .add(Aspect.getAspect("telum"), 16).add(Aspect.getAspect("terra"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 16),
+                new AspectList().add(Aspect.TOOL, 48).add(Aspect.MINE, 24).add(Aspect.ENERGY, 32).add(Aspect.METAL, 24)
+                        .add(Aspect.WEAPON, 16).add(Aspect.EARTH, 8).add(Aspect.MAGIC, 16),
                 getModItem(ElectroMagicTools.ID, "ThaumiumChainsaw", 1, wildcard),
                 getModItem(ElectroMagicTools.ID, "ThaumiumDrill", 1, wildcard),
                 OrePrefixes.plate.get(Materials.TungstenSteel),
@@ -730,9 +704,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ElectricBootsoftheTraveller",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("motus"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("tutamen"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.MOTION, 12).add(Aspect.ENERGY, 9).add(Aspect.ARMOR, 6)
+                        .add(Aspect.EARTH, 3),
                 2,
                 2,
                 3,
@@ -744,9 +717,8 @@ public class ScriptEMT implements IScriptLoader {
                 "ElectricBootsoftheTraveller",
                 getModItem(ElectroMagicTools.ID, "ElectricBootsTraveller", 1, 27),
                 3,
-                new AspectList().add(Aspect.getAspect("motus"), 32).add(Aspect.getAspect("potentia"), 16)
-                        .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 8)
-                        .add(Aspect.getAspect("volatus"), 8).add(Aspect.getAspect("iter"), 8),
+                new AspectList().add(Aspect.MOTION, 32).add(Aspect.ENERGY, 16).add(Aspect.ARMOR, 32)
+                        .add(Aspect.MAGIC, 8).add(Aspect.FLIGHT, 8).add(Aspect.TRAVEL, 8),
                 getModItem(Thaumcraft.ID, "BootsTraveller", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemStaticBoots", 1, 0),
                 OrePrefixes.plate.get(Materials.Diamond),
@@ -766,9 +738,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "NanoBootsoftheTraveller",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("motus"), 15)
-                        .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("tutamen"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("volatus"), 3),
+                new AspectList().add(Aspect.MAGIC, 18).add(Aspect.MOTION, 15).add(Aspect.ENERGY, 12)
+                        .add(Aspect.ARMOR, 9).add(Aspect.EARTH, 6).add(Aspect.FLIGHT, 3),
                 4,
                 2,
                 3,
@@ -779,9 +750,8 @@ public class ScriptEMT implements IScriptLoader {
                 "NanoBootsoftheTraveller",
                 getModItem(ElectroMagicTools.ID, "NanoBootsTraveller", 1, 27),
                 6,
-                new AspectList().add(Aspect.getAspect("motus"), 48).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("volatus"), 8).add(Aspect.getAspect("iter"), 16),
+                new AspectList().add(Aspect.MOTION, 48).add(Aspect.ENERGY, 24).add(Aspect.ARMOR, 32)
+                        .add(Aspect.MAGIC, 16).add(Aspect.FLIGHT, 8).add(Aspect.TRAVEL, 16),
                 getModItem(ElectroMagicTools.ID, "ElectricBootsTraveller", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard),
                 OrePrefixes.plate.get(Materials.Thaumium),
@@ -801,10 +771,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "QuantumBootsoftheTraveller",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 21).add(Aspect.getAspect("motus"), 18)
-                        .add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("tutamen"), 12)
-                        .add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("volatus"), 6)
-                        .add(Aspect.getAspect("auram"), 3),
+                new AspectList().add(Aspect.MAGIC, 21).add(Aspect.MOTION, 18).add(Aspect.ENERGY, 15)
+                        .add(Aspect.ARMOR, 12).add(Aspect.EARTH, 9).add(Aspect.FLIGHT, 6).add(Aspect.AURA, 3),
                 6,
                 2,
                 3,
@@ -816,10 +784,8 @@ public class ScriptEMT implements IScriptLoader {
                 "QuantumBootsoftheTraveller",
                 getModItem(ElectroMagicTools.ID, "QuantumBootsTraveller", 1, 27),
                 9,
-                new AspectList().add(Aspect.getAspect("motus"), 64).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("tutamen"), 48).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("volatus"), 16).add(Aspect.getAspect("iter"), 24)
-                        .add(Aspect.getAspect("aer"), 8),
+                new AspectList().add(Aspect.MOTION, 64).add(Aspect.ENERGY, 32).add(Aspect.ARMOR, 48)
+                        .add(Aspect.MAGIC, 24).add(Aspect.FLIGHT, 16).add(Aspect.TRAVEL, 24).add(Aspect.AIR, 8),
                 getModItem(ElectroMagicTools.ID, "NanoBootsTraveller", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard),
                 OrePrefixes.plate.get(Materials.Void),
@@ -841,9 +807,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ThaumiumDrill",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 18).add(Aspect.getAspect("perfodio"), 15)
-                        .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("lucrum"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("ignis"), 3),
+                new AspectList().add(Aspect.TOOL, 18).add(Aspect.MINE, 15).add(Aspect.ENERGY, 12).add(Aspect.GREED, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.FIRE, 3),
                 2,
                 0,
                 3,
@@ -853,8 +818,8 @@ public class ScriptEMT implements IScriptLoader {
                 "ThaumiumDrill",
                 getModItem(ElectroMagicTools.ID, "ThaumiumDrill", 1, 27),
                 7,
-                new AspectList().add(getAspect("instrumentum"), 32).add(getAspect("perfodio"), 16)
-                        .add(getAspect("potentia"), 32).add(getAspect("lucrum"), 24).add(getAspect("praecantatio"), 8),
+                new AspectList().add(Aspect.TOOL, 32).add(Aspect.MINE, 16).add(Aspect.ENERGY, 32).add(Aspect.GREED, 24)
+                        .add(getAspect("praecantatio"), 8),
                 createItemStack(
                         GregTech.ID,
                         "gt.metatool.01",
@@ -879,10 +844,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "DrilloftheRockbreaker",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 21).add(Aspect.getAspect("perfodio"), 18)
-                        .add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("ignis"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.TOOL, 21).add(Aspect.MINE, 18).add(Aspect.ENERGY, 15).add(Aspect.GREED, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.FIRE, 6).add(Aspect.EARTH, 3),
                 4,
                 0,
                 3,
@@ -893,9 +856,8 @@ public class ScriptEMT implements IScriptLoader {
                 "DrilloftheRockbreaker",
                 getModItem(ElectroMagicTools.ID, "DrillRockbreaker", 1, 27),
                 10,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 48).add(Aspect.getAspect("perfodio"), 24)
-                        .add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("lucrum"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("ignis"), 8),
+                new AspectList().add(Aspect.TOOL, 48).add(Aspect.MINE, 24).add(Aspect.ENERGY, 48).add(Aspect.GREED, 32)
+                        .add(Aspect.MAGIC, 16).add(Aspect.FIRE, 8),
                 getModItem(ElectroMagicTools.ID, "ThaumiumDrill", 1, wildcard),
                 getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0),
@@ -917,9 +879,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ThaumiumChainsaw",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 18).add(Aspect.getAspect("telum"), 15)
-                        .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("lucrum"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("aer"), 3),
+                new AspectList().add(Aspect.TOOL, 18).add(Aspect.WEAPON, 15).add(Aspect.ENERGY, 12).add(Aspect.GREED, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.AIR, 3),
                 0,
                 -4,
                 3,
@@ -930,9 +891,8 @@ public class ScriptEMT implements IScriptLoader {
                 "ThaumiumChainsaw",
                 getModItem(ElectroMagicTools.ID, "ThaumiumChainsaw", 1, 27),
                 7,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 32).add(Aspect.getAspect("telum"), 24)
-                        .add(Aspect.getAspect("potentia"), 24).add(Aspect.getAspect("lucrum"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 8),
+                new AspectList().add(Aspect.TOOL, 32).add(Aspect.WEAPON, 24).add(Aspect.ENERGY, 24)
+                        .add(Aspect.GREED, 16).add(Aspect.MAGIC, 8),
                 getModItem(ElectroMagicTools.ID, "DiamondChainsaw", 1, wildcard),
                 OrePrefixes.screw.get(Materials.Titanium),
                 OrePrefixes.plate.get(Materials.Thaumium),
@@ -952,9 +912,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ChainsawoftheStream",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("arbor"), 3),
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.GREED, 12).add(Aspect.MAGIC, 9).add(Aspect.AIR, 6)
+                        .add(Aspect.TREE, 3),
                 0,
                 -6,
                 3,
@@ -965,9 +924,8 @@ public class ScriptEMT implements IScriptLoader {
                 "ChainsawoftheStream",
                 getModItem(ElectroMagicTools.ID, "ChainsawStream", 1, 27),
                 10,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 48).add(Aspect.getAspect("telum"), 32)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("lucrum"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("aer"), 8),
+                new AspectList().add(Aspect.TOOL, 48).add(Aspect.WEAPON, 32).add(Aspect.ENERGY, 32)
+                        .add(Aspect.GREED, 24).add(Aspect.MAGIC, 16).add(Aspect.AIR, 8),
                 getModItem(ElectroMagicTools.ID, "ThaumiumChainsaw", 1, wildcard),
                 getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0),
@@ -989,9 +947,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "InventoryChargingRing",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("vitreus"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("electrum"), 6)
-                        .add(Aspect.getAspect("auram"), 3),
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.CRYSTAL, 12).add(Aspect.MAGIC, 9)
+                        .add(TCAspects.ELECTRUM.getAspect(), 6).add(Aspect.AURA, 3),
                 0,
                 -8,
                 3,
@@ -1002,9 +959,8 @@ public class ScriptEMT implements IScriptLoader {
                 "InventoryChargingRing",
                 getModItem(ElectroMagicTools.ID, "EMTBaubles", 1, 1),
                 7,
-                new AspectList().add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("vitreus"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("electrum"), 16)
-                        .add(Aspect.getAspect("auram"), 8),
+                new AspectList().add(Aspect.ENERGY, 64).add(Aspect.CRYSTAL, 32).add(Aspect.MAGIC, 48)
+                        .add(TCAspects.ELECTRUM.getAspect(), 16).add(Aspect.AURA, 8),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 1),
                 ItemList.IC2_EnergyCrystal.get(1),
                 ItemList.MagicEnergyAbsorber_LV.get(1),
@@ -1025,9 +981,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ArmorChargingRing",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("tutamen"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("electrum"), 6)
-                        .add(Aspect.getAspect("auram"), 3),
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.ARMOR, 12).add(Aspect.MAGIC, 9)
+                        .add(TCAspects.ELECTRUM.getAspect(), 6).add(Aspect.AURA, 3),
                 0,
                 -10,
                 3,
@@ -1038,9 +993,8 @@ public class ScriptEMT implements IScriptLoader {
                 "ArmorChargingRing",
                 getModItem(ElectroMagicTools.ID, "EMTBaubles", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("tutamen"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("electrum"), 16)
-                        .add(Aspect.getAspect("auram"), 8),
+                new AspectList().add(Aspect.ENERGY, 64).add(Aspect.ARMOR, 32).add(Aspect.MAGIC, 48)
+                        .add(TCAspects.ELECTRUM.getAspect(), 16).add(Aspect.AURA, 8),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 1),
                 ItemList.IC2_EnergyCrystal.get(1),
                 ItemList.MagicEnergyAbsorber_LV.get(1),
@@ -1065,9 +1019,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ElectricGogglesofRevealing",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("sensus"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("electrum"), 3),
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.ENERGY, 12).add(Aspect.SENSES, 9).add(Aspect.MAGIC, 6)
+                        .add(TCAspects.ELECTRUM.getAspect(), 3),
                 -6,
                 -2,
                 3,
@@ -1078,9 +1031,8 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ElectricGogglesofRevealing",
                 getModItem(ElectroMagicTools.ID, "ElectricGogglesRevealing", 1, 165),
-                new AspectList().add(Aspect.getAspect("aer"), 45).add(Aspect.getAspect("ignis"), 45)
-                        .add(Aspect.getAspect("terra"), 45).add(Aspect.getAspect("aqua"), 45)
-                        .add(Aspect.getAspect("ordo"), 45).add(Aspect.getAspect("perditio"), 45),
+                new AspectList().add(Aspect.AIR, 45).add(Aspect.FIRE, 45).add(Aspect.EARTH, 45).add(Aspect.WATER, 45)
+                        .add(Aspect.ORDER, 45).add(Aspect.ENTROPY, 45),
                 "abc",
                 "def",
                 "ghi",
@@ -1110,9 +1062,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "NanosuitGogglesofRevealing",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("tutamen"), 18).add(Aspect.getAspect("potentia"), 15)
-                        .add(Aspect.getAspect("sensus"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("electrum"), 3),
+                new AspectList().add(Aspect.ARMOR, 18).add(Aspect.ENERGY, 15).add(Aspect.SENSES, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.AURA, 6).add(TCAspects.ELECTRUM.getAspect(), 3),
                 -4,
                 -2,
                 3,
@@ -1124,9 +1075,8 @@ public class ScriptEMT implements IScriptLoader {
                 "NanosuitGogglesofRevealing",
                 getModItem(ElectroMagicTools.ID, "NanosuitGogglesRevealing", 1, 27),
                 6,
-                new AspectList().add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("sensus"), 24).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("auram"), 8).add(Aspect.getAspect("electrum"), 8),
+                new AspectList().add(Aspect.ARMOR, 32).add(Aspect.ENERGY, 32).add(Aspect.SENSES, 24)
+                        .add(Aspect.MAGIC, 16).add(Aspect.AURA, 8).add(TCAspects.ELECTRUM.getAspect(), 8),
                 getModItem(ElectroMagicTools.ID, "ElectricGogglesRevealing", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorNanoHelmet", 1, wildcard),
                 OrePrefixes.wireGt04.get(Materials.Electrum),
@@ -1147,10 +1097,9 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "QuantumGogglesofRevealing",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("tutamen"), 21).add(Aspect.getAspect("potentia"), 18)
-                        .add(Aspect.getAspect("sensus"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("electrum"), 3),
+                new AspectList().add(Aspect.ARMOR, 21).add(Aspect.ENERGY, 18).add(Aspect.SENSES, 15)
+                        .add(Aspect.MAGIC, 12).add(Aspect.AURA, 9).add(Aspect.GREED, 6)
+                        .add(TCAspects.ELECTRUM.getAspect(), 3),
                 -2,
                 -2,
                 3,
@@ -1162,10 +1111,9 @@ public class ScriptEMT implements IScriptLoader {
                 "QuantumGogglesofRevealing",
                 getModItem(ElectroMagicTools.ID, "QuantumGogglesRevealing", 1, 27),
                 9,
-                new AspectList().add(Aspect.getAspect("tutamen"), 64).add(Aspect.getAspect("potentia"), 48)
-                        .add(Aspect.getAspect("sensus"), 32).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("auram"), 16).add(Aspect.getAspect("electrum"), 16)
-                        .add(Aspect.getAspect("lucrum"), 8),
+                new AspectList().add(Aspect.ARMOR, 64).add(Aspect.ENERGY, 48).add(Aspect.SENSES, 32)
+                        .add(Aspect.MAGIC, 24).add(Aspect.AURA, 16).add(TCAspects.ELECTRUM.getAspect(), 16)
+                        .add(Aspect.GREED, 8),
                 getModItem(ElectroMagicTools.ID, "NanosuitGogglesRevealing", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorQuantumHelmet", 1, wildcard),
                 OrePrefixes.wireGt08.get(Materials.Titanium),
@@ -1190,11 +1138,9 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "SolarHelmetofRevealing",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("tutamen"), 30).add(Aspect.getAspect("potentia"), 27)
-                        .add(Aspect.getAspect("sensus"), 24).add(Aspect.getAspect("praecantatio"), 21)
-                        .add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("electrum"), 12)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("lux"), 3),
+                new AspectList().add(Aspect.ARMOR, 30).add(Aspect.ENERGY, 27).add(Aspect.SENSES, 24)
+                        .add(Aspect.MAGIC, 21).add(Aspect.AURA, 15).add(TCAspects.ELECTRUM.getAspect(), 12)
+                        .add(Aspect.GREED, 9).add(Aspect.AIR, 6).add(Aspect.LIGHT, 3),
                 -2,
                 -4,
                 3,
@@ -1205,11 +1151,9 @@ public class ScriptEMT implements IScriptLoader {
                 "SolarHelmetofRevealing",
                 getModItem(ElectroMagicTools.ID, "SolarHelmetRevealing", 1, 27),
                 12,
-                new AspectList().add(Aspect.getAspect("tutamen"), 64).add(Aspect.getAspect("potentia"), 48)
-                        .add(Aspect.getAspect("sensus"), 32).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("auram"), 16).add(Aspect.getAspect("electrum"), 16)
-                        .add(Aspect.getAspect("lucrum"), 8).add(Aspect.getAspect("aer"), 16)
-                        .add(Aspect.getAspect("lux"), 32),
+                new AspectList().add(Aspect.ARMOR, 64).add(Aspect.ENERGY, 48).add(Aspect.SENSES, 32)
+                        .add(Aspect.MAGIC, 24).add(Aspect.AURA, 16).add(TCAspects.ELECTRUM.getAspect(), 16)
+                        .add(Aspect.GREED, 8).add(Aspect.AIR, 16).add(Aspect.LIGHT, 32),
                 getModItem(ElectroMagicTools.ID, "QuantumGogglesRevealing", 1, wildcard),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1),
                 OrePrefixes.wireGt12.get(Materials.Osmium),
@@ -1231,9 +1175,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "CompressedSolars",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 18).add(Aspect.getAspect("lux"), 15)
-                        .add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("aer"), 3),
+                new AspectList().add(Aspect.ENERGY, 18).add(Aspect.LIGHT, 15).add(Aspect.METAL, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.FIRE, 6).add(Aspect.AIR, 3),
                 -6,
                 -4,
                 3,
@@ -1242,9 +1185,8 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.WATER, 50).add(Aspect.EARTH, 50).add(Aspect.FIRE, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -1272,9 +1214,8 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 100).add(Aspect.getAspect("aqua"), 100)
-                        .add(Aspect.getAspect("terra"), 100).add(Aspect.getAspect("ignis"), 100)
-                        .add(Aspect.getAspect("ordo"), 100).add(Aspect.getAspect("perditio"), 100),
+                new AspectList().add(Aspect.AIR, 100).add(Aspect.WATER, 100).add(Aspect.EARTH, 100)
+                        .add(Aspect.FIRE, 100).add(Aspect.ORDER, 100).add(Aspect.ENTROPY, 100),
                 "abc",
                 "def",
                 "ghi",
@@ -1303,9 +1244,8 @@ public class ScriptEMT implements IScriptLoader {
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2),
                 15,
-                new AspectList().add(Aspect.getAspect("aer"), 150).add(Aspect.getAspect("aqua"), 150)
-                        .add(Aspect.getAspect("terra"), 150).add(Aspect.getAspect("ignis"), 150)
-                        .add(Aspect.getAspect("ordo"), 150).add(Aspect.getAspect("perditio"), 150),
+                new AspectList().add(Aspect.AIR, 150).add(Aspect.WATER, 150).add(Aspect.EARTH, 150)
+                        .add(Aspect.FIRE, 150).add(Aspect.ORDER, 150).add(Aspect.ENTROPY, 150),
                 NHItemList.IrradiantReinforcedTungstenSteelPlate.get(),
                 NHItemList.IrradiantReinforcedTungstenSteelPlate.get(),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1),
@@ -1324,9 +1264,8 @@ public class ScriptEMT implements IScriptLoader {
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0),
                 20,
-                new AspectList().add(Aspect.getAspect("aer"), 300).add(Aspect.getAspect("aqua"), 300)
-                        .add(Aspect.getAspect("terra"), 300).add(Aspect.getAspect("ignis"), 300)
-                        .add(Aspect.getAspect("ordo"), 300).add(Aspect.getAspect("perditio"), 300),
+                new AspectList().add(Aspect.AIR, 300).add(Aspect.WATER, 300).add(Aspect.EARTH, 300)
+                        .add(Aspect.FIRE, 300).add(Aspect.ORDER, 300).add(Aspect.ENTROPY, 300),
                 NHItemList.IrradiantReinforcedChromePlate.get(),
                 NHItemList.IrradiantReinforcedChromePlate.get(),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2),
@@ -1345,9 +1284,8 @@ public class ScriptEMT implements IScriptLoader {
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7),
                 20,
-                new AspectList().add(Aspect.getAspect("aer"), 600).add(Aspect.getAspect("aqua"), 600)
-                        .add(Aspect.getAspect("terra"), 600).add(Aspect.getAspect("ignis"), 600)
-                        .add(Aspect.getAspect("ordo"), 600).add(Aspect.getAspect("perditio"), 600),
+                new AspectList().add(Aspect.AIR, 600).add(Aspect.WATER, 600).add(Aspect.EARTH, 600)
+                        .add(Aspect.FIRE, 600).add(Aspect.ORDER, 600).add(Aspect.ENTROPY, 600),
                 getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 8),
                 getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 8),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0),
@@ -1366,9 +1304,8 @@ public class ScriptEMT implements IScriptLoader {
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14),
                 20,
-                new AspectList().add(Aspect.getAspect("aer"), 1200).add(Aspect.getAspect("aqua"), 1200)
-                        .add(Aspect.getAspect("terra"), 1200).add(Aspect.getAspect("ignis"), 1200)
-                        .add(Aspect.getAspect("ordo"), 1200).add(Aspect.getAspect("perditio"), 1200),
+                new AspectList().add(Aspect.AIR, 1200).add(Aspect.WATER, 1200).add(Aspect.EARTH, 1200)
+                        .add(Aspect.FIRE, 1200).add(Aspect.ORDER, 1200).add(Aspect.ENTROPY, 1200),
                 NHItemList.IrradiantReinforcedNaquadriaPlate.get(),
                 NHItemList.IrradiantReinforcedNaquadriaPlate.get(),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7),
@@ -1387,9 +1324,8 @@ public class ScriptEMT implements IScriptLoader {
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5),
                 20,
-                new AspectList().add(Aspect.getAspect("aer"), 2400).add(Aspect.getAspect("aqua"), 2400)
-                        .add(Aspect.getAspect("terra"), 2400).add(Aspect.getAspect("ignis"), 2400)
-                        .add(Aspect.getAspect("ordo"), 2400).add(Aspect.getAspect("perditio"), 2400),
+                new AspectList().add(Aspect.AIR, 2400).add(Aspect.WATER, 2400).add(Aspect.EARTH, 2400)
+                        .add(Aspect.FIRE, 2400).add(Aspect.ORDER, 2400).add(Aspect.ENTROPY, 2400),
                 NHItemList.IrradiantReinforcedNeutroniumPlate.get(),
                 NHItemList.IrradiantReinforcedNeutroniumPlate.get(),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14),
@@ -1408,9 +1344,8 @@ public class ScriptEMT implements IScriptLoader {
                 "CompressedSolars",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 12),
                 20,
-                new AspectList().add(Aspect.getAspect("aer"), 4800).add(Aspect.getAspect("aqua"), 4800)
-                        .add(Aspect.getAspect("terra"), 4800).add(Aspect.getAspect("ignis"), 4800)
-                        .add(Aspect.getAspect("ordo"), 4800).add(Aspect.getAspect("perditio"), 4800),
+                new AspectList().add(Aspect.AIR, 4800).add(Aspect.WATER, 4800).add(Aspect.EARTH, 4800)
+                        .add(Aspect.FIRE, 4800).add(Aspect.ORDER, 4800).add(Aspect.ENTROPY, 4800),
                 getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 13),
                 getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 13),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5),
@@ -1430,9 +1365,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "WaterInfusedSolarPanels",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("lux"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.MAGIC, 12).add(Aspect.ENERGY, 9).add(Aspect.LIGHT, 6)
+                        .add(Aspect.GREED, 3),
                 -7,
                 -7,
                 3,
@@ -1442,8 +1376,8 @@ public class ScriptEMT implements IScriptLoader {
                 "WaterInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 3),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("permutatio"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("lux"), 16));
+                new AspectList().add(Aspect.WATER, 32).add(Aspect.EXCHANGE, 32).add(Aspect.MAGIC, 32)
+                        .add(Aspect.LIGHT, 16));
         TCHelper.addResearchPage(
                 "WaterInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 3))));
@@ -1451,8 +1385,8 @@ public class ScriptEMT implements IScriptLoader {
                 "WaterInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 4),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1),
-                new AspectList().add(Aspect.getAspect("aqua"), 64).add(Aspect.getAspect("permutatio"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("lux"), 32));
+                new AspectList().add(Aspect.WATER, 64).add(Aspect.EXCHANGE, 64).add(Aspect.MAGIC, 64)
+                        .add(Aspect.LIGHT, 32));
         TCHelper.addResearchPage(
                 "WaterInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 4))));
@@ -1460,8 +1394,8 @@ public class ScriptEMT implements IScriptLoader {
                 "WaterInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 5),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2),
-                new AspectList().add(Aspect.getAspect("aqua"), 128).add(Aspect.getAspect("permutatio"), 128)
-                        .add(Aspect.getAspect("praecantatio"), 128).add(Aspect.getAspect("lux"), 64));
+                new AspectList().add(Aspect.WATER, 128).add(Aspect.EXCHANGE, 128).add(Aspect.MAGIC, 128)
+                        .add(Aspect.LIGHT, 64));
         TCHelper.addResearchPage(
                 "WaterInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 5))));
@@ -1469,8 +1403,8 @@ public class ScriptEMT implements IScriptLoader {
                 "WaterInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 5),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 256).add(Aspect.getAspect("permutatio"), 256)
-                        .add(Aspect.getAspect("praecantatio"), 256).add(Aspect.getAspect("lux"), 128));
+                new AspectList().add(Aspect.WATER, 256).add(Aspect.EXCHANGE, 256).add(Aspect.MAGIC, 256)
+                        .add(Aspect.LIGHT, 128));
         TCHelper.addResearchPage(
                 "WaterInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 5))));
@@ -1478,8 +1412,8 @@ public class ScriptEMT implements IScriptLoader {
                 "WaterInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 12),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7),
-                new AspectList().add(Aspect.getAspect("aqua"), 512).add(Aspect.getAspect("permutatio"), 512)
-                        .add(Aspect.getAspect("praecantatio"), 512).add(Aspect.getAspect("lux"), 256));
+                new AspectList().add(Aspect.WATER, 512).add(Aspect.EXCHANGE, 512).add(Aspect.MAGIC, 512)
+                        .add(Aspect.LIGHT, 256));
         TCHelper.addResearchPage(
                 "WaterInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 12))));
@@ -1487,8 +1421,8 @@ public class ScriptEMT implements IScriptLoader {
                 "WaterInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 3),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14),
-                new AspectList().add(Aspect.getAspect("aqua"), 1024).add(Aspect.getAspect("permutatio"), 1024)
-                        .add(Aspect.getAspect("praecantatio"), 1024).add(Aspect.getAspect("lux"), 512));
+                new AspectList().add(Aspect.WATER, 1024).add(Aspect.EXCHANGE, 1024).add(Aspect.MAGIC, 1024)
+                        .add(Aspect.LIGHT, 512));
         TCHelper.addResearchPage(
                 "WaterInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 3))));
@@ -1496,8 +1430,8 @@ public class ScriptEMT implements IScriptLoader {
                 "WaterInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 10),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5),
-                new AspectList().add(Aspect.getAspect("aqua"), 2048).add(Aspect.getAspect("permutatio"), 2048)
-                        .add(Aspect.getAspect("praecantatio"), 2048).add(Aspect.getAspect("lux"), 1024));
+                new AspectList().add(Aspect.WATER, 2048).add(Aspect.EXCHANGE, 2048).add(Aspect.MAGIC, 2048)
+                        .add(Aspect.LIGHT, 1024));
         TCHelper.addResearchPage(
                 "WaterInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 10))));
@@ -1505,8 +1439,8 @@ public class ScriptEMT implements IScriptLoader {
                 "WaterInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars5", 1, 1),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 12),
-                new AspectList().add(Aspect.getAspect("aqua"), 4096).add(Aspect.getAspect("permutatio"), 4096)
-                        .add(Aspect.getAspect("praecantatio"), 4096).add(Aspect.getAspect("lux"), 2048));
+                new AspectList().add(Aspect.WATER, 4096).add(Aspect.EXCHANGE, 4096).add(Aspect.MAGIC, 4096)
+                        .add(Aspect.LIGHT, 2048));
         TCHelper.addResearchPage(
                 "WaterInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars5", 1, 1))));
@@ -1515,9 +1449,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "EntropyInfusedSolarPanels",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("perditio"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("lux"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.ENTROPY, 15).add(Aspect.MAGIC, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.LIGHT, 6).add(Aspect.GREED, 3),
                 -8,
                 -6,
                 3,
@@ -1528,8 +1461,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EntropyInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 6),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 32).add(Aspect.getAspect("permutatio"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("lux"), 16));
+                new AspectList().add(Aspect.ENTROPY, 32).add(Aspect.EXCHANGE, 32).add(Aspect.MAGIC, 32)
+                        .add(Aspect.LIGHT, 16));
         TCHelper.addResearchPage(
                 "EntropyInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 6))));
@@ -1537,8 +1470,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EntropyInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 7),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1),
-                new AspectList().add(Aspect.getAspect("perditio"), 64).add(Aspect.getAspect("permutatio"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("lux"), 32));
+                new AspectList().add(Aspect.ENTROPY, 64).add(Aspect.EXCHANGE, 64).add(Aspect.MAGIC, 64)
+                        .add(Aspect.LIGHT, 32));
         TCHelper.addResearchPage(
                 "EntropyInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 7))));
@@ -1546,8 +1479,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EntropyInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 8),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2),
-                new AspectList().add(Aspect.getAspect("perditio"), 128).add(Aspect.getAspect("permutatio"), 128)
-                        .add(Aspect.getAspect("praecantatio"), 128).add(Aspect.getAspect("lux"), 64));
+                new AspectList().add(Aspect.ENTROPY, 128).add(Aspect.EXCHANGE, 128).add(Aspect.MAGIC, 128)
+                        .add(Aspect.LIGHT, 64));
         TCHelper.addResearchPage(
                 "EntropyInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 8))));
@@ -1555,8 +1488,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EntropyInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 2),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 256).add(Aspect.getAspect("permutatio"), 256)
-                        .add(Aspect.getAspect("praecantatio"), 256).add(Aspect.getAspect("lux"), 128));
+                new AspectList().add(Aspect.ENTROPY, 256).add(Aspect.EXCHANGE, 256).add(Aspect.MAGIC, 256)
+                        .add(Aspect.LIGHT, 128));
         TCHelper.addResearchPage(
                 "EntropyInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 2))));
@@ -1564,8 +1497,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EntropyInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 9),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7),
-                new AspectList().add(Aspect.getAspect("perditio"), 512).add(Aspect.getAspect("permutatio"), 512)
-                        .add(Aspect.getAspect("praecantatio"), 512).add(Aspect.getAspect("lux"), 256));
+                new AspectList().add(Aspect.ENTROPY, 512).add(Aspect.EXCHANGE, 512).add(Aspect.MAGIC, 512)
+                        .add(Aspect.LIGHT, 256));
         TCHelper.addResearchPage(
                 "EntropyInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 9))));
@@ -1573,8 +1506,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EntropyInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14),
-                new AspectList().add(Aspect.getAspect("perditio"), 1024).add(Aspect.getAspect("permutatio"), 1024)
-                        .add(Aspect.getAspect("praecantatio"), 1024).add(Aspect.getAspect("lux"), 512));
+                new AspectList().add(Aspect.ENTROPY, 1024).add(Aspect.EXCHANGE, 1024).add(Aspect.MAGIC, 1024)
+                        .add(Aspect.LIGHT, 512));
         TCHelper.addResearchPage(
                 "EntropyInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 0))));
@@ -1582,8 +1515,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EntropyInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 7),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5),
-                new AspectList().add(Aspect.getAspect("perditio"), 2048).add(Aspect.getAspect("permutatio"), 2048)
-                        .add(Aspect.getAspect("praecantatio"), 2048).add(Aspect.getAspect("lux"), 1024));
+                new AspectList().add(Aspect.ENTROPY, 2048).add(Aspect.EXCHANGE, 2048).add(Aspect.MAGIC, 2048)
+                        .add(Aspect.LIGHT, 1024));
         TCHelper.addResearchPage(
                 "EntropyInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 7))));
@@ -1591,8 +1524,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EntropyInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 14),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 12),
-                new AspectList().add(Aspect.getAspect("perditio"), 4096).add(Aspect.getAspect("permutatio"), 4096)
-                        .add(Aspect.getAspect("praecantatio"), 4096).add(Aspect.getAspect("lux"), 2048));
+                new AspectList().add(Aspect.ENTROPY, 4096).add(Aspect.EXCHANGE, 4096).add(Aspect.MAGIC, 4096)
+                        .add(Aspect.LIGHT, 2048));
         TCHelper.addResearchPage(
                 "EntropyInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 14))));
@@ -1601,9 +1534,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "OrderInfusedSolarPanels",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("lux"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.MAGIC, 12).add(Aspect.ENERGY, 9).add(Aspect.LIGHT, 6)
+                        .add(Aspect.GREED, 3),
                 -6,
                 -8,
                 3,
@@ -1613,8 +1545,8 @@ public class ScriptEMT implements IScriptLoader {
                 "OrderInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 9),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 32).add(Aspect.getAspect("permutatio"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("lux"), 16));
+                new AspectList().add(Aspect.ORDER, 32).add(Aspect.EXCHANGE, 32).add(Aspect.MAGIC, 32)
+                        .add(Aspect.LIGHT, 16));
         TCHelper.addResearchPage(
                 "OrderInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 9))));
@@ -1622,8 +1554,8 @@ public class ScriptEMT implements IScriptLoader {
                 "OrderInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 10),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1),
-                new AspectList().add(Aspect.getAspect("ordo"), 64).add(Aspect.getAspect("permutatio"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("lux"), 32));
+                new AspectList().add(Aspect.ORDER, 64).add(Aspect.EXCHANGE, 64).add(Aspect.MAGIC, 64)
+                        .add(Aspect.LIGHT, 32));
         TCHelper.addResearchPage(
                 "OrderInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 10))));
@@ -1631,8 +1563,8 @@ public class ScriptEMT implements IScriptLoader {
                 "OrderInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 11),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2),
-                new AspectList().add(Aspect.getAspect("ordo"), 128).add(Aspect.getAspect("permutatio"), 128)
-                        .add(Aspect.getAspect("praecantatio"), 128).add(Aspect.getAspect("lux"), 64));
+                new AspectList().add(Aspect.ORDER, 128).add(Aspect.EXCHANGE, 128).add(Aspect.MAGIC, 128)
+                        .add(Aspect.LIGHT, 64));
         TCHelper.addResearchPage(
                 "OrderInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 11))));
@@ -1640,8 +1572,8 @@ public class ScriptEMT implements IScriptLoader {
                 "OrderInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 1),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 256).add(Aspect.getAspect("permutatio"), 256)
-                        .add(Aspect.getAspect("praecantatio"), 256).add(Aspect.getAspect("lux"), 128));
+                new AspectList().add(Aspect.ORDER, 256).add(Aspect.EXCHANGE, 256).add(Aspect.MAGIC, 256)
+                        .add(Aspect.LIGHT, 128));
         TCHelper.addResearchPage(
                 "OrderInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 1))));
@@ -1649,8 +1581,8 @@ public class ScriptEMT implements IScriptLoader {
                 "OrderInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 8),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7),
-                new AspectList().add(Aspect.getAspect("ordo"), 512).add(Aspect.getAspect("permutatio"), 512)
-                        .add(Aspect.getAspect("praecantatio"), 512).add(Aspect.getAspect("lux"), 256));
+                new AspectList().add(Aspect.ORDER, 512).add(Aspect.EXCHANGE, 512).add(Aspect.MAGIC, 512)
+                        .add(Aspect.LIGHT, 256));
         TCHelper.addResearchPage(
                 "OrderInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 8))));
@@ -1658,8 +1590,8 @@ public class ScriptEMT implements IScriptLoader {
                 "OrderInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14),
-                new AspectList().add(Aspect.getAspect("ordo"), 1024).add(Aspect.getAspect("permutatio"), 1024)
-                        .add(Aspect.getAspect("praecantatio"), 1024).add(Aspect.getAspect("lux"), 512));
+                new AspectList().add(Aspect.ORDER, 1024).add(Aspect.EXCHANGE, 1024).add(Aspect.MAGIC, 1024)
+                        .add(Aspect.LIGHT, 512));
         TCHelper.addResearchPage(
                 "OrderInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 15))));
@@ -1667,8 +1599,8 @@ public class ScriptEMT implements IScriptLoader {
                 "OrderInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 6),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5),
-                new AspectList().add(Aspect.getAspect("ordo"), 2048).add(Aspect.getAspect("permutatio"), 2048)
-                        .add(Aspect.getAspect("praecantatio"), 2048).add(Aspect.getAspect("lux"), 1024));
+                new AspectList().add(Aspect.ORDER, 2048).add(Aspect.EXCHANGE, 2048).add(Aspect.MAGIC, 2048)
+                        .add(Aspect.LIGHT, 1024));
         TCHelper.addResearchPage(
                 "OrderInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 6))));
@@ -1676,8 +1608,8 @@ public class ScriptEMT implements IScriptLoader {
                 "OrderInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 13),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 12),
-                new AspectList().add(Aspect.getAspect("ordo"), 4096).add(Aspect.getAspect("permutatio"), 4096)
-                        .add(Aspect.getAspect("praecantatio"), 4096).add(Aspect.getAspect("lux"), 2048));
+                new AspectList().add(Aspect.ORDER, 4096).add(Aspect.EXCHANGE, 4096).add(Aspect.MAGIC, 4096)
+                        .add(Aspect.LIGHT, 2048));
         TCHelper.addResearchPage(
                 "OrderInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 13))));
@@ -1686,9 +1618,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "FireInfusedSolarPanels",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("lux"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.MAGIC, 12).add(Aspect.ENERGY, 9).add(Aspect.LIGHT, 6)
+                        .add(Aspect.GREED, 3),
                 -5,
                 -7,
                 3,
@@ -1698,8 +1629,8 @@ public class ScriptEMT implements IScriptLoader {
                 "FireInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 12),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 32).add(Aspect.getAspect("permutatio"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("lux"), 16));
+                new AspectList().add(Aspect.FIRE, 32).add(Aspect.EXCHANGE, 32).add(Aspect.MAGIC, 32)
+                        .add(Aspect.LIGHT, 16));
         TCHelper.addResearchPage(
                 "FireInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 12))));
@@ -1707,8 +1638,8 @@ public class ScriptEMT implements IScriptLoader {
                 "FireInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 13),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1),
-                new AspectList().add(Aspect.getAspect("ignis"), 64).add(Aspect.getAspect("permutatio"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("lux"), 32));
+                new AspectList().add(Aspect.FIRE, 64).add(Aspect.EXCHANGE, 64).add(Aspect.MAGIC, 64)
+                        .add(Aspect.LIGHT, 32));
         TCHelper.addResearchPage(
                 "FireInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 13))));
@@ -1716,8 +1647,8 @@ public class ScriptEMT implements IScriptLoader {
                 "FireInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 14),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2),
-                new AspectList().add(Aspect.getAspect("ignis"), 128).add(Aspect.getAspect("permutatio"), 128)
-                        .add(Aspect.getAspect("praecantatio"), 128).add(Aspect.getAspect("lux"), 64));
+                new AspectList().add(Aspect.FIRE, 128).add(Aspect.EXCHANGE, 128).add(Aspect.MAGIC, 128)
+                        .add(Aspect.LIGHT, 64));
         TCHelper.addResearchPage(
                 "FireInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 14))));
@@ -1725,8 +1656,8 @@ public class ScriptEMT implements IScriptLoader {
                 "FireInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 6),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 256).add(Aspect.getAspect("permutatio"), 256)
-                        .add(Aspect.getAspect("praecantatio"), 256).add(Aspect.getAspect("lux"), 128));
+                new AspectList().add(Aspect.FIRE, 256).add(Aspect.EXCHANGE, 256).add(Aspect.MAGIC, 256)
+                        .add(Aspect.LIGHT, 128));
         TCHelper.addResearchPage(
                 "FireInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 6))));
@@ -1734,8 +1665,8 @@ public class ScriptEMT implements IScriptLoader {
                 "FireInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 13),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7),
-                new AspectList().add(Aspect.getAspect("ignis"), 512).add(Aspect.getAspect("permutatio"), 512)
-                        .add(Aspect.getAspect("praecantatio"), 512).add(Aspect.getAspect("lux"), 256));
+                new AspectList().add(Aspect.FIRE, 512).add(Aspect.EXCHANGE, 512).add(Aspect.MAGIC, 512)
+                        .add(Aspect.LIGHT, 256));
         TCHelper.addResearchPage(
                 "FireInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 13))));
@@ -1743,8 +1674,8 @@ public class ScriptEMT implements IScriptLoader {
                 "FireInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 4),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14),
-                new AspectList().add(Aspect.getAspect("ignis"), 1024).add(Aspect.getAspect("permutatio"), 1024)
-                        .add(Aspect.getAspect("praecantatio"), 1024).add(Aspect.getAspect("lux"), 512));
+                new AspectList().add(Aspect.FIRE, 1024).add(Aspect.EXCHANGE, 1024).add(Aspect.MAGIC, 1024)
+                        .add(Aspect.LIGHT, 512));
         TCHelper.addResearchPage(
                 "FireInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 4))));
@@ -1752,8 +1683,8 @@ public class ScriptEMT implements IScriptLoader {
                 "FireInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 11),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5),
-                new AspectList().add(Aspect.getAspect("ignis"), 2048).add(Aspect.getAspect("permutatio"), 2048)
-                        .add(Aspect.getAspect("praecantatio"), 2048).add(Aspect.getAspect("lux"), 1024));
+                new AspectList().add(Aspect.FIRE, 2048).add(Aspect.EXCHANGE, 2048).add(Aspect.MAGIC, 2048)
+                        .add(Aspect.LIGHT, 1024));
         TCHelper.addResearchPage(
                 "FireInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 11))));
@@ -1761,8 +1692,8 @@ public class ScriptEMT implements IScriptLoader {
                 "FireInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars5", 1, 2),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 12),
-                new AspectList().add(Aspect.getAspect("ignis"), 4096).add(Aspect.getAspect("permutatio"), 4096)
-                        .add(Aspect.getAspect("praecantatio"), 4096).add(Aspect.getAspect("lux"), 2048));
+                new AspectList().add(Aspect.FIRE, 4096).add(Aspect.EXCHANGE, 4096).add(Aspect.MAGIC, 4096)
+                        .add(Aspect.LIGHT, 2048));
         TCHelper.addResearchPage(
                 "FireInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars5", 1, 2))));
@@ -1771,9 +1702,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "AirInfusedSolarPanels",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("lux"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.MAGIC, 12).add(Aspect.ENERGY, 9).add(Aspect.LIGHT, 6)
+                        .add(Aspect.GREED, 3),
                 -4,
                 -6,
                 3,
@@ -1783,8 +1713,8 @@ public class ScriptEMT implements IScriptLoader {
                 "AirInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("permutatio"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("lux"), 16));
+                new AspectList().add(Aspect.AIR, 32).add(Aspect.EXCHANGE, 32).add(Aspect.MAGIC, 32)
+                        .add(Aspect.LIGHT, 16));
         TCHelper.addResearchPage(
                 "AirInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 15))));
@@ -1792,8 +1722,8 @@ public class ScriptEMT implements IScriptLoader {
                 "AirInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars2", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("permutatio"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("lux"), 32));
+                new AspectList().add(Aspect.AIR, 64).add(Aspect.EXCHANGE, 64).add(Aspect.MAGIC, 64)
+                        .add(Aspect.LIGHT, 32));
         TCHelper.addResearchPage(
                 "AirInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars2", 1, 0))));
@@ -1801,8 +1731,8 @@ public class ScriptEMT implements IScriptLoader {
                 "AirInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars2", 1, 1),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 128).add(Aspect.getAspect("permutatio"), 128)
-                        .add(Aspect.getAspect("praecantatio"), 128).add(Aspect.getAspect("lux"), 64));
+                new AspectList().add(Aspect.AIR, 128).add(Aspect.EXCHANGE, 128).add(Aspect.MAGIC, 128)
+                        .add(Aspect.LIGHT, 64));
         TCHelper.addResearchPage(
                 "AirInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars2", 1, 1))));
@@ -1810,8 +1740,8 @@ public class ScriptEMT implements IScriptLoader {
                 "AirInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 3),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 256).add(Aspect.getAspect("permutatio"), 256)
-                        .add(Aspect.getAspect("praecantatio"), 256).add(Aspect.getAspect("lux"), 128));
+                new AspectList().add(Aspect.AIR, 256).add(Aspect.EXCHANGE, 256).add(Aspect.MAGIC, 256)
+                        .add(Aspect.LIGHT, 128));
         TCHelper.addResearchPage(
                 "AirInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 3))));
@@ -1819,8 +1749,8 @@ public class ScriptEMT implements IScriptLoader {
                 "AirInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 10),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7),
-                new AspectList().add(Aspect.getAspect("aer"), 512).add(Aspect.getAspect("permutatio"), 512)
-                        .add(Aspect.getAspect("praecantatio"), 512).add(Aspect.getAspect("lux"), 256));
+                new AspectList().add(Aspect.AIR, 512).add(Aspect.EXCHANGE, 512).add(Aspect.MAGIC, 512)
+                        .add(Aspect.LIGHT, 256));
         TCHelper.addResearchPage(
                 "AirInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 10))));
@@ -1828,8 +1758,8 @@ public class ScriptEMT implements IScriptLoader {
                 "AirInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 1),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14),
-                new AspectList().add(Aspect.getAspect("aer"), 1024).add(Aspect.getAspect("permutatio"), 1024)
-                        .add(Aspect.getAspect("praecantatio"), 1024).add(Aspect.getAspect("lux"), 512));
+                new AspectList().add(Aspect.AIR, 1024).add(Aspect.EXCHANGE, 1024).add(Aspect.MAGIC, 1024)
+                        .add(Aspect.LIGHT, 512));
         TCHelper.addResearchPage(
                 "AirInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 1))));
@@ -1837,8 +1767,8 @@ public class ScriptEMT implements IScriptLoader {
                 "AirInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 8),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5),
-                new AspectList().add(Aspect.getAspect("aer"), 2048).add(Aspect.getAspect("permutatio"), 2048)
-                        .add(Aspect.getAspect("praecantatio"), 2048).add(Aspect.getAspect("lux"), 1024));
+                new AspectList().add(Aspect.AIR, 2048).add(Aspect.EXCHANGE, 2048).add(Aspect.MAGIC, 2048)
+                        .add(Aspect.LIGHT, 1024));
         TCHelper.addResearchPage(
                 "AirInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 8))));
@@ -1846,8 +1776,8 @@ public class ScriptEMT implements IScriptLoader {
                 "AirInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 12),
-                new AspectList().add(Aspect.getAspect("aer"), 4096).add(Aspect.getAspect("permutatio"), 4096)
-                        .add(Aspect.getAspect("praecantatio"), 4096).add(Aspect.getAspect("lux"), 2048));
+                new AspectList().add(Aspect.AIR, 4096).add(Aspect.EXCHANGE, 4096).add(Aspect.MAGIC, 4096)
+                        .add(Aspect.LIGHT, 2048));
         TCHelper.addResearchPage(
                 "AirInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 15))));
@@ -1856,9 +1786,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "EarthInfusedSolarPanels",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("lux"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.MAGIC, 12).add(Aspect.ENERGY, 9).add(Aspect.LIGHT, 6)
+                        .add(Aspect.GREED, 3),
                 -6,
                 -7,
                 3,
@@ -1868,8 +1797,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EarthInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars2", 1, 2),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("permutatio"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("lux"), 16));
+                new AspectList().add(Aspect.EARTH, 32).add(Aspect.EXCHANGE, 32).add(Aspect.MAGIC, 32)
+                        .add(Aspect.LIGHT, 16));
         TCHelper.addResearchPage(
                 "EarthInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars2", 1, 2))));
@@ -1877,8 +1806,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EarthInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars2", 1, 3),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 64).add(Aspect.getAspect("permutatio"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("lux"), 32));
+                new AspectList().add(Aspect.EARTH, 64).add(Aspect.EXCHANGE, 64).add(Aspect.MAGIC, 64)
+                        .add(Aspect.LIGHT, 32));
         TCHelper.addResearchPage(
                 "EarthInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars2", 1, 3))));
@@ -1886,8 +1815,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EarthInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars2", 1, 4),
                 getModItem(ElectroMagicTools.ID, "EMTSolars", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 128).add(Aspect.getAspect("permutatio"), 128)
-                        .add(Aspect.getAspect("praecantatio"), 128).add(Aspect.getAspect("lux"), 64));
+                new AspectList().add(Aspect.EARTH, 128).add(Aspect.EXCHANGE, 128).add(Aspect.MAGIC, 128)
+                        .add(Aspect.LIGHT, 64));
         TCHelper.addResearchPage(
                 "EarthInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars2", 1, 4))));
@@ -1895,8 +1824,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EarthInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 4),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 256).add(Aspect.getAspect("permutatio"), 256)
-                        .add(Aspect.getAspect("praecantatio"), 256).add(Aspect.getAspect("lux"), 128));
+                new AspectList().add(Aspect.EARTH, 256).add(Aspect.EXCHANGE, 256).add(Aspect.MAGIC, 256)
+                        .add(Aspect.LIGHT, 128));
         TCHelper.addResearchPage(
                 "EarthInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 4))));
@@ -1904,8 +1833,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EarthInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 11),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 7),
-                new AspectList().add(Aspect.getAspect("terra"), 512).add(Aspect.getAspect("permutatio"), 512)
-                        .add(Aspect.getAspect("praecantatio"), 512).add(Aspect.getAspect("lux"), 256));
+                new AspectList().add(Aspect.EARTH, 512).add(Aspect.EXCHANGE, 512).add(Aspect.MAGIC, 512)
+                        .add(Aspect.LIGHT, 256));
         TCHelper.addResearchPage(
                 "EarthInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 11))));
@@ -1913,8 +1842,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EarthInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 2),
                 getModItem(ElectroMagicTools.ID, "EMTSolars3", 1, 14),
-                new AspectList().add(Aspect.getAspect("terra"), 1024).add(Aspect.getAspect("permutatio"), 1024)
-                        .add(Aspect.getAspect("praecantatio"), 1024).add(Aspect.getAspect("lux"), 512));
+                new AspectList().add(Aspect.EARTH, 1024).add(Aspect.EXCHANGE, 1024).add(Aspect.MAGIC, 1024)
+                        .add(Aspect.LIGHT, 512));
         TCHelper.addResearchPage(
                 "EarthInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 2))));
@@ -1922,8 +1851,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EarthInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 9),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 5),
-                new AspectList().add(Aspect.getAspect("terra"), 2048).add(Aspect.getAspect("permutatio"), 2048)
-                        .add(Aspect.getAspect("praecantatio"), 2048).add(Aspect.getAspect("lux"), 1024));
+                new AspectList().add(Aspect.EARTH, 2048).add(Aspect.EXCHANGE, 2048).add(Aspect.MAGIC, 2048)
+                        .add(Aspect.LIGHT, 1024));
         TCHelper.addResearchPage(
                 "EarthInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 9))));
@@ -1931,8 +1860,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EarthInfusedSolarPanels",
                 getModItem(ElectroMagicTools.ID, "EMTSolars5", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTSolars4", 1, 12),
-                new AspectList().add(Aspect.getAspect("terra"), 4096).add(Aspect.getAspect("permutatio"), 4096)
-                        .add(Aspect.getAspect("praecantatio"), 4096).add(Aspect.getAspect("lux"), 2048));
+                new AspectList().add(Aspect.EARTH, 4096).add(Aspect.EXCHANGE, 4096).add(Aspect.MAGIC, 4096)
+                        .add(Aspect.LIGHT, 2048));
         TCHelper.addResearchPage(
                 "EarthInfusedSolarPanels",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTSolars5", 1, 0))));
@@ -1941,9 +1870,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ElectricHoeofGrowth",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("messis"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("herba"), 6)
-                        .add(Aspect.getAspect("electrum"), 3),
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.CROP, 12).add(Aspect.MAGIC, 9).add(Aspect.PLANT, 6)
+                        .add(TCAspects.ELECTRUM.getAspect(), 3),
                 2,
                 -2,
                 3,
@@ -1954,9 +1882,8 @@ public class ScriptEMT implements IScriptLoader {
                 "ElectricHoeofGrowth",
                 getModItem(ElectroMagicTools.ID, "ElectricHoeGrowth", 1, 1561),
                 8,
-                new AspectList().add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("messis"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("herba"), 16)
-                        .add(Aspect.getAspect("electrum"), 8),
+                new AspectList().add(Aspect.ENERGY, 32).add(Aspect.CROP, 32).add(Aspect.MAGIC, 48).add(Aspect.PLANT, 16)
+                        .add(TCAspects.ELECTRUM.getAspect(), 8),
                 getModItem(Thaumcraft.ID, "ItemHoeElemental", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemToolHoe", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0),
@@ -1977,9 +1904,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ElectricScribingTools",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("electrum"), 3),
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.DARKNESS, 12).add(Aspect.CRAFT, 9)
+                        .add(Aspect.MAGIC, 6).add(TCAspects.ELECTRUM.getAspect(), 3),
                 6,
                 -4,
                 3,
@@ -1989,8 +1915,7 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ElectricScribingTools",
                 getModItem(ElectroMagicTools.ID, "ElectricScribingTools", 1, 400),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("aqua"), 20).add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.FIRE, 20).add(Aspect.WATER, 20).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -2021,9 +1946,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "Mjolnirnew",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("telum"), 18).add(Aspect.getAspect("tempestas"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("ira"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("ignis"), 3),
+                new AspectList().add(Aspect.WEAPON, 18).add(Aspect.WEATHER, 15).add(Aspect.ELDRITCH, 12)
+                        .add(DarkAspects.WRATH, 9).add(Aspect.AIR, 6).add(Aspect.FIRE, 3),
                 4,
                 -5,
                 3,
@@ -2039,9 +1963,8 @@ public class ScriptEMT implements IScriptLoader {
                 "Mjolnirnew",
                 getModItem(ElectroMagicTools.ID, "Mjolnir", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("telum"), 48).add(Aspect.getAspect("tempestas"), 48)
-                        .add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("ira"), 24)
-                        .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("ignis"), 16),
+                new AspectList().add(Aspect.WEAPON, 48).add(Aspect.WEATHER, 48).add(Aspect.ELDRITCH, 32)
+                        .add(DarkAspects.WRATH, 24).add(Aspect.AIR, 16).add(Aspect.FIRE, 16),
                 getModItem(ElectroMagicTools.ID, "TaintedMjolnir", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0),
                 OrePrefixes.plate.get(Materials.Rubber),
@@ -2063,10 +1986,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "SuperchargedMjolnir",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("telum"), 21).add(Aspect.getAspect("tempestas"), 18)
-                        .add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("bestia"), 12)
-                        .add(Aspect.getAspect("ira"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("ignis"), 3),
+                new AspectList().add(Aspect.WEAPON, 21).add(Aspect.WEATHER, 18).add(Aspect.ELDRITCH, 15)
+                        .add(Aspect.BEAST, 12).add(DarkAspects.WRATH, 9).add(Aspect.AIR, 6).add(Aspect.FIRE, 3),
                 3,
                 -5,
                 3,
@@ -2077,10 +1998,8 @@ public class ScriptEMT implements IScriptLoader {
                 "SuperchargedMjolnir",
                 getModItem(ElectroMagicTools.ID, "SuperchargedMjolnir", 1, 27),
                 15,
-                new AspectList().add(Aspect.getAspect("telum"), 64).add(Aspect.getAspect("potentia"), 64)
-                        .add(Aspect.getAspect("alienis"), 48).add(Aspect.getAspect("ira"), 32)
-                        .add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("ignis"), 24)
-                        .add(Aspect.getAspect("bestia"), 16),
+                new AspectList().add(Aspect.WEAPON, 64).add(Aspect.ENERGY, 64).add(Aspect.ELDRITCH, 48)
+                        .add(DarkAspects.WRATH, 32).add(Aspect.AIR, 24).add(Aspect.FIRE, 24).add(Aspect.BEAST, 16),
                 getModItem(ElectroMagicTools.ID, "Mjolnir", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemNanoSaber", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0),
@@ -2103,9 +2022,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "LightningSummoner",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("tempestas"), 15).add(Aspect.getAspect("aer"), 12)
-                        .add(Aspect.getAspect("ignis"), 9).add(Aspect.getAspect("nebrisum"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3),
+                new AspectList().add(Aspect.WEATHER, 15).add(Aspect.AIR, 12).add(Aspect.FIRE, 9)
+                        .add(TCAspects.NEBRISUM.getAspect(), 6).add(Aspect.EXCHANGE, 3),
                 6,
                 -5,
                 3,
@@ -2116,9 +2034,8 @@ public class ScriptEMT implements IScriptLoader {
                 "LightningSummoner",
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 6),
                 9,
-                new AspectList().add(Aspect.getAspect("tempestas"), 16).add(Aspect.getAspect("aer"), 24)
-                        .add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("nebrisum"), 8)
-                        .add(Aspect.getAspect("permutatio"), 8),
+                new AspectList().add(Aspect.WEATHER, 16).add(Aspect.AIR, 24).add(Aspect.FIRE, 16)
+                        .add(TCAspects.NEBRISUM.getAspect(), 8).add(Aspect.EXCHANGE, 8),
                 getModItem(Thaumcraft.ID, "FocusShock", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 1),
                 getModItem(Minecraft.ID, "skull", 1, 4),
@@ -2137,9 +2054,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "TinyUranium",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("permutatio"), 15).add(Aspect.getAspect("venenum"), 12)
-                        .add(Aspect.getAspect("mortuus"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("metallum"), 3),
+                new AspectList().add(Aspect.EXCHANGE, 15).add(Aspect.POISON, 12).add(Aspect.DEATH, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.METAL, 3),
                 5,
                 -4,
                 3,
@@ -2149,9 +2065,8 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "TinyUranium",
                 ItemList.IC2_Uranium_235_Small.get(7),
-                new AspectList().add(Aspect.getAspect("aer"), 7).add(Aspect.getAspect("ignis"), 7)
-                        .add(Aspect.getAspect("aqua"), 7).add(Aspect.getAspect("terra"), 7)
-                        .add(Aspect.getAspect("ordo"), 7).add(Aspect.getAspect("perditio"), 7),
+                new AspectList().add(Aspect.AIR, 7).add(Aspect.FIRE, 7).add(Aspect.WATER, 7).add(Aspect.EARTH, 7)
+                        .add(Aspect.ORDER, 7).add(Aspect.ENTROPY, 7),
                 ItemList.IC2_Uranium_238.get(1));
         TCHelper.addResearchPage(
                 "TinyUranium",
@@ -2161,9 +2076,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "UUMatterInfusion",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("fabrico"), 15).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("vitreus"), 3),
+                new AspectList().add(Aspect.CRAFT, 15).add(Aspect.ELDRITCH, 12).add(Aspect.EXCHANGE, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.CRYSTAL, 3),
                 5,
                 -3,
                 3,
@@ -2173,8 +2087,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 3),
-                new AspectList().add(Aspect.getAspect("vitreus"), 16).add(Aspect.getAspect("gelum"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 8).add(Aspect.getAspect("permutatio"), 8));
+                new AspectList().add(Aspect.CRYSTAL, 16).add(Aspect.COLD, 8).add(Aspect.MAGIC, 8)
+                        .add(Aspect.EXCHANGE, 8));
         TCHelper.addResearchPage(
                 "UUMatterInfusion",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15))));
@@ -2182,9 +2096,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 getModItem(Minecraft.ID, "coal", 16, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
-                        .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.WATER, 8).add(Aspect.EARTH, 16).add(Aspect.FIRE, 8)
+                        .add(Aspect.ENTROPY, 8).add(Aspect.ORDER, 16),
                 getModItem(Minecraft.ID, "coal", 1, 1),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15));
@@ -2195,9 +2108,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 getModItem(Minecraft.ID, "glowstone", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("aer"), 4).add(Aspect.getAspect("aqua"), 4)
-                        .add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("ignis"), 4)
-                        .add(Aspect.getAspect("perditio"), 4).add(Aspect.getAspect("ordo"), 8),
+                new AspectList().add(Aspect.AIR, 4).add(Aspect.WATER, 4).add(Aspect.EARTH, 4).add(Aspect.FIRE, 4)
+                        .add(Aspect.ENTROPY, 4).add(Aspect.ORDER, 8),
                 getModItem(Minecraft.ID, "glowstone_dust", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15));
         TCHelper.addResearchPage(
@@ -2207,9 +2119,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Iron, 32L),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
-                        .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.WATER, 8).add(Aspect.EARTH, 16).add(Aspect.FIRE, 8)
+                        .add(Aspect.ENTROPY, 8).add(Aspect.ORDER, 16),
                 getModItem(Minecraft.ID, "iron_ingot", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15));
@@ -2221,9 +2132,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Copper, 32L),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
-                        .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.WATER, 8).add(Aspect.EARTH, 16).add(Aspect.FIRE, 8)
+                        .add(Aspect.ENTROPY, 8).add(Aspect.ORDER, 16),
                 OrePrefixes.ingot.get(Materials.Copper),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15));
@@ -2236,9 +2146,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Tin, 32L),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
-                        .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.WATER, 8).add(Aspect.EARTH, 16).add(Aspect.FIRE, 8)
+                        .add(Aspect.ENTROPY, 8).add(Aspect.ORDER, 16),
                 OrePrefixes.ingot.get(Materials.Tin),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15));
@@ -2250,9 +2159,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Gold, 32L),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
-                        .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.WATER, 8).add(Aspect.EARTH, 16).add(Aspect.FIRE, 8)
+                        .add(Aspect.ENTROPY, 8).add(Aspect.ORDER, 16),
                 getModItem(Minecraft.ID, "gold_ingot", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15));
@@ -2264,9 +2172,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Uranium, 32L),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
-                        .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.WATER, 8).add(Aspect.EARTH, 16).add(Aspect.FIRE, 8)
+                        .add(Aspect.ENTROPY, 8).add(Aspect.ORDER, 16),
                 ItemList.IC2_Uranium_238.get(1),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15));
@@ -2279,9 +2186,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Silver, 32L),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
-                        .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.WATER, 8).add(Aspect.EARTH, 16).add(Aspect.FIRE, 8)
+                        .add(Aspect.ENTROPY, 8).add(Aspect.ORDER, 16),
                 OrePrefixes.ingot.get(Materials.Silver),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15));
@@ -2294,9 +2200,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Lead, 32L),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
-                        .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.WATER, 8).add(Aspect.EARTH, 16).add(Aspect.FIRE, 8)
+                        .add(Aspect.ENTROPY, 8).add(Aspect.ORDER, 16),
                 OrePrefixes.ingot.get(Materials.Lead),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15));
@@ -2308,9 +2213,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Redstone, 24L),
                 9,
-                new AspectList().add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("terra"), 24).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("perditio"), 12).add(Aspect.getAspect("ordo"), 24),
+                new AspectList().add(Aspect.AIR, 12).add(Aspect.WATER, 12).add(Aspect.EARTH, 24).add(Aspect.FIRE, 12)
+                        .add(Aspect.ENTROPY, 12).add(Aspect.ORDER, 24),
                 getModItem(Minecraft.ID, "redstone", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
@@ -2324,9 +2228,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 GTOreDictUnificator.get(OrePrefixes.crushed, Materials.Lapis, 24L),
                 9,
-                new AspectList().add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("terra"), 24).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("perditio"), 12).add(Aspect.getAspect("ordo"), 24),
+                new AspectList().add(Aspect.AIR, 12).add(Aspect.WATER, 12).add(Aspect.EARTH, 24).add(Aspect.FIRE, 12)
+                        .add(Aspect.ENTROPY, 12).add(Aspect.ORDER, 24),
                 getModItem(Minecraft.ID, "dye", 1, 4),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
@@ -2340,9 +2243,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 getModItem(Minecraft.ID, "gold_ingot", 2, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 8)
-                        .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.WATER, 8).add(Aspect.EARTH, 16).add(Aspect.FIRE, 8)
+                        .add(Aspect.ENTROPY, 8).add(Aspect.ORDER, 16),
                 getModItem(Minecraft.ID, "iron_ingot", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
@@ -2354,9 +2256,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 getModItem(Minecraft.ID, "diamond", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("aqua"), 16)
-                        .add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("ignis"), 16)
-                        .add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("ordo"), 32),
+                new AspectList().add(Aspect.AIR, 16).add(Aspect.WATER, 16).add(Aspect.EARTH, 32).add(Aspect.FIRE, 16)
+                        .add(Aspect.ENTROPY, 16).add(Aspect.ORDER, 32),
                 getModItem(Minecraft.ID, "gold_ingot", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
@@ -2369,9 +2270,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 ItemList.IC2_Uranium_238.get(2),
                 15,
-                new AspectList().add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("aqua"), 24)
-                        .add(Aspect.getAspect("terra"), 48).add(Aspect.getAspect("ignis"), 24)
-                        .add(Aspect.getAspect("perditio"), 24).add(Aspect.getAspect("ordo"), 48),
+                new AspectList().add(Aspect.AIR, 24).add(Aspect.WATER, 24).add(Aspect.EARTH, 48).add(Aspect.FIRE, 24)
+                        .add(Aspect.ENTROPY, 24).add(Aspect.ORDER, 48),
                 getModItem(Minecraft.ID, "diamond", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
@@ -2388,9 +2288,8 @@ public class ScriptEMT implements IScriptLoader {
                 "UUMatterInfusion",
                 getModItem(IndustrialCraft2.ID, "itemOreIridium", 2, 0),
                 18,
-                new AspectList().add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("aqua"), 32)
-                        .add(Aspect.getAspect("terra"), 64).add(Aspect.getAspect("ignis"), 32)
-                        .add(Aspect.getAspect("perditio"), 32).add(Aspect.getAspect("ordo"), 64),
+                new AspectList().add(Aspect.AIR, 32).add(Aspect.WATER, 32).add(Aspect.EARTH, 64).add(Aspect.FIRE, 32)
+                        .add(Aspect.ENTROPY, 32).add(Aspect.ORDER, 64),
                 ItemList.IC2_Uranium_238.get(1),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 15),
@@ -2412,9 +2311,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "PortableNode",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("vitreus"), 3),
+                new AspectList().add(Aspect.AURA, 15).add(Aspect.ELDRITCH, 12).add(Aspect.GREED, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.CRYSTAL, 3),
                 6,
                 -3,
                 3,
@@ -2431,9 +2329,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ShieldFocus",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("aer"), 12)
-                        .add(Aspect.getAspect("vitreus"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.AIR, 12).add(Aspect.CRYSTAL, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.MIND, 3),
                 2,
                 4,
                 3,
@@ -2444,9 +2341,8 @@ public class ScriptEMT implements IScriptLoader {
                 "ShieldFocus",
                 getModItem(ElectroMagicTools.ID, "ShieldFocus", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("tutamen"), 40)
-                        .add(Aspect.getAspect("victus"), 16).add(Aspect.getAspect("vinculum"), 24)
-                        .add(Aspect.getAspect("vitreus"), 16).add(Aspect.getAspect("praecantatio"), 8),
+                new AspectList().add(Aspect.AIR, 32).add(Aspect.ARMOR, 40).add(Aspect.LIFE, 16).add(Aspect.TRAP, 24)
+                        .add(Aspect.CRYSTAL, 16).add(Aspect.MAGIC, 8),
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0),
                 OrePrefixes.plate.get(Materials.ReinforcedGlass),
                 ItemList.Block_TungstenSteelReinforced.get(1L),
@@ -2466,9 +2362,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ShieldBlock",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("vinculum"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.TRAP, 12).add(Aspect.MIND, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.ELDRITCH, 3),
                 2,
                 6,
                 3,
@@ -2478,8 +2373,7 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ShieldBlock",
                 getModItem(ElectroMagicTools.ID, "ShieldBlock", 10, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 20).add(Aspect.getAspect("ordo"), 20)
-                        .add(Aspect.getAspect("perditio"), 20),
+                new AspectList().add(Aspect.EARTH, 20).add(Aspect.ORDER, 20).add(Aspect.ENTROPY, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -2509,9 +2403,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "KristmasFocus",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("gelum"), 15).add(Aspect.getAspect("bestia"), 12)
-                        .add(Aspect.getAspect("victus"), 9).add(Aspect.getAspect("mortuus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.COLD, 15).add(Aspect.BEAST, 12).add(Aspect.LIFE, 9).add(Aspect.DEATH, 6)
+                        .add(Aspect.MAGIC, 3),
                 3,
                 4,
                 3,
@@ -2521,8 +2414,7 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "KristmasFocus",
                 getModItem(ElectroMagicTools.ID, "ChristmasFocus", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 25).add(Aspect.getAspect("ordo"), 25)
-                        .add(Aspect.getAspect("aqua"), 25),
+                new AspectList().add(Aspect.AIR, 25).add(Aspect.ORDER, 25).add(Aspect.WATER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -2552,8 +2444,7 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "EnergyBallFocus",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("praecantatio"), 18)
-                        .add(Aspect.getAspect("victus"), 9).add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.MAGIC, 18).add(Aspect.LIFE, 9).add(Aspect.MIND, 3),
                 4,
                 4,
                 3,
@@ -2564,8 +2455,7 @@ public class ScriptEMT implements IScriptLoader {
                 "EnergyBallFocus",
                 getModItem(ElectroMagicTools.ID, "EnergyBallFocus", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("potentia"), 24).add(Aspect.getAspect("praecantatio"), 30)
-                        .add(Aspect.getAspect("victus"), 12).add(Aspect.getAspect("cognitio"), 6),
+                new AspectList().add(Aspect.ENERGY, 24).add(Aspect.MAGIC, 30).add(Aspect.LIFE, 12).add(Aspect.MIND, 6),
                 getModItem(Thaumcraft.ID, "FocusShock", 1, 0),
                 getModItem(IndustrialCraft2.ID, "blockMachine2", 1, 1),
                 OrePrefixes.wireGt02.get(Materials.Silver),
@@ -2585,9 +2475,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ExplosionFocus",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("mortuus"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("potentia"), 3),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.DEATH, 12).add(Aspect.WEAPON, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.ENERGY, 3),
                 5,
                 4,
                 3,
@@ -2598,9 +2487,8 @@ public class ScriptEMT implements IScriptLoader {
                 "ExplosionFocus",
                 getModItem(ElectroMagicTools.ID, "ExplosionFocus", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("ignis"), 64).add(Aspect.getAspect("mortuus"), 24)
-                        .add(Aspect.getAspect("motus"), 48).add(Aspect.getAspect("telum"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("potentia"), 10),
+                new AspectList().add(Aspect.FIRE, 64).add(Aspect.DEATH, 24).add(Aspect.MOTION, 48)
+                        .add(Aspect.WEAPON, 32).add(Aspect.MAGIC, 16).add(Aspect.ENERGY, 10),
                 getModItem(Thaumcraft.ID, "FocusHellbat", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemToolMiningLaser", 1, wildcard),
                 NHItemList.ReinforcedGlassLense.get(),
@@ -2622,9 +2510,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "WandFocusCharging",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("permutatio"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.EXCHANGE, 15).add(Aspect.ENERGY, 12).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.MIND, 3),
                 6,
                 4,
                 3,
@@ -2635,9 +2522,8 @@ public class ScriptEMT implements IScriptLoader {
                 "WandFocusCharging",
                 getModItem(ElectroMagicTools.ID, "ChargingFocus", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("permutatio"), 48).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("machina"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("cognitio"), 8),
+                new AspectList().add(Aspect.EXCHANGE, 48).add(Aspect.ENERGY, 24).add(Aspect.MECHANISM, 32)
+                        .add(Aspect.MAGIC, 16).add(Aspect.MIND, 8),
                 getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard),
                 ItemList.Transformer_HV_MV.get(1L),
                 OrePrefixes.rotor.get(Materials.Thaumium),
@@ -2657,9 +2543,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "WandFocusWandCharging",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 18).add(Aspect.getAspect("fabrico"), 15)
-                        .add(Aspect.getAspect("lucrum"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.ENERGY, 18).add(Aspect.CRAFT, 15).add(Aspect.GREED, 12)
+                        .add(Aspect.EXCHANGE, 9).add(Aspect.MAGIC, 6).add(Aspect.MIND, 3),
                 6,
                 6,
                 3,
@@ -2672,10 +2557,8 @@ public class ScriptEMT implements IScriptLoader {
                 "WandFocusWandCharging",
                 getModItem(ElectroMagicTools.ID, "WandChargingFocus", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("fabrico"), 32)
-                        .add(Aspect.getAspect("lucrum"), 64).add(Aspect.getAspect("permutatio"), 48)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("cognitio"), 8)
-                        .add(Aspect.getAspect("auram"), 32),
+                new AspectList().add(Aspect.ENERGY, 48).add(Aspect.CRAFT, 32).add(Aspect.GREED, 64)
+                        .add(Aspect.EXCHANGE, 48).add(Aspect.MAGIC, 16).add(Aspect.MIND, 8).add(Aspect.AURA, 32),
                 getModItem(ElectroMagicTools.ID, "ChargingFocus", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTMachines", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0),
@@ -2701,9 +2584,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "PotentiaGenerator",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("permutatio"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("metallum"), 3),
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.EXCHANGE, 12).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.METAL, 3),
                 -4,
                 2,
                 3,
@@ -2714,9 +2596,8 @@ public class ScriptEMT implements IScriptLoader {
                 "PotentiaGenerator",
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("permutatio"), 32)
-                        .add(Aspect.getAspect("machina"), 16).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("metallum"), 32),
+                new AspectList().add(Aspect.ENERGY, 48).add(Aspect.EXCHANGE, 32).add(Aspect.MECHANISM, 16)
+                        .add(Aspect.MAGIC, 32).add(Aspect.METAL, 32),
                 GregtechItemList.Generator_SemiFluid_LV.get(1),
                 getModItem(Thaumcraft.ID, "FocusTrade", 1, 0),
                 ItemList.Emitter_MV.get(1L),
@@ -2739,8 +2620,7 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "IgnisGenerator",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("ignis"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("aqua"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.FIRE, 12).add(Aspect.EXCHANGE, 9).add(Aspect.WATER, 6).add(Aspect.MAGIC, 3),
                 -6,
                 4,
                 3,
@@ -2751,8 +2631,7 @@ public class ScriptEMT implements IScriptLoader {
                 "IgnisGenerator",
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 1),
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("permutatio"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 8));
+                new AspectList().add(Aspect.FIRE, 16).add(Aspect.EXCHANGE, 8).add(Aspect.MAGIC, 8));
         TCHelper.addResearchPage(
                 "IgnisGenerator",
                 new ResearchPage(
@@ -2762,8 +2641,7 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "AuramGenerator",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("aqua"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.AURA, 12).add(Aspect.EXCHANGE, 9).add(Aspect.WATER, 6).add(Aspect.MAGIC, 3),
                 -4,
                 4,
                 3,
@@ -2774,8 +2652,7 @@ public class ScriptEMT implements IScriptLoader {
                 "AuramGenerator",
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 2),
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 0),
-                new AspectList().add(Aspect.getAspect("auram"), 16).add(Aspect.getAspect("permutatio"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 8));
+                new AspectList().add(Aspect.AURA, 16).add(Aspect.EXCHANGE, 8).add(Aspect.MAGIC, 8));
         TCHelper.addResearchPage(
                 "AuramGenerator",
                 new ResearchPage(
@@ -2785,8 +2662,7 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ArborGenerator",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("arbor"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("aqua"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.TREE, 12).add(Aspect.EXCHANGE, 9).add(Aspect.WATER, 6).add(Aspect.MAGIC, 3),
                 -2,
                 4,
                 3,
@@ -2797,8 +2673,7 @@ public class ScriptEMT implements IScriptLoader {
                 "ArborGenerator",
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 3),
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 16).add(Aspect.getAspect("permutatio"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 8));
+                new AspectList().add(Aspect.TREE, 16).add(Aspect.EXCHANGE, 8).add(Aspect.MAGIC, 8));
         TCHelper.addResearchPage(
                 "ArborGenerator",
                 new ResearchPage(
@@ -2808,8 +2683,7 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "AerGenerator",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("aqua"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.AIR, 12).add(Aspect.EXCHANGE, 9).add(Aspect.WATER, 6).add(Aspect.MAGIC, 3),
                 -4,
                 6,
                 3,
@@ -2820,8 +2694,7 @@ public class ScriptEMT implements IScriptLoader {
                 "AerGenerator",
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 4),
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("permutatio"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 8));
+                new AspectList().add(Aspect.AIR, 16).add(Aspect.EXCHANGE, 8).add(Aspect.MAGIC, 8));
         TCHelper.addResearchPage(
                 "AerGenerator",
                 new ResearchPage(
@@ -2831,8 +2704,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "LucrumGenerator",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("lucrum"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("aqua"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.GREED, 12).add(Aspect.EXCHANGE, 9).add(Aspect.WATER, 6)
+                        .add(Aspect.MAGIC, 3),
                 -4,
                 8,
                 3,
@@ -2850,8 +2723,8 @@ public class ScriptEMT implements IScriptLoader {
                 "LucrumGenerator",
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 5),
                 10,
-                new AspectList().add(Aspect.getAspect("permutatio"), 128).add(Aspect.getAspect("lucrum"), 256)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("nebrisum"), 16),
+                new AspectList().add(Aspect.EXCHANGE, 128).add(Aspect.GREED, 256).add(Aspect.MAGIC, 32)
+                        .add(TCAspects.NEBRISUM.getAspect(), 16),
                 getModItem(ElectroMagicTools.ID, "EssentiaGenerators", 1, 0),
                 getModItem(Minecraft.ID, "gold_block", 1, 0),
                 getModItem(Minecraft.ID, "gold_block", 1, 0),
@@ -2873,9 +2746,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "IndustrialWandChargingStation",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("permutatio"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.EXCHANGE, 15).add(Aspect.ENERGY, 12).add(Aspect.CRAFT, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.GREED, 3),
                 -6,
                 2,
                 3,
@@ -2887,9 +2759,8 @@ public class ScriptEMT implements IScriptLoader {
                 "IndustrialWandChargingStation",
                 getModItem(ElectroMagicTools.ID, "EMTMachines", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("permutatio"), 48).add(Aspect.getAspect("potentia"), 48)
-                        .add(Aspect.getAspect("fabrico"), 48).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("lucrum"), 64).add(Aspect.getAspect("cognitio"), 16),
+                new AspectList().add(Aspect.EXCHANGE, 48).add(Aspect.ENERGY, 48).add(Aspect.CRAFT, 48)
+                        .add(Aspect.MAGIC, 32).add(Aspect.GREED, 64).add(Aspect.MIND, 16),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 5),
                 ItemList.Machine_IV_Replicator.get(1L),
                 getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0),
@@ -2906,9 +2777,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "EtheralProcessor",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("machina"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.MECHANISM, 15).add(Aspect.CRAFT, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.MIND, 3),
                 -2,
                 2,
                 3,
@@ -2919,9 +2789,8 @@ public class ScriptEMT implements IScriptLoader {
                 "EtheralProcessor",
                 getModItem(ElectroMagicTools.ID, "EMTMachines", 1, 1),
                 9,
-                new AspectList().add(Aspect.getAspect("machina"), 16).add(Aspect.getAspect("fabrico"), 16)
-                        .add(Aspect.getAspect("potentia"), 24).add(Aspect.getAspect("praecantatio"), 28)
-                        .add(Aspect.getAspect("cognitio"), 8),
+                new AspectList().add(Aspect.MECHANISM, 16).add(Aspect.CRAFT, 16).add(Aspect.ENERGY, 24)
+                        .add(Aspect.MAGIC, 28).add(Aspect.MIND, 8),
                 ItemList.Machine_MV_Macerator.get(1L),
                 ItemList.Machine_MV_E_Furnace.get(1L),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9),
@@ -2938,8 +2807,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "ResearchCompleter",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("cognitio"), 8).add(Aspect.getAspect("machina"), 5)
-                        .add(Aspect.getAspect("permutatio"), 5).add(Aspect.getAspect("auram"), 4),
+                new AspectList().add(Aspect.MIND, 8).add(Aspect.MECHANISM, 5).add(Aspect.EXCHANGE, 5)
+                        .add(Aspect.AURA, 4),
                 -2,
                 6,
                 1,
@@ -2948,8 +2817,7 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ResearchCompleter",
                 ItemList.Casing_Magical.get(1L),
-                new AspectList().add(Aspect.getAspect("ignis"), 8).add(Aspect.getAspect("aer"), 8)
-                        .add(Aspect.getAspect("ordo"), 8),
+                new AspectList().add(Aspect.FIRE, 8).add(Aspect.AIR, 8).add(Aspect.ORDER, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -2977,9 +2845,8 @@ public class ScriptEMT implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ResearchCompleter",
                 ItemList.ResearchCompleter.get(1),
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("terra"), 50)
-                        .add(Aspect.getAspect("ignis"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.EARTH, 50).add(Aspect.FIRE, 50).add(Aspect.WATER, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -3008,9 +2875,8 @@ public class ScriptEMT implements IScriptLoader {
         new ResearchItem(
                 "MagicalMaintenanceHatch",
                 "EMT",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("machina"), 8)
-                        .add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("custom1"), 6)
-                        .add(Aspect.getAspect("nebrisum"), 4),
+                new AspectList().add(Aspect.MAGIC, 12).add(Aspect.MECHANISM, 8).add(Aspect.ELDRITCH, 6)
+                        .add(TCAspects.AEQUALITAS.getAspect(), 6).add(TCAspects.NEBRISUM.getAspect(), 4),
                 7,
                 6,
                 3,
@@ -3021,9 +2887,9 @@ public class ScriptEMT implements IScriptLoader {
                 "MagicalMaintenanceHatch",
                 ItemList.MagicalMaintenanceHatch.get(1),
                 25,
-                new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("machina"), 48).add(Aspect.getAspect("alienis"), 32)
-                        .add(Aspect.getAspect("custom1"), 32).add(Aspect.getAspect("nebrisum"), 16),
+                new AspectList().add(Aspect.AURA, 128).add(Aspect.MAGIC, 64).add(Aspect.MECHANISM, 48)
+                        .add(Aspect.ELDRITCH, 32).add(TCAspects.AEQUALITAS.getAspect(), 32)
+                        .add(TCAspects.NEBRISUM.getAspect(), 16),
                 ItemList.Hatch_Maintenance.get(1L),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 2),
                 getModItem(ElectroMagicTools.ID, "MaintenanceFocus", 1, 0),

--- a/src/main/java/com/dreammaster/scripts/ScriptEMT.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEMT.java
@@ -31,7 +31,6 @@ import static gregtech.api.recipe.RecipeMaps.fluidSolidifierRecipes;
 import static gregtech.api.recipe.RecipeMaps.formingPressRecipes;
 import static gregtech.api.recipe.RecipeMaps.maceratorRecipes;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
-import static thaumcraft.api.aspects.Aspect.getAspect;
 
 import java.util.Arrays;
 import java.util.List;
@@ -821,7 +820,7 @@ public class ScriptEMT implements IScriptLoader {
                 getModItem(ElectroMagicTools.ID, "ThaumiumDrill", 1, 27),
                 7,
                 new AspectList().add(Aspect.TOOL, 32).add(Aspect.MINE, 16).add(Aspect.ENERGY, 32).add(Aspect.GREED, 24)
-                        .add(getAspect("praecantatio"), 8),
+                        .add(Aspect.MAGIC, 8),
                 createItemStack(
                         GregTech.ID,
                         "gt.metatool.01",

--- a/src/main/java/com/dreammaster/scripts/ScriptEMT.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEMT.java
@@ -11,6 +11,7 @@ import static gregtech.api.enums.Materials.TungstenSteel;
 import static gregtech.api.enums.Mods.AdvancedSolarPanel;
 import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.ElectroMagicTools;
+import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.GalacticraftCore;
 import static gregtech.api.enums.Mods.GregTech;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
@@ -69,6 +70,7 @@ public class ScriptEMT implements IScriptLoader {
                 AdvancedSolarPanel.ID,
                 Avaritia.ID,
                 ElectroMagicTools.ID,
+                ForbiddenMagic.ID,
                 GalacticraftCore.ID,
                 IndustrialCraft2.ID,
                 ProjectRedIntegration.ID,

--- a/src/main/java/com/dreammaster/scripts/ScriptExtraBees.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraBees.java
@@ -390,8 +390,7 @@ public class ScriptExtraBees implements IScriptLoader {
         new ResearchItem(
                 "HEALINGFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("victus"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.CRAFT, 12).add(Aspect.MIND, 9).add(Aspect.LIFE, 6),
                 7,
                 -2,
                 3,
@@ -400,9 +399,8 @@ public class ScriptExtraBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "HEALINGFRAME",
                 getModItem(ExtraBees.ID, "hiveFrame.clay", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("terra"), 4)
-                        .add(Aspect.getAspect("aer"), 4).add(Aspect.getAspect("perditio"), 4)
-                        .add(Aspect.getAspect("ignis"), 4).add(Aspect.getAspect("aqua"), 4),
+                new AspectList().add(Aspect.ORDER, 4).add(Aspect.EARTH, 4).add(Aspect.AIR, 4).add(Aspect.ENTROPY, 4)
+                        .add(Aspect.FIRE, 4).add(Aspect.WATER, 4),
                 "abc",
                 "def",
                 "ghi",
@@ -430,8 +428,7 @@ public class ScriptExtraBees implements IScriptLoader {
         new ResearchItem(
                 "CHOCOLATEFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("fames"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.CRAFT, 12).add(Aspect.MIND, 9).add(Aspect.HUNGER, 6),
                 7,
                 2,
                 3,
@@ -444,9 +441,8 @@ public class ScriptExtraBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CHOCOLATEFRAME",
                 getModItem(ExtraBees.ID, "hiveFrame.cocoa", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("terra"), 4)
-                        .add(Aspect.getAspect("aer"), 4).add(Aspect.getAspect("perditio"), 4)
-                        .add(Aspect.getAspect("ignis"), 4).add(Aspect.getAspect("aqua"), 4),
+                new AspectList().add(Aspect.ORDER, 4).add(Aspect.EARTH, 4).add(Aspect.AIR, 4).add(Aspect.ENTROPY, 4)
+                        .add(Aspect.FIRE, 4).add(Aspect.WATER, 4),
                 "abc",
                 "def",
                 "ghi",
@@ -474,8 +470,7 @@ public class ScriptExtraBees implements IScriptLoader {
         new ResearchItem(
                 "RESTRAINTFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("metallum"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.CRAFT, 12).add(Aspect.MIND, 9).add(Aspect.METAL, 6),
                 9,
                 0,
                 3,
@@ -485,9 +480,8 @@ public class ScriptExtraBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "RESTRAINTFRAME",
                 getModItem(ExtraBees.ID, "hiveFrame.cage", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("terra"), 8)
-                        .add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("perditio"), 8)
-                        .add(Aspect.getAspect("ignis"), 8).add(Aspect.getAspect("aqua"), 8),
+                new AspectList().add(Aspect.ORDER, 8).add(Aspect.EARTH, 8).add(Aspect.AIR, 8).add(Aspect.ENTROPY, 8)
+                        .add(Aspect.FIRE, 8).add(Aspect.WATER, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -515,8 +509,7 @@ public class ScriptExtraBees implements IScriptLoader {
         new ResearchItem(
                 "SOULFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("spiritus"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.CRAFT, 12).add(Aspect.MIND, 9).add(Aspect.SOUL, 6),
                 11,
                 0,
                 3,
@@ -525,9 +518,8 @@ public class ScriptExtraBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SOULFRAME",
                 getModItem(ExtraBees.ID, "hiveFrame.soul", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("perditio"), 16)
-                        .add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("aqua"), 16),
+                new AspectList().add(Aspect.ORDER, 16).add(Aspect.EARTH, 16).add(Aspect.AIR, 16).add(Aspect.ENTROPY, 16)
+                        .add(Aspect.FIRE, 16).add(Aspect.WATER, 16),
                 "abc",
                 "def",
                 "ghi",

--- a/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
@@ -34,7 +34,6 @@ import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
 import static gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList.MagicFeather;
-import static thaumcraft.api.aspects.Aspect.getAspect;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -1378,8 +1377,8 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0),
                 30,
-                new AspectList().add(getAspect("praecantatio"), 200).add(Aspect.FLIGHT, 200).add(Aspect.WEATHER, 200)
-                        .add(getAspect("nebrisum"), 200).add(Aspect.MOTION, 200).add(getAspect("terminus"), 200),
+                new AspectList().add(Aspect.MAGIC, 200).add(Aspect.FLIGHT, 200).add(Aspect.WEATHER, 200)
+                        .add(TCAspects.NEBRISUM.getAspect(), 200).add(Aspect.MOTION, 200).add(Lucrum.ULTRA_DEATH, 200),
                 createItemStack(
                         TinkerConstruct.ID,
                         "travelWings",

--- a/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
@@ -57,10 +57,13 @@ import com.dreammaster.tinkersConstruct.TConstructHelper;
 import com.rwtema.extrautils.tileentity.enderconstructor.EnderConstructorRecipesHandler;
 
 import cpw.mods.fml.common.registry.GameRegistry;
+import fox.spiteful.avaritia.compat.thaumcraft.Lucrum;
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TCAspects;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
@@ -1373,9 +1376,8 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0),
                 30,
-                new AspectList().add(getAspect("praecantatio"), 200).add(getAspect("volatus"), 200)
-                        .add(getAspect("tempestas"), 200).add(getAspect("nebrisum"), 200).add(getAspect("motus"), 200)
-                        .add(getAspect("terminus"), 200),
+                new AspectList().add(getAspect("praecantatio"), 200).add(Aspect.FLIGHT, 200).add(Aspect.WEATHER, 200)
+                        .add(getAspect("nebrisum"), 200).add(Aspect.MOTION, 200).add(getAspect("terminus"), 200),
                 createItemStack(
                         TinkerConstruct.ID,
                         "travelWings",
@@ -1400,8 +1402,7 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 1),
                 4,
-                new AspectList().add(Aspect.getAspect("permutatio"), 50).add(Aspect.getAspect("volatus"), 50)
-                        .add(Aspect.getAspect("aer"), 50),
+                new AspectList().add(Aspect.EXCHANGE, 50).add(Aspect.FLIGHT, 50).add(Aspect.AIR, 50),
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 getModItem(TinkerConstruct.ID, "fletching", 1, 0),
@@ -1410,8 +1411,7 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 2),
                 4,
-                new AspectList().add(Aspect.getAspect("permutatio"), 50).add(Aspect.getAspect("volatus"), 50)
-                        .add(Aspect.getAspect("auram"), 50),
+                new AspectList().add(Aspect.EXCHANGE, 50).add(Aspect.FLIGHT, 50).add(Aspect.AURA, 50),
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 getModItem(TwilightForest.ID, "item.critter", 1, 0),
@@ -1420,8 +1420,7 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 3),
                 4,
-                new AspectList().add(Aspect.getAspect("permutatio"), 50).add(Aspect.getAspect("bestia"), 50)
-                        .add(Aspect.getAspect("infernus"), 50),
+                new AspectList().add(Aspect.EXCHANGE, 50).add(Aspect.BEAST, 50).add(DarkAspects.NETHER, 50),
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 getModItem(Minecraft.ID, "dragon_egg", 1, 0),
@@ -1430,8 +1429,7 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 "EXURINGS_CRAFTING",
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 4),
                 4,
-                new AspectList().add(Aspect.getAspect("permutatio"), 50).add(Aspect.getAspect("metallum"), 50)
-                        .add(Aspect.getAspect("lucrum"), 50),
+                new AspectList().add(Aspect.EXCHANGE, 50).add(Aspect.METAL, 50).add(Aspect.GREED, 50),
                 getModItem(ExtraUtilities.ID, "angelRing", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 OrePrefixes.foil.get(Materials.RoseGold),
@@ -1439,9 +1437,8 @@ public class ScriptExtraUtilities implements IScriptLoader {
         new ResearchItem(
                 "EXURINGS",
                 "ARTIFICE",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 10).add(Aspect.getAspect("volatus"), 10)
-                        .add(Aspect.getAspect("tempestas"), 100).add(Aspect.getAspect("nebrisum"), 10)
-                        .add(Aspect.getAspect("motus"), 10).add(Aspect.getAspect("terminus"), 10),
+                new AspectList().add(Aspect.MAGIC, 10).add(Aspect.FLIGHT, 10).add(Aspect.WEATHER, 100)
+                        .add(TCAspects.NEBRISUM.getAspect(), 10).add(Aspect.MOTION, 10).add(Lucrum.ULTRA_DEATH, 10),
                 1,
                 -5,
                 3,
@@ -1458,9 +1455,8 @@ public class ScriptExtraUtilities implements IScriptLoader {
         new ResearchItem(
                 "EXURINGS_CRAFTING",
                 "ARTIFICE",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 10).add(Aspect.getAspect("volatus"), 10)
-                        .add(Aspect.getAspect("tempestas"), 10).add(Aspect.getAspect("nebrisum"), 10)
-                        .add(Aspect.getAspect("motus"), 10).add(Aspect.getAspect("terminus"), 10),
+                new AspectList().add(Aspect.MAGIC, 10).add(Aspect.FLIGHT, 10).add(Aspect.WEATHER, 10)
+                        .add(TCAspects.NEBRISUM.getAspect(), 10).add(Aspect.MOTION, 10).add(Lucrum.ULTRA_DEATH, 10),
                 -1,
                 -5,
                 3,

--- a/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
@@ -10,6 +10,7 @@ import static gregtech.api.enums.Mods.Botania;
 import static gregtech.api.enums.Mods.BuildCraftFactory;
 import static gregtech.api.enums.Mods.BuildCraftTransport;
 import static gregtech.api.enums.Mods.ExtraUtilities;
+import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.HardcoreEnderExpansion;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.IronChests;
@@ -88,6 +89,7 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 BuildCraftFactory.ID,
                 BuildCraftTransport.ID,
                 ExtraUtilities.ID,
+                ForbiddenMagic.ID,
                 HardcoreEnderExpansion.ID,
                 IndustrialCraft2.ID,
                 IronChests.ID,

--- a/src/main/java/com/dreammaster/scripts/ScriptForbiddenMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptForbiddenMagic.java
@@ -31,10 +31,12 @@ import com.dreammaster.chisel.ChiselHelper;
 import com.dreammaster.thaumcraft.TCHelper;
 
 import WayofTime.alchemicalWizardry.api.altarRecipeRegistry.AltarRecipeRegistry;
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TCAspects;
 import gregtech.api.enums.ToolDictNames;
 import gregtech.api.util.GTOreDictUnificator;
 import thaumcraft.api.ThaumcraftApi;
@@ -119,9 +121,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_vinteum",
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 40).add(Aspect.getAspect("terra"), 40)
-                        .add(Aspect.getAspect("ignis"), 40).add(Aspect.getAspect("aqua"), 40)
-                        .add(Aspect.getAspect("ordo"), 40).add(Aspect.getAspect("perditio"), 40),
+                new AspectList().add(Aspect.AIR, 40).add(Aspect.EARTH, 40).add(Aspect.FIRE, 40).add(Aspect.WATER, 40)
+                        .add(Aspect.ORDER, 40).add(Aspect.ENTROPY, 40),
                 "abc",
                 "def",
                 "ghi",
@@ -146,9 +147,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_witchwood_staff",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 10),
-                new AspectList().add(Aspect.getAspect("aer"), 125).add(Aspect.getAspect("terra"), 125)
-                        .add(Aspect.getAspect("ignis"), 125).add(Aspect.getAspect("aqua"), 125)
-                        .add(Aspect.getAspect("ordo"), 125).add(Aspect.getAspect("perditio"), 125),
+                new AspectList().add(Aspect.AIR, 125).add(Aspect.EARTH, 125).add(Aspect.FIRE, 125)
+                        .add(Aspect.WATER, 125).add(Aspect.ORDER, 125).add(Aspect.ENTROPY, 125),
                 "abc",
                 "def",
                 "ghi",
@@ -174,15 +174,13 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "VINTEUM",
                 GTOreDictUnificator.get(OrePrefixes.nugget, Materials.Vinteum, 1L),
                 "nuggetThaumium",
-                new AspectList().add(Aspect.getAspect("permutatio"), 4).add(Aspect.getAspect("ordo"), 2)
-                        .add(Aspect.getAspect("vitreus"), 2));
+                new AspectList().add(Aspect.EXCHANGE, 4).add(Aspect.ORDER, 2).add(Aspect.CRYSTAL, 2));
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_witchwood",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 4),
                 6,
-                new AspectList().add(Aspect.getAspect("arbor"), 64).add(Aspect.getAspect("praecantatio"), 48)
-                        .add(Aspect.getAspect("herba"), 32).add(Aspect.getAspect("instrumentum"), 24)
-                        .add(Aspect.getAspect("vacuos"), 24),
+                new AspectList().add(Aspect.TREE, 64).add(Aspect.MAGIC, 48).add(Aspect.PLANT, 32).add(Aspect.TOOL, 24)
+                        .add(Aspect.VOID, 24),
                 getModItem(Witchery.ID, "ingredient", 1, 82),
                 OrePrefixes.gem.get(Materials.Vinteum),
                 getModItem(Witchery.ID, "witchsapling", 1, 0),
@@ -199,8 +197,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "JOURNEY",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("iter"), 5).add(Aspect.getAspect("praecantatio"), 10)
-                        .add(Aspect.getAspect("instrumentum"), 3),
+                new AspectList().add(Aspect.TRAVEL, 5).add(Aspect.MAGIC, 10).add(Aspect.TOOL, 3),
                 -3,
                 1,
                 3,
@@ -210,9 +207,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "ROD_infernal",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 1),
                 7,
-                new AspectList().add(Aspect.getAspect("superbia"), 16).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("infernus"), 32).add(Aspect.getAspect("ignis"), 48)
-                        .add(Aspect.getAspect("instrumentum"), 8),
+                new AspectList().add(DarkAspects.PRIDE, 16).add(Aspect.MAGIC, 16).add(DarkAspects.NETHER, 32)
+                        .add(Aspect.FIRE, 48).add(Aspect.TOOL, 8),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 6),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 3),
                 OrePrefixes.plate.get(Materials.Soularium),
@@ -226,18 +222,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 OrePrefixes.plate.get(Materials.Soularium));
         TCHelper.setResearchAspects(
                 "ROD_infernal",
-                new AspectList().add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("instrumentum"), 3));
+                new AspectList().add(DarkAspects.NETHER, 15).add(Aspect.FIRE, 12).add(Aspect.WATER, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.TOOL, 3));
         TCHelper.setResearchComplexity("ROD_infernal", 3);
         ThaumcraftApi.addWarpToResearch("ROD_infernal", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_blood",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 6),
                 9,
-                new AspectList().add(Aspect.getAspect("aqua"), 16).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("victus"), 24).add(Aspect.getAspect("exanimis"), 8)
-                        .add(Aspect.getAspect("alienis"), 8),
+                new AspectList().add(Aspect.WATER, 16).add(Aspect.MAGIC, 32).add(Aspect.LIFE, 24).add(Aspect.UNDEAD, 8)
+                        .add(Aspect.ELDRITCH, 8),
                 getModItem(BloodMagic.ID, "masterBloodOrb", 1, 0),
                 getModItem(BloodMagic.ID, "demonicSlate", 1, 0),
                 getModItem(BloodMagic.ID, "sanctus", 1, 0),
@@ -253,18 +247,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(BloodMagic.ID, "crepitous", 1, 0));
         TCHelper.setResearchAspects(
                 "ROD_blood",
-                new AspectList().add(Aspect.getAspect("victus"), 15).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("telum"), 3));
+                new AspectList().add(Aspect.LIFE, 15).add(Aspect.WATER, 12).add(Aspect.DARKNESS, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.WEAPON, 3));
         TCHelper.setResearchComplexity("ROD_blood", 3);
         ThaumcraftApi.addWarpToResearch("ROD_blood", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_livingwood",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 8),
                 9,
-                new AspectList().add(Aspect.getAspect("arbor"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("victus"), 16).add(Aspect.getAspect("sensus"), 8)
-                        .add(Aspect.getAspect("herba"), 8),
+                new AspectList().add(Aspect.TREE, 32).add(Aspect.MAGIC, 16).add(Aspect.LIFE, 16).add(Aspect.SENSES, 8)
+                        .add(Aspect.PLANT, 8),
                 getModItem(Botania.ID, "livingwood", 1, 0), // livingwood log
                 getModItem(Botania.ID, "manaResource", 1, 2), // mana diamond
                 getModItem(Botania.ID, "rune", 1, 0), // water rune
@@ -275,9 +267,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "ROD_livingwood",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("victus"), 5).add(Aspect.getAspect("praecantatio"), 10)
-                        .add(Aspect.getAspect("herba"), 3).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("arbor"), 5),
+                new AspectList().add(Aspect.LIFE, 5).add(Aspect.MAGIC, 10).add(Aspect.PLANT, 3).add(Aspect.TOOL, 4)
+                        .add(Aspect.TREE, 5),
                 -1,
                 3,
                 3,
@@ -291,9 +282,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "ROD_dreamwood",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 12),
                 9,
-                new AspectList().add(Aspect.getAspect("arbor"), 64).add(Aspect.getAspect("praecantatio"), 48)
-                        .add(Aspect.getAspect("auram"), 32).add(Aspect.getAspect("victus"), 24)
-                        .add(Aspect.getAspect("sensus"), 16).add(Aspect.getAspect("herba"), 8),
+                new AspectList().add(Aspect.TREE, 64).add(Aspect.MAGIC, 48).add(Aspect.AURA, 32).add(Aspect.LIFE, 24)
+                        .add(Aspect.SENSES, 16).add(Aspect.PLANT, 8),
                 getModItem(Botania.ID, "dreamwood", 1, 0), // dreamwood log
                 getModItem(Botania.ID, "manaResource", 1, 9), // dragon stone
                 getModItem(Botania.ID, "rune", 1, 0), // water rune
@@ -308,9 +298,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "ROD_dreamwood",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("auram"), 5).add(Aspect.getAspect("praecantatio"), 10)
-                        .add(Aspect.getAspect("herba"), 3).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("arbor"), 5),
+                new AspectList().add(Aspect.AURA, 5).add(Aspect.MAGIC, 10).add(Aspect.PLANT, 3).add(Aspect.TOOL, 4)
+                        .add(Aspect.TREE, 5),
                 1,
                 4,
                 3,
@@ -325,9 +314,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "ROD_dreamwood_staff",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("auram"), 5).add(Aspect.getAspect("praecantatio"), 10)
-                        .add(Aspect.getAspect("herba"), 3).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("arbor"), 5),
+                new AspectList().add(Aspect.AURA, 5).add(Aspect.MAGIC, 10).add(Aspect.PLANT, 3).add(Aspect.TOOL, 4)
+                        .add(Aspect.TREE, 5),
                 3,
                 4,
                 3,
@@ -336,9 +324,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_dreamwood_staff",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 13),
-                new AspectList().add(Aspect.getAspect("aer"), 125).add(Aspect.getAspect("terra"), 125)
-                        .add(Aspect.getAspect("ignis"), 125).add(Aspect.getAspect("aqua"), 125)
-                        .add(Aspect.getAspect("ordo"), 125).add(Aspect.getAspect("perditio"), 125),
+                new AspectList().add(Aspect.AIR, 125).add(Aspect.EARTH, 125).add(Aspect.FIRE, 125)
+                        .add(Aspect.WATER, 125).add(Aspect.ORDER, 125).add(Aspect.ENTROPY, 125),
                 "abc",
                 "def",
                 "ghi",
@@ -373,9 +360,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "CAP_manasteel",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("metallum"), 5).add(Aspect.getAspect("praecantatio"), 10)
-                        .add(Aspect.getAspect("lucrum"), 3).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("auram"), 5),
+                new AspectList().add(Aspect.METAL, 5).add(Aspect.MAGIC, 10).add(Aspect.GREED, 3).add(Aspect.TOOL, 4)
+                        .add(Aspect.AURA, 5),
                 1,
                 2,
                 3,
@@ -384,8 +370,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "CAP_manasteel",
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 4),
                 6,
-                new AspectList().add(Aspect.getAspect("potentia"), 40).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("auram"), 24).add(Aspect.getAspect("sensus"), 8),
+                new AspectList().add(Aspect.ENERGY, 40).add(Aspect.MAGIC, 24).add(Aspect.AURA, 24)
+                        .add(Aspect.SENSES, 8),
                 // gold cap, 6 manasteel, 6 salis mundus
                 getModItem(Thaumcraft.ID, "WandCap", 1, 1), // gold cap
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14), // salis
@@ -412,9 +398,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "CAP_terrasteel",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("terra"), 5).add(Aspect.getAspect("praecantatio"), 10)
-                        .add(Aspect.getAspect("superbia"), 3).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("strontio"), 2).add(Aspect.getAspect("vitreus"), 5),
+                new AspectList().add(Aspect.EARTH, 5).add(Aspect.MAGIC, 10).add(DarkAspects.PRIDE, 3)
+                        .add(Aspect.TOOL, 4).add(TCAspects.STRONTIO.getAspect(), 2).add(Aspect.CRYSTAL, 5),
                 3,
                 2,
                 3,
@@ -423,9 +408,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "CAP_terrasteel",
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 2),
                 6,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 256).add(Aspect.getAspect("ordo"), 64)
-                        .add(Aspect.getAspect("metallum"), 64).add(Aspect.getAspect("superbia"), 20)
-                        .add(Aspect.getAspect("strontio"), 10),
+                new AspectList().add(Aspect.MAGIC, 256).add(Aspect.ORDER, 64).add(Aspect.METAL, 64)
+                        .add(DarkAspects.PRIDE, 20).add(TCAspects.STRONTIO.getAspect(), 10),
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 3),
                 OrePrefixes.gemExquisite.get(Materials.Emerald),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3),
@@ -448,9 +432,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "CAP_elementium",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("auram"), 5).add(Aspect.getAspect("praecantatio"), 10)
-                        .add(Aspect.getAspect("victus"), 3).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("humanus"), 5),
+                new AspectList().add(Aspect.AURA, 5).add(Aspect.MAGIC, 10).add(Aspect.LIFE, 3).add(Aspect.TOOL, 4)
+                        .add(Aspect.MAN, 5),
                 3,
                 4,
                 3,
@@ -459,8 +442,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_elementium",
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 6),
-                new AspectList().add(Aspect.getAspect("terra"), 40).add(Aspect.getAspect("aqua"), 40)
-                        .add(Aspect.getAspect("aer"), 40),
+                new AspectList().add(Aspect.EARTH, 40).add(Aspect.WATER, 40).add(Aspect.AIR, 40),
                 "abc",
                 "def",
                 "ghi",
@@ -494,8 +476,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "VINTEUM",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("metallum"), 5).add(Aspect.getAspect("permutatio"), 10)
-                        .add(Aspect.getAspect("praecantatio"), 3).add(Aspect.getAspect("lucrum"), 2),
+                new AspectList().add(Aspect.METAL, 5).add(Aspect.EXCHANGE, 10).add(Aspect.MAGIC, 3)
+                        .add(Aspect.GREED, 2),
                 -4,
                 2,
                 3,
@@ -511,9 +493,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "CAP_vinteum",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("permutatio"), 5).add(Aspect.getAspect("praecantatio"), 10)
-                        .add(Aspect.getAspect("lucrum"), 3).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("metallum"), 5),
+                new AspectList().add(Aspect.EXCHANGE, 5).add(Aspect.MAGIC, 10).add(Aspect.GREED, 3).add(Aspect.TOOL, 4)
+                        .add(Aspect.METAL, 5),
                 -5,
                 3,
                 3,
@@ -525,9 +506,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "ROD_witchwood",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("victus"), 5).add(Aspect.getAspect("praecantatio"), 10)
-                        .add(Aspect.getAspect("herba"), 3).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("arbor"), 5),
+                new AspectList().add(Aspect.LIFE, 5).add(Aspect.MAGIC, 10).add(Aspect.PLANT, 3).add(Aspect.TOOL, 4)
+                        .add(Aspect.TREE, 5),
                 -4,
                 0,
                 3,
@@ -539,9 +519,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         new ResearchItem(
                 "ROD_witchwood_staff",
                 "FORBIDDEN",
-                new AspectList().add(Aspect.getAspect("victus"), 5).add(Aspect.getAspect("praecantatio"), 10)
-                        .add(Aspect.getAspect("herba"), 3).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("arbor"), 5),
+                new AspectList().add(Aspect.LIFE, 5).add(Aspect.MAGIC, 10).add(Aspect.PLANT, 3).add(Aspect.TOOL, 4)
+                        .add(Aspect.TREE, 5),
                 -2,
                 0,
                 3,
@@ -592,8 +571,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "RIDINGCROP",
                 getModItem(ForbiddenMagic.ID, "RidingCrop", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("aer"), 5),
+                new AspectList().add(Aspect.EARTH, 5).add(Aspect.FIRE, 5).add(Aspect.AIR, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -617,7 +595,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CRYSTALWELL",
                 getModItem(ForbiddenMagic.ID, "Crystalwell", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 5).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.WATER, 5).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -641,26 +619,24 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14));
         TCHelper.setResearchAspects(
                 "CRYSTALWELL",
-                new AspectList().add(Aspect.getAspect("cognitio"), 18).add(Aspect.getAspect("vitreus"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("sensus"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.MIND, 18).add(Aspect.CRYSTAL, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.SENSES, 9).add(Aspect.AIR, 6).add(Aspect.WATER, 3));
         TCHelper.setResearchComplexity("CRYSTALWELL", 3);
         ThaumcraftApi.addCrucibleRecipe(
                 "BLACKFLOWER",
                 getModItem(ForbiddenMagic.ID, "UmbralBush", 1, 0),
                 getModItem(Minecraft.ID, "double_plant", 1, 4),
-                new AspectList().add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("victus"), 10));
+                new AspectList().add(Aspect.DARKNESS, 16).add(Aspect.LIFE, 10));
         TCHelper.setResearchAspects(
                 "BLACKFLOWER",
-                new AspectList().add(Aspect.getAspect("herba"), 12).add(Aspect.getAspect("tenebrae"), 9)
-                        .add(Aspect.getAspect("sensus"), 6).add(Aspect.getAspect("victus"), 3));
+                new AspectList().add(Aspect.PLANT, 12).add(Aspect.DARKNESS, 9).add(Aspect.SENSES, 6)
+                        .add(Aspect.LIFE, 3));
         TCHelper.setResearchComplexity("BLACKFLOWER", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "RINGFOOD",
                 getModItem(ForbiddenMagic.ID, "RingNutrition", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 35).add(Aspect.getAspect("aer"), 35)
-                        .add(Aspect.getAspect("ignis"), 35).add(Aspect.getAspect("terra"), 35)
-                        .add(Aspect.getAspect("perditio"), 35),
+                new AspectList().add(Aspect.WATER, 35).add(Aspect.AIR, 35).add(Aspect.FIRE, 35).add(Aspect.EARTH, 35)
+                        .add(Aspect.ENTROPY, 35),
                 "abc",
                 "def",
                 "ghi",
@@ -684,16 +660,14 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "screwInfusedFire");
         TCHelper.setResearchAspects(
                 "RINGFOOD",
-                new AspectList().add(Aspect.getAspect("fames"), 15).add(Aspect.getAspect("victus"), 12)
-                        .add(Aspect.getAspect("gula"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.HUNGER, 15).add(Aspect.LIFE, 12).add(DarkAspects.GLUTTONY, 9)
+                        .add(Aspect.GREED, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("RINGFOOD", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BLOODWELL",
                 getModItem(ForbiddenMagic.ID, "Bloodwell", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 25).add(Aspect.getAspect("aer"), 25)
-                        .add(Aspect.getAspect("ignis"), 25).add(Aspect.getAspect("terra"), 25)
-                        .add(Aspect.getAspect("perditio"), 25),
+                new AspectList().add(Aspect.WATER, 25).add(Aspect.AIR, 25).add(Aspect.FIRE, 25).add(Aspect.EARTH, 25)
+                        .add(Aspect.ENTROPY, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -717,17 +691,15 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "screwInfusedFire");
         TCHelper.setResearchAspects(
                 "BLOODWELL",
-                new AspectList().add(Aspect.getAspect("victus"), 15).add(Aspect.getAspect("cognitio"), 12)
-                        .add(Aspect.getAspect("sensus"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.LIFE, 15).add(Aspect.MIND, 12).add(Aspect.SENSES, 9).add(Aspect.GREED, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("BLOODWELL", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUSBLINK",
                 getModItem(ForbiddenMagic.ID, "BlinkFocus", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("desidia"), 16).add(Aspect.getAspect("infernus"), 16)
-                        .add(Aspect.getAspect("iter"), 32).add(Aspect.getAspect("perditio"), 32)
-                        .add(Aspect.getAspect("alienis"), 8).add(Aspect.getAspect("praecantatio"), 8),
+                new AspectList().add(DarkAspects.SLOTH, 16).add(DarkAspects.NETHER, 16).add(Aspect.TRAVEL, 32)
+                        .add(Aspect.ENTROPY, 32).add(Aspect.ELDRITCH, 8).add(Aspect.MAGIC, 8),
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0),
                 getModItem(Witchery.ID, "ingredient", 1, 92),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7),
@@ -743,18 +715,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7));
         TCHelper.setResearchAspects(
                 "FOCUSBLINK",
-                new AspectList().add(Aspect.getAspect("desidia"), 21).add(Aspect.getAspect("iter"), 18)
-                        .add(Aspect.getAspect("perditio"), 15).add(Aspect.getAspect("infernus"), 12)
-                        .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("tenebrae"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(DarkAspects.SLOTH, 21).add(Aspect.TRAVEL, 18).add(Aspect.ENTROPY, 15)
+                        .add(DarkAspects.NETHER, 12).add(Aspect.ELDRITCH, 9).add(Aspect.DARKNESS, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("FOCUSBLINK", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ARCANECAKE",
                 getModItem(ForbiddenMagic.ID, "ArcaneCakeItem", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("fabrico"), 32).add(Aspect.getAspect("fames"), 32)
-                        .add(Aspect.getAspect("gula"), 16).add(Aspect.getAspect("aqua"), 64)
-                        .add(Aspect.getAspect("limus"), 16).add(Aspect.getAspect("praecantatio"), 8),
+                new AspectList().add(Aspect.CRAFT, 32).add(Aspect.HUNGER, 32).add(DarkAspects.GLUTTONY, 16)
+                        .add(Aspect.WATER, 64).add(Aspect.SLIME, 16).add(Aspect.MAGIC, 8),
                 getModItem(Minecraft.ID, "cake", 1, 0),
                 getModItem(ForbiddenMagic.ID, "StarBlock", 1, 0),
                 getModItem(Minecraft.ID, "milk_bucket", 1, 0),
@@ -770,16 +740,15 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(Minecraft.ID, "milk_bucket", 1, 0));
         TCHelper.setResearchAspects(
                 "ARCANECAKE",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("gula"), 15)
-                        .add(Aspect.getAspect("fames"), 12).add(Aspect.getAspect("fabrico"), 9)
-                        .add(Aspect.getAspect("limus"), 6).add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.MAGIC, 18).add(DarkAspects.GLUTTONY, 15).add(Aspect.HUNGER, 12)
+                        .add(Aspect.CRAFT, 9).add(Aspect.SLIME, 6).add(Aspect.WATER, 3));
         TCHelper.setResearchComplexity("ARCANECAKE", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "FORK",
                 getModItem(ForbiddenMagic.ID, "DiabolistFork", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("telum"), 32).add(Aspect.getAspect("infernus"), 24)
-                        .add(Aspect.getAspect("potentia"), 16).add(Aspect.getAspect("machina"), 8),
+                new AspectList().add(Aspect.WEAPON, 32).add(DarkAspects.NETHER, 24).add(Aspect.ENERGY, 16)
+                        .add(Aspect.MECHANISM, 8),
                 getModItem(Thaumcraft.ID, "ItemSwordThaumium", 1, 0),
                 OrePrefixes.stick.get(Materials.BloodInfusedIron),
                 OrePrefixes.screw.get(Materials.InfusedFire),
@@ -792,18 +761,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 1));
         TCHelper.setResearchAspects(
                 "FORK",
-                new AspectList().add(Aspect.getAspect("tenebrae"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("infernus"), 12).add(Aspect.getAspect("machina"), 9)
-                        .add(Aspect.getAspect("instrumentum"), 6).add(Aspect.getAspect("telum"), 3));
+                new AspectList().add(Aspect.DARKNESS, 18).add(Aspect.MAGIC, 15).add(DarkAspects.NETHER, 12)
+                        .add(Aspect.MECHANISM, 9).add(Aspect.TOOL, 6).add(Aspect.WEAPON, 3));
         TCHelper.setResearchComplexity("FORK", 3);
         ThaumcraftApi.addWarpToResearch("FORK", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "SKULLAXE",
                 getModItem(ForbiddenMagic.ID, "SkullAxe", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("infernus"), 32).add(Aspect.getAspect("ira"), 24)
-                        .add(Aspect.getAspect("telum"), 24).add(Aspect.getAspect("potentia"), 16)
-                        .add(Aspect.getAspect("mortuus"), 8),
+                new AspectList().add(DarkAspects.NETHER, 32).add(DarkAspects.WRATH, 24).add(Aspect.WEAPON, 24)
+                        .add(Aspect.ENERGY, 16).add(Aspect.DEATH, 8),
                 getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0),
                 getModItem(Minecraft.ID, "skull", 1, 0),
@@ -817,18 +784,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(Minecraft.ID, "skull", 1, 4));
         TCHelper.setResearchAspects(
                 "SKULLAXE",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("instrumentum"), 15)
-                        .add(Aspect.getAspect("mortuus"), 12).add(Aspect.getAspect("ira"), 9)
-                        .add(Aspect.getAspect("telum"), 6).add(Aspect.getAspect("infernus"), 3));
+                new AspectList().add(Aspect.MAGIC, 18).add(Aspect.TOOL, 15).add(Aspect.DEATH, 12)
+                        .add(DarkAspects.WRATH, 9).add(Aspect.WEAPON, 6).add(DarkAspects.NETHER, 3));
         TCHelper.setResearchComplexity("SKULLAXE", 3);
         ThaumcraftApi.addWarpToResearch("SKULLAXE", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "BLOODRAPIER",
                 getModItem(ForbiddenMagic.ID, "BloodRapier", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("victus"), 24)
-                        .add(Aspect.getAspect("telum"), 16).add(Aspect.getAspect("fames"), 32)
-                        .add(Aspect.getAspect("gula"), 8),
+                new AspectList().add(Aspect.DARKNESS, 16).add(Aspect.LIFE, 24).add(Aspect.WEAPON, 16)
+                        .add(Aspect.HUNGER, 32).add(DarkAspects.GLUTTONY, 8),
                 getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0),
                 getModItem(Minecraft.ID, "feather", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 11),
@@ -842,30 +807,26 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(ForbiddenMagic.ID, "GluttonyShard", 1, 0));
         TCHelper.setResearchAspects(
                 "BLOODRAPIER",
-                new AspectList().add(Aspect.getAspect("tenebrae"), 18).add(Aspect.getAspect("gula"), 15)
-                        .add(Aspect.getAspect("victus"), 12).add(Aspect.getAspect("fames"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("telum"), 3));
+                new AspectList().add(Aspect.DARKNESS, 18).add(DarkAspects.GLUTTONY, 15).add(Aspect.LIFE, 12)
+                        .add(Aspect.HUNGER, 9).add(Aspect.MAGIC, 6).add(Aspect.WEAPON, 3));
         TCHelper.setResearchComplexity("BLOODRAPIER", 3);
         ThaumcraftApi.addWarpToResearch("BLOODRAPIER", 2);
         ThaumcraftApi.addCrucibleRecipe(
                 "TRANSEMERALD",
                 getModItem(ForbiddenMagic.ID, "FMResource", 4, 0),
                 getModItem(ForbiddenMagic.ID, "FMResource", 1, 0),
-                new AspectList().add(Aspect.getAspect("lucrum"), 4).add(Aspect.getAspect("vitreus"), 4));
+                new AspectList().add(Aspect.GREED, 4).add(Aspect.CRYSTAL, 4));
         TCHelper.setResearchAspects(
                 "TRANSEMERALD",
-                new AspectList().add(Aspect.getAspect("permutatio"), 15).add(Aspect.getAspect("vitreus"), 12)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.EXCHANGE, 15).add(Aspect.CRYSTAL, 12).add(Aspect.GREED, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("TRANSEMERALD", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "WRATHCAGE",
                 getModItem(ForbiddenMagic.ID, "WrathCage", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("ira"), 32).add(Aspect.getAspect("machina"), 32)
-                        .add(Aspect.getAspect("bestia"), 64).add(Aspect.getAspect("metallum"), 48)
-                        .add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("exanimis"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 32),
+                new AspectList().add(DarkAspects.WRATH, 32).add(Aspect.MECHANISM, 32).add(Aspect.BEAST, 64)
+                        .add(Aspect.METAL, 48).add(Aspect.ELDRITCH, 16).add(Aspect.UNDEAD, 16).add(Aspect.MAGIC, 32),
                 getModItem(EnderIO.ID, "itemBrokenSpawner", 1, 0),
                 OrePrefixes.block.get(Materials.Thaumium),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0),
@@ -884,23 +845,20 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "WRATHCAGE",
                 getModItem(ForbiddenMagic.ID, "MobCrystal", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("cognitio"), 10).add(Aspect.getAspect("potentia"), 10)
-                        .add(Aspect.getAspect("praecantatio"), 10).add(Aspect.getAspect("vitreus"), 10));
+                new AspectList().add(Aspect.MIND, 10).add(Aspect.ENERGY, 10).add(Aspect.MAGIC, 10)
+                        .add(Aspect.CRYSTAL, 10));
         TCHelper.setResearchAspects(
                 "WRATHCAGE",
-                new AspectList().add(Aspect.getAspect("ira"), 21).add(Aspect.getAspect("machina"), 18)
-                        .add(Aspect.getAspect("bestia"), 15).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("exanimis"), 3));
+                new AspectList().add(DarkAspects.WRATH, 21).add(Aspect.MECHANISM, 18).add(Aspect.BEAST, 15)
+                        .add(Aspect.METAL, 12).add(Aspect.MAGIC, 9).add(Aspect.ELDRITCH, 6).add(Aspect.UNDEAD, 3));
         TCHelper.setResearchComplexity("WRATHCAGE", 3);
         ThaumcraftApi.addWarpToResearch("WRATHCAGE", 5);
         TCHelper.addInfusionCraftingRecipe(
                 "MORPHTOOLS",
                 getModItem(ForbiddenMagic.ID, "MorphPickaxe", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("invidia"), 16).add(Aspect.getAspect("instrumentum"), 16)
-                        .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("cognitio"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("potentia"), 8),
+                new AspectList().add(DarkAspects.ENVY, 16).add(Aspect.TOOL, 16).add(Aspect.EXCHANGE, 32)
+                        .add(Aspect.MIND, 8).add(Aspect.MAGIC, 48).add(Aspect.ENERGY, 8),
                 getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1),
@@ -916,9 +874,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "MORPHTOOLS",
                 getModItem(ForbiddenMagic.ID, "MorphAxe", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("invidia"), 16).add(Aspect.getAspect("instrumentum"), 16)
-                        .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("cognitio"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("potentia"), 8),
+                new AspectList().add(DarkAspects.ENVY, 16).add(Aspect.TOOL, 16).add(Aspect.EXCHANGE, 32)
+                        .add(Aspect.MIND, 8).add(Aspect.MAGIC, 48).add(Aspect.ENERGY, 8),
                 getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1),
@@ -934,9 +891,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "MORPHTOOLS",
                 getModItem(ForbiddenMagic.ID, "MorphShovel", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("invidia"), 16).add(Aspect.getAspect("instrumentum"), 16)
-                        .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("cognitio"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("potentia"), 8),
+                new AspectList().add(DarkAspects.ENVY, 16).add(Aspect.TOOL, 16).add(Aspect.EXCHANGE, 32)
+                        .add(Aspect.MIND, 8).add(Aspect.MAGIC, 48).add(Aspect.ENERGY, 8),
                 getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1),
@@ -952,9 +908,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "MORPHTOOLS",
                 getModItem(ForbiddenMagic.ID, "MorphSword", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("invidia"), 16).add(Aspect.getAspect("telum"), 16)
-                        .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("cognitio"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("potentia"), 8),
+                new AspectList().add(DarkAspects.ENVY, 16).add(Aspect.WEAPON, 16).add(Aspect.EXCHANGE, 32)
+                        .add(Aspect.MIND, 8).add(Aspect.MAGIC, 48).add(Aspect.ENERGY, 8),
                 getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1),
@@ -968,18 +923,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1));
         TCHelper.setResearchAspects(
                 "MORPHTOOLS",
-                new AspectList().add(Aspect.getAspect("invidia"), 18).add(Aspect.getAspect("instrumentum"), 15)
-                        .add(Aspect.getAspect("permutatio"), 12).add(Aspect.getAspect("cognitio"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(DarkAspects.ENVY, 18).add(Aspect.TOOL, 15).add(Aspect.EXCHANGE, 12)
+                        .add(Aspect.MIND, 9).add(Aspect.MAGIC, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("MORPHTOOLS", 3);
         ThaumcraftApi.addWarpToResearch("MORPHTOOLS", 5);
         TCHelper.addInfusionCraftingRecipe(
                 "TAINTSHOVEL",
                 getModItem(ForbiddenMagic.ID, "TaintShovel", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("perfodio"), 16).add(Aspect.getAspect("sano"), 16)
-                        .add(Aspect.getAspect("vitreus"), 32).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("limus"), 8).add(Aspect.getAspect("instrumentum"), 8),
+                new AspectList().add(Aspect.MINE, 16).add(Aspect.HEAL, 16).add(Aspect.CRYSTAL, 32).add(Aspect.MAGIC, 32)
+                        .add(Aspect.SLIME, 8).add(Aspect.TOOL, 8),
                 getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4),
@@ -992,18 +945,15 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4));
         TCHelper.setResearchAspects(
                 "TAINTSHOVEL",
-                new AspectList().add(Aspect.getAspect("vitreus"), 21).add(Aspect.getAspect("vitium"), 18)
-                        .add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("limus"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("venenum"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.CRYSTAL, 21).add(Aspect.TAINT, 18).add(Aspect.TOOL, 15)
+                        .add(Aspect.SLIME, 12).add(Aspect.MAGIC, 9).add(Aspect.POISON, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("TAINTSHOVEL", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "TAINTPICK",
                 getModItem(ForbiddenMagic.ID, "TaintPickaxe", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("perfodio"), 16).add(Aspect.getAspect("instrumentum"), 8)
-                        .add(Aspect.getAspect("vitium"), 16).add(Aspect.getAspect("perditio"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("mortuus"), 8),
+                new AspectList().add(Aspect.MINE, 16).add(Aspect.TOOL, 8).add(Aspect.TAINT, 16).add(Aspect.ENTROPY, 32)
+                        .add(Aspect.MAGIC, 32).add(Aspect.DEATH, 8),
                 getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5),
@@ -1016,25 +966,23 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "TAINTPICK",
-                new AspectList().add(Aspect.getAspect("vitium"), 18).add(Aspect.getAspect("perditio"), 15)
-                        .add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("mortuus"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.TAINT, 18).add(Aspect.ENTROPY, 15).add(Aspect.TOOL, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.DEATH, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("TAINTPICK", 3);
         ThaumcraftApi.addCrucibleRecipe(
                 "TAINTTREE",
                 getModItem(ForbiddenMagic.ID, "TaintSapling", 1, 0),
                 "treeSapling",
-                new AspectList().add(Aspect.getAspect("venenum"), 8).add(Aspect.getAspect("vitium"), 20));
+                new AspectList().add(Aspect.POISON, 8).add(Aspect.TAINT, 20));
         TCHelper.setResearchAspects(
                 "TAINTTREE",
-                new AspectList().add(Aspect.getAspect("vitium"), 18).add(Aspect.getAspect("arbor"), 15)
-                        .add(Aspect.getAspect("herba"), 12).add(Aspect.getAspect("venenum"), 9)
-                        .add(Aspect.getAspect("mortuus"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TAINT, 18).add(Aspect.TREE, 15).add(Aspect.PLANT, 12).add(Aspect.POISON, 9)
+                        .add(Aspect.DEATH, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("TAINTTREE", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TAINTSTONE",
                 getModItem(ForbiddenMagic.ID, "TaintBlock", 9, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("perditio"), 9),
+                new AspectList().add(Aspect.ORDER, 9).add(Aspect.ENTROPY, 9),
                 "abc",
                 "def",
                 "ghi",
@@ -1058,16 +1006,14 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(Minecraft.ID, "stone", 1, 0));
         TCHelper.setResearchAspects(
                 "TAINTSTONE",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("vitium"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("ordo"), 3));
+                new AspectList().add(Aspect.MAGIC, 12).add(Aspect.TAINT, 9).add(Aspect.EARTH, 6).add(Aspect.ORDER, 3));
         TCHelper.setResearchComplexity("TAINTSTONE", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "ELDRITCHORB",
                 getModItem(ForbiddenMagic.ID, "EldritchOrb", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("alienis"), 48).add(Aspect.getAspect("tenebrae"), 32)
-                        .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("victus"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("vitreus"), 8),
+                new AspectList().add(Aspect.ELDRITCH, 48).add(Aspect.DARKNESS, 32).add(Aspect.VOID, 64)
+                        .add(Aspect.LIFE, 64).add(Aspect.MAGIC, 16).add(Aspect.CRYSTAL, 8),
                 getModItem(BloodArsenal.ID, "transparent_orb", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0),
@@ -1083,17 +1029,15 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0));
         TCHelper.setResearchAspects(
                 "ELDRITCHORB",
-                new AspectList().add(Aspect.getAspect("vacuos"), 18).add(Aspect.getAspect("victus"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("vitreus"), 9)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.VOID, 18).add(Aspect.LIFE, 15).add(Aspect.ELDRITCH, 12)
+                        .add(Aspect.CRYSTAL, 9).add(Aspect.DARKNESS, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("ELDRITCHORB", 3);
         ThaumcraftApi.addWarpToResearch("ELDRITCHORB", 6);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "PRIMEWELL",
                 getModItem(ForbiddenMagic.ID, "Primewell", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 100).add(Aspect.getAspect("ignis"), 100)
-                        .add(Aspect.getAspect("aer"), 100).add(Aspect.getAspect("terra"), 100)
-                        .add(Aspect.getAspect("ordo"), 100).add(Aspect.getAspect("perditio"), 100),
+                new AspectList().add(Aspect.WATER, 100).add(Aspect.FIRE, 100).add(Aspect.AIR, 100)
+                        .add(Aspect.EARTH, 100).add(Aspect.ORDER, 100).add(Aspect.ENTROPY, 100),
                 "abc",
                 "def",
                 "ghi",
@@ -1117,18 +1061,16 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "screwInfusedEntropy");
         TCHelper.setResearchAspects(
                 "PRIMEWELL",
-                new AspectList().add(Aspect.getAspect("alienis"), 18).add(Aspect.getAspect("cognitio"), 15)
-                        .add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("vitreus"), 9)
-                        .add(Aspect.getAspect("volatus"), 6).add(Aspect.getAspect("ordo"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 18).add(Aspect.MIND, 15).add(Aspect.CRAFT, 12)
+                        .add(Aspect.CRYSTAL, 9).add(Aspect.FLIGHT, 6).add(Aspect.ORDER, 3));
         TCHelper.setResearchComplexity("PRIMEWELL", 3);
         ThaumcraftApi.addWarpToResearch("PRIMEWELL", 1);
         TCHelper.addInfusionCraftingRecipe(
                 "SUBCOLLAR",
                 getModItem(ForbiddenMagic.ID, "SubCollar", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("vinculum"), 8).add(Aspect.getAspect("infernus"), 8)
-                        .add(Aspect.getAspect("auram"), 16).add(Aspect.getAspect("corpus"), 16)
-                        .add(Aspect.getAspect("luxuria"), 8).add(Aspect.getAspect("praecantatio"), 32),
+                new AspectList().add(Aspect.TRAP, 8).add(DarkAspects.NETHER, 8).add(Aspect.AURA, 16)
+                        .add(Aspect.FLESH, 16).add(DarkAspects.LUST, 8).add(Aspect.MAGIC, 32),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2),
                 getModItem(Thaumcraft.ID, "ItemAmuletVis", 1, 1),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 4),
@@ -1141,74 +1083,63 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(Minecraft.ID, "lead", 1, 0));
         TCHelper.setResearchAspects(
                 "SUBCOLLAR",
-                new AspectList().add(Aspect.getAspect("vinculum"), 18).add(Aspect.getAspect("auram"), 15)
-                        .add(Aspect.getAspect("corpus"), 12).add(Aspect.getAspect("luxuria"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.TRAP, 18).add(Aspect.AURA, 15).add(Aspect.FLESH, 12)
+                        .add(DarkAspects.LUST, 9).add(Aspect.MAGIC, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("SUBCOLLAR", 3);
         TCHelper.setResearchAspects(
                 "HELLFIRE",
-                new AspectList().add(Aspect.getAspect("infernus"), 18).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("iter"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("lux"), 3));
+                new AspectList().add(DarkAspects.NETHER, 18).add(Aspect.FIRE, 15).add(Aspect.TRAVEL, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.ENERGY, 6).add(Aspect.LIGHT, 3));
         TCHelper.setResearchComplexity("HELLFIRE", 3);
         TCHelper.setResearchAspects(
                 "CONSUMING",
-                new AspectList().add(Aspect.getAspect("vacuos"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("perditio"), 12).add(Aspect.getAspect("lucrum"), 9)
-                        .add(Aspect.getAspect("gula"), 6));
+                new AspectList().add(Aspect.VOID, 18).add(Aspect.MAGIC, 15).add(Aspect.ENTROPY, 12).add(Aspect.GREED, 9)
+                        .add(DarkAspects.GLUTTONY, 6));
         TCHelper.setResearchComplexity("CONSUMING", 3);
         TCHelper.setResearchAspects(
                 "EDUCATIONAL",
-                new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(Aspect.MIND, 15).add(Aspect.MAGIC, 12).add(Aspect.WEAPON, 9).add(Aspect.GREED, 6)
+                        .add(Aspect.FIRE, 3));
         TCHelper.setResearchComplexity("EDUCATIONAL", 3);
         TCHelper.setResearchAspects(
                 "GREEDY",
-                new AspectList().add(Aspect.getAspect("lucrum"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("telum"), 12).add(Aspect.getAspect("infernus"), 9)
-                        .add(Aspect.getAspect("luxuria"), 6).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(Aspect.GREED, 18).add(Aspect.MAGIC, 15).add(Aspect.WEAPON, 12)
+                        .add(DarkAspects.NETHER, 9).add(DarkAspects.LUST, 6).add(Aspect.FIRE, 3));
         TCHelper.setResearchComplexity("GREEDY", 3);
         TCHelper.setResearchAspects(
                 "CORRUPTING",
-                new AspectList().add(Aspect.getAspect("infernus"), 18).add(Aspect.getAspect("vitreus"), 15)
-                        .add(Aspect.getAspect("permutatio"), 12).add(Aspect.getAspect("spiritus"), 9)
-                        .add(Aspect.getAspect("nebrisum"), 6).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(DarkAspects.NETHER, 18).add(Aspect.CRYSTAL, 15).add(Aspect.EXCHANGE, 12)
+                        .add(Aspect.SOUL, 9).add(TCAspects.NEBRISUM.getAspect(), 6).add(Aspect.FIRE, 3));
         TCHelper.setResearchComplexity("CORRUPTING", 3);
         ThaumcraftApi.addWarpToResearch("CORRUPTING", 2);
         TCHelper.setResearchAspects(
                 "WRATH",
-                new AspectList().add(Aspect.getAspect("ira"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("telum"), 12).add(Aspect.getAspect("superbia"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(DarkAspects.WRATH, 18).add(Aspect.MAGIC, 15).add(Aspect.WEAPON, 12)
+                        .add(DarkAspects.PRIDE, 9).add(Aspect.ENERGY, 6).add(Aspect.FIRE, 3));
         TCHelper.setResearchComplexity("WRATH", 3);
         ThaumcraftApi.addWarpToResearch("WRATH", 3);
         TCHelper.setResearchAspects(
                 "VOIDTOUCHED",
-                new AspectList().add(Aspect.getAspect("invidia"), 18).add(Aspect.getAspect("alienis"), 15)
-                        .add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("fabrico"), 9)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(DarkAspects.ENVY, 18).add(Aspect.ELDRITCH, 15).add(Aspect.TOOL, 12)
+                        .add(Aspect.CRAFT, 9).add(Aspect.DARKNESS, 6).add(Aspect.FIRE, 3));
         TCHelper.setResearchComplexity("VOIDTOUCHED", 3);
         ThaumcraftApi.addWarpToResearch("VOIDTOUCHED", 2);
         TCHelper.setResearchAspects(
                 "IMPACT",
-                new AspectList().add(Aspect.getAspect("perfodio"), 18).add(Aspect.getAspect("instrumentum"), 15)
-                        .add(Aspect.getAspect("invidia"), 12).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(Aspect.MINE, 18).add(Aspect.TOOL, 15).add(DarkAspects.ENVY, 12)
+                        .add(Aspect.ENTROPY, 9).add(Aspect.GREED, 6).add(Aspect.FIRE, 3));
         TCHelper.setResearchComplexity("IMPACT", 3);
         TCHelper.setResearchAspects(
                 "CLUSTER",
-                new AspectList().add(Aspect.getAspect("invidia"), 18).add(Aspect.getAspect("metallum"), 15)
-                        .add(Aspect.getAspect("infernus"), 12).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(DarkAspects.ENVY, 18).add(Aspect.METAL, 15).add(DarkAspects.NETHER, 12)
+                        .add(Aspect.ENERGY, 9).add(Aspect.GREED, 6).add(Aspect.FIRE, 3));
         TCHelper.setResearchComplexity("CLUSTER", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_tainted",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("vitium"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("perditio"), 48).add(Aspect.getAspect("venenum"), 24)
-                        .add(Aspect.getAspect("alienis"), 8).add(Aspect.getAspect("tenebrae"), 32),
+                new AspectList().add(Aspect.TAINT, 32).add(Aspect.MAGIC, 16).add(Aspect.ENTROPY, 48)
+                        .add(Aspect.POISON, 24).add(Aspect.ELDRITCH, 8).add(Aspect.DARKNESS, 32),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 1),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 2),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 11),
@@ -1224,17 +1155,15 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 12));
         TCHelper.setResearchAspects(
                 "ROD_tainted",
-                new AspectList().add(Aspect.getAspect("vitium"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("venenum"), 6).add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.TAINT, 18).add(Aspect.MAGIC, 15).add(Aspect.TOOL, 12).add(Aspect.ENTROPY, 9)
+                        .add(Aspect.POISON, 6).add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("ROD_tainted", 3);
         ThaumcraftApi.addWarpToResearch("ROD_tainted", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_blood_staff",
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 9),
-                new AspectList().add(Aspect.getAspect("aqua"), 40).add(Aspect.getAspect("ignis"), 40)
-                        .add(Aspect.getAspect("aer"), 40).add(Aspect.getAspect("terra"), 40)
-                        .add(Aspect.getAspect("perditio"), 40).add(Aspect.getAspect("ordo"), 40),
+                new AspectList().add(Aspect.WATER, 40).add(Aspect.FIRE, 40).add(Aspect.AIR, 40).add(Aspect.EARTH, 40)
+                        .add(Aspect.ENTROPY, 40).add(Aspect.ORDER, 40),
                 "abc",
                 "def",
                 "ghi",
@@ -1258,9 +1187,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "screwInfusedEntropy");
         TCHelper.setResearchAspects(
                 "ROD_blood_staff",
-                new AspectList().add(Aspect.getAspect("victus"), 18).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("telum"), 12).add(Aspect.getAspect("terra"), 9)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.LIFE, 18).add(Aspect.WATER, 15).add(Aspect.WEAPON, 12).add(Aspect.EARTH, 9)
+                        .add(Aspect.DARKNESS, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("ROD_blood_staff", 3);
         ThaumcraftApi.addWarpToResearch("ROD_blood_staff", 4);
         TCHelper.clearPages("CAP_alchemical");
@@ -1269,9 +1197,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 "CAP_alchemical",
                 getModItem(ForbiddenMagic.ID, "WandCaps", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("victus"), 16).add(Aspect.getAspect("aqua"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("permutatio"), 8)
-                        .add(Aspect.getAspect("metallum"), 8),
+                new AspectList().add(Aspect.LIFE, 16).add(Aspect.WATER, 32).add(Aspect.MAGIC, 16)
+                        .add(Aspect.EXCHANGE, 8).add(Aspect.METAL, 8),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 1),
                 getModItem(BloodMagic.ID, "magicales", 1, 0),
                 OrePrefixes.dust.get(Materials.Thaumium),
@@ -1288,9 +1215,8 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(ForbiddenMagic.ID, "WandCaps", 1, 0))));
         TCHelper.setResearchAspects(
                 "CAP_alchemical",
-                new AspectList().add(Aspect.getAspect("victus"), 15).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("metallum"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.LIFE, 15).add(Aspect.WATER, 12).add(Aspect.TOOL, 9).add(Aspect.METAL, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("CAP_alchemical", 3);
         ThaumcraftApi.addWarpToResearch("CAP_alchemical", 2);
         TCHelper.refreshResearchPages("RIDINGCROP");

--- a/src/main/java/com/dreammaster/scripts/ScriptForestry.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptForestry.java
@@ -256,8 +256,7 @@ public class ScriptForestry implements IScriptLoader {
         new ResearchItem(
                 "PROVENFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("potentia"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.CRAFT, 12).add(Aspect.MIND, 9).add(Aspect.ENERGY, 6),
                 7,
                 0,
                 3,
@@ -266,9 +265,8 @@ public class ScriptForestry implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "PROVENFRAME",
                 getModItem(Forestry.ID, "frameProven", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("perditio"), 15)
-                        .add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("aqua"), 15),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.EARTH, 15).add(Aspect.AIR, 15).add(Aspect.ENTROPY, 15)
+                        .add(Aspect.FIRE, 15).add(Aspect.WATER, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -296,8 +294,7 @@ public class ScriptForestry implements IScriptLoader {
         new ResearchItem(
                 "PROVENGRAFTER",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("permutatio"), 12)
-                        .add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("arbor"), 6),
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.EXCHANGE, 12).add(Aspect.METAL, 9).add(Aspect.TREE, 6),
                 -5,
                 -3,
                 3,
@@ -307,8 +304,8 @@ public class ScriptForestry implements IScriptLoader {
                 "PROVENGRAFTER",
                 getModItem(Forestry.ID, "grafterProven", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 25).add(Aspect.getAspect("permutatio"), 25)
-                        .add(Aspect.getAspect("metallum"), 20).add(Aspect.getAspect("arbor"), 10),
+                new AspectList().add(Aspect.TOOL, 25).add(Aspect.EXCHANGE, 25).add(Aspect.METAL, 20)
+                        .add(Aspect.TREE, 10),
                 getModItem(Forestry.ID, "grafter", 1, 0),
                 getModItem(Minecraft.ID, "sapling", 1, 1),
                 getModItem(Minecraft.ID, "sapling", 1, 2),

--- a/src/main/java/com/dreammaster/scripts/ScriptGadomancy.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGadomancy.java
@@ -2,6 +2,7 @@ package com.dreammaster.scripts;
 
 import static com.dreammaster.scripts.IngredientFactory.createItemStack;
 import static com.dreammaster.scripts.IngredientFactory.getModItem;
+import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.Gadomancy;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
@@ -37,7 +38,7 @@ public class ScriptGadomancy implements IScriptLoader {
 
     @Override
     public List<String> getDependencies() {
-        return Arrays.asList(Gadomancy.ID, Thaumcraft.ID, ThaumicTinkerer.ID);
+        return Arrays.asList(ForbiddenMagic.ID, Gadomancy.ID, Thaumcraft.ID, ThaumicTinkerer.ID);
     }
 
     @Override

--- a/src/main/java/com/dreammaster/scripts/ScriptGadomancy.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGadomancy.java
@@ -16,10 +16,12 @@ import net.minecraftforge.fluids.FluidRegistry;
 
 import com.dreammaster.thaumcraft.TCHelper;
 
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TCAspects;
 import gregtech.api.enums.TierEU;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
@@ -106,9 +108,8 @@ public class ScriptGadomancy implements IScriptLoader {
                 "GADOMANCY.GOLEMSILVERWOOD",
                 getModItem(Gadomancy.ID, "itemSilverwoodGolemPlacer", 1, 8),
                 8,
-                new AspectList().add(Aspect.getAspect("humanus"), 16).add(Aspect.getAspect("motus"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("sensus"), 16)
-                        .add(Aspect.getAspect("cognitio"), 8).add(Aspect.getAspect("ordo"), 32),
+                new AspectList().add(Aspect.MAN, 16).add(Aspect.MOTION, 16).add(Aspect.MAGIC, 32).add(Aspect.SENSES, 16)
+                        .add(Aspect.MIND, 8).add(Aspect.ORDER, 32),
                 getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 1),
                 getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0),
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1),
@@ -122,18 +123,15 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1));
         TCHelper.setResearchAspects(
                 "GADOMANCY.GOLEMSILVERWOOD",
-                new AspectList().add(Aspect.getAspect("cognitio"), 21).add(Aspect.getAspect("motus"), 18)
-                        .add(Aspect.getAspect("arbor"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("corpus"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.MIND, 21).add(Aspect.MOTION, 18).add(Aspect.TREE, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.ORDER, 9).add(Aspect.FLESH, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("GADOMANCY.GOLEMSILVERWOOD", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.GOLEMCOREBREAK",
                 getModItem(Gadomancy.ID, "ItemGolemCoreBreak", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 32).add(Aspect.getAspect("perditio"), 16)
-                        .add(Aspect.getAspect("machina"), 24).add(Aspect.getAspect("praecantatio"), 8)
-                        .add(Aspect.getAspect("perfodio"), 8),
+                new AspectList().add(Aspect.TOOL, 32).add(Aspect.ENTROPY, 16).add(Aspect.MECHANISM, 24)
+                        .add(Aspect.MAGIC, 8).add(Aspect.MINE, 8),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 3),
                 getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
@@ -146,17 +144,15 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "GADOMANCY.GOLEMCOREBREAK",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("perditio"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("perfodio"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.ENTROPY, 12).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.MINE, 3));
         TCHelper.setResearchComplexity("GADOMANCY.GOLEMCOREBREAK", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.GOLEMCOREBODYGUARD",
                 getModItem(Gadomancy.ID, "ItemGolemCoreBreak", 1, 1),
                 9,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 32).add(Aspect.getAspect("machina"), 24)
-                        .add(Aspect.getAspect("telum"), 16).add(Aspect.getAspect("tutamen"), 24)
-                        .add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("auram"), 8),
+                new AspectList().add(Aspect.TOOL, 32).add(Aspect.MECHANISM, 24).add(Aspect.WEAPON, 16)
+                        .add(Aspect.ARMOR, 24).add(Aspect.ORDER, 8).add(Aspect.AURA, 8),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 4),
                 getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemHelmetThaumium", 1, 0),
@@ -168,21 +164,18 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6));
         TCHelper.setResearchAspects(
                 "GADOMANCY.GOLEMCOREBODYGUARD",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 18).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("machina"), 12).add(Aspect.getAspect("telum"), 9)
-                        .add(Aspect.getAspect("tutamen"), 6).add(Aspect.getAspect("auram"), 3));
+                new AspectList().add(Aspect.TOOL, 18).add(Aspect.ORDER, 15).add(Aspect.MECHANISM, 12)
+                        .add(Aspect.WEAPON, 9).add(Aspect.ARMOR, 6).add(Aspect.AURA, 3));
         TCHelper.setResearchComplexity("GADOMANCY.GOLEMCOREBODYGUARD", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.GOLEMRUNICSHIELD",
-                new AspectList().add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("motus"), 12)
-                        .add(Aspect.getAspect("tutamen"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("ordo"), 3));
+                new AspectList().add(Aspect.AURA, 15).add(Aspect.MOTION, 12).add(Aspect.ARMOR, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.ORDER, 3));
         TCHelper.setResearchComplexity("GADOMANCY.GOLEMRUNICSHIELD", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GADOMANCY.ANCIENT_STONES",
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 6, 11),
-                new AspectList().add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("perditio"), 12)
-                        .add(Aspect.getAspect("ignis"), 6),
+                new AspectList().add(Aspect.EARTH, 6).add(Aspect.ENTROPY, 12).add(Aspect.FIRE, 6),
                 "abc",
                 "def",
                 "ghi",
@@ -206,24 +199,21 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6));
         TCHelper.setResearchAspects(
                 "GADOMANCY.ANCIENT_STONES",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("perditio"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.ELDRITCH, 12).add(Aspect.ENTROPY, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("GADOMANCY.ANCIENT_STONES", 3);
         ThaumcraftApi.addCrucibleRecipe(
                 "GADOMANCY.ANCIENT_STONES",
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 15),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 11),
-                new AspectList().add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("perditio"), 12)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("terra"), 8));
+                new AspectList().add(Aspect.EXCHANGE, 8).add(Aspect.ENTROPY, 12).add(Aspect.ELDRITCH, 12)
+                        .add(Aspect.EARTH, 8));
         TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.NODE_MANIPULATOR",
                 getModItem(Gadomancy.ID, "BlockNodeManipulator", 1, 5),
                 10,
-                new AspectList().add(Aspect.getAspect("alienis"), 48).add(Aspect.getAspect("auram"), 64)
-                        .add(Aspect.getAspect("machina"), 48).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("permutatio"), 24)
-                        .add(Aspect.getAspect("motus"), 8),
+                new AspectList().add(Aspect.ELDRITCH, 48).add(Aspect.AURA, 64).add(Aspect.MECHANISM, 48)
+                        .add(Aspect.MAGIC, 32).add(Aspect.DARKNESS, 16).add(Aspect.EXCHANGE, 24).add(Aspect.MOTION, 8),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 5),
                 OrePrefixes.plateDense.get(Materials.Void),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 0),
@@ -241,10 +231,9 @@ public class ScriptGadomancy implements IScriptLoader {
                 "GADOMANCY.NODE_MANIPULATOR",
                 getModItem(Gadomancy.ID, "BlockStoneMachine", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("alienis"), 24).add(Aspect.getAspect("machina"), 48)
-                        .add(Aspect.getAspect("ordo"), 64).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("nebrisum"), 8)
-                        .add(Aspect.getAspect("lucrum"), 16),
+                new AspectList().add(Aspect.ELDRITCH, 24).add(Aspect.MECHANISM, 48).add(Aspect.ORDER, 64)
+                        .add(Aspect.MAGIC, 16).add(Aspect.DARKNESS, 32).add(TCAspects.NEBRISUM.getAspect(), 8)
+                        .add(Aspect.GREED, 16),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 8),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6),
@@ -258,20 +247,16 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6));
         TCHelper.setResearchAspects(
                 "GADOMANCY.NODE_MANIPULATOR",
-                new AspectList().add(Aspect.getAspect("nebrisum"), 27).add(Aspect.getAspect("alienis"), 24)
-                        .add(Aspect.getAspect("vacuos"), 21).add(Aspect.getAspect("praecantatio"), 18)
-                        .add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("tenebrae"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(TCAspects.NEBRISUM.getAspect(), 27).add(Aspect.ELDRITCH, 24).add(Aspect.VOID, 21)
+                        .add(Aspect.MAGIC, 18).add(Aspect.AURA, 15).add(Aspect.GREED, 12).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.DARKNESS, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("GADOMANCY.NODE_MANIPULATOR", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "GADOMANCY.INFUSIONCLAW",
                 getModItem(Gadomancy.ID, "BlockInfusionClaw", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("machina"), 48)
-                        .add(Aspect.getAspect("ordo"), 48).add(Aspect.getAspect("tenebrae"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("motus"), 16)
-                        .add(Aspect.getAspect("cognitio"), 8),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.MECHANISM, 48).add(Aspect.ORDER, 48)
+                        .add(Aspect.DARKNESS, 32).add(Aspect.MAGIC, 32).add(Aspect.MOTION, 16).add(Aspect.MIND, 8),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 5),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 8),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6),
@@ -287,21 +272,17 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6));
         TCHelper.setResearchAspects(
                 "GADOMANCY.INFUSIONCLAW",
-                new AspectList().add(Aspect.getAspect("alienis"), 21).add(Aspect.getAspect("machina"), 18)
-                        .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("motus"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 21).add(Aspect.MECHANISM, 18).add(Aspect.MAGIC, 15)
+                        .add(Aspect.ORDER, 12).add(Aspect.DARKNESS, 9).add(Aspect.MOTION, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("GADOMANCY.INFUSIONCLAW", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.STICKYJAR",
-                new AspectList().add(Aspect.getAspect("limus"), 12).add(Aspect.getAspect("terra"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.SLIME, 12).add(Aspect.EARTH, 9).add(Aspect.AIR, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("GADOMANCY.STICKYJAR", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GADOMANCY.REMOTEJAR",
                 getModItem(Gadomancy.ID, "BlockRemoteJar", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.EARTH, 15).add(Aspect.ORDER, 15).add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -325,15 +306,13 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0));
         TCHelper.setResearchAspects(
                 "GADOMANCY.REMOTEJAR",
-                new AspectList().add(Aspect.getAspect("machina"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.MECHANISM, 15).add(Aspect.ORDER, 12).add(Aspect.WATER, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("GADOMANCY.REMOTEJAR", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GADOMANCY.ARCANEDROPPER",
                 getModItem(Gadomancy.ID, "BlockArcaneDropper", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("aer"), 20)
-                        .add(Aspect.getAspect("terra"), 20),
+                new AspectList().add(Aspect.ORDER, 20).add(Aspect.AIR, 20).add(Aspect.EARTH, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -357,22 +336,18 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6));
         TCHelper.setResearchAspects(
                 "GADOMANCY.ARCANEDROPPER",
-                new AspectList().add(Aspect.getAspect("machina"), 21).add(Aspect.getAspect("aer"), 18)
-                        .add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("sensus"), 9).add(Aspect.getAspect("motus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.MECHANISM, 21).add(Aspect.AIR, 18).add(Aspect.EARTH, 15)
+                        .add(Aspect.ORDER, 12).add(Aspect.SENSES, 9).add(Aspect.MOTION, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("GADOMANCY.ARCANEDROPPER", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.ARMORDISGUISE",
-                new AspectList().add(Aspect.getAspect("limus"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("tutamen"), 9).add(Aspect.getAspect("cognitio"), 6)
-                        .add(Aspect.getAspect("nebrisum"), 3));
+                new AspectList().add(Aspect.SLIME, 15).add(Aspect.MAGIC, 12).add(Aspect.ARMOR, 9).add(Aspect.MIND, 6)
+                        .add(TCAspects.NEBRISUM.getAspect(), 3));
         TCHelper.setResearchComplexity("GADOMANCY.ARMORDISGUISE", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.REVEALER",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("sensus"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.SENSES, 12).add(Aspect.MAGIC, 9).add(Aspect.ELDRITCH, 6)
+                        .add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("GADOMANCY.REVEALER", 3);
         TCHelper.clearPages("GADOMANCY.BLOCK_PROTECTOR");
         TCHelper.addResearchPage(
@@ -381,7 +356,7 @@ public class ScriptGadomancy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GADOMANCY.BLOCK_PROTECTOR",
                 getModItem(Gadomancy.ID, "BlockStoneMachine", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 150).add(Aspect.getAspect("ordo"), 150),
+                new AspectList().add(Aspect.EARTH, 150).add(Aspect.ORDER, 150),
                 "abc",
                 "def",
                 "ghi",
@@ -414,16 +389,13 @@ public class ScriptGadomancy implements IScriptLoader {
                 new ResearchPage("gadomancy.research_page.BLOCK_PROTECTOR.4"));
         TCHelper.setResearchAspects(
                 "GADOMANCY.BLOCK_PROTECTOR",
-                new AspectList().add(Aspect.getAspect("cognitio"), 21).add(Aspect.getAspect("bestia"), 18)
-                        .add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("lux"), 6)
-                        .add(Aspect.getAspect("tutamen"), 3));
+                new AspectList().add(Aspect.MIND, 21).add(Aspect.BEAST, 18).add(Aspect.EARTH, 15).add(Aspect.ORDER, 12)
+                        .add(Aspect.AURA, 9).add(Aspect.LIGHT, 6).add(Aspect.ARMOR, 3));
         TCHelper.setResearchComplexity("GADOMANCY.BLOCK_PROTECTOR", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GADOMANCY.E_PORTAL_CREATOR",
                 getModItem(Gadomancy.ID, "BlockStoneMachine", 1, 1),
-                new AspectList().add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("ordo"), 30)
-                        .add(Aspect.getAspect("terra"), 30),
+                new AspectList().add(Aspect.ENTROPY, 30).add(Aspect.ORDER, 30).add(Aspect.EARTH, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -449,10 +421,8 @@ public class ScriptGadomancy implements IScriptLoader {
                 "GADOMANCY.E_PORTAL_CREATOR",
                 getModItem(Gadomancy.ID, "BlockStoneMachine", 1, 3),
                 10,
-                new AspectList().add(Aspect.getAspect("alienis"), 48).add(Aspect.getAspect("machina"), 48)
-                        .add(Aspect.getAspect("permutatio"), 64).add(Aspect.getAspect("tenebrae"), 32)
-                        .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("auram"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 8),
+                new AspectList().add(Aspect.ELDRITCH, 48).add(Aspect.MECHANISM, 48).add(Aspect.EXCHANGE, 64)
+                        .add(Aspect.DARKNESS, 32).add(Aspect.VOID, 32).add(Aspect.AURA, 16).add(Aspect.MAGIC, 8),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 8),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5),
@@ -466,80 +436,65 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "GADOMANCY.E_PORTAL_CREATOR",
-                new AspectList().add(Aspect.getAspect("tenebrae"), 21).add(Aspect.getAspect("auram"), 18)
-                        .add(Aspect.getAspect("iter"), 15).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("vacuos"), 9).add(Aspect.getAspect("machina"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.DARKNESS, 21).add(Aspect.AURA, 18).add(Aspect.TRAVEL, 15)
+                        .add(Aspect.ELDRITCH, 12).add(Aspect.VOID, 9).add(Aspect.MECHANISM, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("GADOMANCY.E_PORTAL_CREATOR", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.ETHEREAL_FAMILIAR",
-                new AspectList().add(Aspect.getAspect("terra"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("ignis"), 12).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("ordo"), 3));
+                new AspectList().add(Aspect.EARTH, 18).add(Aspect.MAGIC, 15).add(Aspect.FIRE, 12).add(Aspect.AURA, 9)
+                        .add(Aspect.AIR, 6).add(Aspect.ORDER, 3));
         TCHelper.setResearchComplexity("GADOMANCY.ETHEREAL_FAMILIAR", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.AURA_CORE",
-                new AspectList().add(Aspect.getAspect("tenebrae"), 27).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("auram"), 21).add(Aspect.getAspect("perditio"), 18)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("ignis"), 6)
-                        .add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.DARKNESS, 27).add(Aspect.MAGIC, 24).add(Aspect.AURA, 21)
+                        .add(Aspect.ENTROPY, 18).add(Aspect.ORDER, 15).add(Aspect.WATER, 12).add(Aspect.AIR, 9)
+                        .add(Aspect.FIRE, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("GADOMANCY.AURA_CORE", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.CLEAN_AURA_CORE",
-                new AspectList().add(Aspect.getAspect("aqua"), 27).add(Aspect.getAspect("sano"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 21).add(Aspect.getAspect("auram"), 18)
-                        .add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("perditio"), 9).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("aer"), 3));
+                new AspectList().add(Aspect.WATER, 27).add(Aspect.HEAL, 24).add(Aspect.MAGIC, 21).add(Aspect.AURA, 18)
+                        .add(Aspect.EARTH, 15).add(Aspect.FIRE, 12).add(Aspect.ENTROPY, 9).add(Aspect.ORDER, 6)
+                        .add(Aspect.AIR, 3));
         TCHelper.setResearchComplexity("GADOMANCY.CLEAN_AURA_CORE", 4);
         TCHelper.setResearchAspects(
                 "GADOMANCY.FAMILIAR_POISON",
-                new AspectList().add(Aspect.getAspect("venenum"), 15).add(Aspect.getAspect("telum"), 12)
-                        .add(Aspect.getAspect("perditio"), 9).add(Aspect.getAspect("tenebrae"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.POISON, 15).add(Aspect.WEAPON, 12).add(Aspect.ENTROPY, 9)
+                        .add(Aspect.DARKNESS, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("GADOMANCY.FAMILIAR_POISON", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.FAMILIAR_WEAKNESS",
-                new AspectList().add(Aspect.getAspect("vinculum"), 15).add(Aspect.getAspect("vitium"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.TRAP, 15).add(Aspect.TAINT, 12).add(Aspect.WEAPON, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("GADOMANCY.FAMILIAR_WEAKNESS", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.FAMILIAR_SHOCK",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("tempestas"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.WEATHER, 12).add(Aspect.WEAPON, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("GADOMANCY.FAMILIAR_SHOCK", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.FAMILIAR_FIRE",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("infernus"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.FIRE, 15).add(DarkAspects.NETHER, 12).add(Aspect.WEAPON, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("GADOMANCY.FAMILIAR_FIRE", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.FAMILIAR_DAMAGE",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.FIRE, 12).add(Aspect.WEAPON, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("GADOMANCY.FAMILIAR_DAMAGE", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.FAMILIAR_RANGE",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.ORDER, 12).add(Aspect.WEAPON, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("GADOMANCY.FAMILIAR_RANGE", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.FAMILIAR_SPEED",
-                new AspectList().add(Aspect.getAspect("motus"), 15).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.MOTION, 15).add(Aspect.AURA, 12).add(Aspect.WEAPON, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("GADOMANCY.FAMILIAR_SPEED", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GADOMANCY.ARCANE_PACKAGER",
                 getModItem(Gadomancy.ID, "BlockStoneMachine", 1, 4),
-                new AspectList().add(Aspect.getAspect("ordo"), 100).add(Aspect.getAspect("perditio"), 100)
-                        .add(Aspect.getAspect("aer"), 100),
+                new AspectList().add(Aspect.ORDER, 100).add(Aspect.ENTROPY, 100).add(Aspect.AIR, 100),
                 "abc",
                 "def",
                 "ghi",
@@ -563,15 +518,14 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0));
         TCHelper.setResearchAspects(
                 "GADOMANCY.ARCANE_PACKAGER",
-                new AspectList().add(Aspect.getAspect("machina"), 18).add(Aspect.getAspect("aer"), 15)
-                        .add(Aspect.getAspect("vacuos"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("arbor"), 3));
+                new AspectList().add(Aspect.MECHANISM, 18).add(Aspect.AIR, 15).add(Aspect.VOID, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.ENERGY, 6).add(Aspect.TREE, 3));
         TCHelper.setResearchComplexity("GADOMANCY.ARCANE_PACKAGER", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GADOMANCY.AURA_PYLON",
                 getModItem(Gadomancy.ID, "BlockAuraPylon", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 100).add(Aspect.getAspect("aqua"), 100)
-                        .add(Aspect.getAspect("aer"), 100).add(Aspect.getAspect("ignis"), 100),
+                new AspectList().add(Aspect.ORDER, 100).add(Aspect.WATER, 100).add(Aspect.AIR, 100)
+                        .add(Aspect.FIRE, 100),
                 "abc",
                 "def",
                 "ghi",
@@ -595,15 +549,13 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockTube", 1, 6));
         TCHelper.setResearchAspects(
                 "GADOMANCY.AURA_PYLON",
-                new AspectList().add(Aspect.getAspect("auram"), 18).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("machina"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(Aspect.AURA, 18).add(Aspect.ORDER, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.MECHANISM, 9).add(Aspect.AIR, 6).add(Aspect.FIRE, 3));
         TCHelper.setResearchComplexity("GADOMANCY.AURA_PYLON", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GADOMANCY.AURA_PYLON",
                 getModItem(Gadomancy.ID, "BlockAuraPylon", 1, 1),
-                new AspectList().add(Aspect.getAspect("ordo"), 125).add(Aspect.getAspect("aer"), 125)
-                        .add(Aspect.getAspect("ignis"), 125),
+                new AspectList().add(Aspect.ORDER, 125).add(Aspect.AIR, 125).add(Aspect.FIRE, 125),
                 "abc",
                 "def",
                 "ghi",
@@ -628,8 +580,7 @@ public class ScriptGadomancy implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GADOMANCY.KNOWLEDGE_BOOK",
                 getModItem(Gadomancy.ID, "BlockKnowledgeBook", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("perditio"), 35).add(Aspect.getAspect("aer"), 35),
+                new AspectList().add(Aspect.ORDER, 75).add(Aspect.FIRE, 50).add(Aspect.ENTROPY, 35).add(Aspect.AIR, 35),
                 "abc",
                 "def",
                 "ghi",
@@ -653,18 +604,16 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12));
         TCHelper.setResearchAspects(
                 "GADOMANCY.KNOWLEDGE_BOOK",
-                new AspectList().add(Aspect.getAspect("cognitio"), 24).add(Aspect.getAspect("ordo"), 21)
-                        .add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("machina"), 15)
-                        .add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("motus"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("lucrum"), 3));
+                new AspectList().add(Aspect.MIND, 24).add(Aspect.ORDER, 21).add(Aspect.MAGIC, 18)
+                        .add(Aspect.MECHANISM, 15).add(Aspect.CRAFT, 12).add(Aspect.MOTION, 9).add(Aspect.AIR, 6)
+                        .add(Aspect.GREED, 3));
         TCHelper.setResearchComplexity("GADOMANCY.KNOWLEDGE_BOOK", 3);
         ThaumcraftApi.addWarpToResearch("GADOMANCY.KNOWLEDGE_BOOK", 4);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GADOMANCY.ESSENTIA_COMPRESSOR",
                 getModItem(Gadomancy.ID, "BlockEssentiaCompressor", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 180).add(Aspect.getAspect("aqua"), 200)
-                        .add(Aspect.getAspect("ignis"), 120).add(Aspect.getAspect("terra"), 100)
-                        .add(Aspect.getAspect("perditio"), 140).add(Aspect.getAspect("ordo"), 160),
+                new AspectList().add(Aspect.AIR, 180).add(Aspect.WATER, 200).add(Aspect.FIRE, 120)
+                        .add(Aspect.EARTH, 100).add(Aspect.ENTROPY, 140).add(Aspect.ORDER, 160),
                 "abc",
                 "def",
                 "ghi",
@@ -688,17 +637,14 @@ public class ScriptGadomancy implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockTube", 1, 6));
         TCHelper.setResearchAspects(
                 "GADOMANCY.ESSENTIA_COMPRESSOR",
-                new AspectList().add(Aspect.getAspect("vacuos"), 21).add(Aspect.getAspect("perditio"), 18)
-                        .add(Aspect.getAspect("machina"), 15).add(Aspect.getAspect("aqua"), 18)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.VOID, 21).add(Aspect.ENTROPY, 18).add(Aspect.MECHANISM, 15)
+                        .add(Aspect.WATER, 18).add(Aspect.MAGIC, 9).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("GADOMANCY.ESSENTIA_COMPRESSOR", 3);
         TCHelper.setResearchAspects(
                 "GADOMANCY.AURA_EFFECTS",
-                new AspectList().add(Aspect.getAspect("cognitio"), 27).add(Aspect.getAspect("auram"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 21).add(Aspect.getAspect("ordo"), 18)
-                        .add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("aer"), 12)
-                        .add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("perditio"), 3));
+                new AspectList().add(Aspect.MIND, 27).add(Aspect.AURA, 24).add(Aspect.MAGIC, 21).add(Aspect.ORDER, 18)
+                        .add(Aspect.FIRE, 15).add(Aspect.AIR, 12).add(Aspect.WATER, 9).add(Aspect.EARTH, 6)
+                        .add(Aspect.ENTROPY, 3));
         TCHelper.setResearchComplexity("GADOMANCY.AURA_EFFECTS", 4);
         TCHelper.refreshResearchPages("GADOMANCY.GOLEMSILVERWOOD");
         TCHelper.refreshResearchPages("GADOMANCY.GOLEMCOREBREAK");

--- a/src/main/java/com/dreammaster/scripts/ScriptGregtechPlusPlus.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGregtechPlusPlus.java
@@ -27,15 +27,19 @@ import com.dreammaster.thaumcraft.TCMaterialAspectHelper;
 
 import cpw.mods.fml.common.Optional;
 import forestry.api.recipes.RecipeManagers;
+import fox.spiteful.avaritia.compat.thaumcraft.Lucrum;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TCAspects;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.core.material.MaterialsAlloy;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
+import magicbees.api.MagicBeesAPI;
+import thaumcraft.api.aspects.Aspect;
 
 public class ScriptGregtechPlusPlus implements IScriptLoader {
 
@@ -347,32 +351,35 @@ public class ScriptGregtechPlusPlus implements IScriptLoader {
     }
 
     private void addThaumcraftAspects() {
-        TCMaterialAspectHelper.registerMaterialAspects("Selenium", "metallum", "custom2");
-        TCMaterialAspectHelper.registerMaterialAspects("Iodine", "metallum", "sano");
-        TCMaterialAspectHelper.registerMaterialAspects("Rhenium", "metallum", "alienis");
-        TCMaterialAspectHelper.registerMaterialAspects("Thallium", "metallum", "strontio");
-        TCMaterialAspectHelper.registerMaterialAspects("Germanium", "metallum", "custom1");
-        TCMaterialAspectHelper.registerMaterialAspects("Polonium", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("Radium", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("Protactinium", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("Curium", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("Neptunium", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("Fermium", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("Lithium7", "potentia", "custom1");
-        TCMaterialAspectHelper.registerMaterialAspects("Uranium232", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("Uranium233", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("Plutonium238", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("AdvancedNitinol", "metallum", "custom2");
-        TCMaterialAspectHelper.registerMaterialAspects("AstralTitanium", "metallum", "custom4");
-        TCMaterialAspectHelper.registerMaterialAspects("CelestialTungsten", "metallum", "custom4");
-        TCMaterialAspectHelper.registerMaterialAspects("Hypogen", "metallum", "custom5");
-        TCMaterialAspectHelper.registerMaterialAspects("ChromaticGlass", "vitreus", "custom3");
-        TCMaterialAspectHelper.registerMaterialAspects("BlackMetal", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("WhiteMetal", "metallum", "custom5");
-        TCMaterialAspectHelper.registerMaterialAspects("AncientGranite", "perditio", "custom3");
-        TCMaterialAspectHelper.registerMaterialAspects("Runite", "perditio", "custom3");
-        TCMaterialAspectHelper.registerMaterialAspects("Dragonblood", "metallum", "terminus");
-        TCMaterialAspectHelper.registerMaterialAspects("Staballoy", "metallum", "radio");
-        TCMaterialAspectHelper.registerMaterialAspects("Rhugnor", "terminus", "tempus");
+        TCMaterialAspectHelper.registerMaterialAspects("Selenium", Aspect.METAL, TCAspects.VESANIA.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Iodine", Aspect.METAL, Aspect.HEAL);
+        TCMaterialAspectHelper.registerMaterialAspects("Rhenium", Aspect.METAL, Aspect.ELDRITCH);
+        TCMaterialAspectHelper.registerMaterialAspects("Thallium", Aspect.METAL, TCAspects.STRONTIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Germanium", Aspect.METAL, TCAspects.AEQUALITAS.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Polonium", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Radium", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Protactinium", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Curium", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Neptunium", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Fermium", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Lithium7", Aspect.ENERGY, TCAspects.AEQUALITAS.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Uranium232", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Uranium233", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Plutonium238", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("AdvancedNitinol", Aspect.METAL, TCAspects.VESANIA.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("AstralTitanium", Aspect.METAL, TCAspects.ASTRUM.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("CelestialTungsten", Aspect.METAL, TCAspects.ASTRUM.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Hypogen", Aspect.METAL, TCAspects.GLORIA.getAspect());
+        TCMaterialAspectHelper
+                .registerMaterialAspects("ChromaticGlass", Aspect.CRYSTAL, TCAspects.PRIMORDIUM.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("BlackMetal", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("WhiteMetal", Aspect.METAL, TCAspects.GLORIA.getAspect());
+        TCMaterialAspectHelper
+                .registerMaterialAspects("AncientGranite", Aspect.ENTROPY, TCAspects.PRIMORDIUM.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Runite", Aspect.ENTROPY, TCAspects.PRIMORDIUM.getAspect());
+        TCMaterialAspectHelper.registerMaterialAspects("Dragonblood", Aspect.METAL, Lucrum.ULTRA_DEATH);
+        TCMaterialAspectHelper.registerMaterialAspects("Staballoy", Aspect.METAL, TCAspects.RADIO.getAspect());
+        TCMaterialAspectHelper
+                .registerMaterialAspects("Rhugnor", Lucrum.ULTRA_DEATH, (Aspect) MagicBeesAPI.thaumcraftAspectTempus);
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptGregtechPlusPlus.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGregtechPlusPlus.java
@@ -1,10 +1,12 @@
 package com.dreammaster.scripts;
 
 import static com.dreammaster.scripts.IngredientFactory.getModItem;
+import static gregtech.api.enums.Mods.Avaritia;
 import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.IronTanks;
+import static gregtech.api.enums.Mods.MagicBees;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.RemoteIO;
 import static gregtech.api.enums.Mods.Thaumcraft;
@@ -45,10 +47,12 @@ public class ScriptGregtechPlusPlus implements IScriptLoader {
     @Override
     public List<String> getDependencies() {
         return Arrays.asList(
+                Avaritia.ID,
                 EternalSingularity.ID,
                 Forestry.ID,
                 IndustrialCraft2.ID,
                 IronTanks.ID,
+                MagicBees.ID,
                 RemoteIO.ID,
                 Thaumcraft.ID);
     }

--- a/src/main/java/com/dreammaster/scripts/ScriptMagicBees.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptMagicBees.java
@@ -38,6 +38,7 @@ import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
+import magicbees.api.MagicBeesAPI;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -380,8 +381,7 @@ public class ScriptMagicBees implements IScriptLoader {
         new ResearchItem(
                 "MAGICAPIARY",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("sano"), 12)
-                        .add(Aspect.getAspect("ignis"), 9).add(Aspect.getAspect("lucrum"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.HEAL, 12).add(Aspect.FIRE, 9).add(Aspect.GREED, 6),
                 1,
                 7,
                 3,
@@ -392,9 +392,8 @@ public class ScriptMagicBees implements IScriptLoader {
                 "MAGICAPIARY",
                 getModItem(MagicBees.ID, "magicApiary", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 75).add(Aspect.getAspect("sano"), 75)
-                        .add(Aspect.getAspect("ignis"), 50).add(Aspect.getAspect("lucrum"), 50)
-                        .add(Aspect.getAspect("exanimis"), 25).add(Aspect.getAspect("herba"), 20),
+                new AspectList().add(Aspect.MAGIC, 75).add(Aspect.HEAL, 75).add(Aspect.FIRE, 50).add(Aspect.GREED, 50)
+                        .add(Aspect.UNDEAD, 25).add(Aspect.PLANT, 20),
                 getModItem(Forestry.ID, "apiculture", 1, 0),
                 getModItem(MagicBees.ID, "wax", 1, 0),
                 getModItem(MagicBees.ID, "wax", 1, 1),
@@ -410,9 +409,8 @@ public class ScriptMagicBees implements IScriptLoader {
         TCHelper.addResearchPrereq("MB_VisAuraProvider", "MB_DimensionalSingularity", false);
         TCHelper.setResearchAspects(
                 "MB_VisAuraProvider",
-                new AspectList().add(Aspect.getAspect("lucrum"), 15).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("vitreus"), 12).add(Aspect.getAspect("ordo"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("machina"), 3));
+                new AspectList().add(Aspect.GREED, 15).add(Aspect.METAL, 12).add(Aspect.CRYSTAL, 12)
+                        .add(Aspect.ORDER, 9).add(Aspect.MOTION, 6).add(Aspect.MECHANISM, 3));
         TCHelper.setResearchComplexity("MB_VisAuraProvider", 4);
         ResearchCategories.getResearch("MB_VisAuraProvider").setConcealed();
         ThaumcraftApi.addWarpToResearch("MB_VisAuraProvider", 2);
@@ -421,8 +419,8 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MB_VisAuraProvider",
                 getModItem(MagicBees.ID, "visAuraProvider", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.ORDER, 75).add(Aspect.WATER, 75).add(Aspect.AIR, 75)
+                        .add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -450,8 +448,8 @@ public class ScriptMagicBees implements IScriptLoader {
         new ResearchItem(
                 "CONCENTRATEDCOMPOUND",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("messis"), 15).add(Aspect.getAspect("sano"), 12)
-                        .add(Aspect.getAspect("vitreus"), 9).add(Aspect.getAspect("perditio"), 6),
+                new AspectList().add(Aspect.CROP, 15).add(Aspect.HEAL, 12).add(Aspect.CRYSTAL, 9)
+                        .add(Aspect.ENTROPY, 6),
                 2,
                 -3,
                 3,
@@ -462,7 +460,7 @@ public class ScriptMagicBees implements IScriptLoader {
                 "CONCENTRATEDCOMPOUND",
                 getModItem(MagicBees.ID, "miscResources", 1, 2),
                 GTOreDictUnificator.get(OrePrefixes.gem, Materials.Apatite, 1L),
-                new AspectList().add(Aspect.getAspect("messis"), 6).add(Aspect.getAspect("vitreus"), 3));
+                new AspectList().add(Aspect.CROP, 6).add(Aspect.CRYSTAL, 3));
         TCHelper.addResearchPage(
                 "CONCENTRATEDCOMPOUND",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(MagicBees.ID, "miscResources", 1, 2))));
@@ -472,15 +470,15 @@ public class ScriptMagicBees implements IScriptLoader {
                 "MB_EssenceLife",
                 getModItem(MagicBees.ID, "miscResources", 1, 7),
                 getModItem(Minecraft.ID, "red_flower", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("permutatio"), 16)
-                        .add(Aspect.getAspect("herba"), 16).add(Aspect.getAspect("terra"), 16));
+                new AspectList().add(Aspect.METAL, 16).add(Aspect.EXCHANGE, 16).add(Aspect.PLANT, 16)
+                        .add(Aspect.EARTH, 16));
         TCHelper.addResearchPage(
                 "MB_EssenceLife",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(MagicBees.ID, "miscResources", 1, 7))));
         TCHelper.setResearchAspects(
                 "MB_EssenceLife",
-                new AspectList().add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("herba"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.METAL, 12).add(Aspect.EXCHANGE, 9).add(Aspect.PLANT, 6)
+                        .add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("MB_EssenceLife", 3);
         TCHelper.clearPages("MB_EssenceDeath");
         TCHelper.addResearchPage("MB_EssenceDeath", new ResearchPage("tc.research_page.MB_EssenceDeath.1"));
@@ -488,15 +486,15 @@ public class ScriptMagicBees implements IScriptLoader {
                 "MB_EssenceDeath",
                 getModItem(MagicBees.ID, "miscResources", 1, 8),
                 getModItem(Minecraft.ID, "rotten_flesh", 1, 0),
-                new AspectList().add(Aspect.getAspect("mortuus"), 16).add(Aspect.getAspect("perditio"), 16)
-                        .add(Aspect.getAspect("spiritus"), 16).add(Aspect.getAspect("exanimis"), 16));
+                new AspectList().add(Aspect.DEATH, 16).add(Aspect.ENTROPY, 16).add(Aspect.SOUL, 16)
+                        .add(Aspect.UNDEAD, 16));
         TCHelper.addResearchPage(
                 "MB_EssenceDeath",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(MagicBees.ID, "miscResources", 1, 8))));
         TCHelper.setResearchAspects(
                 "MB_EssenceDeath",
-                new AspectList().add(Aspect.getAspect("mortuus"), 12).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("spiritus"), 6).add(Aspect.getAspect("exanimis"), 3));
+                new AspectList().add(Aspect.DEATH, 12).add(Aspect.ENTROPY, 9).add(Aspect.SOUL, 6)
+                        .add(Aspect.UNDEAD, 3));
         TCHelper.setResearchComplexity("MB_EssenceDeath", 3);
         TCHelper.clearPages("MB_EssenceTime");
         TCHelper.addResearchPage("MB_EssenceTime", new ResearchPage("tc.research_page.MB_EssenceTime.1"));
@@ -504,15 +502,15 @@ public class ScriptMagicBees implements IScriptLoader {
                 "MB_EssenceTime",
                 getModItem(MagicBees.ID, "miscResources", 1, 9),
                 getModItem(Minecraft.ID, "clock", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("vacuos"), 16)
-                        .add(Aspect.getAspect("vinculum"), 16).add(Aspect.getAspect("tempus"), 16));
+                new AspectList().add(Aspect.ORDER, 16).add(Aspect.VOID, 16).add(Aspect.TRAP, 16)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 16));
         TCHelper.addResearchPage(
                 "MB_EssenceTime",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(MagicBees.ID, "miscResources", 1, 9))));
         TCHelper.setResearchAspects(
                 "MB_EssenceTime",
-                new AspectList().add(Aspect.getAspect("ordo"), 12).add(Aspect.getAspect("vacuos"), 9)
-                        .add(Aspect.getAspect("vinculum"), 6).add(Aspect.getAspect("tempus"), 3));
+                new AspectList().add(Aspect.ORDER, 12).add(Aspect.VOID, 9).add(Aspect.TRAP, 6)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 3));
         TCHelper.setResearchComplexity("MB_EssenceTime", 3);
         TCHelper.clearPages("MB_EssenceArmor");
         TCHelper.addResearchPage("MB_EssenceArmor", new ResearchPage("tc.research_page.MB_EssenceArmor.1"));
@@ -520,15 +518,14 @@ public class ScriptMagicBees implements IScriptLoader {
                 "MB_EssenceArmor",
                 getModItem(MagicBees.ID, "miscResources", 1, 10),
                 getModItem(Minecraft.ID, "iron_chestplate", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 16).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("fabrico"), 16));
+                new AspectList().add(Aspect.ARMOR, 16).add(Aspect.MAGIC, 16).add(Aspect.METAL, 16)
+                        .add(Aspect.CRAFT, 16));
         TCHelper.addResearchPage(
                 "MB_EssenceArmor",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(MagicBees.ID, "miscResources", 1, 10))));
         TCHelper.setResearchAspects(
                 "MB_EssenceArmor",
-                new AspectList().add(Aspect.getAspect("tutamen"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("fabrico"), 3));
+                new AspectList().add(Aspect.ARMOR, 12).add(Aspect.MAGIC, 9).add(Aspect.METAL, 6).add(Aspect.CRAFT, 3));
         TCHelper.setResearchComplexity("MB_EssenceArmor", 3);
         TCHelper.clearPages("MB_EssenceUnstable");
         TCHelper.addResearchPage("MB_EssenceUnstable", new ResearchPage("tc.research_page.MB_EssenceUnstable.1"));
@@ -536,15 +533,15 @@ public class ScriptMagicBees implements IScriptLoader {
                 "MB_EssenceUnstable",
                 getModItem(MagicBees.ID, "miscResources", 1, 12),
                 getModItem(MagicBees.ID, "propolis", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("permutatio"), 16)
-                        .add(Aspect.getAspect("limus"), 16).add(Aspect.getAspect("potentia"), 16));
+                new AspectList().add(Aspect.ENTROPY, 16).add(Aspect.EXCHANGE, 16).add(Aspect.SLIME, 16)
+                        .add(Aspect.ENERGY, 16));
         TCHelper.addResearchPage(
                 "MB_EssenceUnstable",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(MagicBees.ID, "miscResources", 1, 12))));
         TCHelper.setResearchAspects(
                 "MB_EssenceUnstable",
-                new AspectList().add(Aspect.getAspect("perditio"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("limus"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.ENTROPY, 12).add(Aspect.EXCHANGE, 9).add(Aspect.SLIME, 6)
+                        .add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("MB_EssenceUnstable", 3);
         TCHelper.clearPages("MB_DimensionalSingularity");
         TCHelper.addResearchPrereq("MB_DimensionalSingularity", "INFUSION", false);
@@ -556,8 +553,8 @@ public class ScriptMagicBees implements IScriptLoader {
                 "MB_DimensionalSingularity",
                 getModItem(MagicBees.ID, "miscResources", 1, 17),
                 6,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("permutatio"), 24)
-                        .add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("tenebrae"), 16),
+                new AspectList().add(Aspect.MAGIC, 24).add(Aspect.EXCHANGE, 24).add(Aspect.ELDRITCH, 16)
+                        .add(Aspect.DARKNESS, 16),
                 getModItem(Minecraft.ID, "gold_block", 1, 0),
                 getModItem(MagicBees.ID, "propolis", 1, 0),
                 getModItem(Minecraft.ID, "ender_eye", 1, 0),
@@ -570,8 +567,8 @@ public class ScriptMagicBees implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(MagicBees.ID, "miscResources", 1, 17))));
         TCHelper.setResearchAspects(
                 "MB_DimensionalSingularity",
-                new AspectList().add(Aspect.getAspect("perditio"), 15).add(Aspect.getAspect("permutatio"), 12)
-                        .add(Aspect.getAspect("limus"), 9).add(Aspect.getAspect("potentia"), 6));
+                new AspectList().add(Aspect.ENTROPY, 15).add(Aspect.EXCHANGE, 12).add(Aspect.SLIME, 9)
+                        .add(Aspect.ENERGY, 6));
         TCHelper.setResearchComplexity("MB_DimensionalSingularity", 3);
         TCHelper.moveResearch("MB_EssenceOblivion", "MAGICBEES", -7, 4);
         TCHelper.clearPages("MB_EssenceOblivion");
@@ -580,8 +577,8 @@ public class ScriptMagicBees implements IScriptLoader {
                 "MB_EssenceOblivion",
                 getModItem(MagicBees.ID, "miscResources", 1, 11),
                 8,
-                new AspectList().add(Aspect.getAspect("alienis"), 100).add(Aspect.getAspect("praecantatio"), 100)
-                        .add(Aspect.getAspect("lucrum"), 75).add(Aspect.getAspect("bestia"), 75),
+                new AspectList().add(Aspect.ELDRITCH, 100).add(Aspect.MAGIC, 100).add(Aspect.GREED, 75)
+                        .add(Aspect.BEAST, 75),
                 getModItem(Minecraft.ID, "dragon_egg", 1, 0),
                 getModItem(MagicBees.ID, "miscResources", 1, 17),
                 getModItem(MagicBees.ID, "miscResources", 1, 17),
@@ -591,8 +588,8 @@ public class ScriptMagicBees implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(MagicBees.ID, "miscResources", 1, 11))));
         TCHelper.setResearchAspects(
                 "MB_EssenceOblivion",
-                new AspectList().add(Aspect.getAspect("alienis"), 5).add(Aspect.getAspect("praecantatio"), 5)
-                        .add(Aspect.getAspect("lucrum"), 5).add(Aspect.getAspect("bestia"), 5));
+                new AspectList().add(Aspect.ELDRITCH, 5).add(Aspect.MAGIC, 5).add(Aspect.GREED, 5)
+                        .add(Aspect.BEAST, 5));
         TCHelper.setResearchComplexity("MB_EssenceOblivion", 3);
         TCHelper.moveResearch("MB_FrameMagic", "MAGICBEES", -4, 0);
         TCHelper.addResearchPrereq("MB_FrameMagic", "MB_Root", false);
@@ -602,9 +599,8 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MB_FrameMagic",
                 getModItem(MagicBees.ID, "frameMagic", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("terra"), 8)
-                        .add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("perditio"), 8)
-                        .add(Aspect.getAspect("ignis"), 8).add(Aspect.getAspect("aqua"), 8),
+                new AspectList().add(Aspect.ORDER, 8).add(Aspect.EARTH, 8).add(Aspect.AIR, 8).add(Aspect.ENTROPY, 8)
+                        .add(Aspect.FIRE, 8).add(Aspect.WATER, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -631,15 +627,13 @@ public class ScriptMagicBees implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(MagicBees.ID, "frameMagic", 1, 0))));
         TCHelper.setResearchAspects(
                 "MB_FrameMagic",
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("perditio"), 6));
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.EARTH, 12).add(Aspect.AIR, 9).add(Aspect.ENTROPY, 6));
         TCHelper.setResearchComplexity("MB_FrameMagic", 4);
         new ResearchItem(
                 "GENTLEFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("victus"), 15).add(Aspect.getAspect("instrumentum"), 15)
-                        .add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("aqua"), 3),
+                new AspectList().add(Aspect.LIFE, 15).add(Aspect.TOOL, 15).add(Aspect.AIR, 12).add(Aspect.FIRE, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.WATER, 3),
                 -7,
                 2,
                 3,
@@ -649,9 +643,8 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GENTLEFRAME",
                 getModItem(MagicBees.ID, "frameGentle", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("perditio"), 16)
-                        .add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("aqua"), 16),
+                new AspectList().add(Aspect.ORDER, 16).add(Aspect.EARTH, 16).add(Aspect.AIR, 16).add(Aspect.ENTROPY, 16)
+                        .add(Aspect.FIRE, 16).add(Aspect.WATER, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -679,9 +672,8 @@ public class ScriptMagicBees implements IScriptLoader {
         new ResearchItem(
                 "RESILIENTFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("pannus"), 15)
-                        .add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("aqua"), 3),
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.CLOTH, 15).add(Aspect.AIR, 12).add(Aspect.FIRE, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.WATER, 3),
                 -7,
                 1,
                 3,
@@ -691,9 +683,8 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "RESILIENTFRAME",
                 getModItem(MagicBees.ID, "frameResilient", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("perditio"), 16)
-                        .add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("aqua"), 16),
+                new AspectList().add(Aspect.ORDER, 16).add(Aspect.EARTH, 16).add(Aspect.AIR, 16).add(Aspect.ENTROPY, 16)
+                        .add(Aspect.FIRE, 16).add(Aspect.WATER, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -721,9 +712,8 @@ public class ScriptMagicBees implements IScriptLoader {
         new ResearchItem(
                 "NECROTICFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("mortuus"), 15).add(Aspect.getAspect("fabrico"), 15)
-                        .add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("aqua"), 3),
+                new AspectList().add(Aspect.DEATH, 15).add(Aspect.CRAFT, 15).add(Aspect.AIR, 12).add(Aspect.FIRE, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.WATER, 3),
                 -7,
                 0,
                 3,
@@ -733,9 +723,8 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NECROTICFRAME",
                 getModItem(MagicBees.ID, "frameNecrotic", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("perditio"), 16)
-                        .add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("aqua"), 16),
+                new AspectList().add(Aspect.ORDER, 16).add(Aspect.EARTH, 16).add(Aspect.AIR, 16).add(Aspect.ENTROPY, 16)
+                        .add(Aspect.FIRE, 16).add(Aspect.WATER, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -763,9 +752,8 @@ public class ScriptMagicBees implements IScriptLoader {
         new ResearchItem(
                 "METABOLICFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("limus"), 15).add(Aspect.getAspect("potentia"), 15)
-                        .add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("aqua"), 3),
+                new AspectList().add(Aspect.SLIME, 15).add(Aspect.ENERGY, 15).add(Aspect.AIR, 12).add(Aspect.FIRE, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.WATER, 3),
                 -7,
                 -1,
                 3,
@@ -775,9 +763,8 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "METABOLICFRAME",
                 getModItem(MagicBees.ID, "frameMetabolic", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("perditio"), 16)
-                        .add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("aqua"), 16),
+                new AspectList().add(Aspect.ORDER, 16).add(Aspect.EARTH, 16).add(Aspect.AIR, 16).add(Aspect.ENTROPY, 16)
+                        .add(Aspect.FIRE, 16).add(Aspect.WATER, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -805,9 +792,8 @@ public class ScriptMagicBees implements IScriptLoader {
         new ResearchItem(
                 "TEMPORALFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("tempus"), 15).add(Aspect.getAspect("vacuos"), 15)
-                        .add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("aqua"), 3),
+                new AspectList().add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 15).add(Aspect.VOID, 15)
+                        .add(Aspect.AIR, 12).add(Aspect.FIRE, 9).add(Aspect.EARTH, 6).add(Aspect.WATER, 3),
                 -7,
                 -2,
                 3,
@@ -817,9 +803,8 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TEMPORALFRAME",
                 getModItem(MagicBees.ID, "frameTemporal", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("perditio"), 16)
-                        .add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("aqua"), 16),
+                new AspectList().add(Aspect.ORDER, 16).add(Aspect.EARTH, 16).add(Aspect.AIR, 16).add(Aspect.ENTROPY, 16)
+                        .add(Aspect.FIRE, 16).add(Aspect.WATER, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -847,9 +832,8 @@ public class ScriptMagicBees implements IScriptLoader {
         new ResearchItem(
                 "OBLIVIONFRAME",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("pannus"), 15)
-                        .add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("aqua"), 3),
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.CLOTH, 15).add(Aspect.AIR, 12).add(Aspect.FIRE, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.WATER, 3),
                 -10,
                 0,
                 3,
@@ -867,9 +851,8 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "OBLIVIONFRAME",
                 getModItem(MagicBees.ID, "frameOblivion", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 32).add(Aspect.getAspect("terra"), 32)
-                        .add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("ignis"), 32)
-                        .add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("perditio"), 32),
+                new AspectList().add(Aspect.ORDER, 32).add(Aspect.EARTH, 32).add(Aspect.AIR, 32).add(Aspect.FIRE, 32)
+                        .add(Aspect.WATER, 32).add(Aspect.ENTROPY, 32),
                 "abc",
                 "def",
                 "ghi",
@@ -899,8 +882,7 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MB_Scoop",
                 getModItem(MagicBees.ID, "item.thaumiumScoop", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("aer"), 10),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.EARTH, 10).add(Aspect.AIR, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -927,16 +909,14 @@ public class ScriptMagicBees implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(MagicBees.ID, "item.thaumiumScoop", 1, 0))));
         TCHelper.setResearchAspects(
                 "MB_Scoop",
-                new AspectList().add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("aer"), 3));
+                new AspectList().add(Aspect.ORDER, 9).add(Aspect.EARTH, 6).add(Aspect.AIR, 3));
         TCHelper.setResearchComplexity("MB_Scoop", 3);
         TCHelper.clearPages("MB_ScoopVoid");
         TCHelper.addResearchPage("MB_ScoopVoid", new ResearchPage("tc.research_page.MB_ScoopVoid.1"));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MB_ScoopVoid",
                 getModItem(MagicBees.ID, "item.voidScoop", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("aer"), 20),
+                new AspectList().add(Aspect.ORDER, 20).add(Aspect.EARTH, 20).add(Aspect.AIR, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -963,8 +943,7 @@ public class ScriptMagicBees implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(MagicBees.ID, "item.voidScoop", 1, 0))));
         TCHelper.setResearchAspects(
                 "MB_ScoopVoid",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("ordo"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("aer"), 3));
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.ORDER, 9).add(Aspect.EARTH, 6).add(Aspect.AIR, 3));
         TCHelper.setResearchComplexity("MB_ScoopVoid", 3);
         ThaumcraftApi.addWarpToResearch("MB_ScoopVoid", 3);
         TCHelper.clearPages("MB_Grafter");
@@ -972,8 +951,7 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MB_Grafter",
                 getModItem(MagicBees.ID, "item.thaumiumGrafter", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.EARTH, 15).add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -994,16 +972,14 @@ public class ScriptMagicBees implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(MagicBees.ID, "item.thaumiumGrafter", 1, 0))));
         TCHelper.setResearchAspects(
                 "MB_Grafter",
-                new AspectList().add(Aspect.getAspect("ordo"), 12).add(Aspect.getAspect("terra"), 9)
-                        .add(Aspect.getAspect("aer"), 6));
+                new AspectList().add(Aspect.ORDER, 12).add(Aspect.EARTH, 9).add(Aspect.AIR, 6));
         TCHelper.setResearchComplexity("MB_Grafter", 3);
         TCHelper.clearPages("MB_GrafterVoid");
         TCHelper.addResearchPage("MB_GrafterVoid", new ResearchPage("tc.research_page.MB_GrafterVoid.1"));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MB_GrafterVoid",
                 getModItem(MagicBees.ID, "item.voidGrafter", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("terra"), 30)
-                        .add(Aspect.getAspect("aer"), 30),
+                new AspectList().add(Aspect.ORDER, 30).add(Aspect.EARTH, 30).add(Aspect.AIR, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -1024,15 +1000,13 @@ public class ScriptMagicBees implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(MagicBees.ID, "item.voidGrafter", 1, 0))));
         TCHelper.setResearchAspects(
                 "MB_GrafterVoid",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("aer"), 6));
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.ORDER, 12).add(Aspect.EARTH, 9).add(Aspect.AIR, 6));
         TCHelper.setResearchComplexity("MB_GrafterVoid", 3);
         ThaumcraftApi.addWarpToResearch("MB_GrafterVoid", 3);
         new ResearchItem(
                 "ENCHANTEDEARTH",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("victus"), 9)
-                        .add(Aspect.getAspect("sano"), 6).add(Aspect.getAspect("ordo"), 3),
+                new AspectList().add(Aspect.EARTH, 9).add(Aspect.LIFE, 9).add(Aspect.HEAL, 6).add(Aspect.ORDER, 3),
                 5,
                 -3,
                 2,
@@ -1041,8 +1015,7 @@ public class ScriptMagicBees implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ENCHANTEDEARTH",
                 getModItem(MagicBees.ID, "magicbees.enchantedEarth", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("aqua"), 10)
-                        .add(Aspect.getAspect("terra"), 10),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.WATER, 10).add(Aspect.EARTH, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -1069,7 +1042,8 @@ public class ScriptMagicBees implements IScriptLoader {
                 "MB_ApimancersDrainer",
                 getModItem(MagicBees.ID, "apimancersDrainer", 1, 0),
                 5,
-                new AspectList().add(Aspect.MAGIC, 100).add(Aspect.HARVEST, 75).add(Aspect.getAspect("tempus"), 50),
+                new AspectList().add(Aspect.MAGIC, 100).add(Aspect.HARVEST, 75)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 50),
                 getModItem(Thaumcraft.ID, "blockEssentiaReservoir", 1, 0),
                 getModItem(Thaumcraft.ID, "blockTube", 1, 2),
                 getModItem(MagicBees.ID, "pollen", 1, 0),

--- a/src/main/java/com/dreammaster/scripts/ScriptOpenBlocks.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptOpenBlocks.java
@@ -714,8 +714,7 @@ public class ScriptOpenBlocks implements IScriptLoader {
         new ResearchItem(
                 "GOLDENEGG",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("bestia"), 12)
-                        .add(Aspect.getAspect("victus"), 9).add(Aspect.getAspect("humanus"), 6),
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.BEAST, 12).add(Aspect.LIFE, 9).add(Aspect.MAN, 6),
                 -4,
                 5,
                 3,
@@ -725,8 +724,8 @@ public class ScriptOpenBlocks implements IScriptLoader {
                 "GOLDENEGG",
                 getModItem(OpenBlocks.ID, "goldenegg", 1, 0),
                 2,
-                new AspectList().add(Aspect.getAspect("alienis"), 75).add(Aspect.getAspect("bestia"), 50)
-                        .add(Aspect.getAspect("victus"), 50).add(Aspect.getAspect("humanus"), 25),
+                new AspectList().add(Aspect.ELDRITCH, 75).add(Aspect.BEAST, 50).add(Aspect.LIFE, 50)
+                        .add(Aspect.MAN, 25),
                 getModItem(Minecraft.ID, "egg", 1, 0),
                 OrePrefixes.plateDense.get(Materials.Gold),
                 getModItem(Minecraft.ID, "skull", 1, 3),

--- a/src/main/java/com/dreammaster/scripts/ScriptRailcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptRailcraft.java
@@ -2179,8 +2179,7 @@ public class ScriptRailcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "RC_Crowbar",
                 getModItem(Railcraft.ID, "tool.crowbar.magic", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 24).add(Aspect.getAspect("ignis"), 24)
-                        .add(Aspect.getAspect("aer"), 24),
+                new AspectList().add(Aspect.ORDER, 24).add(Aspect.FIRE, 24).add(Aspect.AIR, 24),
                 "abc",
                 "def",
                 "ghi",
@@ -2215,8 +2214,7 @@ public class ScriptRailcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "RC_Crowbar_Void",
                 getModItem(Railcraft.ID, "tool.crowbar.void", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("terra"), 50),
+                new AspectList().add(Aspect.ENTROPY, 50).add(Aspect.FIRE, 50).add(Aspect.AIR, 50).add(Aspect.EARTH, 50),
                 "abc",
                 "def",
                 "ghi",

--- a/src/main/java/com/dreammaster/scripts/ScriptRunicTablet.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptRunicTablet.java
@@ -3,6 +3,7 @@ package com.dreammaster.scripts;
 import static com.dreammaster.scripts.IngredientFactory.getModItem;
 import static gregtech.api.enums.Mods.Automagy;
 import static gregtech.api.enums.Mods.DraconicEvolution;
+import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.ThaumicExploration;
 
@@ -27,7 +28,8 @@ public class ScriptRunicTablet implements IScriptLoader {
 
     @Override
     public List<String> getDependencies() {
-        return Arrays.asList(Automagy.ID, DraconicEvolution.ID, Thaumcraft.ID, ThaumicExploration.ID);
+        return Arrays
+                .asList(Automagy.ID, DraconicEvolution.ID, ForbiddenMagic.ID, Thaumcraft.ID, ThaumicExploration.ID);
     }
 
     @Override

--- a/src/main/java/com/dreammaster/scripts/ScriptRunicTablet.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptRunicTablet.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import com.dreammaster.thaumcraft.TCHelper;
 
+import fox.spiteful.forbidden.DarkAspects;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -34,9 +35,8 @@ public class ScriptRunicTablet implements IScriptLoader {
         new ResearchItem(
                 "RUNEDTABLET",
                 "ELDRITCH",
-                new AspectList().add(Aspect.getAspect("alienis"), 30).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("superbia"), 18).add(Aspect.getAspect("spiritus"), 12)
-                        .add(Aspect.getAspect("infernus"), 6),
+                new AspectList().add(Aspect.ELDRITCH, 30).add(Aspect.MAGIC, 24).add(DarkAspects.PRIDE, 18)
+                        .add(Aspect.SOUL, 12).add(DarkAspects.NETHER, 6),
                 -5,
                 0,
                 3,
@@ -47,9 +47,8 @@ public class ScriptRunicTablet implements IScriptLoader {
                 "RUNEDTABLET",
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 2),
                 10,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("iter"), 32)
-                        .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("vacuos"), 32)
-                        .add(Aspect.getAspect("cognitio"), 64).add(Aspect.getAspect("praecantatio"), 128),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.TRAVEL, 32).add(Aspect.DARKNESS, 32)
+                        .add(Aspect.VOID, 32).add(Aspect.MIND, 64).add(Aspect.MAGIC, 128),
                 getModItem(DraconicEvolution.ID, "infoTablet", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 17),

--- a/src/main/java/com/dreammaster/scripts/ScriptTB.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTB.java
@@ -38,9 +38,8 @@ public class ScriptTB implements IScriptLoader {
                 "TB_EMT_Tainted_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemNanoVoid", 1, 27),
                 6,
-                new AspectList().add(Aspect.getAspect("motus"), 48).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("volatus"), 8).add(Aspect.getAspect("iter"), 16),
+                new AspectList().add(Aspect.MOTION, 48).add(Aspect.ENERGY, 24).add(Aspect.ARMOR, 32)
+                        .add(Aspect.MAGIC, 16).add(Aspect.FLIGHT, 8).add(Aspect.TRAVEL, 16),
                 getModItem(ThaumicBoots.ID, "item.ItemElectricVoid", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard),
                 OrePrefixes.plate.get(Materials.Thaumium),
@@ -56,10 +55,8 @@ public class ScriptTB implements IScriptLoader {
                 "TB_EMT_Tainted_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemQuantumVoid", 1, 27),
                 9,
-                new AspectList().add(Aspect.getAspect("motus"), 64).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("tutamen"), 48).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("volatus"), 16).add(Aspect.getAspect("iter"), 24)
-                        .add(Aspect.getAspect("aer"), 8),
+                new AspectList().add(Aspect.MOTION, 64).add(Aspect.ENERGY, 32).add(Aspect.ARMOR, 48)
+                        .add(Aspect.MAGIC, 24).add(Aspect.FLIGHT, 16).add(Aspect.TRAVEL, 24).add(Aspect.AIR, 8),
                 getModItem(ThaumicBoots.ID, "item.ItemNanoVoid", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard),
                 OrePrefixes.plate.get(Materials.Void),
@@ -79,9 +76,8 @@ public class ScriptTB implements IScriptLoader {
                 "TB_Explorations_EMT_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemNanoMeteor", 1, 27),
                 6,
-                new AspectList().add(Aspect.getAspect("motus"), 48).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("volatus"), 8).add(Aspect.getAspect("iter"), 16),
+                new AspectList().add(Aspect.MOTION, 48).add(Aspect.ENERGY, 24).add(Aspect.ARMOR, 32)
+                        .add(Aspect.MAGIC, 16).add(Aspect.FLIGHT, 8).add(Aspect.TRAVEL, 16),
                 getModItem(ThaumicBoots.ID, "item.ItemElectricMeteor", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard),
                 OrePrefixes.plate.get(Materials.Thaumium),
@@ -97,10 +93,8 @@ public class ScriptTB implements IScriptLoader {
                 "TB_Explorations_EMT_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemQuantumMeteor", 1, 27),
                 9,
-                new AspectList().add(Aspect.getAspect("motus"), 64).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("tutamen"), 48).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("volatus"), 16).add(Aspect.getAspect("iter"), 24)
-                        .add(Aspect.getAspect("aer"), 8),
+                new AspectList().add(Aspect.MOTION, 64).add(Aspect.ENERGY, 32).add(Aspect.ARMOR, 48)
+                        .add(Aspect.MAGIC, 24).add(Aspect.FLIGHT, 16).add(Aspect.TRAVEL, 24).add(Aspect.AIR, 8),
                 getModItem(ThaumicBoots.ID, "item.ItemNanoMeteor", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard),
                 OrePrefixes.plate.get(Materials.Void),
@@ -120,9 +114,8 @@ public class ScriptTB implements IScriptLoader {
                 "TB_Explorations_EMT_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemNanoComet", 1, 27),
                 6,
-                new AspectList().add(Aspect.getAspect("motus"), 48).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("volatus"), 8).add(Aspect.getAspect("iter"), 16),
+                new AspectList().add(Aspect.MOTION, 48).add(Aspect.ENERGY, 24).add(Aspect.ARMOR, 32)
+                        .add(Aspect.MAGIC, 16).add(Aspect.FLIGHT, 8).add(Aspect.TRAVEL, 16),
                 getModItem(ThaumicBoots.ID, "item.ItemElectricComet", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorNanoBoots", 1, wildcard),
                 OrePrefixes.plate.get(Materials.Thaumium),
@@ -138,10 +131,8 @@ public class ScriptTB implements IScriptLoader {
                 "TB_Explorations_EMT_Compat",
                 getModItem(ThaumicBoots.ID, "item.ItemQuantumComet", 1, 27),
                 9,
-                new AspectList().add(Aspect.getAspect("motus"), 64).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("tutamen"), 48).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("volatus"), 16).add(Aspect.getAspect("iter"), 24)
-                        .add(Aspect.getAspect("aer"), 8),
+                new AspectList().add(Aspect.MOTION, 64).add(Aspect.ENERGY, 32).add(Aspect.ARMOR, 48)
+                        .add(Aspect.MAGIC, 24).add(Aspect.FLIGHT, 16).add(Aspect.TRAVEL, 24).add(Aspect.AIR, 8),
                 getModItem(ThaumicBoots.ID, "item.ItemNanoComet", 1, wildcard),
                 getModItem(IndustrialCraft2.ID, "itemArmorQuantumBoots", 1, wildcard),
                 OrePrefixes.plate.get(Materials.Void),

--- a/src/main/java/com/dreammaster/scripts/ScriptTCCoreMod.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTCCoreMod.java
@@ -29,7 +29,6 @@ import static gregtech.api.util.GTRecipeBuilder.STACKS;
 import static gregtech.api.util.GTRecipeConstants.DEFC_CASING_TIER;
 import static gtPlusPlus.api.recipe.GTPPRecipeMaps.electrolyzerNonCellRecipes;
 import static kubatech.loaders.DEFCRecipes.fusionCraftingRecipes;
-import static thaumcraft.api.aspects.Aspect.getAspect;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,13 +36,17 @@ import java.util.List;
 import com.dreammaster.item.NHItemList;
 import com.dreammaster.thaumcraft.TCHelper;
 
+import fox.spiteful.avaritia.compat.thaumcraft.Lucrum;
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TCAspects;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
 import gtPlusPlus.core.material.MaterialsElements;
+import magicbees.api.MagicBeesAPI;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -88,9 +91,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "WITHERRING",
                 "ARTIFICE",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("superbia"), 9).add(Aspect.getAspect("spiritus"), 6)
-                        .add(Aspect.getAspect("infernus"), 3),
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.MAGIC, 12).add(DarkAspects.PRIDE, 9)
+                        .add(Aspect.SOUL, 6).add(DarkAspects.NETHER, 3),
                 3,
                 2,
                 3,
@@ -100,9 +102,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "WITHERRING",
                 NHItemList.WitherProtectionRing.get(),
                 3,
-                new AspectList().add(Aspect.getAspect("alienis"), 45).add(Aspect.getAspect("praecantatio"), 35)
-                        .add(Aspect.getAspect("spiritus"), 30).add(Aspect.getAspect("superbia"), 25)
-                        .add(Aspect.getAspect("infernus"), 15),
+                new AspectList().add(Aspect.ELDRITCH, 45).add(Aspect.MAGIC, 35).add(Aspect.SOUL, 30)
+                        .add(DarkAspects.PRIDE, 25).add(DarkAspects.NETHER, 15),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 1),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(Minecraft.ID, "milk_bucket", 1, 0),
@@ -116,8 +117,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "EMINENCESTONE",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("sensus"), 12)
-                        .add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("aer"), 6),
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.SENSES, 12).add(Aspect.EARTH, 9)
+                        .add(Aspect.AIR, 6),
                 0,
                 4,
                 3,
@@ -127,9 +128,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "EMINENCESTONE",
                 getModItem(ExtraUtilities.ID, "decorativeBlock1", 2, 14),
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.FIRE, 50).add(Aspect.EARTH, 50).add(Aspect.WATER, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -157,8 +157,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "PORTALMILLENIUM",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("sensus"), 12)
-                        .add(Aspect.getAspect("terra"), 9),
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.SENSES, 12).add(Aspect.EARTH, 9),
                 2,
                 6,
                 3,
@@ -169,9 +168,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "PORTALMILLENIUM",
                 getModItem(ExtraUtilities.ID, "dark_portal", 1, 2),
                 4,
-                new AspectList().add(Aspect.getAspect("alienis"), 75).add(Aspect.getAspect("sensus"), 25)
-                        .add(Aspect.getAspect("praecantatio"), 75).add(Aspect.getAspect("terra"), 25)
-                        .add(Aspect.getAspect("vacuos"), 75),
+                new AspectList().add(Aspect.ELDRITCH, 75).add(Aspect.SENSES, 25).add(Aspect.MAGIC, 75)
+                        .add(Aspect.EARTH, 25).add(Aspect.VOID, 75),
                 getModItem(Minecraft.ID, "clock", 1, 0),
                 getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 14),
                 getModItem(ExtraUtilities.ID, "decorativeBlock1", 1, 2),
@@ -188,9 +186,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "PORTALDEEPDARK",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("vacuos"), 27).add(Aspect.getAspect("tempus"), 24)
-                        .add(Aspect.getAspect("luxuria"), 21).add(Aspect.getAspect("gula"), 12)
-                        .add(Aspect.getAspect("superbia"), 9),
+                new AspectList().add(Aspect.VOID, 27).add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 24)
+                        .add(DarkAspects.LUST, 21).add(DarkAspects.GLUTTONY, 12).add(DarkAspects.PRIDE, 9),
                 2,
                 8,
                 3,
@@ -201,10 +198,9 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "PORTALDEEPDARK",
                 getModItem(ExtraUtilities.ID, "dark_portal", 1, 0),
                 32,
-                new AspectList().add(Aspect.getAspect("vacuos"), 512).add(Aspect.getAspect("tempus"), 512)
-                        .add(Aspect.getAspect("luxuria"), 512).add(Aspect.getAspect("alienis"), 512)
-                        .add(Aspect.getAspect("terminus"), 512).add(Aspect.getAspect("gula"), 512)
-                        .add(Aspect.getAspect("superbia"), 512),
+                new AspectList().add(Aspect.VOID, 512).add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 512)
+                        .add(DarkAspects.LUST, 512).add(Aspect.ELDRITCH, 512).add(Lucrum.ULTRA_DEATH, 512)
+                        .add(DarkAspects.GLUTTONY, 512).add(DarkAspects.PRIDE, 512),
                 ItemList.Block_BedrockiumCompressed.get(1L),
                 ItemList.Field_Generator_UIV.get(1L),
                 getModItem(EternalSingularity.ID, "eternal_singularity", 1, 0),
@@ -221,9 +217,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "MAGICALWOOD",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("arbor"), 9).add(Aspect.getAspect("cognitio"), 6)
-                        .add(Aspect.getAspect("pannus"), 3),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.GREED, 12).add(Aspect.TREE, 9).add(Aspect.MIND, 6)
+                        .add(Aspect.CLOTH, 3),
                 -2,
                 6,
                 3,
@@ -232,9 +227,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MAGICALWOOD",
                 getModItem(ExtraUtilities.ID, "decorativeBlock1", 4, 8),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("terra"), 10).add(Aspect.getAspect("aqua"), 10)
-                        .add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.FIRE, 10).add(Aspect.EARTH, 10).add(Aspect.WATER, 10)
+                        .add(Aspect.ORDER, 10).add(Aspect.ENTROPY, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -262,8 +256,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "ANGELBLOCK",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("ignis"), 9).add(Aspect.getAspect("terra"), 6),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.GREED, 12).add(Aspect.FIRE, 9).add(Aspect.EARTH, 6),
                 -2,
                 8,
                 3,
@@ -272,7 +265,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ANGELBLOCK",
                 getModItem(ExtraUtilities.ID, "angelBlock", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 50),
+                new AspectList().add(Aspect.AIR, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -300,9 +293,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "DEZILSMARSHMALLOW",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("superbia"), 9).add(Aspect.getAspect("sano"), 6)
-                        .add(Aspect.getAspect("potentia"), 3),
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.MAGIC, 12).add(DarkAspects.PRIDE, 9)
+                        .add(Aspect.HEAL, 6).add(Aspect.ENERGY, 3),
                 -2,
                 2,
                 3,
@@ -312,9 +304,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "DEZILSMARSHMALLOW",
                 getModItem(DraconicEvolution.ID, "dezilsMarshmallow", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("superbia"), 24).add(Aspect.getAspect("sano"), 28)
-                        .add(Aspect.getAspect("iter"), 20).add(Aspect.getAspect("potentia"), 12),
+                new AspectList().add(Aspect.ELDRITCH, 32).add(Aspect.MAGIC, 16).add(DarkAspects.PRIDE, 24)
+                        .add(Aspect.HEAL, 28).add(Aspect.TRAVEL, 20).add(Aspect.ENERGY, 12),
                 NHItemList.Marshmallow.get(),
                 getModItem(PamsHarvestCraft.ID, "epicbaconItem", 1, 0),
                 getModItem(PamsHarvestCraft.ID, "deluxechickencurryItem", 1, 0),
@@ -330,8 +321,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "ENCHANTINGTABLE",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("potentia"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.CRAFT, 12).add(Aspect.MIND, 9).add(Aspect.ENERGY, 6),
                 0,
                 0,
                 3,
@@ -340,8 +330,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ENCHANTINGTABLE",
                 getModItem(Minecraft.ID, "enchanting_table", 1, 0),
-                new AspectList().add(getAspect("aer"), 45).add(getAspect("aqua"), 45).add(getAspect("terra"), 45)
-                        .add(getAspect("ignis"), 45).add(getAspect("ordo"), 45).add(getAspect("perditio"), 45),
+                new AspectList().add(Aspect.AIR, 45).add(Aspect.WATER, 45).add(Aspect.EARTH, 45).add(Aspect.FIRE, 45)
+                        .add(Aspect.ORDER, 45).add(Aspect.ENTROPY, 45),
                 "abc",
                 "def",
                 "ghi",
@@ -369,9 +359,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "DISENCHANTINGTABLE",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("alienis"), 21).add(Aspect.getAspect("perditio"), 18)
-                        .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("potentia"), 6),
+                new AspectList().add(Aspect.ELDRITCH, 21).add(Aspect.ENTROPY, 18).add(Aspect.MAGIC, 15)
+                        .add(Aspect.CRAFT, 12).add(Aspect.MIND, 9).add(Aspect.ENERGY, 6),
                 2,
                 2,
                 3,
@@ -384,9 +373,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DISENCHANTINGTABLE",
                 getModItem(DraconicEvolution.ID, "dissEnchanter", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("terra"), 75).add(Aspect.getAspect("ignis"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.WATER, 75).add(Aspect.EARTH, 75).add(Aspect.FIRE, 75)
+                        .add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -415,10 +403,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "BREWINGSTAND",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("fabrico"), 15)
-                        .add(Aspect.getAspect("cognitio"), 12).add(Aspect.getAspect("perditio"), 12)
-                        .add(Aspect.getAspect("ignis"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("aqua"), 3),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.CRAFT, 15).add(Aspect.MIND, 12)
+                        .add(Aspect.ENTROPY, 12).add(Aspect.FIRE, 9).add(Aspect.EARTH, 6).add(Aspect.WATER, 3),
                 2,
                 0,
                 3,
@@ -431,9 +417,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BREWINGSTAND",
                 getModItem(Minecraft.ID, "brewing_stand", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("aqua"), 20)
-                        .add(Aspect.getAspect("terra"), 20).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("perditio"), 20),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.WATER, 20).add(Aspect.EARTH, 20).add(Aspect.FIRE, 20)
+                        .add(Aspect.ORDER, 20).add(Aspect.ENTROPY, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -461,8 +446,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "BEACON",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("fames"), 6),
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.MAGIC, 12).add(Aspect.AURA, 9)
+                        .add(Aspect.HUNGER, 6),
                 4,
                 0,
                 3,
@@ -472,9 +457,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "BEACON",
                 getModItem(Minecraft.ID, "beacon", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("alienis"), 64)
-                        .add(Aspect.getAspect("lux"), 64).add(Aspect.getAspect("ordo"), 64)
-                        .add(Aspect.getAspect("ignis"), 64).add(Aspect.getAspect("terra"), 64),
+                new AspectList().add(Aspect.MAGIC, 64).add(Aspect.ELDRITCH, 64).add(Aspect.LIGHT, 64)
+                        .add(Aspect.ORDER, 64).add(Aspect.FIRE, 64).add(Aspect.EARTH, 64),
                 getModItem(Minecraft.ID, "diamond_block", 1, 0),
                 getModItem(Minecraft.ID, "glass", 1, 0),
                 OrePrefixes.plate.get(Materials.Obsidian),
@@ -495,8 +479,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "DRAGONEGG",
                 "MAGICBEES",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("victus"), 9).add(Aspect.getAspect("bestia"), 6),
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.MAGIC, 12).add(Aspect.LIFE, 9)
+                        .add(Aspect.BEAST, 6),
                 2,
                 5,
                 3,
@@ -507,8 +491,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "DRAGONEGG",
                 getModItem(Minecraft.ID, "dragon_egg", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("bestia"), 56)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("victus"), 48),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.BEAST, 56).add(Aspect.MAGIC, 48)
+                        .add(Aspect.LIFE, 48),
                 getModItem(MagicBees.ID, "miscResources", 1, 7),
                 getModItem(MagicBees.ID, "miscResources", 1, 6),
                 getModItem(MagicBees.ID, "miscResources", 1, 6),
@@ -525,9 +509,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "SILKYCRYSTAL",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("pannus"), 15).add(Aspect.getAspect("lucrum"), 2)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.CLOTH, 15).add(Aspect.GREED, 2).add(Aspect.TOOL, 9).add(Aspect.AIR, 6)
+                        .add(Aspect.MAGIC, 3),
                 -2,
                 -2,
                 3,
@@ -537,9 +520,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SILKYCRYSTAL",
                 getModItem(TinkerConstruct.ID, "materials", 1, 25),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("aqua"), 25)
-                        .add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.WATER, 25).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15)
+                        .add(Aspect.ORDER, 10).add(Aspect.ENTROPY, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -568,9 +550,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "SILKYCRYSTAL",
                 getModItem(TinkerConstruct.ID, "materials", 1, 26),
                 4,
-                new AspectList().add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("ordo"), 35).add(Aspect.getAspect("praecantatio"), 35)
-                        .add(Aspect.getAspect("vitreus"), 20),
+                new AspectList().add(Aspect.FIRE, 20).add(Aspect.EARTH, 20).add(Aspect.ORDER, 35).add(Aspect.MAGIC, 35)
+                        .add(Aspect.CRYSTAL, 20),
                 OrePrefixes.gemFlawless.get(Materials.Diamond),
                 getModItem(TinkerConstruct.ID, "materials", 1, 25),
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 0),
@@ -584,8 +565,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "LAVACRYSTAL",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("vacuos"), 9).add(Aspect.getAspect("perditio"), 6),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.MAGIC, 12).add(Aspect.VOID, 9).add(Aspect.ENTROPY, 6),
                 2,
                 -2,
                 3,
@@ -596,8 +576,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "LAVACRYSTAL",
                 getModItem(TinkerConstruct.ID, "materials", 1, 7),
                 3,
-                new AspectList().add(Aspect.getAspect("ignis"), 25).add(Aspect.getAspect("perditio"), 25)
-                        .add(Aspect.getAspect("vacuos"), 20).add(Aspect.getAspect("praecantatio"), 35),
+                new AspectList().add(Aspect.FIRE, 25).add(Aspect.ENTROPY, 25).add(Aspect.VOID, 20)
+                        .add(Aspect.MAGIC, 35),
                 getModItem(Minecraft.ID, "fire_charge", 1, 0),
                 getModItem(Minecraft.ID, "blaze_rod", 1, 0),
                 getModItem(Minecraft.ID, "lava_bucket", 1, 0),
@@ -613,8 +593,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "BALLOFMOSS",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("sano"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9),
+                new AspectList().add(Aspect.HEAL, 15).add(Aspect.EARTH, 12).add(Aspect.TOOL, 9),
                 0,
                 -4,
                 3,
@@ -625,8 +604,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "BALLOFMOSS",
                 getModItem(TinkerConstruct.ID, "materials", 1, 6),
                 5,
-                new AspectList().add(Aspect.getAspect("sano"), 30).add(Aspect.getAspect("terra"), 25)
-                        .add(Aspect.getAspect("instrumentum"), 35),
+                new AspectList().add(Aspect.HEAL, 30).add(Aspect.EARTH, 25).add(Aspect.TOOL, 35),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
                 OrePrefixes.dust.get(Materials.InfusedEarth),
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 3),
@@ -640,8 +618,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "NECROTICBONE",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("exanimis"), 15).add(Aspect.getAspect("mortuus"), 12)
-                        .add(Aspect.getAspect("spiritus"), 9).add(Aspect.getAspect("venenum"), 6),
+                new AspectList().add(Aspect.UNDEAD, 15).add(Aspect.DEATH, 12).add(Aspect.SOUL, 9).add(Aspect.POISON, 6),
                 0,
                 -2,
                 3,
@@ -653,9 +630,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "NECROTICBONE",
                 getModItem(TinkerConstruct.ID, "materials", 1, 8),
                 getModItem(Minecraft.ID, "bone", 1, 0),
-                new AspectList().add(Aspect.getAspect("exanimis"), 20).add(Aspect.getAspect("mortuus"), 30)
-                        .add(Aspect.getAspect("infernus"), 20).add(Aspect.getAspect("spiritus"), 20)
-                        .add(Aspect.getAspect("venenum"), 20).add(Aspect.getAspect("corpus"), 5));
+                new AspectList().add(Aspect.UNDEAD, 20).add(Aspect.DEATH, 30).add(DarkAspects.NETHER, 20)
+                        .add(Aspect.SOUL, 20).add(Aspect.POISON, 20).add(Aspect.FLESH, 5));
         TCHelper.addResearchPage(
                 "NECROTICBONE",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(TinkerConstruct.ID, "materials", 1, 8))));
@@ -663,9 +639,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "REDHEART",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("sano"), 9).add(Aspect.getAspect("mortuus"), 6)
-                        .add(Aspect.getAspect("exanimis"), 3),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.MAGIC, 12).add(Aspect.HEAL, 9).add(Aspect.DEATH, 6)
+                        .add(Aspect.UNDEAD, 3),
                 0,
                 -6,
                 3,
@@ -676,9 +651,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "REDHEART",
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 1),
                 3,
-                new AspectList().add(Aspect.getAspect("exanimis"), 25).add(Aspect.getAspect("ignis"), 35)
-                        .add(Aspect.getAspect("lucrum"), 35).add(Aspect.getAspect("sano"), 50)
-                        .add(Aspect.getAspect("praecantatio"), 50),
+                new AspectList().add(Aspect.UNDEAD, 25).add(Aspect.FIRE, 35).add(Aspect.GREED, 35).add(Aspect.HEAL, 50)
+                        .add(Aspect.MAGIC, 50),
                 getModItem(Minecraft.ID, "golden_apple", 1, 0),
                 getModItem(TinkerConstruct.ID, "jerky", 1, 6),
                 getModItem(Minecraft.ID, "apple", 1, 0),
@@ -697,9 +671,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "REDHEARTCANISTER",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("lucrum"), 15)
-                        .add(Aspect.getAspect("sano"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("mortuus"), 6).add(Aspect.getAspect("exanimis"), 3),
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.GREED, 15).add(Aspect.HEAL, 12).add(Aspect.FIRE, 9)
+                        .add(Aspect.DEATH, 6).add(Aspect.UNDEAD, 3),
                 0,
                 -8,
                 3,
@@ -709,9 +682,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "REDHEARTCANISTER",
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ignis"), 50).add(Aspect.getAspect("terra"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.WATER, 50).add(Aspect.FIRE, 50).add(Aspect.EARTH, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -730,9 +702,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "YELLOWHEART",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("mortuus"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("exanimis"), 9).add(Aspect.getAspect("sano"), 6)
-                        .add(Aspect.getAspect("ignis"), 3),
+                new AspectList().add(Aspect.DEATH, 15).add(Aspect.MAGIC, 12).add(Aspect.UNDEAD, 9).add(Aspect.HEAL, 6)
+                        .add(Aspect.FIRE, 3),
                 -2,
                 -7,
                 3,
@@ -742,9 +713,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "YELLOWHEART",
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 3),
                 3,
-                new AspectList().add(Aspect.getAspect("exanimis"), 50).add(Aspect.getAspect("ignis"), 75)
-                        .add(Aspect.getAspect("lucrum"), 75).add(Aspect.getAspect("sano"), 100)
-                        .add(Aspect.getAspect("praecantatio"), 100),
+                new AspectList().add(Aspect.UNDEAD, 50).add(Aspect.FIRE, 75).add(Aspect.GREED, 75).add(Aspect.HEAL, 100)
+                        .add(Aspect.MAGIC, 100),
                 getModItem(Minecraft.ID, "golden_apple", 1, 1),
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 1),
                 getModItem(TinkerConstruct.ID, "materials", 1, 8),
@@ -763,9 +733,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "YELLOWHEARTCANISTER",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("lucrum"), 15)
-                        .add(Aspect.getAspect("sano"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("mortuus"), 6).add(Aspect.getAspect("exanimis"), 3),
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.GREED, 15).add(Aspect.HEAL, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.DEATH, 6).add(Aspect.UNDEAD, 3),
                 -2,
                 -9,
                 3,
@@ -775,9 +744,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "YELLOWHEARTCANISTER",
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 4),
-                new AspectList().add(Aspect.getAspect("aer"), 100).add(Aspect.getAspect("aqua"), 100)
-                        .add(Aspect.getAspect("ignis"), 100).add(Aspect.getAspect("terra"), 100)
-                        .add(Aspect.getAspect("ordo"), 100).add(Aspect.getAspect("perditio"), 100),
+                new AspectList().add(Aspect.AIR, 100).add(Aspect.WATER, 100).add(Aspect.FIRE, 100)
+                        .add(Aspect.EARTH, 100).add(Aspect.ORDER, 100).add(Aspect.ENTROPY, 100),
                 "abc",
                 "def",
                 "ghi",
@@ -800,9 +768,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "GREENHEART",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("spiritus"), 9)
-                        .add(Aspect.getAspect("fames"), 6).add(Aspect.getAspect("corpus"), 3),
+                new AspectList().add(DarkAspects.NETHER, 15).add(Aspect.GREED, 12).add(Aspect.MAGIC, 12)
+                        .add(Aspect.SOUL, 9).add(Aspect.HUNGER, 6).add(Aspect.FLESH, 3),
                 -4,
                 -7,
                 3,
@@ -813,9 +780,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "GREENHEART",
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 5),
                 3,
-                new AspectList().add(Aspect.getAspect("exanimis"), 100).add(Aspect.getAspect("ignis"), 150)
-                        .add(Aspect.getAspect("lucrum"), 150).add(Aspect.getAspect("sano"), 200)
-                        .add(Aspect.getAspect("praecantatio"), 200),
+                new AspectList().add(Aspect.UNDEAD, 100).add(Aspect.FIRE, 150).add(Aspect.GREED, 150)
+                        .add(Aspect.HEAL, 200).add(Aspect.MAGIC, 200),
                 getModItem(TinkerConstruct.ID, "diamondApple", 1, 0),
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 3),
                 getModItem(TinkerConstruct.ID, "materials", 1, 8),
@@ -834,10 +800,9 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "GREENHEARTCANISTER",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("metallum"), 15)
-                        .add(Aspect.getAspect("lucrum"), 12).add(Aspect.getAspect("sano"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("spiritus"), 9)
-                        .add(Aspect.getAspect("fames"), 6).add(Aspect.getAspect("corpus"), 3),
+                new AspectList().add(DarkAspects.NETHER, 15).add(Aspect.METAL, 15).add(Aspect.GREED, 12)
+                        .add(Aspect.HEAL, 12).add(Aspect.MAGIC, 12).add(Aspect.SOUL, 9).add(Aspect.HUNGER, 6)
+                        .add(Aspect.FLESH, 3),
                 -4,
                 -9,
                 3,
@@ -850,9 +815,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GREENHEARTCANISTER",
                 getModItem(TinkerConstruct.ID, "heartCanister", 1, 6),
-                new AspectList().add(Aspect.getAspect("aer"), 200).add(Aspect.getAspect("aqua"), 200)
-                        .add(Aspect.getAspect("ignis"), 200).add(Aspect.getAspect("terra"), 200)
-                        .add(Aspect.getAspect("ordo"), 200).add(Aspect.getAspect("perditio"), 200),
+                new AspectList().add(Aspect.AIR, 200).add(Aspect.WATER, 200).add(Aspect.FIRE, 200)
+                        .add(Aspect.EARTH, 200).add(Aspect.ORDER, 200).add(Aspect.ENTROPY, 200),
                 "abc",
                 "def",
                 "ghi",
@@ -881,9 +845,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "ENDERCHEST",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("electrum"), 15)
-                        .add(Aspect.getAspect("machina"), 12).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("fabrico"), 3),
+                new AspectList().add(Aspect.METAL, 15).add(TCAspects.ELECTRUM.getAspect(), 15).add(Aspect.MECHANISM, 12)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.GREED, 6).add(Aspect.CRAFT, 3),
                 -4,
                 0,
                 3,
@@ -892,8 +855,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ENDERCHEST",
                 getModItem(EnderStorage.ID, "enderChest", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 100).add(Aspect.getAspect("aqua"), 100)
-                        .add(Aspect.getAspect("ignis"), 100).add(Aspect.getAspect("terra"), 100),
+                new AspectList().add(Aspect.AIR, 100).add(Aspect.WATER, 100).add(Aspect.FIRE, 100)
+                        .add(Aspect.EARTH, 100),
                 "abc",
                 "def",
                 "ghi",
@@ -921,9 +884,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "ENDERTANK",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("electrum"), 15)
-                        .add(Aspect.getAspect("machina"), 12).add(Aspect.getAspect("ignis"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("sensus"), 3),
+                new AspectList().add(Aspect.METAL, 15).add(TCAspects.ELECTRUM.getAspect(), 15).add(Aspect.MECHANISM, 12)
+                        .add(Aspect.FIRE, 9).add(Aspect.GREED, 6).add(Aspect.SENSES, 3),
                 -4,
                 2,
                 3,
@@ -932,9 +894,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ENDERTANK",
                 getModItem(EnderStorage.ID, "enderChest", 1, 4096),
-                new AspectList().add(Aspect.getAspect("aer"), 100).add(Aspect.getAspect("aqua"), 100)
-                        .add(Aspect.getAspect("ignis"), 100).add(Aspect.getAspect("terra"), 100)
-                        .add(Aspect.getAspect("ordo"), 100),
+                new AspectList().add(Aspect.AIR, 100).add(Aspect.WATER, 100).add(Aspect.FIRE, 100)
+                        .add(Aspect.EARTH, 100).add(Aspect.ORDER, 100),
                 "abc",
                 "def",
                 "ghi",
@@ -962,9 +923,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "ENDERPOUCHE",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("lucrum"), 15).add(Aspect.getAspect("vitreus"), 15)
-                        .add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("electrum"), 9)
-                        .add(Aspect.getAspect("machina"), 6).add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.GREED, 15).add(Aspect.CRYSTAL, 15).add(Aspect.METAL, 12)
+                        .add(TCAspects.ELECTRUM.getAspect(), 9).add(Aspect.MECHANISM, 6).add(Aspect.ELDRITCH, 3),
                 -4,
                 4,
                 3,
@@ -973,9 +933,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ENDERPOUCHE",
                 getModItem(EnderStorage.ID, "enderPouch", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 100).add(Aspect.getAspect("aqua"), 100)
-                        .add(Aspect.getAspect("ignis"), 100).add(Aspect.getAspect("terra"), 100)
-                        .add(Aspect.getAspect("ordo"), 100).add(Aspect.getAspect("perditio"), 100),
+                new AspectList().add(Aspect.AIR, 100).add(Aspect.WATER, 100).add(Aspect.FIRE, 100)
+                        .add(Aspect.EARTH, 100).add(Aspect.ORDER, 100).add(Aspect.ENTROPY, 100),
                 "abc",
                 "def",
                 "ghi",
@@ -1003,8 +962,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "AUTOENCHANTINGTABLE",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("potentia"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.CRAFT, 12).add(Aspect.MIND, 9).add(Aspect.ENERGY, 6),
                 0,
                 2,
                 3,
@@ -1017,8 +975,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "AUTOENCHANTINGTABLE",
                 getModItem(OpenBlocks.ID, "autoenchantmenttable", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.WATER, 75).add(Aspect.FIRE, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -1047,9 +1004,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "LUGGAGE",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("sensus"), 15)
-                        .add(Aspect.getAspect("iter"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("fabrico"), 6).add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.SENSES, 15).add(Aspect.TRAVEL, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.CRAFT, 6).add(Aspect.GREED, 3),
                 -2,
                 0,
                 3,
@@ -1062,9 +1018,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "LUGGAGE",
                 getModItem(OpenBlocks.ID, "luggage", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("perditio"), 75).add(Aspect.getAspect("ordo"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.WATER, 75).add(Aspect.FIRE, 75).add(Aspect.EARTH, 75)
+                        .add(Aspect.ENTROPY, 75).add(Aspect.ORDER, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -1093,10 +1048,9 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "GHOSTAMULET",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("potentia"), 21).add(Aspect.getAspect("auram"), 18)
-                        .add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("spiritus"), 9)
-                        .add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("corpus"), 3),
+                new AspectList().add(Aspect.ENERGY, 21).add(Aspect.AURA, 18).add(DarkAspects.NETHER, 15)
+                        .add(Aspect.GREED, 12).add(Aspect.MAGIC, 12).add(Aspect.SOUL, 9).add(Aspect.ELDRITCH, 6)
+                        .add(Aspect.FLESH, 3),
                 4,
                 2,
                 3,
@@ -1107,10 +1061,9 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "GHOSTAMULET",
                 getModItem(HardcoreEnderExpansion.ID, "ghost_amulet", 1, 1),
                 9,
-                new AspectList().add(Aspect.getAspect("auram"), 64).add(Aspect.getAspect("potentia"), 64)
-                        .add(Aspect.getAspect("vitium"), 32).add(Aspect.getAspect("vitreus"), 48)
-                        .add(Aspect.getAspect("spiritus"), 32).add(Aspect.getAspect("corpus"), 16)
-                        .add(Aspect.getAspect("alienis"), 24).add(Aspect.getAspect("lucrum"), 8),
+                new AspectList().add(Aspect.AURA, 64).add(Aspect.ENERGY, 64).add(Aspect.TAINT, 32)
+                        .add(Aspect.CRYSTAL, 48).add(Aspect.SOUL, 32).add(Aspect.FLESH, 16).add(Aspect.ELDRITCH, 24)
+                        .add(Aspect.GREED, 8),
                 getModItem(HardcoreEnderExpansion.ID, "ghost_amulet", 1, 0),
                 OrePrefixes.ingot.get(Materials.Draconium),
                 getModItem(HardcoreEnderExpansion.ID, "instability_orb", 1, 0),
@@ -1134,9 +1087,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "SFSWORD",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("auram"), 8).add(Aspect.getAspect("corpus"), 8)
-                        .add(Aspect.getAspect("exanimis"), 8).add(Aspect.getAspect("metallum"), 8)
-                        .add(Aspect.getAspect("mortuus"), 8),
+                new AspectList().add(Aspect.AURA, 8).add(Aspect.FLESH, 8).add(Aspect.UNDEAD, 8).add(Aspect.METAL, 8)
+                        .add(Aspect.DEATH, 8),
                 4,
                 4,
                 3,
@@ -1146,9 +1098,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "SFSWORD",
                 getModItem(Avaritia.ID, "Skull_Sword", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("auram"), 64).add(Aspect.getAspect("corpus"), 64)
-                        .add(Aspect.getAspect("exanimis"), 64).add(Aspect.getAspect("metallum"), 64)
-                        .add(Aspect.getAspect("mortuus"), 64),
+                new AspectList().add(Aspect.AURA, 64).add(Aspect.FLESH, 64).add(Aspect.UNDEAD, 64).add(Aspect.METAL, 64)
+                        .add(Aspect.DEATH, 64),
                 getModItem(TwilightForest.ID, "item.fierySword", 1, 0),
                 getModItem(Minecraft.ID, "blaze_rod", 1, 0),
                 getModItem(Minecraft.ID, "blaze_powder", 1, 0),
@@ -1169,7 +1120,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "MAGICOBSIDIAN",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("terra"), 8),
+                new AspectList().add(Aspect.ENTROPY, 8).add(Aspect.EARTH, 8),
                 2,
                 4,
                 2,
@@ -1178,7 +1129,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MAGICOBSIDIAN",
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 4, 1),
-                new AspectList().add(Aspect.getAspect("ignis"), 4).add(Aspect.getAspect("terra"), 4),
+                new AspectList().add(Aspect.FIRE, 4).add(Aspect.EARTH, 4),
                 "abc",
                 "def",
                 "ghi",
@@ -1197,8 +1148,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "MAGICOBSIDIAN",
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 4, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("tenebrae"), 16)
-                        .add(Aspect.getAspect("terra"), 16),
+                new AspectList().add(Aspect.ENTROPY, 16).add(Aspect.DARKNESS, 16).add(Aspect.EARTH, 16),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1),
@@ -1211,8 +1161,8 @@ public class ScriptTCCoreMod implements IScriptLoader {
         new ResearchItem(
                 "HELLISHMETAL",
                 "NEWHORIZONS",
-                new AspectList().add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("fames"), 6).add(Aspect.getAspect("ignis"), 3),
+                new AspectList().add(DarkAspects.NETHER, 15).add(Aspect.GREED, 12).add(Aspect.HUNGER, 6)
+                        .add(Aspect.FIRE, 3),
                 0,
                 6,
                 3,
@@ -1222,7 +1172,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 "HELLISHMETAL",
                 GTOreDictUnificator.get(OrePrefixes.block, Materials.HellishMetal, 1),
                 1,
-                new AspectList().add(Aspect.getAspect("ignis"), 8),
+                new AspectList().add(Aspect.FIRE, 8),
                 MaterialsElements.getInstance().RHODIUM.getBlock(1),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6),
                 OrePrefixes.ingot.get(Materials.Thaumium),

--- a/src/main/java/com/dreammaster/scripts/ScriptTCCoreMod.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTCCoreMod.java
@@ -10,6 +10,7 @@ import static gregtech.api.enums.Mods.DraconicEvolution;
 import static gregtech.api.enums.Mods.EnderStorage;
 import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.ExtraUtilities;
+import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.ForgeMicroblocks;
 import static gregtech.api.enums.Mods.HardcoreEnderExpansion;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
@@ -71,6 +72,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                 EnderStorage.ID,
                 EternalSingularity.ID,
                 ExtraUtilities.ID,
+                ForbiddenMagic.ID,
                 ForgeMicroblocks.ID,
                 HardcoreEnderExpansion.ID,
                 IndustrialCraft2.ID,

--- a/src/main/java/com/dreammaster/scripts/ScriptTaintedMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTaintedMagic.java
@@ -5,6 +5,7 @@ import static com.dreammaster.scripts.IngredientFactory.getModItem;
 import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
+import static gregtech.api.enums.Mods.MagicBees;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.TaintedMagic;
 import static gregtech.api.enums.Mods.Thaumcraft;
@@ -41,6 +42,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 ForbiddenMagic.ID,
                 Forestry.ID,
                 IndustrialCraft2.ID,
+                MagicBees.ID,
                 TaintedMagic.ID,
                 Thaumcraft.ID,
                 TinkersGregworks.ID);

--- a/src/main/java/com/dreammaster/scripts/ScriptTaintedMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTaintedMagic.java
@@ -9,7 +9,6 @@ import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.TaintedMagic;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.TinkersGregworks;
-import static thaumcraft.api.aspects.Aspect.getAspect;
 
 import java.util.Arrays;
 import java.util.List;
@@ -17,9 +16,11 @@ import java.util.List;
 import com.dreammaster.item.NHItemList;
 import com.dreammaster.thaumcraft.TCHelper;
 
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.util.GTOreDictUnificator;
+import magicbees.api.MagicBeesAPI;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -103,8 +104,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "ShadowmetalGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("potentia"), 3),
+                new AspectList().add(Aspect.METAL, 12).add(Aspect.MAGIC, 9).add(Aspect.DARKNESS, 6)
+                        .add(Aspect.ENERGY, 3),
                 0,
                 1,
                 2,
@@ -114,8 +115,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "ShadowmetalGTNH",
                 getModItem(TaintedMagic.ID, "BlockShadowOre", 1, 0),
                 getModItem(Minecraft.ID, "stone", 1, 0),
-                new AspectList().add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("praecantatio"), 8)
-                        .add(Aspect.getAspect("metallum"), 8).add(Aspect.getAspect("vacuos"), 4));
+                new AspectList().add(Aspect.DARKNESS, 6).add(Aspect.MAGIC, 8).add(Aspect.METAL, 8).add(Aspect.VOID, 4));
         TCHelper.addResearchPage(
                 "ShadowmetalGTNH",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(TaintedMagic.ID, "BlockShadowOre", 1, 0))));
@@ -123,7 +123,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ShadowmetalGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowmetalHoe", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 45).add(Aspect.getAspect("terra"), 30),
+                new AspectList().add(Aspect.ENTROPY, 45).add(Aspect.EARTH, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -145,7 +145,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ShadowmetalGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowmetalPick", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 45).add(Aspect.getAspect("terra"), 30),
+                new AspectList().add(Aspect.ENTROPY, 45).add(Aspect.EARTH, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -169,7 +169,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ShadowmetalGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowmetalAxe", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 45).add(Aspect.getAspect("terra"), 30),
+                new AspectList().add(Aspect.ENTROPY, 45).add(Aspect.EARTH, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -193,7 +193,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ShadowmetalGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowmetalSpade", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 45).add(Aspect.getAspect("terra"), 30),
+                new AspectList().add(Aspect.ENTROPY, 45).add(Aspect.EARTH, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -213,7 +213,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ShadowmetalGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowmetalSword", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 45).add(Aspect.getAspect("terra"), 30),
+                new AspectList().add(Aspect.ENTROPY, 45).add(Aspect.EARTH, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -235,9 +235,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "EvilshardsGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("vitreus"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("tenebrae"), 6)
-                        .add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(DarkAspects.NETHER, 15).add(Aspect.CRYSTAL, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.DARKNESS, 6).add(Aspect.ELDRITCH, 3),
                 4,
                 0,
                 3,
@@ -247,8 +246,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "EvilshardsGTNH",
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3),
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 6),
-                new AspectList().add(Aspect.getAspect("alienis"), 8).add(Aspect.getAspect("praecantatio"), 8)
-                        .add(Aspect.getAspect("permutatio"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 8).add(Aspect.MAGIC, 8).add(Aspect.EXCHANGE, 8));
         TCHelper.addResearchPage(
                 "EvilshardsGTNH",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3))));
@@ -256,8 +254,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "EvilshardsGTNH",
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4),
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 6),
-                new AspectList().add(Aspect.getAspect("vitium"), 8).add(Aspect.getAspect("praecantatio"), 8)
-                        .add(Aspect.getAspect("permutatio"), 8));
+                new AspectList().add(Aspect.TAINT, 8).add(Aspect.MAGIC, 8).add(Aspect.EXCHANGE, 8));
         TCHelper.addResearchPage(
                 "EvilshardsGTNH",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4))));
@@ -267,9 +264,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "MagicFunguarGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("gula"), 15).add(Aspect.getAspect("fames"), 12)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("herba"), 3),
+                new AspectList().add(DarkAspects.GLUTTONY, 15).add(Aspect.HUNGER, 12).add(Aspect.GREED, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.PLANT, 3),
                 3,
                 -2,
                 3,
@@ -278,9 +274,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MagicFunguarGTNH",
                 getModItem(TaintedMagic.ID, "ItemMagicFunguar", 4, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 10).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.WATER, 10).add(Aspect.EARTH, 10).add(Aspect.ORDER, 10).add(Aspect.FIRE, 10)
+                        .add(Aspect.AIR, 10).add(Aspect.ENTROPY, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -311,9 +306,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "WarpTreeGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("alienis"), 18).add(Aspect.getAspect("tenebrae"), 15)
-                        .add(Aspect.getAspect("vitium"), 12).add(Aspect.getAspect("arbor"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("herba"), 3),
+                new AspectList().add(Aspect.ELDRITCH, 18).add(Aspect.DARKNESS, 15).add(Aspect.TAINT, 12)
+                        .add(Aspect.TREE, 9).add(Aspect.MAGIC, 6).add(Aspect.PLANT, 3),
                 6,
                 -1,
                 3,
@@ -324,9 +318,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "WarpTreeGTNH",
                 getModItem(TaintedMagic.ID, "BlockWarpwoodSapling", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("arbor"), 16)
-                        .add(Aspect.getAspect("tenebrae"), 12).add(Aspect.getAspect("vitium"), 8)
-                        .add(Aspect.getAspect("permutatio"), 8),
+                new AspectList().add(Aspect.ELDRITCH, 16).add(Aspect.TREE, 16).add(Aspect.DARKNESS, 12)
+                        .add(Aspect.TAINT, 8).add(Aspect.EXCHANGE, 8),
                 getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3),
@@ -350,9 +343,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "WarpedGogglesGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("sensus"), 6)
-                        .add(Aspect.getAspect("aer"), 3),
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.ELDRITCH, 12).add(Aspect.DARKNESS, 9)
+                        .add(Aspect.SENSES, 6).add(Aspect.AIR, 3),
                 2,
                 3,
                 3,
@@ -365,9 +357,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "WarpedGogglesGTNH",
                 getModItem(TaintedMagic.ID, "ItemWarpedGoggles", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("alienis"), 40).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("tenebrae"), 24).add(Aspect.getAspect("tutamen"), 16)
-                        .add(Aspect.getAspect("sensus"), 8),
+                new AspectList().add(Aspect.ELDRITCH, 40).add(Aspect.MAGIC, 32).add(Aspect.DARKNESS, 24)
+                        .add(Aspect.ARMOR, 16).add(Aspect.SENSES, 8),
                 getModItem(Thaumcraft.ID, "ItemGoggles", 1, 0),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3),
                 OrePrefixes.plate.get(Materials.Shadow),
@@ -388,9 +379,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "FocusShardGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("motus"), 18).add(Aspect.getAspect("vitreus"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("aer"), 9)
-                        .add(Aspect.getAspect("perditio"), 6).add(Aspect.getAspect("ordo"), 3),
+                new AspectList().add(Aspect.MOTION, 18).add(Aspect.CRYSTAL, 15).add(Aspect.MAGIC, 12).add(Aspect.AIR, 9)
+                        .add(Aspect.ENTROPY, 6).add(Aspect.ORDER, 3),
                 3,
                 1,
                 3,
@@ -399,8 +389,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FocusShardGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusVisShard", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("aer"), 50)
-                        .add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.ORDER, 50).add(Aspect.AIR, 50).add(Aspect.ENTROPY, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -431,9 +420,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "MaceFocusGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("perditio"), 18).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("telum"), 9)
-                        .add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.ENTROPY, 18).add(Aspect.EARTH, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.WEAPON, 9).add(Aspect.METAL, 6).add(Aspect.MIND, 3),
                 0,
                 4,
                 3,
@@ -444,9 +432,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "MaceFocusGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusMageMace", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("perditio"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("telum"), 64)
-                        .add(Aspect.getAspect("cognitio"), 8),
+                new AspectList().add(Aspect.METAL, 16).add(Aspect.ENTROPY, 32).add(Aspect.MAGIC, 48)
+                        .add(Aspect.WEAPON, 64).add(Aspect.MIND, 8),
                 getModItem(TaintedMagic.ID, "ItemShadowmetalSword", 1, 0),
                 OrePrefixes.block.get(Materials.Shadow),
                 OrePrefixes.screw.get(Materials.Shadow),
@@ -467,9 +454,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "ShadowClothGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("pannus"), 15).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("tutamen"), 3),
+                new AspectList().add(Aspect.CLOTH, 15).add(Aspect.DARKNESS, 12).add(Aspect.MAGIC, 9).add(Aspect.AIR, 6)
+                        .add(Aspect.ARMOR, 3),
                 -1,
                 2,
                 3,
@@ -478,9 +464,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ShadowClothGTNH",
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15)
+                        .add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -511,9 +496,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "CreationShardGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("aer"), 21).add(Aspect.getAspect("aqua"), 21)
-                        .add(Aspect.getAspect("ignis"), 21).add(Aspect.getAspect("terra"), 21)
-                        .add(Aspect.getAspect("ordo"), 21).add(Aspect.getAspect("perditio"), 21),
+                new AspectList().add(Aspect.AIR, 21).add(Aspect.WATER, 21).add(Aspect.FIRE, 21).add(Aspect.EARTH, 21)
+                        .add(Aspect.ORDER, 21).add(Aspect.ENTROPY, 21),
                 8,
                 -5,
                 3,
@@ -523,8 +507,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "CreationShardGTNH",
                 NHItemList.VoidEssence.get(2),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 16),
-                new AspectList().add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("vacuos"), 16)
-                        .add(Aspect.getAspect("tenebrae"), 16));
+                new AspectList().add(Aspect.ELDRITCH, 16).add(Aspect.VOID, 16).add(Aspect.DARKNESS, 16));
         TCHelper.addResearchPage(
                 "CreationShardGTNH",
                 new ResearchPage(TCHelper.findCrucibleRecipe(NHItemList.VoidEssence.get(1))));
@@ -532,9 +515,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "CreationShardGTNH",
                 getModItem(TaintedMagic.ID, "ItemMaterial", 2, 5),
                 12,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("vacuos"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("auram"), 64)
-                        .add(Aspect.getAspect("tenebrae"), 64),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.VOID, 64).add(Aspect.MAGIC, 64)
+                        .add(Aspect.AURA, 64).add(Aspect.DARKNESS, 64),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
@@ -557,9 +539,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "EldritchFocusGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("alienis"), 18).add(Aspect.getAspect("perditio"), 15)
-                        .add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("tenebrae"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("ira"), 3),
+                new AspectList().add(Aspect.ELDRITCH, 18).add(Aspect.ENTROPY, 15).add(Aspect.AIR, 12)
+                        .add(Aspect.DARKNESS, 9).add(Aspect.ENERGY, 6).add(DarkAspects.WRATH, 3),
                 8,
                 -4,
                 3,
@@ -571,9 +552,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "EldritchFocusGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusEldritch", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("aer"), 84).add(Aspect.getAspect("alienis"), 72)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("tenebrae"), 64)
-                        .add(Aspect.getAspect("ira"), 32).add(Aspect.getAspect("potentia"), 16),
+                new AspectList().add(Aspect.AIR, 84).add(Aspect.ELDRITCH, 72).add(Aspect.MAGIC, 64)
+                        .add(Aspect.DARKNESS, 64).add(DarkAspects.WRATH, 32).add(Aspect.ENERGY, 16),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 5),
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0),
                 OrePrefixes.plate.get(Materials.Void),
@@ -597,9 +577,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "CrystalDaggerGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("telum"), 18).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("sano"), 12).add(Aspect.getAspect("fames"), 9)
-                        .add(Aspect.getAspect("infernus"), 6).add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.WEAPON, 18).add(Aspect.FIRE, 15).add(Aspect.HEAL, 12).add(Aspect.HUNGER, 9)
+                        .add(DarkAspects.NETHER, 6).add(Aspect.GREED, 3),
                 0,
                 -3,
                 3,
@@ -613,8 +592,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CrystalDaggerGTNH",
                 getModItem(TaintedMagic.ID, "ItemCrystalDagger", 1, 0),
-                new AspectList().add(getAspect("terra"), 100).add(getAspect("ignis"), 100)
-                        .add(getAspect("perditio"), 100).add(getAspect("ordo"), 50).add(getAspect("aer"), 50),
+                new AspectList().add(Aspect.EARTH, 100).add(Aspect.FIRE, 100).add(Aspect.ENTROPY, 100)
+                        .add(Aspect.ORDER, 50).add(Aspect.AIR, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -641,9 +620,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "CrimsonRobesGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("pannus"), 18).add(Aspect.getAspect("permutatio"), 15)
-                        .add(Aspect.getAspect("tutamen"), 12).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.CLOTH, 18).add(Aspect.EXCHANGE, 15).add(Aspect.ARMOR, 12)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.DARKNESS, 6).add(Aspect.MAGIC, 3),
                 -2,
                 -5,
                 3,
@@ -656,9 +634,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CrimsonRobesGTNH",
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 25).add(Aspect.getAspect("ignis"), 25)
-                        .add(Aspect.getAspect("perditio"), 25).add(Aspect.getAspect("aqua"), 25)
-                        .add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("aer"), 25),
+                new AspectList().add(Aspect.EARTH, 25).add(Aspect.FIRE, 25).add(Aspect.ENTROPY, 25)
+                        .add(Aspect.WATER, 25).add(Aspect.ORDER, 25).add(Aspect.AIR, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -687,9 +664,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CrimsonRobesGTNH",
                 getModItem(Thaumcraft.ID, "ItemHelmetCultistRobe", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("aqua"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("aer"), 30),
+                new AspectList().add(Aspect.EARTH, 30).add(Aspect.FIRE, 30).add(Aspect.ENTROPY, 30)
+                        .add(Aspect.WATER, 30).add(Aspect.ORDER, 30).add(Aspect.AIR, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -713,9 +689,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CrimsonRobesGTNH",
                 getModItem(Thaumcraft.ID, "ItemChestplateCultistRobe", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("aqua"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("aer"), 30),
+                new AspectList().add(Aspect.EARTH, 30).add(Aspect.FIRE, 30).add(Aspect.ENTROPY, 30)
+                        .add(Aspect.WATER, 30).add(Aspect.ORDER, 30).add(Aspect.AIR, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -744,9 +719,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CrimsonRobesGTNH",
                 getModItem(Thaumcraft.ID, "ItemLeggingsCultistRobe", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("aqua"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("aer"), 30),
+                new AspectList().add(Aspect.EARTH, 30).add(Aspect.FIRE, 30).add(Aspect.ENTROPY, 30)
+                        .add(Aspect.WATER, 30).add(Aspect.ORDER, 30).add(Aspect.AIR, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -775,9 +749,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CrimsonRobesGTNH",
                 getModItem(Thaumcraft.ID, "ItemBootsCultist", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("aqua"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("aer"), 30),
+                new AspectList().add(Aspect.EARTH, 30).add(Aspect.FIRE, 30).add(Aspect.ENTROPY, 30)
+                        .add(Aspect.WATER, 30).add(Aspect.ORDER, 30).add(Aspect.AIR, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -800,9 +773,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ResearchCategories.getResearch("BLOODLUSTUPGRADE").setConcealed();
         TCHelper.setResearchAspects(
                 "BLOODLUSTUPGRADE",
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("sano"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("ira"), 3));
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.HEAL, 12).add(Aspect.WEAPON, 9).add(Aspect.MAGIC, 6)
+                        .add(DarkAspects.WRATH, 3));
         TCHelper.setResearchComplexity("BLOODLUSTUPGRADE", 3);
         ThaumcraftApi.addWarpToResearch("BLOODLUSTUPGRADE", 2);
         TCHelper.orphanResearch("KNIGHTROBES");
@@ -810,10 +782,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "KnightRobesGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("pannus"), 21).add(Aspect.getAspect("permutatio"), 18)
-                        .add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("metallum"), 3),
+                new AspectList().add(Aspect.CLOTH, 21).add(Aspect.EXCHANGE, 18).add(Aspect.ARMOR, 15)
+                        .add(Aspect.ELDRITCH, 12).add(Aspect.DARKNESS, 9).add(Aspect.MAGIC, 6).add(Aspect.METAL, 3),
                 -4,
                 -4,
                 3,
@@ -823,10 +793,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "KnightRobesGTNH",
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 8),
                 6,
-                new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("alienis"), 32)
-                        .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("ignis"), 32)
-                        .add(Aspect.getAspect("fames"), 32),
+                new AspectList().add(Aspect.METAL, 32).add(Aspect.MAGIC, 32).add(Aspect.DARKNESS, 32)
+                        .add(Aspect.ELDRITCH, 32).add(Aspect.ARMOR, 32).add(Aspect.FIRE, 32).add(Aspect.HUNGER, 32),
                 OrePrefixes.plateQuadruple.get(Materials.Thaumium),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 2),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7),
@@ -851,9 +819,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "KnightRobesGTNH",
                 getModItem(Thaumcraft.ID, "ItemHelmetCultistPlate", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("perditio"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("aer"), 50),
+                new AspectList().add(Aspect.EARTH, 50).add(Aspect.FIRE, 50).add(Aspect.ENTROPY, 50)
+                        .add(Aspect.WATER, 50).add(Aspect.ORDER, 50).add(Aspect.AIR, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -877,9 +844,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "KnightRobesGTNH",
                 getModItem(Thaumcraft.ID, "ItemChestplateCultistPlate", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("perditio"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("aer"), 50),
+                new AspectList().add(Aspect.EARTH, 50).add(Aspect.FIRE, 50).add(Aspect.ENTROPY, 50)
+                        .add(Aspect.WATER, 50).add(Aspect.ORDER, 50).add(Aspect.AIR, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -908,9 +874,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "KnightRobesGTNH",
                 getModItem(Thaumcraft.ID, "ItemLeggingsCultistPlate", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("perditio"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("aer"), 50),
+                new AspectList().add(Aspect.EARTH, 50).add(Aspect.FIRE, 50).add(Aspect.ENTROPY, 50)
+                        .add(Aspect.WATER, 50).add(Aspect.ORDER, 50).add(Aspect.AIR, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -941,10 +906,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "PraetorarmorGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("pannus"), 24).add(Aspect.getAspect("permutatio"), 21)
-                        .add(Aspect.getAspect("tutamen"), 18).add(Aspect.getAspect("alienis"), 15)
-                        .add(Aspect.getAspect("tenebrae"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("potentia"), 3),
+                new AspectList().add(Aspect.CLOTH, 24).add(Aspect.EXCHANGE, 21).add(Aspect.ARMOR, 18)
+                        .add(Aspect.ELDRITCH, 15).add(Aspect.DARKNESS, 12).add(Aspect.MAGIC, 9).add(Aspect.METAL, 6)
+                        .add(Aspect.ENERGY, 3),
                 -6,
                 -4,
                 3,
@@ -954,9 +918,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "PraetorarmorGTNH",
                 getModItem(Thaumcraft.ID, "ItemHelmetCultistLeaderPlate", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("metallum"), 64).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("tenebrae"), 64).add(Aspect.getAspect("alienis"), 64)
-                        .add(Aspect.getAspect("tutamen"), 64),
+                new AspectList().add(Aspect.METAL, 64).add(Aspect.MAGIC, 64).add(Aspect.DARKNESS, 64)
+                        .add(Aspect.ELDRITCH, 64).add(Aspect.ARMOR, 64),
                 getModItem(Thaumcraft.ID, "ItemHelmetCultistPlate", 1, 0),
                 OrePrefixes.plate.get(Materials.RoseGold),
                 OrePrefixes.ring.get(Materials.Shadow),
@@ -979,9 +942,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "PraetorarmorGTNH",
                 getModItem(Thaumcraft.ID, "ItemChestplateCultistLeaderPlate", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("metallum"), 64).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("tenebrae"), 64).add(Aspect.getAspect("alienis"), 64)
-                        .add(Aspect.getAspect("tutamen"), 64),
+                new AspectList().add(Aspect.METAL, 64).add(Aspect.MAGIC, 64).add(Aspect.DARKNESS, 64)
+                        .add(Aspect.ELDRITCH, 64).add(Aspect.ARMOR, 64),
                 getModItem(Thaumcraft.ID, "ItemChestplateCultistPlate", 1, 0),
                 OrePrefixes.plate.get(Materials.RoseGold),
                 OrePrefixes.ring.get(Materials.Shadow),
@@ -1004,9 +966,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "PraetorarmorGTNH",
                 getModItem(Thaumcraft.ID, "ItemLeggingsCultistLeaderPlate", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("metallum"), 64).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("tenebrae"), 64).add(Aspect.getAspect("alienis"), 64)
-                        .add(Aspect.getAspect("tutamen"), 64),
+                new AspectList().add(Aspect.METAL, 64).add(Aspect.MAGIC, 64).add(Aspect.DARKNESS, 64)
+                        .add(Aspect.ELDRITCH, 64).add(Aspect.ARMOR, 64),
                 getModItem(Thaumcraft.ID, "ItemLeggingsCultistPlate", 1, 0),
                 OrePrefixes.plate.get(Materials.RoseGold),
                 OrePrefixes.ring.get(Materials.Shadow),
@@ -1030,9 +991,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "VoidsentGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("tenebrae"), 33).add(Aspect.getAspect("tutamen"), 18)
-                        .add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.DARKNESS, 33).add(Aspect.ARMOR, 18).add(Aspect.VOID, 15).add(Aspect.AURA, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.ELDRITCH, 3),
                 -7,
                 -5,
                 3,
@@ -1042,9 +1002,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "VoidsentGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidsentBlood", 1, 0),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7),
-                new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("tutamen"), 12).add(Aspect.getAspect("vacuos"), 16)
-                        .add(Aspect.getAspect("alienis"), 16));
+                new AspectList().add(Aspect.AURA, 12).add(Aspect.DARKNESS, 12).add(Aspect.ARMOR, 12)
+                        .add(Aspect.VOID, 16).add(Aspect.ELDRITCH, 16));
         TCHelper.addResearchPage(
                 "VoidsentGTNH",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(TaintedMagic.ID, "ItemVoidsentBlood", 1, 0))));
@@ -1054,9 +1013,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "CrimsonBladeGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("perditio"), 18).add(Aspect.getAspect("telum"), 15)
-                        .add(Aspect.getAspect("vacuos"), 12).add(Aspect.getAspect("tenebrae"), 9)
-                        .add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("potentia"), 3),
+                new AspectList().add(Aspect.ENTROPY, 18).add(Aspect.WEAPON, 15).add(Aspect.VOID, 12)
+                        .add(Aspect.DARKNESS, 9).add(Aspect.METAL, 6).add(Aspect.ENERGY, 3),
                 -7,
                 -3,
                 3,
@@ -1066,9 +1024,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "CrimsonBladeGTNH",
                 getModItem(Thaumcraft.ID, "ItemSwordCrimson", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("metallum"), 24)
-                        .add(Aspect.getAspect("perditio"), 32).add(Aspect.getAspect("telum"), 64)
-                        .add(Aspect.getAspect("vacuos"), 48).add(Aspect.getAspect("tenebrae"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 16).add(Aspect.METAL, 24).add(Aspect.ENTROPY, 32)
+                        .add(Aspect.WEAPON, 64).add(Aspect.VOID, 48).add(Aspect.DARKNESS, 32),
                 getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0),
                 getModItem(TaintedMagic.ID, "ItemCrystalDagger", 1, 0),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 7),
@@ -1091,10 +1048,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "VoidgogglesGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("sensus"), 21).add(Aspect.getAspect("vacuos"), 18)
-                        .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("vitreus"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("metallum"), 3),
+                new AspectList().add(Aspect.SENSES, 21).add(Aspect.VOID, 18).add(Aspect.MAGIC, 15)
+                        .add(Aspect.DARKNESS, 12).add(Aspect.CRYSTAL, 9).add(Aspect.ELDRITCH, 6).add(Aspect.METAL, 3),
                 3,
                 5,
                 3,
@@ -1104,10 +1059,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "VoidgogglesGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidmetalGoggles", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("sensus"), 32).add(Aspect.getAspect("tenebrae"), 32)
-                        .add(Aspect.getAspect("tutamen"), 48).add(Aspect.getAspect("vacuos"), 64)
-                        .add(Aspect.getAspect("vitreus"), 24).add(Aspect.getAspect("alienis"), 8)
-                        .add(Aspect.getAspect("metallum"), 16),
+                new AspectList().add(Aspect.SENSES, 32).add(Aspect.DARKNESS, 32).add(Aspect.ARMOR, 48)
+                        .add(Aspect.VOID, 64).add(Aspect.CRYSTAL, 24).add(Aspect.ELDRITCH, 8).add(Aspect.METAL, 16),
                 getModItem(TaintedMagic.ID, "ItemWarpedGoggles", 1, 0),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 1),
                 OrePrefixes.plate.get(Materials.Void),
@@ -1129,9 +1082,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "TaintFocusGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("vitium"), 18).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("limus"), 12).add(Aspect.getAspect("aer"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("potentia"), 3),
+                new AspectList().add(Aspect.TAINT, 18).add(Aspect.WATER, 15).add(Aspect.SLIME, 12).add(Aspect.AIR, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.ENERGY, 3),
                 5,
                 2,
                 3,
@@ -1142,9 +1094,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "TaintFocusGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusTaint", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("aqua"), 72).add(Aspect.getAspect("limus"), 72)
-                        .add(Aspect.getAspect("praecantatio"), 72).add(Aspect.getAspect("vitium"), 72)
-                        .add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("potentia"), 32),
+                new AspectList().add(Aspect.WATER, 72).add(Aspect.SLIME, 72).add(Aspect.MAGIC, 72).add(Aspect.TAINT, 72)
+                        .add(Aspect.AIR, 64).add(Aspect.ENERGY, 32),
                 getModItem(Thaumcraft.ID, "FocusPech", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 11),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 4),
@@ -1168,9 +1119,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "FocusTaintedBlastGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 21).add(Aspect.getAspect("vitium"), 18)
-                        .add(Aspect.getAspect("motus"), 18).add(Aspect.getAspect("aer"), 12)
-                        .add(Aspect.getAspect("perditio"), 9).add(Aspect.getAspect("telum"), 6),
+                new AspectList().add(Aspect.MAGIC, 21).add(Aspect.TAINT, 18).add(Aspect.MOTION, 18).add(Aspect.AIR, 12)
+                        .add(Aspect.ENTROPY, 9).add(Aspect.WEAPON, 6),
                 5,
                 3,
                 3,
@@ -1181,9 +1131,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "FocusTaintedBlastGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusTaintedBlast", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("motus"), 64).add(Aspect.getAspect("praecantatio"), 80)
-                        .add(Aspect.getAspect("telum"), 72).add(Aspect.getAspect("vitium"), 84)
-                        .add(Aspect.getAspect("cognitio"), 32).add(Aspect.getAspect("aer"), 48),
+                new AspectList().add(Aspect.MOTION, 64).add(Aspect.MAGIC, 80).add(Aspect.WEAPON, 72)
+                        .add(Aspect.TAINT, 84).add(Aspect.MIND, 32).add(Aspect.AIR, 48),
                 getModItem(TaintedMagic.ID, "ItemFocusTaint", 1, 0),
                 getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0),
@@ -1207,9 +1156,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "ThaumicdisassemblerGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("telum"), 18).add(Aspect.getAspect("metallum"), 15)
-                        .add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("vitium"), 3),
+                new AspectList().add(Aspect.WEAPON, 18).add(Aspect.METAL, 15).add(Aspect.TOOL, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.ELDRITCH, 6).add(Aspect.TAINT, 3),
                 5,
                 -6,
                 3,
@@ -1219,8 +1167,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ThaumicdisassemblerGTNH",
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 6),
-                new AspectList().add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75)
-                        .add(Aspect.getAspect("terra"), 50),
+                new AspectList().add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75).add(Aspect.EARTH, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -1251,9 +1198,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "ThaumicdisassemblerGTNH",
                 getModItem(TaintedMagic.ID, "ItemThaumicDisassembler", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 32).add(Aspect.getAspect("metallum"), 32)
-                        .add(Aspect.getAspect("telum"), 24).add(Aspect.getAspect("vacuos"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("potentia"), 16),
+                new AspectList().add(Aspect.TOOL, 32).add(Aspect.METAL, 32).add(Aspect.WEAPON, 24).add(Aspect.VOID, 24)
+                        .add(Aspect.MAGIC, 16).add(Aspect.ENERGY, 16),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 6),
                 getModItem(Thaumcraft.ID, "ItemPickVoid", 1, 0),
                 OrePrefixes.plate.get(Materials.Shadow),
@@ -1272,10 +1218,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "VoidWalkerBootsGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("tenebrae"), 21).add(Aspect.getAspect("tutamen"), 18)
-                        .add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("iter"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("volatus"), 3),
+                new AspectList().add(Aspect.DARKNESS, 21).add(Aspect.ARMOR, 18).add(Aspect.ELDRITCH, 15)
+                        .add(Aspect.MAGIC, 12).add(Aspect.TRAVEL, 9).add(Aspect.AIR, 6).add(Aspect.FLIGHT, 3),
                 4,
                 -8,
                 3,
@@ -1287,9 +1231,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "VoidWalkerBootsGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidwalkerBoots", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("iter"), 84)
-                        .add(Aspect.getAspect("tenebrae"), 72).add(Aspect.getAspect("tutamen"), 64)
-                        .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("praecantatio"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.TRAVEL, 84).add(Aspect.DARKNESS, 72)
+                        .add(Aspect.ARMOR, 64).add(Aspect.VOID, 64).add(Aspect.MAGIC, 32),
                 getModItem(Thaumcraft.ID, "BootsTraveller", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0),
                 OrePrefixes.plate.get(Materials.Void),
@@ -1315,10 +1258,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "VoidSashGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("metallum"), 24).add(Aspect.getAspect("vacuos"), 21)
-                        .add(Aspect.getAspect("tutamen"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("tenebrae"), 9)
-                        .add(Aspect.getAspect("iter"), 6).add(Aspect.getAspect("aer"), 3),
+                new AspectList().add(Aspect.METAL, 24).add(Aspect.VOID, 21).add(Aspect.ARMOR, 18).add(Aspect.MAGIC, 15)
+                        .add(Aspect.ELDRITCH, 12).add(Aspect.DARKNESS, 9).add(Aspect.TRAVEL, 6).add(Aspect.AIR, 3),
                 3,
                 -8,
                 3,
@@ -1331,10 +1272,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "VoidSashGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidwalkerSash", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("iter"), 48).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("tutamen"), 84).add(Aspect.getAspect("vacuos"), 72)
-                        .add(Aspect.getAspect("volatus"), 32).add(Aspect.getAspect("alienis"), 24)
-                        .add(Aspect.getAspect("aer"), 16),
+                new AspectList().add(Aspect.TRAVEL, 48).add(Aspect.MAGIC, 64).add(Aspect.ARMOR, 84).add(Aspect.VOID, 72)
+                        .add(Aspect.FLIGHT, 32).add(Aspect.ELDRITCH, 24).add(Aspect.AIR, 16),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3),
                 getModItem(Thaumcraft.ID, "ItemGirdleRunic", 1, 0),
                 OrePrefixes.plate.get(Materials.Void),
@@ -1357,10 +1296,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "VoidFortressGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("tutamen"), 21).add(Aspect.getAspect("vacuos"), 18)
-                        .add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("victus"), 9).add(Aspect.getAspect("cognitio"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.ARMOR, 21).add(Aspect.VOID, 18).add(Aspect.ELDRITCH, 15)
+                        .add(Aspect.DARKNESS, 12).add(Aspect.LIFE, 9).add(Aspect.MIND, 6).add(Aspect.EARTH, 3),
                 7,
                 -8,
                 3,
@@ -1371,10 +1308,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "VoidFortressGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidFortressHelmet", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("metallum"), 48)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("tutamen"), 48)
-                        .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("tenebrae"), 16)
-                        .add(Aspect.getAspect("potentia"), 16).add(Aspect.getAspect("victus"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 32).add(Aspect.METAL, 48).add(Aspect.MAGIC, 48)
+                        .add(Aspect.ARMOR, 48).add(Aspect.VOID, 32).add(Aspect.DARKNESS, 16).add(Aspect.ENERGY, 16)
+                        .add(Aspect.LIFE, 32),
                 getModItem(Thaumcraft.ID, "ItemHelmetVoid", 1, 0),
                 OrePrefixes.gemExquisite.get(Materials.Emerald),
                 OrePrefixes.plate.get(Materials.RoseGold),
@@ -1395,10 +1331,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "VoidFortressGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidFortressChestplate", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("metallum"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("tutamen"), 64)
-                        .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("tenebrae"), 16)
-                        .add(Aspect.getAspect("potentia"), 16).add(Aspect.getAspect("cognitio"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 32).add(Aspect.METAL, 64).add(Aspect.MAGIC, 64)
+                        .add(Aspect.ARMOR, 64).add(Aspect.VOID, 32).add(Aspect.DARKNESS, 16).add(Aspect.ENERGY, 16)
+                        .add(Aspect.MIND, 32),
                 getModItem(Thaumcraft.ID, "ItemChestplateVoid", 1, 0),
                 OrePrefixes.plate.get(Materials.Void),
                 OrePrefixes.plate.get(Materials.Void),
@@ -1422,10 +1357,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "VoidFortressGTNH",
                 getModItem(TaintedMagic.ID, "ItemVoidFortressLeggings", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("metallum"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("tutamen"), 32)
-                        .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("tenebrae"), 16)
-                        .add(Aspect.getAspect("potentia"), 16).add(Aspect.getAspect("terra"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 32).add(Aspect.METAL, 32).add(Aspect.MAGIC, 32)
+                        .add(Aspect.ARMOR, 32).add(Aspect.VOID, 32).add(Aspect.DARKNESS, 16).add(Aspect.ENERGY, 16)
+                        .add(Aspect.EARTH, 32),
                 getModItem(Thaumcraft.ID, "ItemLeggingsVoid", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2),
                 OrePrefixes.plate.get(Materials.RoseGold),
@@ -1446,10 +1380,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "ShadowFortressArmorGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("tutamen"), 24).add(Aspect.getAspect("vacuos"), 21)
-                        .add(Aspect.getAspect("alienis"), 18).add(Aspect.getAspect("tenebrae"), 15)
-                        .add(Aspect.getAspect("victus"), 12).add(Aspect.getAspect("cognitio"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("superbia"), 3),
+                new AspectList().add(Aspect.ARMOR, 24).add(Aspect.VOID, 21).add(Aspect.ELDRITCH, 18)
+                        .add(Aspect.DARKNESS, 15).add(Aspect.LIFE, 12).add(Aspect.MIND, 9).add(Aspect.EARTH, 6)
+                        .add(DarkAspects.PRIDE, 3),
                 8,
                 -9,
                 3,
@@ -1460,10 +1393,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "ShadowFortressArmorGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowFortressHelmet", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("alienis"), 48).add(Aspect.getAspect("metallum"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("tutamen"), 64)
-                        .add(Aspect.getAspect("vacuos"), 48).add(Aspect.getAspect("tenebrae"), 32)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("victus"), 48),
+                new AspectList().add(Aspect.ELDRITCH, 48).add(Aspect.METAL, 64).add(Aspect.MAGIC, 64)
+                        .add(Aspect.ARMOR, 64).add(Aspect.VOID, 48).add(Aspect.DARKNESS, 32).add(Aspect.ENERGY, 32)
+                        .add(Aspect.LIFE, 48),
                 getModItem(TaintedMagic.ID, "ItemVoidFortressHelmet", 1, 0),
                 OrePrefixes.gemExquisite.get(Materials.Emerald),
                 OrePrefixes.plate.get(Materials.InfusedGold),
@@ -1484,10 +1416,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "ShadowFortressArmorGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowFortressChestplate", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("alienis"), 48).add(Aspect.getAspect("metallum"), 84)
-                        .add(Aspect.getAspect("praecantatio"), 84).add(Aspect.getAspect("tutamen"), 84)
-                        .add(Aspect.getAspect("vacuos"), 48).add(Aspect.getAspect("tenebrae"), 32)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("cognitio"), 48),
+                new AspectList().add(Aspect.ELDRITCH, 48).add(Aspect.METAL, 84).add(Aspect.MAGIC, 84)
+                        .add(Aspect.ARMOR, 84).add(Aspect.VOID, 48).add(Aspect.DARKNESS, 32).add(Aspect.ENERGY, 32)
+                        .add(Aspect.MIND, 48),
                 getModItem(TaintedMagic.ID, "ItemVoidFortressChestplate", 1, 0),
                 OrePrefixes.block.get(Materials.Shadow),
                 OrePrefixes.block.get(Materials.Shadow),
@@ -1512,10 +1443,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "ShadowFortressArmorGTNH",
                 getModItem(TaintedMagic.ID, "ItemShadowFortressLeggings", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("alienis"), 48).add(Aspect.getAspect("metallum"), 48)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("tutamen"), 48)
-                        .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("tenebrae"), 32)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("terra"), 48),
+                new AspectList().add(Aspect.ELDRITCH, 48).add(Aspect.METAL, 48).add(Aspect.MAGIC, 48)
+                        .add(Aspect.ARMOR, 48).add(Aspect.VOID, 32).add(Aspect.DARKNESS, 32).add(Aspect.ENERGY, 32)
+                        .add(Aspect.EARTH, 48),
                 getModItem(TaintedMagic.ID, "ItemVoidFortressLeggings", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2),
                 OrePrefixes.plate.get(Materials.InfusedGold),
@@ -1536,9 +1466,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "ThaumiumKatanaGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("telum"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("motus"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("mortuus"), 3),
+                new AspectList().add(Aspect.METAL, 18).add(Aspect.WEAPON, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.MOTION, 9).add(Aspect.ENERGY, 6).add(Aspect.DEATH, 3),
                 7,
                 1,
                 3,
@@ -1549,9 +1478,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "ThaumiumKatanaGTNH",
                 getModItem(TaintedMagic.ID, "ItemKatana", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("metallum"), 64).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("telum"), 48).add(Aspect.getAspect("mortuus"), 24)
-                        .add(Aspect.getAspect("potentia"), 16).add(Aspect.getAspect("motus"), 8),
+                new AspectList().add(Aspect.METAL, 64).add(Aspect.MAGIC, 32).add(Aspect.WEAPON, 48)
+                        .add(Aspect.DEATH, 24).add(Aspect.ENERGY, 16).add(Aspect.MOTION, 8),
                 getModItem(Thaumcraft.ID, "ItemSwordThaumium", 1, 0),
                 OrePrefixes.plate.get(Materials.Obsidian),
                 OrePrefixes.plate.get(Materials.Thaumium),
@@ -1574,10 +1502,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "VoidMetalKatanaGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("metallum"), 21).add(Aspect.getAspect("telum"), 18)
-                        .add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("motus"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("mortuus"), 3),
+                new AspectList().add(Aspect.METAL, 21).add(Aspect.WEAPON, 18).add(Aspect.VOID, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.MOTION, 9).add(Aspect.ENERGY, 6).add(Aspect.DEATH, 3),
                 7,
                 0,
                 3,
@@ -1588,10 +1514,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "VoidMetalKatanaGTNH",
                 getModItem(TaintedMagic.ID, "ItemKatana", 1, 1),
                 9,
-                new AspectList().add(Aspect.getAspect("alienis"), 48).add(Aspect.getAspect("metallum"), 72)
-                        .add(Aspect.getAspect("praecantatio"), 48).add(Aspect.getAspect("telum"), 64)
-                        .add(Aspect.getAspect("mortuus"), 32).add(Aspect.getAspect("potentia"), 24)
-                        .add(Aspect.getAspect("motus"), 16).add(Aspect.getAspect("vacuos"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 48).add(Aspect.METAL, 72).add(Aspect.MAGIC, 48)
+                        .add(Aspect.WEAPON, 64).add(Aspect.DEATH, 32).add(Aspect.ENERGY, 24).add(Aspect.MOTION, 16)
+                        .add(Aspect.VOID, 32),
                 getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0),
                 OrePrefixes.plate.get(Materials.Manyullyn),
                 OrePrefixes.plate.get(Materials.Void),
@@ -1614,10 +1539,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "ShadowMetalKatanaGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("tenebrae"), 24).add(Aspect.getAspect("metallum"), 21)
-                        .add(Aspect.getAspect("telum"), 18).add(Aspect.getAspect("vacuos"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("motus"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("mortuus"), 3),
+                new AspectList().add(Aspect.DARKNESS, 24).add(Aspect.METAL, 21).add(Aspect.WEAPON, 18)
+                        .add(Aspect.VOID, 15).add(Aspect.MAGIC, 12).add(Aspect.MOTION, 9).add(Aspect.ENERGY, 6)
+                        .add(Aspect.DEATH, 3),
                 8,
                 -1,
                 3,
@@ -1628,11 +1552,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "ShadowMetalKatanaGTNH",
                 getModItem(TaintedMagic.ID, "ItemKatana", 1, 2),
                 12,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("metallum"), 84)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("telum"), 72)
-                        .add(Aspect.getAspect("mortuus"), 48).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("motus"), 24).add(Aspect.getAspect("vacuos"), 48)
-                        .add(Aspect.getAspect("tenebrae"), 48),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.METAL, 84).add(Aspect.MAGIC, 64)
+                        .add(Aspect.WEAPON, 72).add(Aspect.DEATH, 48).add(Aspect.ENERGY, 32).add(Aspect.MOTION, 24)
+                        .add(Aspect.VOID, 48).add(Aspect.DARKNESS, 48),
                 getModItem(TaintedMagic.ID, "ItemShadowmetalSword", 1, 0),
                 OrePrefixes.plate.get(Materials.Shadow),
                 OrePrefixes.plate.get(Materials.Shadow),
@@ -1654,27 +1576,24 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ResearchCategories.getResearch("INSCRIPTIONFIRE").setConcealed();
         TCHelper.setResearchAspects(
                 "INSCRIPTIONFIRE",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("lux"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.METAL, 12).add(Aspect.LIGHT, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("INSCRIPTIONFIRE", 3);
         ThaumcraftApi.addWarpToResearch("INSCRIPTIONFIRE", 2);
         TCHelper.addResearchPrereq("INSCRIPTIONTAINT", "ThaumiumKatanaGTNH", false);
         ResearchCategories.getResearch("INSCRIPTIONTAINT").setConcealed();
         TCHelper.setResearchAspects(
                 "INSCRIPTIONTAINT",
-                new AspectList().add(Aspect.getAspect("vitium"), 15).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("corpus"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.TAINT, 15).add(Aspect.METAL, 12).add(Aspect.FLESH, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("INSCRIPTIONTAINT", 3);
         ThaumcraftApi.addWarpToResearch("INSCRIPTIONTAINT", 3);
         TCHelper.addResearchPrereq("INSCRIPTIONUNDEAD", "ThaumiumKatanaGTNH", false);
         ResearchCategories.getResearch("INSCRIPTIONUNDEAD").setConcealed();
         TCHelper.setResearchAspects(
                 "INSCRIPTIONUNDEAD",
-                new AspectList().add(Aspect.getAspect("sano"), 15).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("exanimis"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.HEAL, 15).add(Aspect.METAL, 12).add(Aspect.UNDEAD, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("INSCRIPTIONUNDEAD", 3);
         ThaumcraftApi.addWarpToResearch("INSCRIPTIONUNDEAD", 4);
         TCHelper.orphanResearch("ROD_warpwood");
@@ -1682,9 +1601,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "ROD_warpwood",
                 "TM",
-                new AspectList().add(Aspect.getAspect("arbor"), 18).add(Aspect.getAspect("tenebrae"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("instrumentum"), 6).add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.TREE, 18).add(Aspect.DARKNESS, 15).add(Aspect.ELDRITCH, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.TOOL, 6).add(Aspect.EARTH, 3),
                 8,
                 -2,
                 3,
@@ -1695,9 +1613,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "ROD_warpwood",
                 getModItem(TaintedMagic.ID, "ItemWandRod", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("arbor"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("tenebrae"), 48)
-                        .add(Aspect.getAspect("instrumentum"), 32).add(Aspect.getAspect("terra"), 24),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.TREE, 64).add(Aspect.MAGIC, 64)
+                        .add(Aspect.DARKNESS, 48).add(Aspect.TOOL, 32).add(Aspect.EARTH, 24),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3),
                 getModItem(TaintedMagic.ID, "BlockWarpwoodLog", 1, 0),
                 OrePrefixes.ring.get(Materials.Tungsten),
@@ -1725,9 +1642,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "ROD_warpwood_staff",
                 "TM",
-                new AspectList().add(Aspect.getAspect("arbor"), 18).add(Aspect.getAspect("tenebrae"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("instrumentum"), 3),
+                new AspectList().add(Aspect.TREE, 18).add(Aspect.DARKNESS, 15).add(Aspect.ELDRITCH, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.ENERGY, 6).add(Aspect.TOOL, 3),
                 9,
                 -2,
                 3,
@@ -1736,9 +1652,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_warpwood_staff",
                 getModItem(TaintedMagic.ID, "ItemWandRod", 1, 1),
-                new AspectList().add(Aspect.getAspect("aqua"), 150).add(Aspect.getAspect("terra"), 150)
-                        .add(Aspect.getAspect("ignis"), 150).add(Aspect.getAspect("aer"), 150)
-                        .add(Aspect.getAspect("ordo"), 150).add(Aspect.getAspect("perditio"), 150),
+                new AspectList().add(Aspect.WATER, 150).add(Aspect.EARTH, 150).add(Aspect.FIRE, 150)
+                        .add(Aspect.AIR, 150).add(Aspect.ORDER, 150).add(Aspect.ENTROPY, 150),
                 "abc",
                 "def",
                 "ghi",
@@ -1769,11 +1684,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "FocusTimeGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("tempus"), 27).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("aqua"), 21).add(Aspect.getAspect("ignis"), 18)
-                        .add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("perditio"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3),
+                new AspectList().add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 27).add(Aspect.MAGIC, 24)
+                        .add(Aspect.WATER, 21).add(Aspect.FIRE, 18).add(Aspect.EARTH, 15).add(Aspect.ORDER, 12)
+                        .add(Aspect.ENTROPY, 9).add(Aspect.AIR, 6).add(Aspect.EXCHANGE, 3),
                 11,
                 -8,
                 3,
@@ -1784,10 +1697,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "FocusTimeGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusTime", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("alienis"), 84).add(Aspect.getAspect("lux"), 72)
-                        .add(Aspect.getAspect("tenebrae"), 64).add(Aspect.getAspect("vacuos"), 48)
-                        .add(Aspect.getAspect("tempus"), 24).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("permutatio"), 16),
+                new AspectList().add(Aspect.ELDRITCH, 84).add(Aspect.LIGHT, 72).add(Aspect.DARKNESS, 64)
+                        .add(Aspect.VOID, 48).add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 24)
+                        .add(Aspect.MAGIC, 32).add(Aspect.EXCHANGE, 16),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 5),
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
@@ -1810,11 +1722,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "FocusWeatherGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("volatus"), 27).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("aqua"), 21).add(Aspect.getAspect("ignis"), 18)
-                        .add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("perditio"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("tempestas"), 3),
+                new AspectList().add(Aspect.FLIGHT, 27).add(Aspect.MAGIC, 24).add(Aspect.WATER, 21).add(Aspect.FIRE, 18)
+                        .add(Aspect.EARTH, 15).add(Aspect.ORDER, 12).add(Aspect.ENTROPY, 9).add(Aspect.AIR, 6)
+                        .add(Aspect.WEATHER, 3),
                 12,
                 -7,
                 3,
@@ -1825,10 +1735,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "FocusWeatherGTNH",
                 getModItem(TaintedMagic.ID, "ItemFocusMeteorology", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("alienis"), 84).add(Aspect.getAspect("aqua"), 72)
-                        .add(Aspect.getAspect("tempestas"), 64).add(Aspect.getAspect("vacuos"), 48)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("volatus"), 24)
-                        .add(Aspect.getAspect("perditio"), 16),
+                new AspectList().add(Aspect.ELDRITCH, 84).add(Aspect.WATER, 72).add(Aspect.WEATHER, 64)
+                        .add(Aspect.VOID, 48).add(Aspect.MAGIC, 32).add(Aspect.FLIGHT, 24).add(Aspect.ENTROPY, 16),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 5),
                 getModItem(Thaumcraft.ID, "FocusShock", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2),
@@ -1852,10 +1760,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "PrimalBladeGTNH",
                 "TM",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("alienis"), 21)
-                        .add(Aspect.getAspect("telum"), 18).add(Aspect.getAspect("tenebrae"), 15)
-                        .add(Aspect.getAspect("vacuos"), 12).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.MAGIC, 24).add(Aspect.ELDRITCH, 21).add(Aspect.WEAPON, 18)
+                        .add(Aspect.DARKNESS, 15).add(Aspect.VOID, 12).add(Aspect.AURA, 9).add(Aspect.ENERGY, 6)
+                        .add(Aspect.MIND, 3),
                 11,
                 -5,
                 3,
@@ -1869,10 +1776,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "PrimalBladeGTNH",
                 getModItem(TaintedMagic.ID, "ItemPrimordialEdge", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("alienis"), 96).add(Aspect.getAspect("metallum"), 84)
-                        .add(Aspect.getAspect("telum"), 72).add(Aspect.getAspect("tenebrae"), 64)
-                        .add(Aspect.getAspect("vacuos"), 48).add(Aspect.getAspect("auram"), 32)
-                        .add(Aspect.getAspect("cognitio"), 24).add(Aspect.getAspect("potentia"), 16),
+                new AspectList().add(Aspect.ELDRITCH, 96).add(Aspect.METAL, 84).add(Aspect.WEAPON, 72)
+                        .add(Aspect.DARKNESS, 64).add(Aspect.VOID, 48).add(Aspect.AURA, 32).add(Aspect.MIND, 24)
+                        .add(Aspect.ENERGY, 16),
                 getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemPrimalCrusher", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5),
@@ -1898,8 +1804,7 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "CAP_cloth",
                 "TM",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("pannus"), 9)
-                        .add(Aspect.getAspect("sano"), 6).add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.MAGIC, 12).add(Aspect.CLOTH, 9).add(Aspect.HEAL, 6).add(Aspect.ELDRITCH, 3),
                 7,
                 5,
                 3,
@@ -1908,8 +1813,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_cloth",
                 getModItem(TaintedMagic.ID, "ItemWandCap", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 25).add(Aspect.getAspect("ignis"), 25)
-                        .add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("perditio"), 25),
+                new AspectList().add(Aspect.EARTH, 25).add(Aspect.FIRE, 25).add(Aspect.ORDER, 25)
+                        .add(Aspect.ENTROPY, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -1940,9 +1845,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "CAP_shadowcloth",
                 "TM",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("pannus"), 15)
-                        .add(Aspect.getAspect("tenebrae"), 12).add(Aspect.getAspect("vacuos"), 9)
-                        .add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.MAGIC, 18).add(Aspect.CLOTH, 15).add(Aspect.DARKNESS, 12)
+                        .add(Aspect.VOID, 9).add(Aspect.METAL, 6).add(Aspect.ELDRITCH, 3),
                 -2,
                 3,
                 3,
@@ -1952,8 +1856,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_shadowcloth",
                 getModItem(TaintedMagic.ID, "ItemWandCap", 1, 3),
-                new AspectList().add(Aspect.getAspect("terra"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.EARTH, 50).add(Aspect.FIRE, 50).add(Aspect.ORDER, 50)
+                        .add(Aspect.ENTROPY, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -1984,9 +1888,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "CAP_crimsoncloth",
                 "TM",
-                new AspectList().add(Aspect.getAspect("tenebrae"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("pannus"), 12).add(Aspect.getAspect("sano"), 9)
-                        .add(Aspect.getAspect("aqua"), 6).add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.DARKNESS, 18).add(Aspect.MAGIC, 15).add(Aspect.CLOTH, 12)
+                        .add(Aspect.HEAL, 9).add(Aspect.WATER, 6).add(Aspect.ELDRITCH, 3),
                 -1,
                 -6,
                 3,
@@ -1996,9 +1899,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_crimsoncloth",
                 getModItem(TaintedMagic.ID, "ItemWandCap", 1, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 100).add(Aspect.getAspect("ignis"), 100)
-                        .add(Aspect.getAspect("aqua"), 100).add(Aspect.getAspect("terra"), 100)
-                        .add(Aspect.getAspect("ordo"), 100).add(Aspect.getAspect("perditio"), 100),
+                new AspectList().add(Aspect.AIR, 100).add(Aspect.FIRE, 100).add(Aspect.WATER, 100)
+                        .add(Aspect.EARTH, 100).add(Aspect.ORDER, 100).add(Aspect.ENTROPY, 100),
                 "abc",
                 "def",
                 "ghi",
@@ -2029,10 +1931,8 @@ public class ScriptTaintedMagic implements IScriptLoader {
         new ResearchItem(
                 "CAP_shadowmetal",
                 "TM",
-                new AspectList().add(Aspect.getAspect("metallum"), 21).add(Aspect.getAspect("tenebrae"), 18)
-                        .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.METAL, 21).add(Aspect.DARKNESS, 18).add(Aspect.MAGIC, 15)
+                        .add(Aspect.ELDRITCH, 12).add(Aspect.EARTH, 9).add(Aspect.GREED, 6).add(Aspect.MIND, 3),
                 -4,
                 4,
                 3,
@@ -2043,10 +1943,9 @@ public class ScriptTaintedMagic implements IScriptLoader {
                 "CAP_shadowmetal",
                 getModItem(TaintedMagic.ID, "ItemWandCap", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("alienis"), 96).add(Aspect.getAspect("praecantatio"), 96)
-                        .add(Aspect.getAspect("tenebrae"), 84).add(Aspect.getAspect("metallum"), 72)
-                        .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("cognitio"), 68)
-                        .add(Aspect.getAspect("lucrum"), 32).add(Aspect.getAspect("fames"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 96).add(Aspect.MAGIC, 96).add(Aspect.DARKNESS, 84)
+                        .add(Aspect.METAL, 72).add(Aspect.VOID, 64).add(Aspect.MIND, 68).add(Aspect.GREED, 32)
+                        .add(Aspect.HUNGER, 32),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 7),
                 getModItem(TaintedMagic.ID, "ItemMaterial", 1, 3),

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumcraft.java
@@ -60,17 +60,20 @@ import com.dreammaster.chisel.ChiselHelper;
 import com.dreammaster.item.NHItemList;
 import com.dreammaster.thaumcraft.TCHelper;
 
+import fox.spiteful.forbidden.DarkAspects;
 import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TCAspects;
 import gregtech.api.enums.TierEU;
 import gregtech.api.objects.OreDictItemStack;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
 import gregtech.common.items.MetaGeneratedItem98;
 import gregtech.common.items.MetaGeneratedTool01;
+import magicbees.api.MagicBeesAPI;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -182,9 +185,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ASPECTS",
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("terra"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.EARTH, 5).add(Aspect.FIRE, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -205,9 +207,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ASPECTS",
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("terra"), 5)
-                        .add(Aspect.getAspect("ignis"), 10).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.EARTH, 5).add(Aspect.FIRE, 10).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -228,9 +229,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ASPECTS",
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("terra"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("aqua"), 10)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.EARTH, 5).add(Aspect.FIRE, 5).add(Aspect.WATER, 10)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -251,9 +251,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ASPECTS",
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.EARTH, 10).add(Aspect.FIRE, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -274,9 +273,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ASPECTS",
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("terra"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.EARTH, 5).add(Aspect.FIRE, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 10).add(Aspect.ENTROPY, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -297,9 +295,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ASPECTS",
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("terra"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.EARTH, 5).add(Aspect.FIRE, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -320,9 +317,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ASPECTS",
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("ignis"), 10).add(Aspect.getAspect("aqua"), 10)
-                        .add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.EARTH, 10).add(Aspect.FIRE, 10).add(Aspect.WATER, 10)
+                        .add(Aspect.ORDER, 10).add(Aspect.ENTROPY, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -372,35 +368,31 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.addResearchPage("ORE", new ResearchPage("tc.research_page.ORE.4"));
         TCHelper.setResearchAspects(
                 "RESEARCHER1",
-                new AspectList().add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("sensus"), 6)
-                        .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("lux"), 3));
+                new AspectList().add(Aspect.MIND, 6).add(Aspect.SENSES, 6).add(Aspect.ORDER, 6).add(Aspect.LIGHT, 3));
         TCHelper.setResearchComplexity("RESEARCHER1", 1);
         TCHelper.setResearchAspects(
                 "RESEARCHER2",
-                new AspectList().add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("sensus"), 9)
-                        .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("lux"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.MIND, 9).add(Aspect.SENSES, 9).add(Aspect.ORDER, 6).add(Aspect.LIGHT, 6)
+                        .add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("RESEARCHER2", 2);
         TCHelper.setResearchAspects(
                 "NODETAPPER1",
-                new AspectList().add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.EXCHANGE, 9).add(Aspect.AURA, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("NODETAPPER1", 2);
         TCHelper.setResearchAspects(
                 "NODETAPPER2",
-                new AspectList().add(Aspect.getAspect("permutatio"), 12).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("motus"), 6)
-                        .add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.EXCHANGE, 12).add(Aspect.AURA, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.MOTION, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("NODETAPPER2", 3);
         TCHelper.setResearchAspects(
                 "NODEPRESERVE",
-                new AspectList().add(Aspect.getAspect("perditio"), 9).add(Aspect.getAspect("cognitio"), 9)
-                        .add(Aspect.getAspect("fabrico"), 6).add(Aspect.getAspect("instrumentum"), 3));
+                new AspectList().add(Aspect.ENTROPY, 9).add(Aspect.MIND, 9).add(Aspect.CRAFT, 6).add(Aspect.TOOL, 3));
         TCHelper.setResearchComplexity("NODEPRESERVE", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DECONSTRUCTOR",
                 getModItem(Thaumcraft.ID, "blockTable", 1, 14),
-                new AspectList().add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("perditio"), 20),
+                new AspectList().add(Aspect.ORDER, 20).add(Aspect.ENTROPY, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -424,20 +416,17 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "plateThaumium");
         TCHelper.setResearchAspects(
                 "DECONSTRUCTOR",
-                new AspectList().add(Aspect.getAspect("sensus"), 9).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("fames"), 3));
+                new AspectList().add(Aspect.SENSES, 9).add(Aspect.AURA, 9).add(Aspect.GREED, 6).add(Aspect.HUNGER, 3));
         TCHelper.setResearchComplexity("DECONSTRUCTOR", 2);
         TCHelper.setResearchAspects(
                 "NODEJAR",
-                new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("motus"), 12)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("permutatio"), 6)
-                        .add(Aspect.getAspect("vitreus"), 3));
+                new AspectList().add(Aspect.AURA, 12).add(Aspect.MOTION, 12).add(Aspect.GREED, 9)
+                        .add(Aspect.EXCHANGE, 6).add(Aspect.CRYSTAL, 3));
         TCHelper.setResearchComplexity("NODEJAR", 3);
         TCHelper.setResearchAspects(
                 "RESEARCHDUPE",
-                new AspectList().add(Aspect.getAspect("sensus"), 12).add(Aspect.getAspect("cognitio"), 12)
-                        .add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("lucrum"), 9)
-                        .add(Aspect.getAspect("perditio"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.SENSES, 12).add(Aspect.MIND, 12).add(Aspect.CRAFT, 12).add(Aspect.GREED, 9)
+                        .add(Aspect.ENTROPY, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("RESEARCHDUPE", 3);
         TCHelper.refreshResearchPages("DECONSTRUCTOR");
         new ResearchItem("WARPWARNING", "BASICS", new AspectList(), 1, 1, 1, getModItem(Minecraft.ID, "skull", 1, 1))
@@ -539,8 +528,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_copper",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 3),
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.FIRE, 15).add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -567,8 +555,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(Thaumcraft.ID, "WandCap", 1, 3))));
         TCHelper.setResearchAspects(
                 "CAP_copper",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 3).add(Aspect.getAspect("metallum"), 6)
-                        .add(Aspect.getAspect("permutatio"), 6));
+                new AspectList().add(Aspect.TOOL, 3).add(Aspect.METAL, 6).add(Aspect.EXCHANGE, 6));
         TCHelper.setResearchComplexity("CAP_copper", 1);
         TCHelper.addResearchPage("SCEPTRE", new ResearchPage("tc.research_page.RESEARCH.1"));
         TCHelper.clearPages("CAP_gold");
@@ -576,8 +563,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_gold",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 1),
-                new AspectList().add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("aer"), 20),
+                new AspectList().add(Aspect.ORDER, 20).add(Aspect.FIRE, 20).add(Aspect.AIR, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -604,16 +590,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(Thaumcraft.ID, "WandCap", 1, 1))));
         TCHelper.setResearchAspects(
                 "CAP_gold",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("metallum"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3));
+                new AspectList().add(Aspect.TOOL, 9).add(Aspect.METAL, 6).add(Aspect.GREED, 3));
         TCHelper.setResearchComplexity("CAP_gold", 2);
         TCHelper.clearPages("CAP_silver");
         TCHelper.addResearchPage("CAP_silver", new ResearchPage("tc.research_page.CAP_silver.1"));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_silver",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 5),
-                new AspectList().add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("ignis"), 25)
-                        .add(Aspect.getAspect("aer"), 25),
+                new AspectList().add(Aspect.ORDER, 25).add(Aspect.FIRE, 25).add(Aspect.AIR, 25),
                 "aba",
                 "bcb",
                 "aba",
@@ -630,8 +614,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "CAP_silver",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 4),
                 5,
-                new AspectList().add(Aspect.getAspect("auram"), 18).add(Aspect.getAspect("potentia"), 30)
-                        .add(Aspect.getAspect("praecantatio"), 18),
+                new AspectList().add(Aspect.AURA, 18).add(Aspect.ENERGY, 30).add(Aspect.MAGIC, 18),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 5),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 OrePrefixes.dust.get(Materials.Silver),
@@ -647,8 +630,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_thaumium",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 6),
-                new AspectList().add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("aer"), 30),
+                new AspectList().add(Aspect.ORDER, 30).add(Aspect.FIRE, 30).add(Aspect.AIR, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -677,8 +659,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "CAP_thaumium",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 2),
                 5,
-                new AspectList().add(Aspect.getAspect("auram"), 25).add(Aspect.getAspect("potentia"), 40)
-                        .add(Aspect.getAspect("praecantatio"), 25),
+                new AspectList().add(Aspect.AURA, 25).add(Aspect.ENERGY, 40).add(Aspect.MAGIC, 25),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 6),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 OrePrefixes.dust.get(Materials.Thaumium),
@@ -691,25 +672,22 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Thaumcraft.ID, "WandCap", 1, 2))));
         TCHelper.setResearchAspects(
                 "CAP_thaumium",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 6).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TOOL, 6).add(Aspect.AURA, 9).add(Aspect.METAL, 12).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("CAP_thaumium", 3);
         TCHelper.clearPages("SCEPTRE");
         TCHelper.addResearchPage("SCEPTRE", new ResearchPage("tc.research_page.SCEPTRE.1"));
         TCHelper.setResearchAspects(
                 "SCEPTRE",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("arbor"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.TOOL, 12).add(Aspect.CRAFT, 12).add(Aspect.TREE, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("SCEPTRE", 3);
         TCHelper.clearPages("ROD_greatwood");
         TCHelper.addResearchPage("ROD_greatwood", new ResearchPage("tc.research_page.ROD_greatwood.1"));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_greatwood",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("aqua"), 20)
-                        .add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("perditio"), 20),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.EARTH, 20).add(Aspect.FIRE, 20).add(Aspect.WATER, 20)
+                        .add(Aspect.ORDER, 20).add(Aspect.ENTROPY, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -724,15 +702,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(Thaumcraft.ID, "WandRod", 1, 0))));
         TCHelper.setResearchAspects(
                 "ROD_greatwood",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("arbor"), 3));
+                new AspectList().add(Aspect.TOOL, 9).add(Aspect.MAGIC, 6).add(Aspect.TREE, 3));
         TCHelper.setResearchComplexity("ROD_greatwood", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_reed",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 5),
                 2,
-                new AspectList().add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("motus"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("vitreus"), 6),
+                new AspectList().add(Aspect.AIR, 24).add(Aspect.MOTION, 12).add(Aspect.MAGIC, 12)
+                        .add(Aspect.CRYSTAL, 6),
                 getModItem(TinkerConstruct.ID, "trap.punji", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 6),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
@@ -740,9 +717,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0));
         TCHelper.setResearchAspects(
                 "ROD_reed",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("herba"), 6)
-                        .add(Aspect.getAspect("arbor"), 3));
+                new AspectList().add(Aspect.TOOL, 9).add(Aspect.MAGIC, 9).add(Aspect.AIR, 6).add(Aspect.PLANT, 6)
+                        .add(Aspect.TREE, 3));
         TCHelper.setResearchComplexity("ROD_reed", 2);
         TCHelper.addResearchPage(
                 "SCEPTRE",
@@ -758,8 +734,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "ROD_blaze",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 6),
                 2,
-                new AspectList().add(Aspect.getAspect("bestia"), 12).add(Aspect.getAspect("ignis"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("vitreus"), 6),
+                new AspectList().add(Aspect.BEAST, 12).add(Aspect.FIRE, 24).add(Aspect.MAGIC, 12)
+                        .add(Aspect.CRYSTAL, 6),
                 getModItem(Minecraft.ID, "blaze_rod", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 6),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1),
@@ -767,16 +743,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1));
         TCHelper.setResearchAspects(
                 "ROD_blaze",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("herba"), 6)
-                        .add(Aspect.getAspect("arbor"), 3));
+                new AspectList().add(Aspect.TOOL, 9).add(Aspect.MAGIC, 9).add(Aspect.AIR, 6).add(Aspect.PLANT, 6)
+                        .add(Aspect.TREE, 3));
         TCHelper.setResearchComplexity("ROD_blaze", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_obsidian",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 1),
                 2,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("terra"), 24).add(Aspect.getAspect("vitreus"), 6),
+                new AspectList().add(Aspect.MAGIC, 12).add(Aspect.DARKNESS, 12).add(Aspect.EARTH, 24)
+                        .add(Aspect.CRYSTAL, 6),
                 getModItem(RandomThings.ID, "ingredient", 1, 1),
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 6),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3),
@@ -784,16 +759,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3));
         TCHelper.setResearchAspects(
                 "ROD_obsidian",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("arbor"), 3));
+                new AspectList().add(Aspect.TOOL, 9).add(Aspect.MAGIC, 9).add(Aspect.FIRE, 6).add(Aspect.ENERGY, 6)
+                        .add(Aspect.TREE, 3));
         TCHelper.setResearchComplexity("ROD_obsidian", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_ice",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 3),
                 2,
-                new AspectList().add(Aspect.getAspect("aqua"), 24).add(Aspect.getAspect("gelum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("vitreus"), 6),
+                new AspectList().add(Aspect.WATER, 24).add(Aspect.COLD, 12).add(Aspect.MAGIC, 12)
+                        .add(Aspect.CRYSTAL, 6),
                 getModItem(BiomesOPlenty.ID, "hardIce", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 6),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2),
@@ -801,16 +775,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2));
         TCHelper.setResearchAspects(
                 "ROD_ice",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("aqua"), 6).add(Aspect.getAspect("gelum"), 6)
-                        .add(Aspect.getAspect("arbor"), 3));
+                new AspectList().add(Aspect.TOOL, 9).add(Aspect.MAGIC, 9).add(Aspect.WATER, 6).add(Aspect.COLD, 6)
+                        .add(Aspect.TREE, 3));
         TCHelper.setResearchComplexity("ROD_ice", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_quartz",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 4),
                 2,
-                new AspectList().add(Aspect.getAspect("ordo"), 24).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("vitreus"), 6),
+                new AspectList().add(Aspect.ORDER, 24).add(Aspect.MAGIC, 12).add(Aspect.ENERGY, 12)
+                        .add(Aspect.CRYSTAL, 6),
                 NHItemList.ChargedCertusQuartzRod.get(1),
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 6),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4),
@@ -818,16 +791,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4));
         TCHelper.setResearchAspects(
                 "ROD_quartz",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("arbor"), 3));
+                new AspectList().add(Aspect.TOOL, 9).add(Aspect.MAGIC, 9).add(Aspect.EARTH, 6).add(Aspect.ORDER, 6)
+                        .add(Aspect.TREE, 3));
         TCHelper.setResearchComplexity("ROD_quartz", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_bone",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 7),
                 3,
-                new AspectList().add(Aspect.getAspect("exanimis"), 12).add(Aspect.getAspect("perditio"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("vitreus"), 6),
+                new AspectList().add(Aspect.UNDEAD, 12).add(Aspect.ENTROPY, 24).add(Aspect.MAGIC, 12)
+                        .add(Aspect.CRYSTAL, 6),
                 getModItem(TinkerConstruct.ID, "toolRod", 1, 5),
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 6),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5),
@@ -835,19 +807,16 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "ROD_bone",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("exanimis"), 6).add(Aspect.getAspect("perditio"), 6)
-                        .add(Aspect.getAspect("arbor"), 3));
+                new AspectList().add(Aspect.TOOL, 9).add(Aspect.MAGIC, 9).add(Aspect.UNDEAD, 6).add(Aspect.ENTROPY, 6)
+                        .add(Aspect.TREE, 3));
         TCHelper.setResearchComplexity("ROD_bone", 2);
         ThaumcraftApi.addWarpToResearch("ROD_bone", 1);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_silverwood",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2),
                 5,
-                new AspectList().add(Aspect.getAspect("aer"), 48).add(Aspect.getAspect("aqua"), 48)
-                        .add(Aspect.getAspect("ignis"), 48).add(Aspect.getAspect("ordo"), 48)
-                        .add(Aspect.getAspect("perditio"), 48).add(Aspect.getAspect("praecantatio"), 48)
-                        .add(Aspect.getAspect("terra"), 48),
+                new AspectList().add(Aspect.AIR, 48).add(Aspect.WATER, 48).add(Aspect.FIRE, 48).add(Aspect.ORDER, 48)
+                        .add(Aspect.ENTROPY, 48).add(Aspect.MAGIC, 48).add(Aspect.EARTH, 48),
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1),
@@ -858,16 +827,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6));
         TCHelper.setResearchAspects(
                 "ROD_silverwood",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("herba"), 6)
-                        .add(Aspect.getAspect("arbor"), 3));
+                new AspectList().add(Aspect.TOOL, 12).add(Aspect.MAGIC, 12).add(Aspect.MIND, 9).add(Aspect.PLANT, 6)
+                        .add(Aspect.TREE, 3));
         TCHelper.setResearchComplexity("ROD_silverwood", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_greatwood_staff",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 50),
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("terra"), 50)
-                        .add(Aspect.getAspect("ignis"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.EARTH, 50).add(Aspect.FIRE, 50).add(Aspect.WATER, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -891,16 +858,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "ROD_greatwood_staff",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("arbor"), 9).add(Aspect.getAspect("ignis"), 6)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.TOOL, 12).add(Aspect.MAGIC, 12).add(Aspect.TREE, 9).add(Aspect.FIRE, 6)
+                        .add(Aspect.AIR, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ROD_greatwood_staff", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_reed_staff",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 55),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.EARTH, 75).add(Aspect.FIRE, 75).add(Aspect.WATER, 75)
+                        .add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -924,16 +889,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "ROD_reed_staff",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("herba"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.TOOL, 12).add(Aspect.MAGIC, 12).add(Aspect.PLANT, 9).add(Aspect.AIR, 6)
+                        .add(Aspect.FIRE, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ROD_reed_staff", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_blaze_staff",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 56),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.EARTH, 75).add(Aspect.FIRE, 75).add(Aspect.WATER, 75)
+                        .add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -957,16 +920,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "ROD_blaze_staff",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("ignis"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.TOOL, 12).add(Aspect.MAGIC, 12).add(Aspect.FIRE, 9).add(Aspect.ENERGY, 6)
+                        .add(Aspect.AIR, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ROD_blaze_staff", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_obsidian_staff",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 51),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.EARTH, 75).add(Aspect.FIRE, 75).add(Aspect.WATER, 75)
+                        .add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -990,9 +951,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "ROD_obsidian_staff",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("ignis"), 6)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.TOOL, 12).add(Aspect.MAGIC, 12).add(Aspect.EARTH, 9).add(Aspect.FIRE, 6)
+                        .add(Aspect.AIR, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("ROD_obsidian_staff", 3);
         TCHelper.addResearchPage(
                 "ROD_obsidian_staff",
@@ -1007,9 +967,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_ice_staff",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 53),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.EARTH, 75).add(Aspect.FIRE, 75).add(Aspect.WATER, 75)
+                        .add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -1033,16 +992,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "ROD_ice_staff",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("gelum"), 9).add(Aspect.getAspect("aqua"), 6)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.TOOL, 12).add(Aspect.MAGIC, 12).add(Aspect.COLD, 9).add(Aspect.WATER, 6)
+                        .add(Aspect.AIR, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ROD_ice_staff", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_quartz_staff",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 54),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.EARTH, 75).add(Aspect.FIRE, 75).add(Aspect.WATER, 75)
+                        .add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -1066,16 +1023,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "ROD_quartz_staff",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("vitreus"), 9).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.TOOL, 12).add(Aspect.MAGIC, 12).add(Aspect.CRYSTAL, 9).add(Aspect.ORDER, 6)
+                        .add(Aspect.AIR, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ROD_quartz_staff", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_bone_staff",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 57),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.EARTH, 75).add(Aspect.FIRE, 75).add(Aspect.WATER, 75)
+                        .add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -1099,17 +1054,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "ROD_bone_staff",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("exanimis"), 9).add(Aspect.getAspect("perditio"), 6)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.TOOL, 12).add(Aspect.MAGIC, 12).add(Aspect.UNDEAD, 9).add(Aspect.ENTROPY, 6)
+                        .add(Aspect.AIR, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ROD_bone_staff", 3);
         ThaumcraftApi.addWarpToResearch("ROD_bone_staff", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_silverwood_staff",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 52),
-                new AspectList().add(Aspect.getAspect("aer"), 125).add(Aspect.getAspect("terra"), 125)
-                        .add(Aspect.getAspect("ignis"), 125).add(Aspect.getAspect("aqua"), 125)
-                        .add(Aspect.getAspect("ordo"), 125).add(Aspect.getAspect("perditio"), 125),
+                new AspectList().add(Aspect.AIR, 125).add(Aspect.EARTH, 125).add(Aspect.FIRE, 125)
+                        .add(Aspect.WATER, 125).add(Aspect.ORDER, 125).add(Aspect.ENTROPY, 125),
                 "abc",
                 "def",
                 "ghi",
@@ -1133,9 +1086,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5));
         TCHelper.setResearchAspects(
                 "ROD_silverwood_staff",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("arbor"), 12).add(Aspect.getAspect("ordo"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.MAGIC, 15).add(Aspect.TREE, 12).add(Aspect.ORDER, 9)
+                        .add(Aspect.AIR, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ROD_silverwood_staff", 4);
         TCHelper.addResearchPage(
                 "SCEPTRE",
@@ -1150,8 +1102,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCUSFIRE",
                 getModItem(Thaumcraft.ID, "FocusFire", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("perditio"), 20)
-                        .add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.FIRE, 20).add(Aspect.ENTROPY, 20).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -1175,14 +1126,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1));
         TCHelper.setResearchAspects(
                 "FOCUSFIRE",
-                new AspectList().add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.FIRE, 6).add(Aspect.MAGIC, 6).add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("FOCUSFIRE", 1);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCUSEXCAVATION",
                 getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("perditio"), 20)
-                        .add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.EARTH, 30).add(Aspect.ENTROPY, 20).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -1206,14 +1155,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3));
         TCHelper.setResearchAspects(
                 "FOCUSEXCAVATION",
-                new AspectList().add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("perditio"), 6).add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.EARTH, 9).add(Aspect.MAGIC, 9).add(Aspect.ENTROPY, 6)
+                        .add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("FOCUSEXCAVATION", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCUSFROST",
                 getModItem(Thaumcraft.ID, "FocusFrost", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 30).add(Aspect.getAspect("perditio"), 20)
-                        .add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.WATER, 30).add(Aspect.ENTROPY, 20).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -1237,14 +1185,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2));
         TCHelper.setResearchAspects(
                 "FOCUSFROST",
-                new AspectList().add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("gelum"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.WATER, 9).add(Aspect.COLD, 9).add(Aspect.MAGIC, 6).add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("FOCUSFROST", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCUSSHOCK",
                 getModItem(Thaumcraft.ID, "FocusShock", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("perditio"), 20)
-                        .add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.ENTROPY, 20).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -1268,14 +1214,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0));
         TCHelper.setResearchAspects(
                 "FOCUSSHOCK",
-                new AspectList().add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.AIR, 9).add(Aspect.MAGIC, 6).add(Aspect.ENERGY, 9).add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("FOCUSSHOCK", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCUSTRADE",
                 getModItem(Thaumcraft.ID, "FocusTrade", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("ordo"), 30),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.EARTH, 20).add(Aspect.ENTROPY, 30)
+                        .add(Aspect.ORDER, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -1299,16 +1244,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6));
         TCHelper.setResearchAspects(
                 "FOCUSTRADE",
-                new AspectList().add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.EXCHANGE, 9).add(Aspect.MAGIC, 9).add(Aspect.EARTH, 6)
+                        .add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("FOCUSTRADE", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUSWARDING",
                 getModItem(Thaumcraft.ID, "FocusWarding", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("ordo"), 25)
-                        .add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("tutamen"), 25)
-                        .add(Aspect.getAspect("praecantatio"), 10),
+                new AspectList().add(Aspect.MIND, 15).add(Aspect.ORDER, 25).add(Aspect.EARTH, 30).add(Aspect.ARMOR, 25)
+                        .add(Aspect.MAGIC, 10),
                 OrePrefixes.lens.get(Materials.NetherStar),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 3),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3),
@@ -1320,17 +1264,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4));
         TCHelper.setResearchAspects(
                 "FOCUSWARDING",
-                new AspectList().add(Aspect.getAspect("terra"), 12).add(Aspect.getAspect("cognitio"), 12)
-                        .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("tutamen"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.EARTH, 12).add(Aspect.MIND, 12).add(Aspect.ORDER, 9).add(Aspect.ARMOR, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("FOCUSWARDING", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUSPORTABLEHOLE",
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("alienis"), 40).add(Aspect.getAspect("iter"), 30)
-                        .add(Aspect.getAspect("perditio"), 20).add(Aspect.getAspect("permutatio"), 10)
-                        .add(Aspect.getAspect("praecantatio"), 5),
+                new AspectList().add(Aspect.ELDRITCH, 40).add(Aspect.TRAVEL, 30).add(Aspect.ENTROPY, 20)
+                        .add(Aspect.EXCHANGE, 10).add(Aspect.MAGIC, 5),
                 OrePrefixes.lens.get(Materials.EnderPearl),
                 getModItem(Botania.ID, "quartz", 1, 1),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3),
@@ -1342,18 +1284,16 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3));
         TCHelper.setResearchAspects(
                 "FOCUSPORTABLEHOLE",
-                new AspectList().add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("perditio"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.AIR, 12).add(Aspect.TRAVEL, 12).add(Aspect.ELDRITCH, 9)
+                        .add(Aspect.ENTROPY, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("FOCUSPORTABLEHOLE", 3);
         ThaumcraftApi.addWarpToResearch("NODESTABILIZERADV", 1);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUSHELLBAT",
                 getModItem(Thaumcraft.ID, "FocusHellbat", 1, 0),
                 7,
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("ignis"), 40)
-                        .add(Aspect.getAspect("bestia"), 20).add(Aspect.getAspect("perditio"), 10)
-                        .add(Aspect.getAspect("praecantatio"), 5),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.FIRE, 40).add(Aspect.BEAST, 20).add(Aspect.ENTROPY, 10)
+                        .add(Aspect.MAGIC, 5),
                 OrePrefixes.lens.get(Materials.Firestone),
                 getModItem(Botania.ID, "quartz", 1, 4),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
@@ -1365,17 +1305,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0));
         TCHelper.setResearchAspects(
                 "FOCUSHELLBAT",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("iter"), 9)
-                        .add(Aspect.getAspect("ignis"), 9).add(Aspect.getAspect("bestia"), 6)
-                        .add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.MAGIC, 12).add(Aspect.TRAVEL, 9).add(Aspect.FIRE, 9).add(Aspect.BEAST, 6)
+                        .add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("FOCUSHELLBAT", 3);
         ThaumcraftApi.addWarpToResearch("NODESTABILIZERADV", 2);
         ThaumcraftApi.addWarpToItem(getModItem(Thaumcraft.ID, "FocusHellbat", 1, 0), 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCUSPOUCH",
                 getModItem(Thaumcraft.ID, "FocusPouch", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 20).add(Aspect.getAspect("perditio"), 20)
-                        .add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.EARTH, 20).add(Aspect.ENTROPY, 20).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -1399,14 +1337,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(PamsHarvestCraft.ID, "hardenedleatherItem", 1, 0));
         TCHelper.setResearchAspects(
                 "FOCUSPOUCH",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("vacuos"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("pannus"), 3));
+                new AspectList().add(Aspect.TOOL, 9).add(Aspect.VOID, 9).add(Aspect.MAGIC, 6).add(Aspect.CLOTH, 3));
         TCHelper.setResearchComplexity("FOCUSPOUCH", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "NODESTABILIZER",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 9),
-                new AspectList().add(Aspect.getAspect("aqua"), 35).add(Aspect.getAspect("terra"), 35)
-                        .add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.WATER, 35).add(Aspect.EARTH, 35).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -1430,15 +1366,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7));
         TCHelper.setResearchAspects(
                 "NODESTABILIZER",
-                new AspectList().add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("ordo"), 3));
+                new AspectList().add(Aspect.AURA, 9).add(Aspect.ENERGY, 9).add(Aspect.MAGIC, 6).add(Aspect.ORDER, 3));
         TCHelper.setResearchComplexity("NODESTABILIZER", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "NODESTABILIZERADV",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10),
                 10,
-                new AspectList().add(Aspect.getAspect("auram"), 32).add(Aspect.getAspect("ordo"), 32)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("praecantatio"), 32),
+                new AspectList().add(Aspect.AURA, 32).add(Aspect.ORDER, 32).add(Aspect.ENERGY, 32)
+                        .add(Aspect.MAGIC, 32),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 9),
                 getModItem(Minecraft.ID, "redstone_block", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 1),
@@ -1452,16 +1387,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Minecraft.ID, "glowstone", 1, 0));
         TCHelper.setResearchAspects(
                 "NODESTABILIZERADV",
-                new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.AURA, 12).add(Aspect.ENERGY, 9).add(Aspect.MAGIC, 9).add(Aspect.ORDER, 6)
+                        .add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("NODESTABILIZERADV", 3);
         ThaumcraftApi.addWarpToResearch("NODESTABILIZERADV", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VISPOWER",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11),
-                new AspectList().add(Aspect.getAspect("ignis"), 32).add(Aspect.getAspect("aer"), 32)
-                        .add(Aspect.getAspect("perditio"), 32).add(Aspect.getAspect("ordo"), 32),
+                new AspectList().add(Aspect.FIRE, 32).add(Aspect.AIR, 32).add(Aspect.ENTROPY, 32).add(Aspect.ORDER, 32),
                 "abc",
                 "def",
                 "ghi",
@@ -1486,7 +1419,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VISPOWER",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 14),
-                new AspectList().add(Aspect.getAspect("ignis"), 10).add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.FIRE, 10).add(Aspect.ORDER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -1510,15 +1443,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "screwSteel");
         TCHelper.setResearchAspects(
                 "VISPOWER",
-                new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 3).add(Aspect.getAspect("machina"), 6));
+                new AspectList().add(Aspect.AURA, 12).add(Aspect.ENERGY, 9).add(Aspect.MAGIC, 3)
+                        .add(Aspect.MECHANISM, 6));
         TCHelper.setResearchComplexity("VISPOWER", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "WANDPED",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 5),
                 2,
-                new AspectList().add(Aspect.getAspect("auram"), 10).add(Aspect.getAspect("permutatio"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 20).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.AURA, 10).add(Aspect.EXCHANGE, 15).add(Aspect.MAGIC, 20)
+                        .add(Aspect.ORDER, 5),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 1),
                 OrePrefixes.plate.get(Materials.Gold),
                 OrePrefixes.gemFlawless.get(Materials.Diamond),
@@ -1526,16 +1459,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 OrePrefixes.gemFlawless.get(Materials.Diamond));
         TCHelper.setResearchAspects(
                 "WANDPED",
-                new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 3).add(Aspect.getAspect("permutatio"), 6));
+                new AspectList().add(Aspect.AURA, 12).add(Aspect.ENERGY, 9).add(Aspect.MAGIC, 3)
+                        .add(Aspect.EXCHANGE, 6));
         TCHelper.setResearchComplexity("WANDPED", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "VISAMULET",
                 getModItem(Thaumcraft.ID, "ItemAmuletVis", 1, 1),
                 7,
-                new AspectList().add(Aspect.getAspect("vacuos"), 48).add(Aspect.getAspect("auram"), 48)
-                        .add(Aspect.getAspect("potentia"), 88).add(Aspect.getAspect("praecantatio"), 88)
-                        .add(Aspect.getAspect("vitreus"), 24),
+                new AspectList().add(Aspect.VOID, 48).add(Aspect.AURA, 48).add(Aspect.ENERGY, 88).add(Aspect.MAGIC, 88)
+                        .add(Aspect.CRYSTAL, 24),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6),
@@ -1547,17 +1479,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6));
         TCHelper.setResearchAspects(
                 "VISAMULET",
-                new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("auram"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("vitreus"), 6).add(Aspect.getAspect("tempus"), 3));
+                new AspectList().add(Aspect.VOID, 15).add(Aspect.AURA, 15).add(Aspect.MAGIC, 9).add(Aspect.ENERGY, 12)
+                        .add(Aspect.CRYSTAL, 6).add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 3));
         TCHelper.setResearchComplexity("VISAMULET", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "WANDPEDFOC",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 8),
                 5,
-                new AspectList().add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("permutatio"), 25)
-                        .add(Aspect.getAspect("praecantatio"), 30).add(Aspect.getAspect("potentia"), 15)
-                        .add(Aspect.getAspect("cognitio"), 15),
+                new AspectList().add(Aspect.ORDER, 25).add(Aspect.EXCHANGE, 25).add(Aspect.MAGIC, 30)
+                        .add(Aspect.ENERGY, 15).add(Aspect.MIND, 15),
                 getModItem(ProjectRedIntegration.ID, "projectred.integration.gate", 1, 26),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 8),
@@ -1569,16 +1499,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 8));
         TCHelper.setResearchAspects(
                 "WANDPEDFOC",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("auram"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("cognitio"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.AURA, 15).add(Aspect.MAGIC, 12).add(Aspect.ENERGY, 12)
+                        .add(Aspect.EXCHANGE, 9).add(Aspect.MIND, 6).add(Aspect.GREED, 3));
         TCHelper.setResearchComplexity("WANDPEDFOC", 4);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VISCHARGERELAY",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 2),
-                new AspectList().add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("ordo"), 20)
-                        .add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("terra"), 10),
+                new AspectList().add(Aspect.FIRE, 20).add(Aspect.ORDER, 20).add(Aspect.AIR, 20).add(Aspect.EARTH, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -1602,16 +1529,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "WandRod", 1, 0));
         TCHelper.setResearchAspects(
                 "VISCHARGERELAY",
-                new AspectList().add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("aer"), 3));
+                new AspectList().add(Aspect.ENERGY, 12).add(Aspect.MAGIC, 12).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.AURA, 9).add(Aspect.FIRE, 6).add(Aspect.AIR, 3));
         TCHelper.setResearchComplexity("VISCHARGERELAY", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCALMANIPULATION",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 13),
-                new AspectList().add(Aspect.getAspect("ignis"), 64).add(Aspect.getAspect("ordo"), 64)
-                        .add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("terra"), 64)
-                        .add(Aspect.getAspect("aqua"), 64).add(Aspect.getAspect("perditio"), 64),
+                new AspectList().add(Aspect.FIRE, 64).add(Aspect.ORDER, 64).add(Aspect.AIR, 64).add(Aspect.EARTH, 64)
+                        .add(Aspect.WATER, 64).add(Aspect.ENTROPY, 64),
                 "abc",
                 "def",
                 "ghi",
@@ -1635,17 +1560,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "plateThaumium");
         TCHelper.setResearchAspects(
                 "FOCALMANIPULATION",
-                new AspectList().add(Aspect.getAspect("potentia"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("vitreus"), 9)
-                        .add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("alienis"), 3)
-                        .add(Aspect.getAspect("cognitio"), 5));
+                new AspectList().add(Aspect.ENERGY, 15).add(Aspect.MAGIC, 12).add(Aspect.TOOL, 12)
+                        .add(Aspect.CRYSTAL, 9).add(Aspect.CRAFT, 9).add(Aspect.ELDRITCH, 3).add(Aspect.MIND, 5));
         TCHelper.setResearchComplexity("FOCALMANIPULATION", 4);
         TCHelper.setResearchAspects(
                 "VAMPBAT",
-                new AspectList().add(Aspect.getAspect("fames"), 15).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("victus"), 12).add(Aspect.getAspect("exanimis"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("ira"), 3)
-                        .add(Aspect.getAspect("alienis"), 6));
+                new AspectList().add(Aspect.HUNGER, 15).add(Aspect.MAGIC, 15).add(Aspect.LIFE, 12)
+                        .add(Aspect.UNDEAD, 12).add(Aspect.MIND, 9).add(DarkAspects.WRATH, 3).add(Aspect.ELDRITCH, 6));
         TCHelper.setResearchComplexity("VAMPBAT", 4);
         ThaumcraftApi.addWarpToResearch("VAMPBAT", 4);
         TCHelper.refreshResearchPages("CAP_copper");
@@ -1747,20 +1668,17 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "TALLOW",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 4),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Soapstone, 1L),
-                new AspectList().add(Aspect.getAspect("praecantatio"), 2).add(Aspect.getAspect("corpus"), 4)
-                        .add(Aspect.getAspect("mortuus"), 2));
+                new AspectList().add(Aspect.MAGIC, 2).add(Aspect.FLESH, 4).add(Aspect.DEATH, 2));
         TCHelper.setResearchAspects(
                 "TALLOW",
-                new AspectList().add(Aspect.getAspect("corpus"), 6).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.FLESH, 6).add(Aspect.MAGIC, 6).add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("TALLOW", 1);
         TCHelper.clearPages("TALLOW");
         TCHelper.addResearchPage("TALLOW", new ResearchPage("tc.research_page.TALLOW.1"));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TALLOW",
                 getModItem(Thaumcraft.ID, "blockCandle", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 3).add(Aspect.getAspect("ordo"), 1)
-                        .add(Aspect.getAspect("perditio"), 1).add(Aspect.getAspect("aer"), 3),
+                new AspectList().add(Aspect.FIRE, 3).add(Aspect.ORDER, 1).add(Aspect.ENTROPY, 1).add(Aspect.AIR, 3),
                 "abc",
                 "def",
                 "ghi",
@@ -1780,57 +1698,49 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "NITOR",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 1),
                 getModItem(Minecraft.ID, "glowstone_dust", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 4).add(Aspect.getAspect("lux"), 4)
-                        .add(Aspect.getAspect("potentia"), 4));
+                new AspectList().add(Aspect.FIRE, 4).add(Aspect.LIGHT, 4).add(Aspect.ENERGY, 4));
         TCHelper.setResearchAspects(
                 "NITOR",
-                new AspectList().add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.LIGHT, 6).add(Aspect.FIRE, 3).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("NITOR", 1);
         ThaumcraftApi.addCrucibleRecipe(
                 "ALUMENTUM",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 0),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Coal, 1L),
-                new AspectList().add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("perditio"), 3)
-                        .add(Aspect.getAspect("potentia"), 6));
+                new AspectList().add(Aspect.FIRE, 6).add(Aspect.ENTROPY, 3).add(Aspect.ENERGY, 6));
         ThaumcraftApi.addCrucibleRecipe(
                 "ALUMENTUM",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 0),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Charcoal, 1L),
-                new AspectList().add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("perditio"), 3)
-                        .add(Aspect.getAspect("potentia"), 6));
+                new AspectList().add(Aspect.FIRE, 6).add(Aspect.ENTROPY, 3).add(Aspect.ENERGY, 6));
         ThaumcraftApi.addCrucibleRecipe(
                 "ALUMENTUM",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 0),
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Lignite, 1L),
-                new AspectList().add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("perditio"), 3)
-                        .add(Aspect.getAspect("potentia"), 6));
+                new AspectList().add(Aspect.FIRE, 6).add(Aspect.ENTROPY, 3).add(Aspect.ENERGY, 6));
         TCHelper.setResearchAspects(
                 "ALUMENTUM",
-                new AspectList().add(Aspect.getAspect("ignis"), 3).add(Aspect.getAspect("praecantatio"), 3)
-                        .add(Aspect.getAspect("perditio"), 6));
+                new AspectList().add(Aspect.FIRE, 3).add(Aspect.MAGIC, 3).add(Aspect.ENTROPY, 6));
         TCHelper.setResearchComplexity("ALUMENTUM", 1);
         TCHelper.addResearchPage("ALUMENTUM", new ResearchPage("tc.research_page.ALUMENTUM.2"));
         TCHelper.setResearchAspects(
                 "ALCHEMICALDUPLICATION",
-                new AspectList().add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.CRAFT, 9).add(Aspect.MAGIC, 6).add(Aspect.GREED, 9)
+                        .add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("ALCHEMICALDUPLICATION", 2);
         TCHelper.setResearchAspects(
                 "ALCHEMICALMANUFACTURE",
-                new AspectList().add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.CRAFT, 9).add(Aspect.MAGIC, 9).add(Aspect.GREED, 6)
+                        .add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("ALCHEMICALMANUFACTURE", 2);
         TCHelper.setResearchAspects(
                 "ENTROPICPROCESSING",
-                new AspectList().add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("perditio"), 3));
+                new AspectList().add(Aspect.CRAFT, 9).add(Aspect.MAGIC, 9).add(Aspect.GREED, 6).add(Aspect.ENTROPY, 3));
         TCHelper.setResearchComplexity("ENTROPICPROCESSING", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DISTILESSENTIA",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("aer"), 10)
-                        .add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.AIR, 10).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -1854,13 +1764,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 7));
         TCHelper.setResearchAspects(
                 "DISTILESSENTIA",
-                new AspectList().add(Aspect.getAspect("limus"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("ignis"), 3).add(Aspect.getAspect("aqua"), 9));
+                new AspectList().add(Aspect.SLIME, 9).add(Aspect.MAGIC, 6).add(Aspect.FIRE, 3).add(Aspect.WATER, 9));
         TCHelper.setResearchComplexity("DISTILESSENTIA", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DISTILESSENTIA",
                 getModItem(Thaumcraft.ID, "ItemResource", 3, 8),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("aqua"), 5),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.WATER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -1885,8 +1794,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DISTILESSENTIA",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 10)
-                        .add(Aspect.getAspect("ignis"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 10).add(Aspect.FIRE, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -1911,8 +1819,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DISTILESSENTIA",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 9),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.WATER, 5).add(Aspect.FIRE, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -1937,7 +1844,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TUBES",
                 getModItem(Thaumcraft.ID, "blockTube", 4, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("aqua"), 8),
+                new AspectList().add(Aspect.ORDER, 8).add(Aspect.WATER, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -1961,13 +1868,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "screwThaumium");
         TCHelper.setResearchAspects(
                 "TUBES",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("permutatio"), 6)
-                        .add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("ordo"), 3));
+                new AspectList().add(Aspect.MAGIC, 9).add(Aspect.EXCHANGE, 6).add(Aspect.WATER, 9)
+                        .add(Aspect.ORDER, 3));
         TCHelper.setResearchComplexity("TUBES", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TUBES",
                 getModItem(Thaumcraft.ID, "blockTube", 1, 1),
-                new AspectList().add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("aqua"), 8),
+                new AspectList().add(Aspect.ORDER, 8).add(Aspect.WATER, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -1986,7 +1893,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TUBES",
                 getModItem(Thaumcraft.ID, "ItemResonator", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("aqua"), 8),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.WATER, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -2009,7 +1916,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TUBEFILTER",
                 getModItem(Thaumcraft.ID, "blockTube", 1, 3),
-                new AspectList().add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("aqua"), 16),
+                new AspectList().add(Aspect.ORDER, 16).add(Aspect.WATER, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -2029,14 +1936,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 8));
         TCHelper.setResearchAspects(
                 "TUBEFILTER",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("aqua"), 12).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("limus"), 3));
+                new AspectList().add(Aspect.MAGIC, 12).add(Aspect.EXCHANGE, 9).add(Aspect.WATER, 12)
+                        .add(Aspect.ORDER, 6).add(Aspect.SLIME, 3));
         TCHelper.setResearchComplexity("TUBEFILTER", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TUBEFILTER",
                 getModItem(Thaumcraft.ID, "blockTube", 1, 5),
-                new AspectList().add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("aqua"), 16),
+                new AspectList().add(Aspect.EARTH, 16).add(Aspect.WATER, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -2049,8 +1955,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TUBEFILTER",
                 getModItem(Thaumcraft.ID, "blockTube", 1, 6),
-                new AspectList().add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("perditio"), 8)
-                        .add(Aspect.getAspect("aqua"), 8),
+                new AspectList().add(Aspect.ORDER, 16).add(Aspect.ENTROPY, 8).add(Aspect.WATER, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -2063,8 +1968,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CENTRIFUGE",
                 getModItem(Thaumcraft.ID, "blockTube", 1, 2),
-                new AspectList().add(Aspect.getAspect("ordo"), 32).add(Aspect.getAspect("perditio"), 16)
-                        .add(Aspect.getAspect("aqua"), 16),
+                new AspectList().add(Aspect.ORDER, 32).add(Aspect.ENTROPY, 16).add(Aspect.WATER, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -2088,14 +1992,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "screwThaumium");
         TCHelper.setResearchAspects(
                 "CENTRIFUGE",
-                new AspectList().add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("permutatio"), 12).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("machina"), 3));
+                new AspectList().add(Aspect.CRAFT, 12).add(Aspect.ENTROPY, 9).add(Aspect.EXCHANGE, 12)
+                        .add(Aspect.MAGIC, 6).add(Aspect.MECHANISM, 3));
         TCHelper.setResearchComplexity("CENTRIFUGE", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CENTRIFUGE",
                 getModItem(Thaumcraft.ID, "blockTube", 4, 4),
-                new AspectList().add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("aqua"), 20),
+                new AspectList().add(Aspect.ORDER, 20).add(Aspect.WATER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -2120,8 +2023,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ESSENTIACRYSTAL",
                 getModItem(Thaumcraft.ID, "blockTube", 1, 7),
-                new AspectList().add(Aspect.getAspect("terra"), 20).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("aqua"), 10),
+                new AspectList().add(Aspect.EARTH, 20).add(Aspect.ORDER, 15).add(Aspect.WATER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -2145,15 +2047,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "screwThaumium");
         TCHelper.setResearchAspects(
                 "ESSENTIACRYSTAL",
-                new AspectList().add(Aspect.getAspect("aqua"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("permutatio"), 12).add(Aspect.getAspect("vitreus"), 6)
-                        .add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.WATER, 12).add(Aspect.MAGIC, 9).add(Aspect.EXCHANGE, 12)
+                        .add(Aspect.CRYSTAL, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ESSENTIACRYSTAL", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "THAUMATORIUM",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
-                new AspectList().add(Aspect.getAspect("ignis"), 10).add(Aspect.getAspect("ordo"), 10)
-                        .add(Aspect.getAspect("aqua"), 10),
+                new AspectList().add(Aspect.FIRE, 10).add(Aspect.ORDER, 10).add(Aspect.WATER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -2177,74 +2077,62 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "plateThaumium");
         TCHelper.setResearchAspects(
                 "THAUMATORIUM",
-                new AspectList().add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("aqua"), 9)
-                        .add(Aspect.getAspect("permutatio"), 12).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.CRAFT, 12).add(Aspect.WATER, 9).add(Aspect.EXCHANGE, 12)
+                        .add(Aspect.MAGIC, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("THAUMATORIUM", 3);
         TCHelper.setResearchAspects(
                 "TRANSIRON",
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("ordo"), 3)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.ORDER, 3).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("TRANSIRON", 1);
         TCHelper.setResearchAspects(
                 "TRANSGOLD",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.GREED, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("TRANSGOLD", 2);
         TCHelper.setResearchAspects(
                 "TRANSCOPPER",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.ORDER, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("TRANSCOPPER", 2);
         TCHelper.setResearchAspects(
                 "TRANSTIN",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("vitreus"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.CRYSTAL, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("TRANSTIN", 2);
         TCHelper.setResearchAspects(
                 "TRANSLEAD",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.ORDER, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("TRANSLEAD", 2);
         TCHelper.setResearchAspects(
                 "TRANSSILVER",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.GREED, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("TRANSSILVER", 2);
         TCHelper.setResearchAspects(
                 "PUREIRON",
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("vitreus"), 3));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.ORDER, 6).add(Aspect.CRYSTAL, 3));
         TCHelper.setResearchComplexity("PUREIRON", 1);
         TCHelper.setResearchAspects(
                 "PUREGOLD",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("lucrum"), 9)
-                        .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.GREED, 9).add(Aspect.ORDER, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("PUREGOLD", 2);
         TCHelper.setResearchAspects(
                 "PURECOPPER",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.ORDER, 15).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("PURECOPPER", 2);
         TCHelper.setResearchAspects(
                 "PURETIN",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("vitreus"), 9)
-                        .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.CRYSTAL, 9).add(Aspect.ORDER, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("PURETIN", 2);
         TCHelper.setResearchAspects(
                 "PURELEAD",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.EXCHANGE, 9).add(Aspect.ORDER, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("PURELEAD", 2);
         TCHelper.setResearchAspects(
                 "PURESILVER",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("lucrum"), 9)
-                        .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.GREED, 9).add(Aspect.ORDER, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("PURESILVER", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JARLABEL",
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 2),
+                new AspectList().add(Aspect.WATER, 2),
                 "abc",
                 "def",
                 "ghi",
@@ -2270,8 +2158,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "JARVOID",
                 getModItem(Thaumcraft.ID, "blockJar", 1, 3),
                 2,
-                new AspectList().add(Aspect.getAspect("vacuos"), 7).add(Aspect.getAspect("praecantatio"), 7)
-                        .add(Aspect.getAspect("perditio"), 7).add(Aspect.getAspect("aqua"), 7),
+                new AspectList().add(Aspect.VOID, 7).add(Aspect.MAGIC, 7).add(Aspect.ENTROPY, 7).add(Aspect.WATER, 7),
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0),
                 OrePrefixes.plate.get(Materials.Obsidian),
                 getModItem(Minecraft.ID, "blaze_powder", 1, 0),
@@ -2282,32 +2169,28 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Thaumcraft.ID, "blockJar", 1, 3))));
         TCHelper.setResearchAspects(
                 "JARVOID",
-                new AspectList().add(Aspect.getAspect("vacuos"), 6).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6));
+                new AspectList().add(Aspect.VOID, 6).add(Aspect.ENTROPY, 9).add(Aspect.MAGIC, 6));
         TCHelper.setResearchComplexity("JARVOID", 1);
         ThaumcraftApi.addCrucibleRecipe(
                 "BATHSALTS",
                 getModItem(Thaumcraft.ID, "ItemBathSalts", 2, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
-                new AspectList().add(Aspect.getAspect("sano"), 10).add(Aspect.getAspect("cognitio"), 10)
-                        .add(Aspect.getAspect("auram"), 10).add(Aspect.getAspect("ordo"), 10));
+                new AspectList().add(Aspect.HEAL, 10).add(Aspect.MIND, 10).add(Aspect.AURA, 10).add(Aspect.ORDER, 10));
         TCHelper.setResearchAspects(
                 "BATHSALTS",
-                new AspectList().add(Aspect.getAspect("sano"), 9).add(Aspect.getAspect("cognitio"), 6)
-                        .add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.HEAL, 9).add(Aspect.MIND, 6).add(Aspect.AURA, 9).add(Aspect.ORDER, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("BATHSALTS", 2);
         ThaumcraftApi.addCrucibleRecipe(
                 "SANESOAP",
                 getModItem(Thaumcraft.ID, "ItemSanitySoap", 2, 0),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 5),
-                new AspectList().add(Aspect.getAspect("alienis"), 20).add(Aspect.getAspect("cognitio"), 20)
-                        .add(Aspect.getAspect("sano"), 20).add(Aspect.getAspect("ordo"), 20));
+                new AspectList().add(Aspect.ELDRITCH, 20).add(Aspect.MIND, 20).add(Aspect.HEAL, 20)
+                        .add(Aspect.ORDER, 20));
         TCHelper.setResearchAspects(
                 "SANESOAP",
-                new AspectList().add(Aspect.getAspect("sano"), 12).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.HEAL, 12).add(Aspect.ELDRITCH, 12).add(Aspect.MIND, 9).add(Aspect.ORDER, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("SANESOAP", 3);
         TCHelper.clearPages("ARCANESPA");
         TCHelper.addResearchPage("ARCANESPA", new ResearchPage("tc.research_page.ARCANESPA.1"));
@@ -2315,9 +2198,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "ARCANESPA",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 12),
                 4,
-                new AspectList().add(Aspect.getAspect("ordo"), 24).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("sano"), 16).add(Aspect.getAspect("aqua"), 32)
-                        .add(Aspect.getAspect("machina"), 8),
+                new AspectList().add(Aspect.ORDER, 24).add(Aspect.MAGIC, 16).add(Aspect.HEAL, 16).add(Aspect.WATER, 32)
+                        .add(Aspect.MECHANISM, 8),
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0),
                 BlockList.StainlessSteelBars.get(),
                 getModItem(Minecraft.ID, "quartz_block", 1, 0),
@@ -2332,28 +2214,24 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 12))));
         TCHelper.setResearchAspects(
                 "ARCANESPA",
-                new AspectList().add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("aqua"), 9)
-                        .add(Aspect.getAspect("machina"), 6).add(Aspect.getAspect("sano"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.ORDER, 9).add(Aspect.WATER, 9).add(Aspect.MECHANISM, 6).add(Aspect.HEAL, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("ARCANESPA", 3);
         TCHelper.setResearchAspects(
                 "LIQUIDDEATH",
-                new AspectList().add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("mortuus"), 9)
-                        .add(Aspect.getAspect("perditio"), 6).add(Aspect.getAspect("venenum"), 6)
-                        .add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.WATER, 9).add(Aspect.DEATH, 9).add(Aspect.ENTROPY, 6).add(Aspect.POISON, 6)
+                        .add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("LIQUIDDEATH", 3);
         TCHelper.setResearchAspects(
                 "ETHEREALBLOOM",
-                new AspectList().add(Aspect.getAspect("vitium"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("sano"), 6).add(Aspect.getAspect("herba"), 6)
-                        .add(Aspect.getAspect("lux"), 3).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.TAINT, 9).add(Aspect.MAGIC, 9).add(Aspect.HEAL, 6).add(Aspect.PLANT, 6)
+                        .add(Aspect.LIGHT, 3).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ETHEREALBLOOM", 3);
         TCHelper.setResearchAspects(
                 "BOTTLETAINT",
-                new AspectList().add(Aspect.getAspect("vitium"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("aqua"), 12).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("venenum"), 6)
-                        .add(Aspect.getAspect("strontio"), 3));
+                new AspectList().add(Aspect.TAINT, 12).add(Aspect.MAGIC, 12).add(Aspect.WATER, 12)
+                        .add(Aspect.ENTROPY, 9).add(Aspect.DARKNESS, 9).add(Aspect.POISON, 6)
+                        .add(TCAspects.STRONTIO.getAspect(), 3));
         TCHelper.setResearchComplexity("BOTTLETAINT", 3);
         ThaumcraftApi.addWarpToResearch("BOTTLETAINT", 5);
         ThaumcraftApi.addWarpToItem(getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0), 1);
@@ -2361,12 +2239,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "THAUMIUM",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 2),
                 getModItem(Minecraft.ID, "iron_ingot", 1, 0),
-                new AspectList().add(Aspect.getAspect("praecantatio"), 4));
+                new AspectList().add(Aspect.MAGIC, 4));
         ThaumcraftApi.addCrucibleRecipe(
                 "GT_CRYSTALLISATION",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 6),
                 "dustAmber",
-                new AspectList().add(Aspect.getAspect("vitreus"), 4));
+                new AspectList().add(Aspect.CRYSTAL, 4));
         TCHelper.refreshResearchPages("CRUCIBLE");
         TCHelper.refreshResearchPages("TALLOW");
         TCHelper.refreshResearchPages("NITOR");
@@ -2577,9 +2455,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GOGGLES",
                 getModItem(Thaumcraft.ID, "ItemGoggles", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("terra"), 30)
-                        .add(Aspect.getAspect("ignis"), 30).add(Aspect.getAspect("aqua"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("perditio"), 30),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.EARTH, 30).add(Aspect.FIRE, 30).add(Aspect.WATER, 30)
+                        .add(Aspect.ORDER, 30).add(Aspect.ENTROPY, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -2603,17 +2480,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemThaumometer", 1, 0));
         TCHelper.setResearchAspects(
                 "GOGGLES",
-                new AspectList().add(Aspect.getAspect("auram"), 3).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("sensus"), 9).add(Aspect.getAspect("instrumentum"), 6));
+                new AspectList().add(Aspect.AURA, 3).add(Aspect.MAGIC, 9).add(Aspect.SENSES, 9).add(Aspect.TOOL, 6));
         TCHelper.setResearchComplexity("GOGGLES", 2);
         TCHelper.clearPages("BASICARTIFACE");
         TCHelper.addResearchPage("BASICARTIFACE", new ResearchPage("tc.research_page.BASICARTIFACE.1"));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BASICARTIFACE",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("terra"), 50)
-                        .add(Aspect.getAspect("ignis"), 50).add(Aspect.getAspect("aqua"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.EARTH, 50).add(Aspect.FIRE, 50).add(Aspect.WATER, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -2641,8 +2516,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BASICARTIFACE",
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 5).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.EARTH, 5).add(Aspect.FIRE, 10).add(Aspect.ORDER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -2670,8 +2544,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BASICARTIFACE",
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 10).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.EARTH, 10).add(Aspect.FIRE, 10).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -2699,8 +2572,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BASICARTIFACE",
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 10).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.EARTH, 10).add(Aspect.FIRE, 5).add(Aspect.ORDER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -2728,8 +2600,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BASICARTIFACE",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 10),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("terra"), 30)
-                        .add(Aspect.getAspect("ignis"), 30),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.EARTH, 30).add(Aspect.FIRE, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -2757,9 +2628,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ARCANESTONE",
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 8, 6),
-                new AspectList().add(Aspect.getAspect("aer"), 8).add(Aspect.getAspect("terra"), 8)
-                        .add(Aspect.getAspect("ignis"), 8).add(Aspect.getAspect("aqua"), 8)
-                        .add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("perditio"), 8),
+                new AspectList().add(Aspect.AIR, 8).add(Aspect.EARTH, 8).add(Aspect.FIRE, 8).add(Aspect.WATER, 8)
+                        .add(Aspect.ORDER, 8).add(Aspect.ENTROPY, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -2797,9 +2667,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "INFUSION",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 40).add(Aspect.getAspect("terra"), 40)
-                        .add(Aspect.getAspect("ignis"), 40).add(Aspect.getAspect("aqua"), 40)
-                        .add(Aspect.getAspect("ordo"), 40).add(Aspect.getAspect("perditio"), 40),
+                new AspectList().add(Aspect.AIR, 40).add(Aspect.EARTH, 40).add(Aspect.FIRE, 40).add(Aspect.WATER, 40)
+                        .add(Aspect.ORDER, 40).add(Aspect.ENTROPY, 40),
                 "abc",
                 "def",
                 "ghi",
@@ -2824,7 +2693,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "INFUSION",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 20),
+                new AspectList().add(Aspect.AIR, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -2844,17 +2713,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6));
         TCHelper.setResearchAspects(
                 "INFUSION",
-                new AspectList().add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("machina"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("cognitio"), 6)
-                        .add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.CRAFT, 9).add(Aspect.MECHANISM, 9).add(Aspect.MAGIC, 6).add(Aspect.MIND, 6)
+                        .add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("INFUSION", 2);
         TCHelper.clearPages("PAVETRAVEL");
         TCHelper.addResearchPage("PAVETRAVEL", new ResearchPage("tc.research_page.PAVETRAVEL.1"));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "PAVETRAVEL",
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 4, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("terra"), 12),
+                new AspectList().add(Aspect.AIR, 12).add(Aspect.ORDER, 12).add(Aspect.EARTH, 12),
                 "abc",
                 "def",
                 "ghi",
@@ -2881,16 +2748,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 2))));
         TCHelper.setResearchAspects(
                 "PAVETRAVEL",
-                new AspectList().add(Aspect.getAspect("iter"), 9).add(Aspect.getAspect("volatus"), 6)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.TRAVEL, 9).add(Aspect.FLIGHT, 6).add(Aspect.EARTH, 6)
+                        .add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("PAVETRAVEL", 2);
         TCHelper.clearPages("PAVEWARD");
         TCHelper.addResearchPage("PAVEWARD", new ResearchPage("tc.research_page.PAVEWARD.1"));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "PAVEWARD",
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 4, 3),
-                new AspectList().add(Aspect.getAspect("ignis"), 12).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("terra"), 12),
+                new AspectList().add(Aspect.FIRE, 12).add(Aspect.ORDER, 12).add(Aspect.EARTH, 12),
                 "abc",
                 "def",
                 "ghi",
@@ -2918,16 +2784,14 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.addResearchPage("PAVEWARD", new ResearchPage("tc.research_page.PAVEWARD.2"));
         TCHelper.setResearchAspects(
                 "PAVEWARD",
-                new AspectList().add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("bestia"), 9)
-                        .add(Aspect.getAspect("vinculum"), 3).add(Aspect.getAspect("telum"), 6));
+                new AspectList().add(Aspect.MOTION, 6).add(Aspect.BEAST, 9).add(Aspect.TRAP, 3).add(Aspect.WEAPON, 6));
         TCHelper.setResearchComplexity("PAVEWARD", 2);
         TCHelper.clearPages("GRATE");
         TCHelper.addResearchPage("GRATE", new ResearchPage("tc.research_page.GRATE.1"));
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GRATE",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 5),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.FIRE, 5).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -2957,9 +2821,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ENCHFABRIC",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 7),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("terra"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.EARTH, 5).add(Aspect.FIRE, 5).add(Aspect.WATER, 5)
+                        .add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -2983,8 +2846,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Minecraft.ID, "string", 1, 0));
         TCHelper.setResearchAspects(
                 "ENCHFABRIC",
-                new AspectList().add(Aspect.getAspect("pannus"), 6).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("tutamen"), 3));
+                new AspectList().add(Aspect.CLOTH, 6).add(Aspect.MAGIC, 6).add(Aspect.ARMOR, 3));
         TCHelper.setResearchComplexity("ENCHFABRIC", 1);
         TCHelper.addResearchPage(
                 "ENCHFABRIC",
@@ -2993,8 +2855,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ENCHFABRIC",
                 getModItem(Thaumcraft.ID, "ItemChestplateRobe", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("ordo"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.WATER, 15).add(Aspect.ORDER, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -3022,8 +2883,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ENCHFABRIC",
                 getModItem(Thaumcraft.ID, "ItemLeggingsRobe", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.WATER, 15).add(Aspect.ENTROPY, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -3051,8 +2911,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ENCHFABRIC",
                 getModItem(Thaumcraft.ID, "ItemBootsRobe", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("aqua"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.EARTH, 15).add(Aspect.FIRE, 15).add(Aspect.WATER, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -3074,8 +2933,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ARCANELAMP",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("perditio"), 5)
-                        .add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("aqua"), 5),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.ENTROPY, 5).add(Aspect.FIRE, 15).add(Aspect.WATER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -3099,15 +2957,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "paneGlassColorless");
         TCHelper.setResearchAspects(
                 "ARCANELAMP",
-                new AspectList().add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("tenebrae"), 3)
-                        .add(Aspect.getAspect("sensus"), 6));
+                new AspectList().add(Aspect.LIGHT, 6).add(Aspect.DARKNESS, 3).add(Aspect.SENSES, 6));
         TCHelper.setResearchComplexity("ARCANELAMP", 1);
         TCHelper.addInfusionCraftingRecipe(
                 "LAMPGROWTH",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 8),
                 5,
-                new AspectList().add(Aspect.getAspect("herba"), 20).add(Aspect.getAspect("lux"), 10)
-                        .add(Aspect.getAspect("victus"), 20).add(Aspect.getAspect("messis"), 10),
+                new AspectList().add(Aspect.PLANT, 20).add(Aspect.LIGHT, 10).add(Aspect.LIFE, 20).add(Aspect.CROP, 10),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7),
                 OrePrefixes.plate.get(Materials.Gold),
                 getModItem(Minecraft.ID, "dye", 1, 15),
@@ -3117,15 +2973,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3));
         TCHelper.setResearchAspects(
                 "LAMPGROWTH",
-                new AspectList().add(Aspect.getAspect("messis"), 9).add(Aspect.getAspect("lux"), 3)
-                        .add(Aspect.getAspect("herba"), 6).add(Aspect.getAspect("victus"), 9));
+                new AspectList().add(Aspect.CROP, 9).add(Aspect.LIGHT, 3).add(Aspect.PLANT, 6).add(Aspect.LIFE, 9));
         TCHelper.setResearchComplexity("LAMPGROWTH", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "LAMPFERTILITY",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 13),
                 5,
-                new AspectList().add(Aspect.getAspect("bestia"), 20).add(Aspect.getAspect("lux"), 10)
-                        .add(Aspect.getAspect("victus"), 20).add(Aspect.getAspect("sano"), 10),
+                new AspectList().add(Aspect.BEAST, 20).add(Aspect.LIGHT, 10).add(Aspect.LIFE, 20).add(Aspect.HEAL, 10),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 7),
                 OrePrefixes.plate.get(Materials.Gold),
                 getModItem(Minecraft.ID, "wheat", 1, 0),
@@ -3135,14 +2989,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1));
         TCHelper.setResearchAspects(
                 "LAMPFERTILITY",
-                new AspectList().add(Aspect.getAspect("bestia"), 9).add(Aspect.getAspect("lux"), 3)
-                        .add(Aspect.getAspect("victus"), 9).add(Aspect.getAspect("sano"), 6));
+                new AspectList().add(Aspect.BEAST, 9).add(Aspect.LIGHT, 3).add(Aspect.LIFE, 9).add(Aspect.HEAL, 6));
         TCHelper.setResearchComplexity("LAMPFERTILITY", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "LEVITATOR",
                 getModItem(Thaumcraft.ID, "blockLifter", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.EARTH, 10).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -3166,14 +3018,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6));
         TCHelper.setResearchAspects(
                 "LEVITATOR",
-                new AspectList().add(Aspect.getAspect("aer"), 3).add(Aspect.getAspect("volatus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3).add(Aspect.getAspect("motus"), 6));
+                new AspectList().add(Aspect.AIR, 3).add(Aspect.FLIGHT, 6).add(Aspect.MAGIC, 3).add(Aspect.MOTION, 6));
         TCHelper.setResearchComplexity("LEVITATOR", 1);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "WARDEDARCANA",
                 getModItem(Thaumcraft.ID, "ItemArcaneDoor", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.FIRE, 5).add(Aspect.ORDER, 20)
+                        .add(Aspect.ENTROPY, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -3197,14 +3048,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "craftingToolSaw");
         TCHelper.setResearchAspects(
                 "WARDEDARCANA",
-                new AspectList().add(Aspect.getAspect("tutamen"), 6).add(Aspect.getAspect("instrumentum"), 6)
-                        .add(Aspect.getAspect("machina"), 6).add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.ARMOR, 6).add(Aspect.TOOL, 6).add(Aspect.MECHANISM, 6)
+                        .add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("WARDEDARCANA", 1);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "WARDEDARCANA",
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.FIRE, 5).add(Aspect.ORDER, 20)
+                        .add(Aspect.ENTROPY, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -3229,9 +3080,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "WARDEDARCANA",
                 getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 4, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("aqua"), 10)
-                        .add(Aspect.getAspect("ignis"), 10).add(Aspect.getAspect("ordo"), 10)
-                        .add(Aspect.getAspect("perditio"), 10).add(Aspect.getAspect("terra"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.WATER, 10).add(Aspect.FIRE, 10).add(Aspect.ORDER, 10)
+                        .add(Aspect.ENTROPY, 10).add(Aspect.EARTH, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -3256,8 +3106,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "WARDEDARCANA",
                 getModItem(Thaumcraft.ID, "ArcaneDoorKey", 2, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.FIRE, 5).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -3280,8 +3129,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "WARDEDARCANA",
                 getModItem(Thaumcraft.ID, "ArcaneDoorKey", 2, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.FIRE, 10).add(Aspect.ORDER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -3304,8 +3152,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ARCANEEAR",
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.EARTH, 10).add(Aspect.ORDER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -3329,16 +3176,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6));
         TCHelper.setResearchAspects(
                 "ARCANEEAR",
-                new AspectList().add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("sensus"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 3).add(Aspect.getAspect("potentia"), 6));
+                new AspectList().add(Aspect.AIR, 9).add(Aspect.SENSES, 9).add(Aspect.MAGIC, 3).add(Aspect.ENERGY, 6));
         TCHelper.setResearchComplexity("ARCANEEAR", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "SINSTONE",
                 getModItem(Thaumcraft.ID, "ItemCompassStone", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("alienis"), 10).add(Aspect.getAspect("auram"), 10)
-                        .add(Aspect.getAspect("sensus"), 10).add(Aspect.getAspect("tenebrae"), 10)
-                        .add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.ELDRITCH, 10).add(Aspect.AURA, 10).add(Aspect.SENSES, 10)
+                        .add(Aspect.DARKNESS, 10).add(Aspect.ORDER, 10),
                 getModItem(Minecraft.ID, "flint", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 1),
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 4),
@@ -3348,14 +3193,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 6));
         TCHelper.setResearchAspects(
                 "SINSTONE",
-                new AspectList().add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("sensus"), 3)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("alienis"), 6));
+                new AspectList().add(Aspect.AURA, 6).add(Aspect.SENSES, 3).add(Aspect.DARKNESS, 6)
+                        .add(Aspect.ELDRITCH, 6));
         TCHelper.setResearchComplexity("SINSTONE", 2);
         ThaumcraftApi.addWarpToResearch("SINSTONE", 1);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BELLOWS",
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.ORDER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -3379,8 +3224,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSlabWood", 1, 0));
         TCHelper.setResearchAspects(
                 "BELLOWS",
-                new AspectList().add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("aer"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 3).add(Aspect.getAspect("machina"), 9));
+                new AspectList().add(Aspect.MOTION, 6).add(Aspect.AIR, 12).add(Aspect.MAGIC, 3)
+                        .add(Aspect.MECHANISM, 9));
         TCHelper.setResearchComplexity("BELLOWS", 2);
         TCHelper.clearPages("FLUXSCRUB");
         TCHelper.addResearchPage("FLUXSCRUB", new ResearchPage("tc.research_page.FLUXSCRUB.1"));
@@ -3388,9 +3233,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "FLUXSCRUB",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 14),
                 4,
-                new AspectList().add(Aspect.getAspect("aqua"), 25).add(Aspect.getAspect("aer"), 20)
-                        .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("vinculum"), 10)
-                        .add(Aspect.getAspect("vitium"), 5),
+                new AspectList().add(Aspect.WATER, 25).add(Aspect.AIR, 20).add(Aspect.MAGIC, 15).add(Aspect.TRAP, 10)
+                        .add(Aspect.TAINT, 5),
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 0),
                 getModItem(Thaumcraft.ID, "blockTube", 1, 0),
                 BlockList.SteelBars.get(),
@@ -3405,16 +3249,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 14))));
         TCHelper.setResearchAspects(
                 "FLUXSCRUB",
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("vinculum"), 6)
-                        .add(Aspect.getAspect("vitium"), 3));
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.MAGIC, 12).add(Aspect.AIR, 9).add(Aspect.TRAP, 6)
+                        .add(Aspect.TAINT, 3));
         TCHelper.setResearchComplexity("FLUXSCRUB", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "BOOTSTRAVELLER",
                 getModItem(Thaumcraft.ID, "BootsTraveller", 1, 0),
                 2,
-                new AspectList().add(Aspect.getAspect("volatus"), 25).add(Aspect.getAspect("aer"), 25)
-                        .add(Aspect.getAspect("iter"), 25).add(Aspect.getAspect("aqua"), 5),
+                new AspectList().add(Aspect.FLIGHT, 25).add(Aspect.AIR, 25).add(Aspect.TRAVEL, 25).add(Aspect.WATER, 5),
                 getModItem(Minecraft.ID, "leather_boots", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 7),
@@ -3426,16 +3268,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 7));
         TCHelper.setResearchAspects(
                 "BOOTSTRAVELLER",
-                new AspectList().add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("iter"), 15)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("volatus"), 12)
-                        .add(Aspect.getAspect("aer"), 3));
+                new AspectList().add(Aspect.WATER, 9).add(Aspect.TRAVEL, 15).add(Aspect.EARTH, 6).add(Aspect.FLIGHT, 12)
+                        .add(Aspect.AIR, 3));
         TCHelper.setResearchComplexity("BOOTSTRAVELLER", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "RUNICARMOR",
                 getModItem(Thaumcraft.ID, "ItemRingRunic", 1, 1),
                 2,
-                new AspectList().add(Aspect.getAspect("potentia"), 25).add(Aspect.getAspect("tutamen"), 25)
-                        .add(Aspect.getAspect("praecantatio"), 25).add(Aspect.getAspect("alienis"), 5),
+                new AspectList().add(Aspect.ENERGY, 25).add(Aspect.ARMOR, 25).add(Aspect.MAGIC, 25)
+                        .add(Aspect.ELDRITCH, 5),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 1),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
                 OrePrefixes.gemFlawless.get(Materials.Amber),
@@ -3445,17 +3286,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 OrePrefixes.gemFlawless.get(Materials.Amber));
         TCHelper.setResearchAspects(
                 "RUNICARMOR",
-                new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("tutamen"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.MIND, 15).add(Aspect.ARMOR, 12).add(Aspect.AIR, 9).add(Aspect.ENERGY, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("RUNICARMOR", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "RUNICCHARGED",
                 getModItem(Thaumcraft.ID, "ItemRingRunic", 1, 2),
                 6,
-                new AspectList().add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("tutamen"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("alienis"), 16)
-                        .add(Aspect.getAspect("aer"), 8),
+                new AspectList().add(Aspect.ENERGY, 64).add(Aspect.ARMOR, 32).add(Aspect.MAGIC, 32)
+                        .add(Aspect.ELDRITCH, 16).add(Aspect.AIR, 8),
                 getModItem(Thaumcraft.ID, "ItemRingRunic", 1, 1),
                 getModItem(Minecraft.ID, "potion", 1, 8226),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1),
@@ -3467,18 +3306,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1));
         TCHelper.setResearchAspects(
                 "RUNICCHARGED",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("tutamen"), 9).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("cognitio"), 6)
-                        .add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.ENERGY, 12).add(Aspect.ARMOR, 9)
+                        .add(Aspect.ELDRITCH, 12).add(Aspect.AIR, 9).add(Aspect.MIND, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("RUNICCHARGED", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "RUNICHEALING",
                 getModItem(Thaumcraft.ID, "ItemRingRunic", 1, 3),
                 6,
-                new AspectList().add(Aspect.getAspect("aqua"), 64).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("sano"), 32).add(Aspect.getAspect("tutamen"), 32)
-                        .add(Aspect.getAspect("aer"), 8),
+                new AspectList().add(Aspect.WATER, 64).add(Aspect.MAGIC, 32).add(Aspect.HEAL, 32).add(Aspect.ARMOR, 32)
+                        .add(Aspect.AIR, 8),
                 getModItem(Thaumcraft.ID, "ItemRingRunic", 1, 1),
                 getModItem(Minecraft.ID, "potion", 1, 8225),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2),
@@ -3490,17 +3326,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2));
         TCHelper.setResearchAspects(
                 "RUNICHEALING",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 18).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("sano"), 12).add(Aspect.getAspect("tutamen"), 9)
-                        .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.MAGIC, 18).add(Aspect.WATER, 15).add(Aspect.HEAL, 12).add(Aspect.ARMOR, 9)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.AIR, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("RUNICHEALING", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "RUNICARMOR",
                 getModItem(Thaumcraft.ID, "ItemAmuletRunic", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("potentia"), 40).add(Aspect.getAspect("tutamen"), 40)
-                        .add(Aspect.getAspect("praecantatio"), 40).add(Aspect.getAspect("alienis"), 20),
+                new AspectList().add(Aspect.ENERGY, 40).add(Aspect.ARMOR, 40).add(Aspect.MAGIC, 40)
+                        .add(Aspect.ELDRITCH, 20),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
                 OrePrefixes.gemFlawless.get(Materials.Amber),
@@ -3514,9 +3348,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "RUNICEMERGENCY",
                 getModItem(Thaumcraft.ID, "ItemAmuletRunic", 1, 1),
                 8,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("terra"), 64)
-                        .add(Aspect.getAspect("tutamen"), 64).add(Aspect.getAspect("vacuos"), 32)
-                        .add(Aspect.getAspect("sano"), 8),
+                new AspectList().add(Aspect.MAGIC, 64).add(Aspect.EARTH, 64).add(Aspect.ARMOR, 64).add(Aspect.VOID, 32)
+                        .add(Aspect.HEAL, 8),
                 getModItem(Thaumcraft.ID, "ItemAmuletRunic", 1, 0),
                 getModItem(Minecraft.ID, "potion", 1, 8233),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3),
@@ -3528,17 +3361,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3));
         TCHelper.setResearchAspects(
                 "RUNICEMERGENCY",
-                new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("tutamen"), 9)
-                        .add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("sano"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.VOID, 15).add(Aspect.MAGIC, 12).add(Aspect.EARTH, 9).add(Aspect.ARMOR, 9)
+                        .add(Aspect.ELDRITCH, 6).add(Aspect.HEAL, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("RUNICEMERGENCY", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "RUNICARMOR",
                 getModItem(Thaumcraft.ID, "ItemGirdleRunic", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("potentia"), 55).add(Aspect.getAspect("tutamen"), 55)
-                        .add(Aspect.getAspect("praecantatio"), 55).add(Aspect.getAspect("alienis"), 35),
+                new AspectList().add(Aspect.ENERGY, 55).add(Aspect.ARMOR, 55).add(Aspect.MAGIC, 55)
+                        .add(Aspect.ELDRITCH, 35),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
                 OrePrefixes.gemFlawless.get(Materials.Amber),
@@ -3554,9 +3385,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "RUNICKINETIC",
                 getModItem(Thaumcraft.ID, "ItemGirdleRunic", 1, 1),
                 8,
-                new AspectList().add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("tutamen"), 64).add(Aspect.getAspect("bestia"), 32)
-                        .add(Aspect.getAspect("telum"), 8),
+                new AspectList().add(Aspect.AIR, 64).add(Aspect.MAGIC, 64).add(Aspect.ARMOR, 64).add(Aspect.BEAST, 32)
+                        .add(Aspect.WEAPON, 8),
                 getModItem(Thaumcraft.ID, "ItemGirdleRunic", 1, 0),
                 getModItem(Minecraft.ID, "potion", 1, 16428),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
@@ -3568,18 +3398,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0));
         TCHelper.setResearchAspects(
                 "RUNICKINETIC",
-                new AspectList().add(Aspect.getAspect("aer"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("tutamen"), 12).add(Aspect.getAspect("telum"), 9)
-                        .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("bestia"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.AIR, 18).add(Aspect.MAGIC, 15).add(Aspect.ARMOR, 12).add(Aspect.WEAPON, 9)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.BEAST, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("RUNICKINETIC", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ARCANEBORE",
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 5),
                 6,
-                new AspectList().add(Aspect.getAspect("machina"), 64).add(Aspect.getAspect("motus"), 32)
-                        .add(Aspect.getAspect("perditio"), 64).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("vacuos"), 32),
+                new AspectList().add(Aspect.MECHANISM, 64).add(Aspect.MOTION, 32).add(Aspect.ENTROPY, 64)
+                        .add(Aspect.ENERGY, 32).add(Aspect.VOID, 32),
                 ItemList.Electric_Piston_MV.get(1L),
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6),
                 OrePrefixes.plate.get(Materials.Gold),
@@ -3593,15 +3420,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemPickThaumium", 1, 0));
         TCHelper.setResearchAspects(
                 "ARCANEBORE",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("perfodio"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("motus"), 9)
-                        .add(Aspect.getAspect("vacuos"), 3).add(Aspect.getAspect("cognitio"), 6));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.MINE, 12).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.MOTION, 9).add(Aspect.VOID, 3).add(Aspect.MIND, 6));
         TCHelper.setResearchComplexity("ARCANEBORE", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ARCANEBORE",
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 4),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("ordo"), 30)
-                        .add(Aspect.getAspect("terra"), 30),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.ORDER, 30).add(Aspect.EARTH, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -3627,8 +3452,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "ELEMENTALPICK",
                 getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("perfodio"), 20)
-                        .add(Aspect.getAspect("sensus"), 20).add(Aspect.getAspect("lucrum"), 20),
+                new AspectList().add(Aspect.FIRE, 20).add(Aspect.MINE, 20).add(Aspect.SENSES, 20).add(Aspect.GREED, 20),
                 getModItem(Thaumcraft.ID, "ItemPickThaumium", 1, 0),
                 OrePrefixes.gemFlawless.get(Materials.Ruby),
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1),
@@ -3638,16 +3462,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1));
         TCHelper.setResearchAspects(
                 "ELEMENTALPICK",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("perfodio"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.FIRE, 12).add(Aspect.MINE, 9).add(Aspect.GREED, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("ELEMENTALPICK", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ELEMENTALAXE",
                 getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("aqua"), 10).add(Aspect.getAspect("arbor"), 20)
-                        .add(Aspect.getAspect("fabrico"), 20).add(Aspect.getAspect("motus"), 20),
+                new AspectList().add(Aspect.WATER, 10).add(Aspect.TREE, 20).add(Aspect.CRAFT, 20)
+                        .add(Aspect.MOTION, 20),
                 getModItem(Thaumcraft.ID, "ItemAxeThaumium", 1, 0),
                 OrePrefixes.gemFlawless.get(Materials.Sapphire),
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1),
@@ -3657,16 +3480,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2));
         TCHelper.setResearchAspects(
                 "ELEMENTALAXE",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("motus"), 12)
-                        .add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("aqua"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.MOTION, 12).add(Aspect.CRAFT, 9).add(Aspect.WATER, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("ELEMENTALAXE", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ELEMENTALSWORD",
                 getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("motus"), 20)
-                        .add(Aspect.getAspect("potentia"), 20).add(Aspect.getAspect("telum"), 20),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.MOTION, 20).add(Aspect.ENERGY, 20)
+                        .add(Aspect.WEAPON, 20),
                 getModItem(Thaumcraft.ID, "ItemSwordThaumium", 1, 0),
                 OrePrefixes.gemFlawless.get(Materials.GarnetYellow),
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1),
@@ -3676,16 +3498,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0));
         TCHelper.setResearchAspects(
                 "ELEMENTALSWORD",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("telum"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.WEAPON, 12).add(Aspect.ENERGY, 9).add(Aspect.AIR, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("ELEMENTALSWORD", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ELEMENTALSHOVEL",
                 getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("fabrico"), 20).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("perfodio"), 10).add(Aspect.getAspect("praecantatio"), 20),
+                new AspectList().add(Aspect.CRAFT, 20).add(Aspect.EARTH, 20).add(Aspect.MINE, 10).add(Aspect.MAGIC, 20),
                 getModItem(Thaumcraft.ID, "ItemShovelThaumium", 1, 0),
                 OrePrefixes.gemFlawless.get(Materials.Emerald),
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1),
@@ -3695,16 +3515,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3));
         TCHelper.setResearchAspects(
                 "ELEMENTALSHOVEL",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("perfodio"), 9).add(Aspect.getAspect("fabrico"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.EARTH, 12).add(Aspect.MINE, 9).add(Aspect.CRAFT, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("ELEMENTALSHOVEL", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ELEMENTALHOE",
                 getModItem(Thaumcraft.ID, "ItemHoeElemental", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("meto"), 10).add(Aspect.getAspect("herba"), 20)
-                        .add(Aspect.getAspect("terra"), 20).add(Aspect.getAspect("messis"), 20),
+                new AspectList().add(Aspect.HARVEST, 10).add(Aspect.PLANT, 20).add(Aspect.EARTH, 20)
+                        .add(Aspect.CROP, 20),
                 getModItem(Thaumcraft.ID, "ItemHoeThaumium", 1, 0),
                 OrePrefixes.gemFlawless.get(Materials.Amber),
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1),
@@ -3714,17 +3533,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4));
         TCHelper.setResearchAspects(
                 "ELEMENTALHOE",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("victus"), 12)
-                        .add(Aspect.getAspect("meto"), 9).add(Aspect.getAspect("messis"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.LIFE, 12).add(Aspect.HARVEST, 9).add(Aspect.CROP, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("ELEMENTALHOE", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "HOVERHARNESS",
                 getModItem(Thaumcraft.ID, "HoverHarness", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("iter"), 32).add(Aspect.getAspect("machina"), 64)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("volatus"), 32)
-                        .add(Aspect.getAspect("tutamen"), 16),
+                new AspectList().add(Aspect.TRAVEL, 32).add(Aspect.MECHANISM, 64).add(Aspect.ENERGY, 32)
+                        .add(Aspect.FLIGHT, 32).add(Aspect.ARMOR, 16),
                 getModItem(Minecraft.ID, "leather_chestplate", 1, 0),
                 OrePrefixes.plate.get(Materials.Thaumium),
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6),
@@ -3738,17 +3555,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6));
         TCHelper.setResearchAspects(
                 "HOVERHARNESS",
-                new AspectList().add(Aspect.getAspect("volatus"), 15).add(Aspect.getAspect("machina"), 12)
-                        .add(Aspect.getAspect("iter"), 9).add(Aspect.getAspect("aer"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("tutamen"), 3));
+                new AspectList().add(Aspect.FLIGHT, 15).add(Aspect.MECHANISM, 12).add(Aspect.TRAVEL, 9)
+                        .add(Aspect.AIR, 9).add(Aspect.MAGIC, 6).add(Aspect.ARMOR, 3));
         TCHelper.setResearchComplexity("HOVERHARNESS", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "HOVERGIRDLE",
                 getModItem(Thaumcraft.ID, "ItemGirdleHover", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("iter"), 32)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("volatus"), 32)
-                        .add(Aspect.getAspect("tutamen"), 16),
+                new AspectList().add(Aspect.AIR, 64).add(Aspect.TRAVEL, 32).add(Aspect.ENERGY, 32)
+                        .add(Aspect.FLIGHT, 32).add(Aspect.ARMOR, 16),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
                 getModItem(Minecraft.ID, "feather", 1, 0),
@@ -3761,16 +3576,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(TwilightForest.ID, "item.tfFeather", 1, 0));
         TCHelper.setResearchAspects(
                 "HOVERGIRDLE",
-                new AspectList().add(Aspect.getAspect("volatus"), 15).add(Aspect.getAspect("motus"), 12)
-                        .add(Aspect.getAspect("iter"), 9).add(Aspect.getAspect("aer"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("tutamen"), 3));
+                new AspectList().add(Aspect.FLIGHT, 15).add(Aspect.MOTION, 12).add(Aspect.TRAVEL, 9).add(Aspect.AIR, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.ARMOR, 3));
         TCHelper.setResearchComplexity("HOVERGIRDLE", 3);
         TCHelper.setResearchAspects(
                 "RUNICARMOR",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("tutamen"), 9)
-                        .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.GREED, 12).add(Aspect.EXCHANGE, 9)
+                        .add(Aspect.ARMOR, 9).add(Aspect.MIND, 6).add(Aspect.ELDRITCH, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("RUNICARMOR", 3);
 
         TCHelper.clearPages("MIRROR");
@@ -3780,8 +3592,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "MIRROR",
                 getModItem(Thaumcraft.ID, "blockMirror", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("iter"), 32).add(Aspect.getAspect("permutatio"), 24)
-                        .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("alienis"), 8),
+                new AspectList().add(Aspect.TRAVEL, 32).add(Aspect.EXCHANGE, 24).add(Aspect.DARKNESS, 16)
+                        .add(Aspect.ELDRITCH, 8),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 10),
                 OrePrefixes.plate.get(Materials.VibrantAlloy),
                 OrePrefixes.screw.get(Materials.Thaumium),
@@ -3799,18 +3611,16 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.addResearchPage("MIRROR", new ResearchPage("tc.research_page.MIRROR.3fixed"));
         TCHelper.setResearchAspects(
                 "MIRROR",
-                new AspectList().add(Aspect.getAspect("vitreus"), 15).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.CRYSTAL, 15).add(Aspect.TRAVEL, 12).add(Aspect.DARKNESS, 9)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.MIND, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("MIRROR", 3);
         ThaumcraftApi.addWarpToResearch("MIRROR", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "MIRRORHAND",
                 getModItem(Thaumcraft.ID, "HandMirror", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 64).add(Aspect.getAspect("iter"), 32)
-                        .add(Aspect.getAspect("motus"), 24).add(Aspect.getAspect("alienis"), 16)
-                        .add(Aspect.getAspect("potentia"), 8),
+                new AspectList().add(Aspect.TOOL, 64).add(Aspect.TRAVEL, 32).add(Aspect.MOTION, 24)
+                        .add(Aspect.ELDRITCH, 16).add(Aspect.ENERGY, 8),
                 getModItem(Thaumcraft.ID, "blockMirror", 1, 0),
                 getModItem(Minecraft.ID, "compass", 1, 0),
                 OrePrefixes.screw.get(Materials.Thaumium),
@@ -3822,18 +3632,16 @@ public class ScriptThaumcraft implements IScriptLoader {
                 OrePrefixes.screw.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "MIRRORHAND",
-                new AspectList().add(Aspect.getAspect("iter"), 18).add(Aspect.getAspect("instrumentum"), 15)
-                        .add(Aspect.getAspect("vitreus"), 12).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TRAVEL, 18).add(Aspect.TOOL, 15).add(Aspect.CRYSTAL, 12)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.MIND, 6).add(Aspect.ENERGY, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("MIRRORHAND", 3);
         ThaumcraftApi.addWarpToResearch("MIRRORHAND", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "MIRRORESSENTIA",
                 getModItem(Thaumcraft.ID, "blockMirror", 1, 6),
                 2,
-                new AspectList().add(Aspect.getAspect("aqua"), 24).add(Aspect.getAspect("iter"), 32)
-                        .add(Aspect.getAspect("permutatio"), 16).add(Aspect.getAspect("vitreus"), 8),
+                new AspectList().add(Aspect.WATER, 24).add(Aspect.TRAVEL, 32).add(Aspect.EXCHANGE, 16)
+                        .add(Aspect.CRYSTAL, 8),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 10),
                 OrePrefixes.plate.get(Materials.Tantalum),
                 OrePrefixes.screw.get(Materials.Thaumium),
@@ -3845,18 +3653,16 @@ public class ScriptThaumcraft implements IScriptLoader {
                 OrePrefixes.screw.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "MIRRORESSENTIA",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("vitreus"), 9).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.TRAVEL, 12).add(Aspect.CRYSTAL, 9)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.MIND, 6).add(Aspect.ENERGY, 6).add(Aspect.WATER, 3));
         TCHelper.setResearchComplexity("MIRRORESSENTIA", 3);
         ThaumcraftApi.addWarpToResearch("MIRRORESSENTIA", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "JARBRAIN",
                 getModItem(Thaumcraft.ID, "blockJar", 1, 1),
                 5,
-                new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("exanimis"), 30)
-                        .add(Aspect.getAspect("sensus"), 15).add(Aspect.getAspect("alienis"), 10),
+                new AspectList().add(Aspect.MIND, 15).add(Aspect.UNDEAD, 30).add(Aspect.SENSES, 15)
+                        .add(Aspect.ELDRITCH, 10),
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0),
                 getModItem(Minecraft.ID, "poisonous_potato", 1, 0),
@@ -3866,23 +3672,19 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Minecraft.ID, "poisonous_potato", 1, 0));
         TCHelper.setResearchAspects(
                 "JARBRAIN",
-                new AspectList().add(Aspect.getAspect("lucrum"), 15).add(Aspect.getAspect("fames"), 12)
-                        .add(Aspect.getAspect("exanimis"), 9).add(Aspect.getAspect("cognitio"), 9)
-                        .add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.GREED, 15).add(Aspect.HUNGER, 12).add(Aspect.UNDEAD, 9).add(Aspect.MIND, 9)
+                        .add(Aspect.ELDRITCH, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("JARBRAIN", 3);
         TCHelper.setResearchAspects(
                 "INFUSIONENCHANTMENT",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("tutamen"), 12).add(Aspect.getAspect("cognitio"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("alienis"), 6));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.MAGIC, 15).add(Aspect.ARMOR, 12).add(Aspect.MIND, 12)
+                        .add(Aspect.WEAPON, 9).add(Aspect.ENERGY, 12).add(Aspect.ELDRITCH, 6));
         TCHelper.setResearchComplexity("INFUSIONENCHANTMENT", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "ARMORFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemHelmetFortress", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("victus"), 16),
+                new AspectList().add(Aspect.METAL, 32).add(Aspect.MAGIC, 32).add(Aspect.ARMOR, 32).add(Aspect.LIFE, 16),
                 getModItem(Thaumcraft.ID, "ItemHelmetThaumium", 1, 0),
                 OrePrefixes.gemFlawless.get(Materials.Emerald),
                 OrePrefixes.plate.get(Materials.Gold),
@@ -3894,16 +3696,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 OrePrefixes.plate.get(Materials.Gold));
         TCHelper.setResearchAspects(
                 "ARMORFORTRESS",
-                new AspectList().add(Aspect.getAspect("fabrico"), 15).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("tutamen"), 9).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.CRAFT, 15).add(Aspect.METAL, 12).add(Aspect.ARMOR, 9)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.MIND, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("ARMORFORTRESS", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ARMORFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemChestplateFortress", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("tutamen"), 40).add(Aspect.getAspect("cognitio"), 16),
+                new AspectList().add(Aspect.METAL, 32).add(Aspect.MAGIC, 32).add(Aspect.ARMOR, 40).add(Aspect.MIND, 16),
                 getModItem(Thaumcraft.ID, "ItemChestplateThaumium", 1, 0),
                 OrePrefixes.plate.get(Materials.Thaumium),
                 OrePrefixes.plate.get(Materials.Thaumium),
@@ -3919,8 +3719,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "ARMORFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemLeggingsFortress", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("tutamen"), 24).add(Aspect.getAspect("terra"), 16),
+                new AspectList().add(Aspect.METAL, 32).add(Aspect.MAGIC, 32).add(Aspect.ARMOR, 24)
+                        .add(Aspect.EARTH, 16),
                 getModItem(Thaumcraft.ID, "ItemLeggingsThaumium", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2),
                 OrePrefixes.plate.get(Materials.Gold),
@@ -3932,36 +3732,31 @@ public class ScriptThaumcraft implements IScriptLoader {
                 OrePrefixes.plate.get(Materials.Gold));
         TCHelper.setResearchAspects(
                 "HELMGOGGLES",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("sensus"), 12)
-                        .add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("fabrico"), 3));
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.SENSES, 12).add(Aspect.AURA, 9)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.MAGIC, 6).add(Aspect.CRAFT, 3));
         TCHelper.setResearchComplexity("HELMGOGGLES", 3);
         TCHelper.setResearchAspects(
                 "MASKGRINNINGDEVIL",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("sano"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("fabrico"), 3));
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.HEAL, 12).add(Aspect.MIND, 9).add(Aspect.ELDRITCH, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.CRAFT, 3));
         TCHelper.setResearchComplexity("MASKGRINNINGDEVIL", 3);
         ThaumcraftApi.addWarpToResearch("MASKGRINNINGDEVIL", 1);
         TCHelper.setResearchAspects(
                 "MASKANGRYGHOST",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("perditio"), 12)
-                        .add(Aspect.getAspect("mortuus"), 9).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("fabrico"), 3));
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.ENTROPY, 12).add(Aspect.DEATH, 9)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.MAGIC, 6).add(Aspect.CRAFT, 3));
         TCHelper.setResearchComplexity("MASKANGRYGHOST", 3);
         ThaumcraftApi.addWarpToResearch("MASKANGRYGHOST", 1);
         TCHelper.setResearchAspects(
                 "MASKSIPPINGFIEND",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("exanimis"), 12)
-                        .add(Aspect.getAspect("victus"), 9).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.UNDEAD, 12).add(Aspect.LIFE, 9)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.MIND, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("MASKSIPPINGFIEND", 3);
         ThaumcraftApi.addWarpToResearch("MASKSIPPINGFIEND", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "BONEBOW",
                 getModItem(Thaumcraft.ID, "ItemBowBone", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("perditio"), 32)
-                        .add(Aspect.getAspect("terra"), 32),
+                new AspectList().add(Aspect.AIR, 32).add(Aspect.ENTROPY, 32).add(Aspect.EARTH, 32),
                 "abc",
                 "def",
                 "ghi",
@@ -3987,8 +3782,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "THAUMONOMICON",
                 getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 2).add(Aspect.getAspect("perditio"), 2)
-                        .add(Aspect.getAspect("terra"), 2),
+                new AspectList().add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 2).add(Aspect.EARTH, 2),
                 new ItemStack(Items.book),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
@@ -4002,8 +3796,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "BASICARTIFACE",
                 getModItem(Thaumcraft.ID, "blockTable", 1, 15),
-                new AspectList().add(Aspect.getAspect("ordo"), 2).add(Aspect.getAspect("perditio"), 2)
-                        .add(Aspect.getAspect("terra"), 2),
+                new AspectList().add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 2).add(Aspect.EARTH, 2),
                 getModItem(Thaumcraft.ID, "blockTable", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
@@ -4017,8 +3810,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "BASICARTIFACE",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 2).add(Aspect.getAspect("perditio"), 2)
-                        .add(Aspect.getAspect("ignis"), 2),
+                new AspectList().add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 2).add(Aspect.FIRE, 2),
                 new ItemStack(Items.cauldron),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
@@ -4031,8 +3823,7 @@ public class ScriptThaumcraft implements IScriptLoader {
 
         TCHelper.setResearchAspects(
                 "BONEBOW",
-                new AspectList().add(Aspect.getAspect("telum"), 12).add(Aspect.getAspect("motus"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("exanimis"), 3));
+                new AspectList().add(Aspect.WEAPON, 12).add(Aspect.MOTION, 9).add(Aspect.AIR, 6).add(Aspect.UNDEAD, 3));
         TCHelper.setResearchComplexity("BONEBOW", 2);
         TCHelper.refreshResearchPages("THAUMOMETER");
         TCHelper.refreshResearchPages("GOGGLES");
@@ -4122,8 +3913,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "HUNGRYCHEST",
                 getModItem(Thaumcraft.ID, "blockChestHungry", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.EARTH, 10).add(Aspect.ORDER, 5).add(Aspect.ENTROPY, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4147,15 +3937,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "screwThaumium");
         TCHelper.setResearchAspects(
                 "HUNGRYCHEST",
-                new AspectList().add(Aspect.getAspect("fames"), 9).add(Aspect.getAspect("vacuos"), 6)
-                        .add(Aspect.getAspect("iter"), 3));
+                new AspectList().add(Aspect.HUNGER, 9).add(Aspect.VOID, 6).add(Aspect.TRAVEL, 3));
         TCHelper.setResearchComplexity("HUNGRYCHEST", 1);
         TCHelper.addInfusionCraftingRecipe(
                 "TRAVELTRUNK",
                 getModItem(Thaumcraft.ID, "TrunkSpawner", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("iter"), 16).add(Aspect.getAspect("motus"), 16)
-                        .add(Aspect.getAspect("spiritus"), 16).add(Aspect.getAspect("vacuos"), 32),
+                new AspectList().add(Aspect.TRAVEL, 16).add(Aspect.MOTION, 16).add(Aspect.SOUL, 16)
+                        .add(Aspect.VOID, 32),
                 getModItem(Thaumcraft.ID, "blockChestHungry", 1, 0),
                 OrePrefixes.plate.get(Materials.StainlessSteel),
                 OrePrefixes.ring.get(Materials.StainlessSteel),
@@ -4167,14 +3956,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 OrePrefixes.ring.get(Materials.StainlessSteel));
         TCHelper.setResearchAspects(
                 "TRAVELTRUNK",
-                new AspectList().add(Aspect.getAspect("spiritus"), 12).add(Aspect.getAspect("vacuos"), 12)
-                        .add(Aspect.getAspect("arbor"), 9).add(Aspect.getAspect("iter"), 6)
-                        .add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.SOUL, 12).add(Aspect.VOID, 12).add(Aspect.TREE, 9).add(Aspect.TRAVEL, 6)
+                        .add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("TRAVELTRUNK", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GOLEMFETTER",
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 9),
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ordo"), 15),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.ORDER, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -4198,32 +3986,27 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6));
         TCHelper.setResearchAspects(
                 "GOLEMFETTER",
-                new AspectList().add(Aspect.getAspect("vinculum"), 9).add(Aspect.getAspect("machina"), 9)
-                        .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TRAP, 9).add(Aspect.MECHANISM, 9).add(Aspect.MIND, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("GOLEMFETTER", 2);
         ThaumcraftApi.addCrucibleRecipe(
                 "GOLEMSTRAW",
                 getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 0),
                 getModItem(Minecraft.ID, "hay_block", 1, 0),
-                new AspectList().add(Aspect.getAspect("humanus"), 10).add(Aspect.getAspect("motus"), 10)
-                        .add(Aspect.getAspect("spiritus"), 10));
+                new AspectList().add(Aspect.MAN, 10).add(Aspect.MOTION, 10).add(Aspect.SOUL, 10));
         TCHelper.setResearchAspects(
                 "GOLEMSTRAW",
-                new AspectList().add(Aspect.getAspect("messis"), 9).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("spiritus"), 9).add(Aspect.getAspect("motus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.CROP, 9).add(Aspect.EXCHANGE, 9).add(Aspect.SOUL, 9).add(Aspect.MOTION, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("GOLEMSTRAW", 2);
         ThaumcraftApi.addCrucibleRecipe(
                 "GOLEMWOOD",
                 getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 1),
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0),
-                new AspectList().add(Aspect.getAspect("humanus"), 14).add(Aspect.getAspect("motus"), 14)
-                        .add(Aspect.getAspect("spiritus"), 14));
+                new AspectList().add(Aspect.MAN, 14).add(Aspect.MOTION, 14).add(Aspect.SOUL, 14));
         TCHelper.setResearchAspects(
                 "GOLEMWOOD",
-                new AspectList().add(Aspect.getAspect("arbor"), 12).add(Aspect.getAspect("permutatio"), 12)
-                        .add(Aspect.getAspect("spiritus"), 9).add(Aspect.getAspect("motus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TREE, 12).add(Aspect.EXCHANGE, 12).add(Aspect.SOUL, 9).add(Aspect.MOTION, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("GOLEMWOOD", 3);
         TCHelper.clearPages("GOLEMTALLOW");
         TCHelper.addResearchPage("GOLEMTALLOW", new ResearchPage("tc.research_page.GOLEMTALLOW.1"));
@@ -4231,28 +4014,24 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "GOLEMTALLOW",
                 getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 2),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 5),
-                new AspectList().add(Aspect.getAspect("humanus"), 26).add(Aspect.getAspect("mortuus"), 26)
-                        .add(Aspect.getAspect("spiritus"), 26));
+                new AspectList().add(Aspect.MAN, 26).add(Aspect.DEATH, 26).add(Aspect.SOUL, 26));
         TCHelper.addResearchPage(
                 "GOLEMTALLOW",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 2))));
         TCHelper.setResearchAspects(
                 "GOLEMTALLOW",
-                new AspectList().add(Aspect.getAspect("spiritus"), 12).add(Aspect.getAspect("permutatio"), 12)
-                        .add(Aspect.getAspect("corpus"), 15).add(Aspect.getAspect("motus"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6));
+                new AspectList().add(Aspect.SOUL, 12).add(Aspect.EXCHANGE, 12).add(Aspect.FLESH, 15)
+                        .add(Aspect.MOTION, 9).add(Aspect.MAGIC, 6));
         TCHelper.setResearchComplexity("GOLEMTALLOW", 3);
         ThaumcraftApi.addCrucibleRecipe(
                 "GOLEMCLAY",
                 getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 3),
                 getModItem(Minecraft.ID, "clay", 1, 0),
-                new AspectList().add(Aspect.getAspect("humanus"), 20).add(Aspect.getAspect("motus"), 20)
-                        .add(Aspect.getAspect("spiritus"), 20));
+                new AspectList().add(Aspect.MAN, 20).add(Aspect.MOTION, 20).add(Aspect.SOUL, 20));
         TCHelper.setResearchAspects(
                 "GOLEMCLAY",
-                new AspectList().add(Aspect.getAspect("spiritus"), 12).add(Aspect.getAspect("permutatio"), 12)
-                        .add(Aspect.getAspect("motus"), 12).add(Aspect.getAspect("terra"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.SOUL, 12).add(Aspect.EXCHANGE, 12).add(Aspect.MOTION, 12)
+                        .add(Aspect.EARTH, 9).add(Aspect.MAGIC, 6).add(Aspect.WATER, 3));
         TCHelper.setResearchComplexity("GOLEMCLAY", 3);
         TCHelper.clearPages("GOLEMFLESH");
         TCHelper.addResearchPage("GOLEMFLESH", new ResearchPage("tc.research_page.GOLEMFLESH.1"));
@@ -4260,41 +4039,34 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "GOLEMFLESH",
                 getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 4),
                 getModItem(Thaumcraft.ID, "blockTaint", 1, 2),
-                new AspectList().add(Aspect.getAspect("humanus"), 20).add(Aspect.getAspect("motus"), 20)
-                        .add(Aspect.getAspect("spiritus"), 20));
+                new AspectList().add(Aspect.MAN, 20).add(Aspect.MOTION, 20).add(Aspect.SOUL, 20));
         TCHelper.addResearchPage(
                 "GOLEMFLESH",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 4))));
         TCHelper.setResearchAspects(
                 "GOLEMFLESH",
-                new AspectList().add(Aspect.getAspect("corpus"), 12).add(Aspect.getAspect("permutatio"), 12)
-                        .add(Aspect.getAspect("spiritus"), 12).add(Aspect.getAspect("motus"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("mortuus"), 3));
+                new AspectList().add(Aspect.FLESH, 12).add(Aspect.EXCHANGE, 12).add(Aspect.SOUL, 12)
+                        .add(Aspect.MOTION, 9).add(Aspect.MAGIC, 6).add(Aspect.DEATH, 3));
         TCHelper.setResearchComplexity("GOLEMFLESH", 3);
         ThaumcraftApi.addCrucibleRecipe(
                 "GOLEMSTONE",
                 getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 5),
                 getModItem(ExtraUtilities.ID, "cobblestone_compressed", 1, 0),
-                new AspectList().add(Aspect.getAspect("humanus"), 26).add(Aspect.getAspect("mortuus"), 26)
-                        .add(Aspect.getAspect("spiritus"), 26));
+                new AspectList().add(Aspect.MAN, 26).add(Aspect.DEATH, 26).add(Aspect.SOUL, 26));
         TCHelper.setResearchAspects(
                 "GOLEMSTONE",
-                new AspectList().add(Aspect.getAspect("spiritus"), 12).add(Aspect.getAspect("permutatio"), 12)
-                        .add(Aspect.getAspect("motus"), 12).add(Aspect.getAspect("terra"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("perditio"), 3));
+                new AspectList().add(Aspect.SOUL, 12).add(Aspect.EXCHANGE, 12).add(Aspect.MOTION, 12)
+                        .add(Aspect.EARTH, 9).add(Aspect.MAGIC, 6).add(Aspect.ENTROPY, 3));
         TCHelper.setResearchComplexity("GOLEMSTONE", 3);
         ThaumcraftApi.addCrucibleRecipe(
                 "GOLEMIRON",
                 getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 6),
                 getModItem(Minecraft.ID, "iron_block", 1, 0),
-                new AspectList().add(Aspect.getAspect("humanus"), 32).add(Aspect.getAspect("mortuus"), 32)
-                        .add(Aspect.getAspect("spiritus"), 32));
+                new AspectList().add(Aspect.MAN, 32).add(Aspect.DEATH, 32).add(Aspect.SOUL, 32));
         TCHelper.setResearchAspects(
                 "GOLEMIRON",
-                new AspectList().add(Aspect.getAspect("permutatio"), 12).add(Aspect.getAspect("spiritus"), 12)
-                        .add(Aspect.getAspect("motus"), 12).add(Aspect.getAspect("metallum"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("humanus"), 3));
+                new AspectList().add(Aspect.EXCHANGE, 12).add(Aspect.SOUL, 12).add(Aspect.MOTION, 12)
+                        .add(Aspect.METAL, 9).add(Aspect.MAGIC, 9).add(Aspect.EARTH, 6).add(Aspect.MAN, 3));
         TCHelper.setResearchComplexity("GOLEMIRON", 3);
         TCHelper.clearPages("GOLEMTHAUMIUM");
         TCHelper.addResearchPage("GOLEMTHAUMIUM", new ResearchPage("tc.research_page.GOLEMTHAUMIUM.1"));
@@ -4302,30 +4074,25 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "GOLEMTHAUMIUM",
                 getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 7),
                 "blockThaumium",
-                new AspectList().add(Aspect.getAspect("humanus"), 40).add(Aspect.getAspect("mortuus"), 40)
-                        .add(Aspect.getAspect("spiritus"), 40));
+                new AspectList().add(Aspect.MAN, 40).add(Aspect.DEATH, 40).add(Aspect.SOUL, 40));
         TCHelper.addResearchPage(
                 "GOLEMTHAUMIUM",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(Thaumcraft.ID, "ItemGolemPlacer", 1, 7))));
         TCHelper.setResearchAspects(
                 "GOLEMTHAUMIUM",
-                new AspectList().add(Aspect.getAspect("permutatio"), 12).add(Aspect.getAspect("spiritus"), 12)
-                        .add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("motus"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("terra"), 9)
-                        .add(Aspect.getAspect("humanus"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.EXCHANGE, 12).add(Aspect.SOUL, 12).add(Aspect.METAL, 12)
+                        .add(Aspect.MOTION, 9).add(Aspect.MAGIC, 9).add(Aspect.EARTH, 9).add(Aspect.MAN, 6)
+                        .add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("GOLEMTHAUMIUM", 3);
         TCHelper.setResearchAspects(
                 "ADVANCEDGOLEM",
-                new AspectList().add(Aspect.getAspect("sensus"), 15).add(Aspect.getAspect("victus"), 15)
-                        .add(Aspect.getAspect("cognitio"), 12).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.SENSES, 15).add(Aspect.LIFE, 15).add(Aspect.MIND, 12).add(Aspect.ENERGY, 12)
+                        .add(Aspect.MAGIC, 12).add(Aspect.ELDRITCH, 9).add(Aspect.MOTION, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ADVANCEDGOLEM", 4);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "COREGATHER",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 100),
-                new AspectList().add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.ORDER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4351,28 +4118,26 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "COREGATHER",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 2),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 100),
-                new AspectList().add(Aspect.getAspect("lucrum"), 10).add(Aspect.getAspect("terra"), 10));
+                new AspectList().add(Aspect.GREED, 10).add(Aspect.EARTH, 10));
         ThaumcraftApi.addCrucibleRecipe(
                 "COREEMPTY",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 1),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 100),
-                new AspectList().add(Aspect.getAspect("lucrum"), 10).add(Aspect.getAspect("vacuos"), 10));
+                new AspectList().add(Aspect.GREED, 10).add(Aspect.VOID, 10));
         TCHelper.setResearchAspects(
                 "COREEMPTY",
-                new AspectList().add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("vacuos"), 9)
-                        .add(Aspect.getAspect("permutatio"), 6).add(Aspect.getAspect("motus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.GREED, 9).add(Aspect.VOID, 9).add(Aspect.EXCHANGE, 6).add(Aspect.MOTION, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("COREEMPTY", 2);
         ThaumcraftApi.addCrucibleRecipe(
                 "COREFILL",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 100),
-                new AspectList().add(Aspect.getAspect("fames"), 10).add(Aspect.getAspect("vacuos"), 10));
+                new AspectList().add(Aspect.HUNGER, 10).add(Aspect.VOID, 10));
         TCHelper.setResearchAspects(
                 "COREFILL",
-                new AspectList().add(Aspect.getAspect("fames"), 9).add(Aspect.getAspect("vacuos"), 9)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("motus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.HUNGER, 9).add(Aspect.VOID, 9).add(Aspect.EXCHANGE, 9).add(Aspect.MOTION, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("COREFILL", 2);
         TCHelper.clearPages("COREHARVEST");
         TCHelper.addResearchPage("COREHARVEST", new ResearchPage("tc.research_page.COREHARVEST.1"));
@@ -4380,8 +4145,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "COREHARVEST",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 3),
                 4,
-                new AspectList().add(Aspect.getAspect("messis"), 10).add(Aspect.getAspect("meto"), 10)
-                        .add(Aspect.getAspect("herba"), 20),
+                new AspectList().add(Aspect.CROP, 10).add(Aspect.HARVEST, 10).add(Aspect.PLANT, 20),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 100),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0),
@@ -4393,9 +4157,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.addResearchPage("COREHARVEST", new ResearchPage("tc.research_page.COREHARVEST.2"));
         TCHelper.setResearchAspects(
                 "COREHARVEST",
-                new AspectList().add(Aspect.getAspect("meto"), 12).add(Aspect.getAspect("messis"), 12)
-                        .add(Aspect.getAspect("iter"), 9).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.HARVEST, 12).add(Aspect.CROP, 12).add(Aspect.TRAVEL, 9)
+                        .add(Aspect.EXCHANGE, 9).add(Aspect.MOTION, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("COREHARVEST", 3);
         TCHelper.clearPages("COREGUARD");
         TCHelper.addResearchPage("COREGUARD", new ResearchPage("tc.research_page.COREGUARD.1"));
@@ -4403,8 +4166,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "COREGUARD",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 4),
                 4,
-                new AspectList().add(Aspect.getAspect("telum"), 20).add(Aspect.getAspect("vinculum"), 20)
-                        .add(Aspect.getAspect("tutamen"), 20),
+                new AspectList().add(Aspect.WEAPON, 20).add(Aspect.TRAP, 20).add(Aspect.ARMOR, 20),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 100),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 OrePrefixes.plate.get(Materials.Obsidian),
@@ -4416,16 +4178,15 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.addResearchPage("COREGUARD", new ResearchPage("tc.research_page.COREGUARD.2"));
         TCHelper.setResearchAspects(
                 "COREGUARD",
-                new AspectList().add(Aspect.getAspect("sensus"), 12).add(Aspect.getAspect("telum"), 12)
-                        .add(Aspect.getAspect("vinculum"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.SENSES, 12).add(Aspect.WEAPON, 12).add(Aspect.TRAP, 12)
+                        .add(Aspect.EXCHANGE, 9).add(Aspect.MOTION, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("COREGUARD", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "COREUSE",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 8),
                 4,
-                new AspectList().add(Aspect.getAspect("humanus"), 20).add(Aspect.getAspect("instrumentum"), 20)
-                        .add(Aspect.getAspect("machina"), 20).add(Aspect.getAspect("lucrum"), 20),
+                new AspectList().add(Aspect.MAN, 20).add(Aspect.TOOL, 20).add(Aspect.MECHANISM, 20)
+                        .add(Aspect.GREED, 20),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 1),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(ProjectRedIntegration.ID, "projectred.integration.gate", 1, 26),
@@ -4435,16 +4196,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Minecraft.ID, "shears", 1, 0));
         TCHelper.setResearchAspects(
                 "COREUSE",
-                new AspectList().add(Aspect.getAspect("humanus"), 12).add(Aspect.getAspect("instrumentum"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.MAN, 12).add(Aspect.TOOL, 12).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.EXCHANGE, 9).add(Aspect.MOTION, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("COREUSE", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "CORESORTING",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 10),
                 4,
-                new AspectList().add(Aspect.getAspect("lucrum"), 20).add(Aspect.getAspect("fames"), 20)
-                        .add(Aspect.getAspect("permutatio"), 20).add(Aspect.getAspect("vacuos"), 20),
+                new AspectList().add(Aspect.GREED, 20).add(Aspect.HUNGER, 20).add(Aspect.EXCHANGE, 20)
+                        .add(Aspect.VOID, 20),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 100),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 1),
@@ -4454,9 +4214,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(ProjectRedIntegration.ID, "projectred.integration.gate", 1, 26));
         TCHelper.setResearchAspects(
                 "CORESORTING",
-                new AspectList().add(Aspect.getAspect("fames"), 12).add(Aspect.getAspect("vacuos"), 12)
-                        .add(Aspect.getAspect("lucrum"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.HUNGER, 12).add(Aspect.VOID, 12).add(Aspect.GREED, 12)
+                        .add(Aspect.EXCHANGE, 9).add(Aspect.MOTION, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("CORESORTING", 3);
         TCHelper.clearPages("CORELIQUID");
         TCHelper.addResearchPage("CORELIQUID", new ResearchPage("tc.research_page.CORELIQUID.1"));
@@ -4464,8 +4223,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "CORELIQUID",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 5),
                 4,
-                new AspectList().add(Aspect.getAspect("aqua"), 20).add(Aspect.getAspect("vacuos"), 20)
-                        .add(Aspect.getAspect("metallum"), 20).add(Aspect.getAspect("iter"), 20),
+                new AspectList().add(Aspect.WATER, 20).add(Aspect.VOID, 20).add(Aspect.METAL, 20)
+                        .add(Aspect.TRAVEL, 20),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 0),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(BuildCraftFactory.ID, "tankBlock", 1, 0),
@@ -4479,16 +4238,15 @@ public class ScriptThaumcraft implements IScriptLoader {
         TCHelper.addResearchPage("CORELIQUID", new ResearchPage("tc.research_page.CORELIQUID.2"));
         TCHelper.setResearchAspects(
                 "CORELIQUID",
-                new AspectList().add(Aspect.getAspect("iter"), 12).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TRAVEL, 12).add(Aspect.WATER, 12).add(Aspect.METAL, 9)
+                        .add(Aspect.EXCHANGE, 9).add(Aspect.MOTION, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("CORELIQUID", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "COREALCHEMY",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 6),
                 7,
-                new AspectList().add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("motus"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("permutatio"), 32),
+                new AspectList().add(Aspect.WATER, 32).add(Aspect.MOTION, 32).add(Aspect.MAGIC, 32)
+                        .add(Aspect.EXCHANGE, 32),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 5),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(Minecraft.ID, "potion", 1, 0),
@@ -4500,9 +4258,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0));
         TCHelper.setResearchAspects(
                 "COREALCHEMY",
-                new AspectList().add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("iter"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.ENERGY, 12).add(Aspect.WATER, 12).add(Aspect.TRAVEL, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.MOTION, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("COREALCHEMY", 3);
         TCHelper.clearPages("COREBUTCHER");
         TCHelper.addResearchPage("COREBUTCHER", new ResearchPage("tc.research_page.COREBUTCHER.1"));
@@ -4510,8 +4267,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "COREBUTCHER",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 9),
                 7,
-                new AspectList().add(Aspect.getAspect("bestia"), 32).add(Aspect.getAspect("corpus"), 32)
-                        .add(Aspect.getAspect("mortuus"), 32).add(Aspect.getAspect("telum"), 32),
+                new AspectList().add(Aspect.BEAST, 32).add(Aspect.FLESH, 32).add(Aspect.DEATH, 32)
+                        .add(Aspect.WEAPON, 32),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 3),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 MetaGeneratedTool01.INSTANCE.getToolWithStats(BUTCHERYKNIFE.ID, 1, null, null, null),
@@ -4524,17 +4281,16 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 9))));
         TCHelper.setResearchAspects(
                 "COREBUTCHER",
-                new AspectList().add(Aspect.getAspect("meto"), 12).add(Aspect.getAspect("telum"), 12)
-                        .add(Aspect.getAspect("bestia"), 9).add(Aspect.getAspect("sensus"), 12)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.HARVEST, 12).add(Aspect.WEAPON, 12).add(Aspect.BEAST, 9)
+                        .add(Aspect.SENSES, 12).add(Aspect.MOTION, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("COREBUTCHER", 3);
         ThaumcraftApi.addWarpToResearch("COREBUTCHER", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "COREFISHING",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 11),
                 7,
-                new AspectList().add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("meto"), 20)
-                        .add(Aspect.getAspect("bestia"), 32).add(Aspect.getAspect("fames"), 32),
+                new AspectList().add(Aspect.WATER, 32).add(Aspect.HARVEST, 20).add(Aspect.BEAST, 32)
+                        .add(Aspect.HUNGER, 32),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 3),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(Minecraft.ID, "fish", 1, 0),
@@ -4544,16 +4300,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 MetaGeneratedTool01.INSTANCE.getToolWithStats(KNIFE.ID, 1, null, null, null));
         TCHelper.setResearchAspects(
                 "COREFISHING",
-                new AspectList().add(Aspect.getAspect("fames"), 12).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("bestia"), 12).add(Aspect.getAspect("meto"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.HUNGER, 12).add(Aspect.WATER, 12).add(Aspect.BEAST, 12)
+                        .add(Aspect.HARVEST, 9).add(Aspect.MOTION, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("COREFISHING", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "CORELUMBER",
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 7),
                 7,
-                new AspectList().add(Aspect.getAspect("arbor"), 32).add(Aspect.getAspect("instrumentum"), 32)
-                        .add(Aspect.getAspect("meto"), 20).add(Aspect.getAspect("potentia"), 32),
+                new AspectList().add(Aspect.TREE, 32).add(Aspect.TOOL, 32).add(Aspect.HARVEST, 20)
+                        .add(Aspect.ENERGY, 32),
                 getModItem(Thaumcraft.ID, "ItemGolemCore", 1, 3),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemAxeThaumium", 1, 0),
@@ -4562,9 +4317,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemAxeThaumium", 1, 0));
         TCHelper.setResearchAspects(
                 "CORELUMBER",
-                new AspectList().add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("arbor"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("meto"), 12)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.ENERGY, 12).add(Aspect.TREE, 12).add(Aspect.TOOL, 9).add(Aspect.HARVEST, 12)
+                        .add(Aspect.MOTION, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("CORELUMBER", 3);
 
         TCHelper.removeArcaneRecipe(getModItem(Thaumcraft.ID, "GolemBell", 1, 0));
@@ -4574,7 +4328,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GOLEMBELL",
                 getModItem(Thaumcraft.ID, "GolemBell", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("aer"), 5),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.AIR, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4602,7 +4356,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "UPGRADEAIR",
                 getModItem(Thaumcraft.ID, "ItemGolemUpgrade", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4626,13 +4380,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "nuggetGold");
         TCHelper.setResearchAspects(
                 "UPGRADEAIR",
-                new AspectList().add(Aspect.getAspect("motus"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.MOTION, 9).add(Aspect.AIR, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("UPGRADEAIR", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "UPGRADEEARTH",
                 getModItem(Thaumcraft.ID, "ItemGolemUpgrade", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4656,13 +4409,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "nuggetGold");
         TCHelper.setResearchAspects(
                 "UPGRADEEARTH",
-                new AspectList().add(Aspect.getAspect("victus"), 9).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.LIFE, 9).add(Aspect.EARTH, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("UPGRADEEARTH", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "UPGRADEFIRE",
                 getModItem(Thaumcraft.ID, "ItemGolemUpgrade", 1, 2),
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4686,13 +4438,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "nuggetGold");
         TCHelper.setResearchAspects(
                 "UPGRADEFIRE",
-                new AspectList().add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("ignis"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.ENERGY, 9).add(Aspect.FIRE, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("UPGRADEFIRE", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "UPGRADEWATER",
                 getModItem(Thaumcraft.ID, "ItemGolemUpgrade", 1, 3),
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4716,13 +4467,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "nuggetGold");
         TCHelper.setResearchAspects(
                 "UPGRADEWATER",
-                new AspectList().add(Aspect.getAspect("sensus"), 9).add(Aspect.getAspect("aqua"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.SENSES, 9).add(Aspect.WATER, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("UPGRADEWATER", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "UPGRADEORDER",
                 getModItem(Thaumcraft.ID, "ItemGolemUpgrade", 1, 4),
-                new AspectList().add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -4746,13 +4496,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "nuggetGold");
         TCHelper.setResearchAspects(
                 "UPGRADEORDER",
-                new AspectList().add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("ordo"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.MIND, 6).add(Aspect.ORDER, 9).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("UPGRADEORDER", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "UPGRADEENTROPY",
                 getModItem(Thaumcraft.ID, "ItemGolemUpgrade", 1, 5),
-                new AspectList().add(Aspect.getAspect("perditio"), 15).add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.ENTROPY, 15).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4776,14 +4525,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "nuggetGold");
         TCHelper.setResearchAspects(
                 "UPGRADEENTROPY",
-                new AspectList().add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.MIND, 6).add(Aspect.ENTROPY, 9).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("UPGRADEENTROPY", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TINYHAT",
                 getModItem(Thaumcraft.ID, "ItemGolemDecoration", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.FIRE, 10).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4803,14 +4550,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "blockWoolBlack");
         TCHelper.setResearchAspects(
                 "TINYHAT",
-                new AspectList().add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("pannus"), 9)
-                        .add(Aspect.getAspect("victus"), 6).add(Aspect.getAspect("sano"), 3));
+                new AspectList().add(Aspect.GREED, 9).add(Aspect.CLOTH, 9).add(Aspect.LIFE, 6).add(Aspect.HEAL, 3));
         TCHelper.setResearchComplexity("TINYHAT", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TINYGLASSES",
                 getModItem(Thaumcraft.ID, "ItemGolemDecoration", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4832,14 +4577,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "lensGlass");
         TCHelper.setResearchAspects(
                 "TINYGLASSES",
-                new AspectList().add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("pannus"), 6)
-                        .add(Aspect.getAspect("sensus"), 6).add(Aspect.getAspect("ordo"), 3));
+                new AspectList().add(Aspect.GREED, 9).add(Aspect.CLOTH, 6).add(Aspect.SENSES, 6).add(Aspect.ORDER, 3));
         TCHelper.setResearchComplexity("TINYGLASSES", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TINYBOWTIE",
                 getModItem(Thaumcraft.ID, "ItemGolemDecoration", 1, 2),
-                new AspectList().add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("aer"), 5)
-                        .add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.ORDER, 5).add(Aspect.AIR, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4855,14 +4598,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "blockWoolBlack");
         TCHelper.setResearchAspects(
                 "TINYBOWTIE",
-                new AspectList().add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("pannus"), 9)
-                        .add(Aspect.getAspect("iter"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.GREED, 9).add(Aspect.CLOTH, 9).add(Aspect.TRAVEL, 6).add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("TINYBOWTIE", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TINYFEZ",
                 getModItem(Thaumcraft.ID, "ItemGolemDecoration", 1, 3),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4886,14 +4627,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Minecraft.ID, "string", 1, 0));
         TCHelper.setResearchAspects(
                 "TINYFEZ",
-                new AspectList().add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("pannus"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("sano"), 3));
+                new AspectList().add(Aspect.GREED, 9).add(Aspect.CLOTH, 9).add(Aspect.ENERGY, 6).add(Aspect.HEAL, 3));
         TCHelper.setResearchComplexity("TINYFEZ", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TINYDART",
                 getModItem(Thaumcraft.ID, "ItemGolemDecoration", 1, 4),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4917,14 +4656,13 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Minecraft.ID, "arrow", 1, 0));
         TCHelper.setResearchAspects(
                 "TINYDART",
-                new AspectList().add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("volatus"), 9)
-                        .add(Aspect.getAspect("telum"), 6).add(Aspect.getAspect("potentia"), 3));
+                new AspectList().add(Aspect.GREED, 9).add(Aspect.FLIGHT, 9).add(Aspect.WEAPON, 6)
+                        .add(Aspect.ENERGY, 3));
         TCHelper.setResearchComplexity("TINYDART", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TINYVISOR",
                 getModItem(Thaumcraft.ID, "ItemGolemDecoration", 1, 5),
-                new AspectList().add(Aspect.getAspect("aqua"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -4942,14 +4680,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "plateSteel");
         TCHelper.setResearchAspects(
                 "TINYVISOR",
-                new AspectList().add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("sensus"), 9)
-                        .add(Aspect.getAspect("tutamen"), 6).add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.GREED, 9).add(Aspect.SENSES, 9).add(Aspect.ARMOR, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("TINYVISOR", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TINYARMOR",
                 getModItem(Thaumcraft.ID, "ItemGolemDecoration", 1, 6),
-                new AspectList().add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 10),
+                new AspectList().add(Aspect.ORDER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -4967,14 +4703,12 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "plateSteel");
         TCHelper.setResearchAspects(
                 "TINYARMOR",
-                new AspectList().add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("metallum"), 9)
-                        .add(Aspect.getAspect("tutamen"), 6).add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.GREED, 9).add(Aspect.METAL, 9).add(Aspect.ARMOR, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("TINYARMOR", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TINYHAMMER",
                 getModItem(Thaumcraft.ID, "ItemGolemDecoration", 1, 7),
-                new AspectList().add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("terra"), 10),
+                new AspectList().add(Aspect.ORDER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -4994,8 +4728,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "stickWood");
         TCHelper.setResearchAspects(
                 "TINYHAMMER",
-                new AspectList().add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("metallum"), 9)
-                        .add(Aspect.getAspect("telum"), 6).add(Aspect.getAspect("vinculum"), 3));
+                new AspectList().add(Aspect.GREED, 9).add(Aspect.METAL, 9).add(Aspect.WEAPON, 6).add(Aspect.TRAP, 3));
         TCHelper.setResearchComplexity("TINYHAMMER", 2);
         TCHelper.refreshResearchPages("HUNGRYCHEST");
         TCHelper.refreshResearchPages("TRAVELTRUNK");
@@ -5057,8 +4790,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "ELDRITCHMINOR",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 17),
                 "listAllseed",
-                new AspectList().add(Aspect.getAspect("alienis"), 8).add(Aspect.getAspect("tenebrae"), 8)
-                        .add(Aspect.getAspect("vacuos"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 8).add(Aspect.DARKNESS, 8).add(Aspect.VOID, 8));
         TCHelper.addResearchPage(
                 "ELDRITCHMINOR",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(Thaumcraft.ID, "ItemResource", 1, 17))));
@@ -5068,22 +4800,21 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "VOIDMETAL",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 16),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 17),
-                new AspectList().add(Aspect.getAspect("metallum"), 16));
+                new AspectList().add(Aspect.METAL, 16));
         TCHelper.addResearchPage(
                 "VOIDMETAL",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(Thaumcraft.ID, "ItemResource", 1, 16))));
         TCHelper.addResearchPage("VOIDMETAL", new ResearchPage("tc.research_page.VOIDMETAL.2"));
         TCHelper.setResearchAspects(
                 "VOIDMETAL",
-                new AspectList().add(Aspect.getAspect("vacuos"), 12).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("gelum"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.VOID, 12).add(Aspect.METAL, 12).add(Aspect.DARKNESS, 9)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.COLD, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("VOIDMETAL", 3);
         ThaumcraftApi.addWarpToResearch("VOIDMETAL", 1);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(Thaumcraft.ID, "ItemAxeVoid", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("terra"), 15),
+                new AspectList().add(Aspect.ENTROPY, 30).add(Aspect.EARTH, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -5107,7 +4838,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(Thaumcraft.ID, "ItemSwordVoid", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("terra"), 15),
+                new AspectList().add(Aspect.ENTROPY, 30).add(Aspect.EARTH, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -5127,7 +4858,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(Thaumcraft.ID, "ItemPickVoid", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("terra"), 15),
+                new AspectList().add(Aspect.ENTROPY, 30).add(Aspect.EARTH, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -5151,7 +4882,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(Thaumcraft.ID, "ItemShovelVoid", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("terra"), 15),
+                new AspectList().add(Aspect.ENTROPY, 30).add(Aspect.EARTH, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -5171,7 +4902,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(Thaumcraft.ID, "ItemHoeVoid", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 30).add(Aspect.getAspect("terra"), 15),
+                new AspectList().add(Aspect.ENTROPY, 30).add(Aspect.EARTH, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -5193,7 +4924,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(Thaumcraft.ID, "ItemHelmetVoid", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 40).add(Aspect.getAspect("terra"), 20),
+                new AspectList().add(Aspect.ENTROPY, 40).add(Aspect.EARTH, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -5215,7 +4946,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(Thaumcraft.ID, "ItemChestplateVoid", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 40).add(Aspect.getAspect("terra"), 20),
+                new AspectList().add(Aspect.ENTROPY, 40).add(Aspect.EARTH, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -5243,7 +4974,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(Thaumcraft.ID, "ItemLeggingsVoid", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 40).add(Aspect.getAspect("terra"), 20),
+                new AspectList().add(Aspect.ENTROPY, 40).add(Aspect.EARTH, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -5269,7 +5000,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(Thaumcraft.ID, "ItemBootsVoid", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 40).add(Aspect.getAspect("terra"), 20),
+                new AspectList().add(Aspect.ENTROPY, 40).add(Aspect.EARTH, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -5289,7 +5020,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(ThaumicBases.ID, "voidFAS", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 40).add(Aspect.getAspect("terra"), 20),
+                new AspectList().add(Aspect.ENTROPY, 40).add(Aspect.EARTH, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -5305,7 +5036,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "VOIDMETAL",
                 getModItem(ThaumicBases.ID, "voidShears", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 40).add(Aspect.getAspect("terra"), 20),
+                new AspectList().add(Aspect.ENTROPY, 40).add(Aspect.EARTH, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -5327,8 +5058,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_void",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 8),
-                new AspectList().add(Aspect.getAspect("ordo"), 40).add(Aspect.getAspect("ignis"), 40)
-                        .add(Aspect.getAspect("aer"), 40).add(Aspect.getAspect("perditio"), 40),
+                new AspectList().add(Aspect.ORDER, 40).add(Aspect.FIRE, 40).add(Aspect.AIR, 40).add(Aspect.ENTROPY, 40),
                 "abc",
                 "def",
                 "ghi",
@@ -5357,8 +5087,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "CAP_void",
                 getModItem(Thaumcraft.ID, "WandCap", 1, 7),
                 8,
-                new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("auram"), 32)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("vacuos"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 32).add(Aspect.AURA, 32).add(Aspect.ENERGY, 32)
+                        .add(Aspect.VOID, 32),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 8),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 17),
@@ -5371,17 +5101,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 new ResearchPage(TCHelper.findInfusionRecipe(getModItem(Thaumcraft.ID, "WandCap", 1, 7))));
         TCHelper.setResearchAspects(
                 "CAP_void",
-                new AspectList().add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("vacuos"), 12)
-                        .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("instrumentum"), 6).add(Aspect.getAspect("terra"), 6)
-                        .add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.AURA, 12).add(Aspect.VOID, 12).add(Aspect.ELDRITCH, 9).add(Aspect.MAGIC, 9)
+                        .add(Aspect.TOOL, 6).add(Aspect.EARTH, 6).add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("CAP_void", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ESSENTIARESERVOIR",
                 getModItem(Thaumcraft.ID, "blockEssentiaReservoir", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("aqua"), 16).add(Aspect.getAspect("permutatio"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("vacuos"), 16),
+                new AspectList().add(Aspect.WATER, 16).add(Aspect.EXCHANGE, 16).add(Aspect.MAGIC, 16)
+                        .add(Aspect.VOID, 16),
                 getModItem(Thaumcraft.ID, "blockTube", 1, 4),
                 OrePrefixes.plate.get(Materials.Void),
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0),
@@ -5393,16 +5121,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockJar", 1, 0));
         TCHelper.setResearchAspects(
                 "ESSENTIARESERVOIR",
-                new AspectList().add(Aspect.getAspect("aqua"), 12).add(Aspect.getAspect("permutatio"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("vacuos"), 9)
-                        .add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.WATER, 12).add(Aspect.EXCHANGE, 12).add(Aspect.MAGIC, 9).add(Aspect.VOID, 9)
+                        .add(Aspect.ELDRITCH, 6).add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("ESSENTIARESERVOIR", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCUSPRIMAL",
                 getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("aer"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.WATER, 75).add(Aspect.EARTH, 75).add(Aspect.FIRE, 75).add(Aspect.AIR, 75)
+                        .add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -5426,19 +5152,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "gemExquisiteDiamond");
         TCHelper.setResearchAspects(
                 "FOCUSPRIMAL",
-                new AspectList().add(Aspect.getAspect("aqua"), 12).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("terra"), 9)
-                        .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.WATER, 12).add(Aspect.FIRE, 12).add(Aspect.AIR, 12).add(Aspect.EARTH, 9)
+                        .add(Aspect.ORDER, 9).add(Aspect.ENTROPY, 9).add(Aspect.MAGIC, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("FOCUSPRIMAL", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_primal_staff",
                 getModItem(Thaumcraft.ID, "WandRod", 1, 100),
                 10,
-                new AspectList().add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("aqua"), 64)
-                        .add(Aspect.getAspect("terra"), 64).add(Aspect.getAspect("ignis"), 64)
-                        .add(Aspect.getAspect("ordo"), 64).add(Aspect.getAspect("perditio"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 128),
+                new AspectList().add(Aspect.AIR, 64).add(Aspect.WATER, 64).add(Aspect.EARTH, 64).add(Aspect.FIRE, 64)
+                        .add(Aspect.ORDER, 64).add(Aspect.ENTROPY, 64).add(Aspect.MAGIC, 128),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 1),
@@ -5450,20 +5172,16 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "WandRod", 1, 7));
         TCHelper.setResearchAspects(
                 "ROD_primal_staff",
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("terra"), 12)
-                        .add(Aspect.getAspect("ordo"), 12).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("instrumentum"), 6)
-                        .add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.FIRE, 15).add(Aspect.AIR, 12).add(Aspect.EARTH, 12)
+                        .add(Aspect.ORDER, 12).add(Aspect.ENTROPY, 9).add(Aspect.MAGIC, 9).add(Aspect.TOOL, 6)
+                        .add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("ROD_primal_staff", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "ARMORVOIDFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemHelmetVoidFortress", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("alienis"), 24).add(Aspect.getAspect("metallum"), 24)
-                        .add(Aspect.getAspect("pannus"), 24).add(Aspect.getAspect("sensus"), 24)
-                        .add(Aspect.getAspect("tutamen"), 24).add(Aspect.getAspect("vacuos"), 24)
-                        .add(Aspect.getAspect("praecantatio"), 24),
+                new AspectList().add(Aspect.ELDRITCH, 24).add(Aspect.METAL, 24).add(Aspect.CLOTH, 24)
+                        .add(Aspect.SENSES, 24).add(Aspect.ARMOR, 24).add(Aspect.VOID, 24).add(Aspect.MAGIC, 24),
                 getModItem(Thaumcraft.ID, "ItemHelmetVoid", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemGoggles", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 7),
@@ -5477,19 +5195,16 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 7));
         TCHelper.setResearchAspects(
                 "ARMORVOIDFORTRESS",
-                new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("tenebrae"), 15)
-                        .add(Aspect.getAspect("tutamen"), 12).add(Aspect.getAspect("pannus"), 12)
-                        .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("sensus"), 6).add(Aspect.getAspect("metallum"), 3));
+                new AspectList().add(Aspect.VOID, 15).add(Aspect.DARKNESS, 15).add(Aspect.ARMOR, 12)
+                        .add(Aspect.CLOTH, 12).add(Aspect.ELDRITCH, 9).add(Aspect.MAGIC, 9).add(Aspect.SENSES, 6)
+                        .add(Aspect.METAL, 3));
         TCHelper.setResearchComplexity("ARMORVOIDFORTRESS", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "ARMORVOIDFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemChestplateVoidFortress", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("metallum"), 32)
-                        .add(Aspect.getAspect("pannus"), 32).add(Aspect.getAspect("sensus"), 32)
-                        .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("vacuos"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 32).add(Aspect.METAL, 32).add(Aspect.CLOTH, 32)
+                        .add(Aspect.SENSES, 32).add(Aspect.ARMOR, 32).add(Aspect.VOID, 32).add(Aspect.MAGIC, 32),
                 getModItem(Thaumcraft.ID, "ItemChestplateVoid", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemChestplateRobe", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 7),
@@ -5505,10 +5220,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "ARMORVOIDFORTRESS",
                 getModItem(Thaumcraft.ID, "ItemLeggingsVoidFortress", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("alienis"), 28).add(Aspect.getAspect("metallum"), 28)
-                        .add(Aspect.getAspect("pannus"), 28).add(Aspect.getAspect("sensus"), 28)
-                        .add(Aspect.getAspect("tutamen"), 28).add(Aspect.getAspect("vacuos"), 28)
-                        .add(Aspect.getAspect("praecantatio"), 28),
+                new AspectList().add(Aspect.ELDRITCH, 28).add(Aspect.METAL, 28).add(Aspect.CLOTH, 28)
+                        .add(Aspect.SENSES, 28).add(Aspect.ARMOR, 28).add(Aspect.VOID, 28).add(Aspect.MAGIC, 28),
                 getModItem(Thaumcraft.ID, "ItemLeggingsVoid", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemLeggingsRobe", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 7),
@@ -5524,8 +5237,8 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "SANITYCHECK",
                 getModItem(Thaumcraft.ID, "ItemSanityChecker", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("cognitio"), 32)
-                        .add(Aspect.getAspect("sensus"), 24).add(Aspect.getAspect("sano"), 16),
+                new AspectList().add(Aspect.ELDRITCH, 16).add(Aspect.MIND, 32).add(Aspect.SENSES, 24)
+                        .add(Aspect.HEAL, 16),
                 getModItem(Thaumcraft.ID, "ItemThaumometer", 1, 0),
                 getModItem(Thaumcraft.ID, "blockMirror", 1, 0),
                 OrePrefixes.screw.get(Materials.Thaumium),
@@ -5537,16 +5250,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 OrePrefixes.screw.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "SANITYCHECK",
-                new AspectList().add(Aspect.getAspect("sensus"), 12).add(Aspect.getAspect("cognitio"), 12)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("sano"), 6).add(Aspect.getAspect("victus"), 3));
+                new AspectList().add(Aspect.SENSES, 12).add(Aspect.MIND, 12).add(Aspect.ELDRITCH, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.HEAL, 6).add(Aspect.LIFE, 3));
         TCHelper.setResearchComplexity("SANITYCHECK", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "OCULUS",
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0),
                 7,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("iter"), 32)
-                        .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("vacuos"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.TRAVEL, 32).add(Aspect.DARKNESS, 32)
+                        .add(Aspect.VOID, 32),
                 getModItem(StevesCarts2.ID, "ModuleComponents", 1, 45),
                 getModItem(Minecraft.ID, "ender_eye", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 17),
@@ -5558,19 +5270,15 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 17));
         TCHelper.setResearchAspects(
                 "OCULUS",
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("cognitio"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("iter"), 9)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("vitium"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.MIND, 12).add(Aspect.DARKNESS, 9)
+                        .add(Aspect.TRAVEL, 9).add(Aspect.EXCHANGE, 9).add(Aspect.TAINT, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("OCULUS", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "PRIMALCRUSHER",
                 getModItem(Thaumcraft.ID, "ItemPrimalCrusher", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("alienis"), 24).add(Aspect.getAspect("instrumentum"), 24)
-                        .add(Aspect.getAspect("lucrum"), 24).add(Aspect.getAspect("perditio"), 24)
-                        .add(Aspect.getAspect("perfodio"), 24).add(Aspect.getAspect("telum"), 24)
-                        .add(Aspect.getAspect("vacuos"), 24),
+                new AspectList().add(Aspect.ELDRITCH, 24).add(Aspect.TOOL, 24).add(Aspect.GREED, 24)
+                        .add(Aspect.ENTROPY, 24).add(Aspect.MINE, 24).add(Aspect.WEAPON, 24).add(Aspect.VOID, 24),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3),
                 getModItem(Thaumcraft.ID, "ItemPickVoid", 1, 0),
@@ -5580,16 +5288,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0));
         TCHelper.setResearchAspects(
                 "PRIMALCRUSHER",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("lucrum"), 9)
-                        .add(Aspect.getAspect("perditio"), 9).add(Aspect.getAspect("perfodio"), 9)
-                        .add(Aspect.getAspect("telum"), 6).add(Aspect.getAspect("vacuos"), 3));
+                new AspectList().add(Aspect.MAGIC, 12).add(Aspect.ELDRITCH, 12).add(Aspect.TOOL, 12)
+                        .add(Aspect.GREED, 9).add(Aspect.ENTROPY, 9).add(Aspect.MINE, 9).add(Aspect.WEAPON, 6)
+                        .add(Aspect.VOID, 3));
         TCHelper.setResearchComplexity("PRIMALCRUSHER", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ADVALCHEMYFURNACE",
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 4, 3),
-                new AspectList().add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("terra"), 32)
-                        .add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("ordo"), 32),
+                new AspectList().add(Aspect.WATER, 32).add(Aspect.EARTH, 32).add(Aspect.AIR, 32).add(Aspect.ORDER, 32),
                 "abc",
                 "def",
                 "ghi",
@@ -5613,17 +5319,14 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "plateVoid");
         TCHelper.setResearchAspects(
                 "ADVALCHEMYFURNACE",
-                new AspectList().add(Aspect.getAspect("perditio"), 12).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("ordo"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.ENTROPY, 12).add(Aspect.AURA, 12).add(Aspect.AIR, 9).add(Aspect.ORDER, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("ADVALCHEMYFURNACE", 3);
         new ResearchItem(
                 "CRIMSONRITES",
                 "ELDRITCH",
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3).add(Aspect.getAspect("spiritus"), 12)
-                        .add(Aspect.getAspect("vacuos"), 9).add(Aspect.getAspect("infernus"), 2)
-                        .add(Aspect.getAspect("vitium"), 5),
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.MAGIC, 6).add(Aspect.MIND, 3).add(Aspect.SOUL, 12)
+                        .add(Aspect.VOID, 9).add(DarkAspects.NETHER, 2).add(Aspect.TAINT, 5),
                 -3,
                 -3,
                 5,
@@ -5634,8 +5337,7 @@ public class ScriptThaumcraft implements IScriptLoader {
                 "CRIMSONRITES",
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 1),
                 10,
-                new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("infernus"), 16),
+                new AspectList().add(Aspect.ELDRITCH, 32).add(Aspect.MAGIC, 64).add(DarkAspects.NETHER, 16),
                 getModItem(Thaumcraft.ID, "ItemThaumonomicon", 1, 0),
                 getModItem(TaintedMagic.ID, "ItemCrystalDagger", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
@@ -5659,8 +5361,7 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CRIMSONRITES",
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 8),
-                new AspectList().add(Aspect.getAspect("aqua"), 5).add(Aspect.getAspect("terra"), 5)
-                        .add(Aspect.getAspect("perditio"), 5),
+                new AspectList().add(Aspect.WATER, 5).add(Aspect.EARTH, 5).add(Aspect.ENTROPY, 5),
                 "aba",
                 "bcb",
                 "ada",
@@ -5710,9 +5411,8 @@ public class ScriptThaumcraft implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "INFUSION",
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 45).add(Aspect.getAspect("ignis"), 45)
-                        .add(Aspect.getAspect("terra"), 45).add(Aspect.getAspect("aqua"), 45)
-                        .add(Aspect.getAspect("ordo"), 45).add(Aspect.getAspect("perditio"), 45),
+                new AspectList().add(Aspect.AIR, 45).add(Aspect.FIRE, 45).add(Aspect.EARTH, 45).add(Aspect.WATER, 45)
+                        .add(Aspect.ORDER, 45).add(Aspect.ENTROPY, 45),
                 "aba",
                 "bcb",
                 "aba",
@@ -5734,1471 +5434,1251 @@ public class ScriptThaumcraft implements IScriptLoader {
 
         ThaumcraftApi.registerObjectTag(
                 getModItem(BiomesOPlenty.ID, "bones", 1, 0),
-                new AspectList().add(Aspect.getAspect("corpus"), 1).add(Aspect.getAspect("exanimis"), 3)
-                        .add(Aspect.getAspect("mortuus"), 2));
+                new AspectList().add(Aspect.FLESH, 1).add(Aspect.UNDEAD, 3).add(Aspect.DEATH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(BiomesOPlenty.ID, "bones", 1, 1),
-                new AspectList().add(Aspect.getAspect("corpus"), 2).add(Aspect.getAspect("exanimis"), 6)
-                        .add(Aspect.getAspect("mortuus"), 4));
+                new AspectList().add(Aspect.FLESH, 2).add(Aspect.UNDEAD, 6).add(Aspect.DEATH, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(BiomesOPlenty.ID, "bones", 1, 2),
-                new AspectList().add(Aspect.getAspect("corpus"), 3).add(Aspect.getAspect("exanimis"), 9)
-                        .add(Aspect.getAspect("mortuus"), 6));
+                new AspectList().add(Aspect.FLESH, 3).add(Aspect.UNDEAD, 9).add(Aspect.DEATH, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(ForbiddenMagic.ID, "WandCores", 1, 5),
-                new AspectList().add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("praecantatio"), 24)
-                        .add(Aspect.getAspect("vitreus"), 16).add(Aspect.getAspect("infernus"), 8)
-                        .add(Aspect.getAspect("tenebrae"), 4));
+                new AspectList().add(Aspect.EARTH, 32).add(Aspect.MAGIC, 24).add(Aspect.CRYSTAL, 16)
+                        .add(DarkAspects.NETHER, 8).add(Aspect.DARKNESS, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "tile.moonBlock", 1, 3),
-                new AspectList().add(Aspect.getAspect("alienis"), 2).add(Aspect.getAspect("vacuos"), 2)
-                        .add(Aspect.getAspect("tenebrae"), 2));
+                new AspectList().add(Aspect.ELDRITCH, 2).add(Aspect.VOID, 2).add(Aspect.DARKNESS, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "tile.moonBlock", 1, 4),
-                new AspectList().add(Aspect.getAspect("alienis"), 2).add(Aspect.getAspect("vacuos"), 3)
-                        .add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 2).add(Aspect.VOID, 3).add(Aspect.DARKNESS, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "tile.moonBlock", 1, 5),
-                new AspectList().add(Aspect.getAspect("alienis"), 1).add(Aspect.getAspect("vacuos"), 1)
-                        .add(Aspect.getAspect("tenebrae"), 1));
+                new AspectList().add(Aspect.ELDRITCH, 1).add(Aspect.VOID, 1).add(Aspect.DARKNESS, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "tile.moonBlock", 1, 14),
-                new AspectList().add(Aspect.getAspect("alienis"), 4).add(Aspect.getAspect("ira"), 1)
-                        .add(Aspect.getAspect("superbia"), 1));
+                new AspectList().add(Aspect.ELDRITCH, 4).add(DarkAspects.WRATH, 1).add(DarkAspects.PRIDE, 1));
         ThaumcraftApi.registerObjectTag(
                 NHItemList.MoonStoneDust.get(),
-                new AspectList().add(Aspect.getAspect("alienis"), 1).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.ELDRITCH, 1).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.mars", 1, 4),
-                new AspectList().add(Aspect.getAspect("alienis"), 1).add(Aspect.getAspect("perditio"), 1)
-                        .add(Aspect.getAspect("ignis"), 1).add(Aspect.getAspect("terra"), 1));
+                new AspectList().add(Aspect.ELDRITCH, 1).add(Aspect.ENTROPY, 1).add(Aspect.FIRE, 1)
+                        .add(Aspect.EARTH, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.mars", 1, 5),
-                new AspectList().add(Aspect.getAspect("alienis"), 1).add(Aspect.getAspect("metallum"), 1)
-                        .add(Aspect.getAspect("ignis"), 2).add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.ELDRITCH, 1).add(Aspect.METAL, 1).add(Aspect.FIRE, 2).add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.mars", 1, 6),
-                new AspectList().add(Aspect.getAspect("alienis"), 2).add(Aspect.getAspect("metallum"), 2)
-                        .add(Aspect.getAspect("ignis"), 2).add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.ELDRITCH, 2).add(Aspect.METAL, 2).add(Aspect.FIRE, 2).add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.mars", 1, 7),
-                new AspectList().add(Aspect.getAspect("alienis"), 1).add(Aspect.getAspect("metallum"), 1)
-                        .add(Aspect.getAspect("ira"), 2).add(Aspect.getAspect("superbia"), 2));
+                new AspectList().add(Aspect.ELDRITCH, 1).add(Aspect.METAL, 1).add(DarkAspects.WRATH, 2)
+                        .add(DarkAspects.PRIDE, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.mars", 1, 9),
-                new AspectList().add(Aspect.getAspect("alienis"), 2).add(Aspect.getAspect("metallum"), 3)
-                        .add(Aspect.getAspect("ignis"), 3).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 2).add(Aspect.METAL, 3).add(Aspect.FIRE, 3).add(Aspect.EARTH, 3));
         ThaumcraftApi.registerObjectTag(
                 NHItemList.MarsStoneDust.get(),
-                new AspectList().add(Aspect.getAspect("alienis"), 1).add(Aspect.getAspect("perditio"), 1)
-                        .add(Aspect.getAspect("terra"), 1));
+                new AspectList().add(Aspect.ELDRITCH, 1).add(Aspect.ENTROPY, 1).add(Aspect.EARTH, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.asteroidsBlock", 1, 0),
-                new AspectList().add(Aspect.getAspect("alienis"), 1).add(Aspect.getAspect("tenebrae"), 1)
-                        .add(Aspect.getAspect("vacuos"), 1).add(Aspect.getAspect("gelum"), 1));
+                new AspectList().add(Aspect.ELDRITCH, 1).add(Aspect.DARKNESS, 1).add(Aspect.VOID, 1)
+                        .add(Aspect.COLD, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.asteroidsBlock", 1, 1),
-                new AspectList().add(Aspect.getAspect("alienis"), 2).add(Aspect.getAspect("tenebrae"), 2)
-                        .add(Aspect.getAspect("vacuos"), 2).add(Aspect.getAspect("gelum"), 2));
+                new AspectList().add(Aspect.ELDRITCH, 2).add(Aspect.DARKNESS, 2).add(Aspect.VOID, 2)
+                        .add(Aspect.COLD, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.asteroidsBlock", 1, 2),
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("tenebrae"), 3)
-                        .add(Aspect.getAspect("vacuos"), 3).add(Aspect.getAspect("gelum"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.DARKNESS, 3).add(Aspect.VOID, 3)
+                        .add(Aspect.COLD, 3));
         ThaumcraftApi.registerObjectTag(
                 NHItemList.AsteroidsStoneDust.get(),
-                new AspectList().add(Aspect.getAspect("alienis"), 1).add(Aspect.getAspect("perditio"), 1)
-                        .add(Aspect.getAspect("gelum"), 1));
+                new AspectList().add(Aspect.ELDRITCH, 1).add(Aspect.ENTROPY, 1).add(Aspect.COLD, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "tile.landingPad", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 5).add(Aspect.getAspect("ordo"), 5));
+                new AspectList().add(Aspect.METAL, 5).add(Aspect.ORDER, 5));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 6),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("fabrico"), 2)
-                        .add(Aspect.getAspect("permutatio"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.CRAFT, 2).add(Aspect.EXCHANGE, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 7),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("fabrico"), 2)
-                        .add(Aspect.getAspect("vitreus"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.CRAFT, 2).add(Aspect.CRYSTAL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 8),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("volatus"), 2));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.FLIGHT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 9),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("ordo"), 2));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.ORDER, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 10),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 11),
-                new AspectList().add(Aspect.getAspect("metallum"), 8));
+                new AspectList().add(Aspect.METAL, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.meteoricIronIngot", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("magneto"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(TCAspects.MAGNETO.getAspect(), 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.null", 1, 5),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("vacuos"), 2)
-                        .add(Aspect.getAspect("tenebrae"), 1));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.VOID, 2).add(Aspect.DARKNESS, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.itemBasicAsteroids", 1, 6),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("tutamen"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.ARMOR, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 13),
-                new AspectList().add(Aspect.getAspect("fabrico"), 6).add(Aspect.getAspect("ordo"), 5)
-                        .add(Aspect.getAspect("machina"), 4).add(Aspect.getAspect("instrumentum"), 3)
-                        .add(Aspect.getAspect("metallum"), 3));
+                new AspectList().add(Aspect.CRAFT, 6).add(Aspect.ORDER, 5).add(Aspect.MECHANISM, 4).add(Aspect.TOOL, 3)
+                        .add(Aspect.METAL, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 14),
-                new AspectList().add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("ordo"), 7)
-                        .add(Aspect.getAspect("machina"), 6).add(Aspect.getAspect("instrumentum"), 5)
-                        .add(Aspect.getAspect("metallum"), 5).add(Aspect.getAspect("lux"), 4));
+                new AspectList().add(Aspect.CRAFT, 9).add(Aspect.ORDER, 7).add(Aspect.MECHANISM, 6).add(Aspect.TOOL, 5)
+                        .add(Aspect.METAL, 5).add(Aspect.LIGHT, 4));
         ThaumcraftApi.registerObjectTag(
                 NHItemList.WaferTier3.get(),
-                new AspectList().add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("ordo"), 10)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("instrumentum"), 8)
-                        .add(Aspect.getAspect("metallum"), 7).add(Aspect.getAspect("lux"), 6)
-                        .add(Aspect.getAspect("alienis"), 4));
+                new AspectList().add(Aspect.CRAFT, 12).add(Aspect.ORDER, 10).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.TOOL, 8).add(Aspect.METAL, 7).add(Aspect.LIGHT, 6).add(Aspect.ELDRITCH, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "tile.aluminumWire", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("volatus"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.FLIGHT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "tile.oxygenPipe", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("gelum"), 1)
-                        .add(Aspect.getAspect("vitreus"), 1));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.COLD, 1).add(Aspect.CRYSTAL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "tile.glowstoneTorch", 1, 0),
-                new AspectList().add(Aspect.getAspect("potentia"), 1).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("lux"), 1).add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.ENERGY, 1).add(Aspect.MECHANISM, 1).add(Aspect.LIGHT, 1)
+                        .add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "tile.arclamp", 1, 0),
-                new AspectList().add(Aspect.getAspect("potentia"), 5).add(Aspect.getAspect("machina"), 2)
-                        .add(Aspect.getAspect("lux"), 5).add(Aspect.getAspect("tenebrae"), 2));
+                new AspectList().add(Aspect.ENERGY, 5).add(Aspect.MECHANISM, 2).add(Aspect.LIGHT, 5)
+                        .add(Aspect.DARKNESS, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 0),
-                new AspectList().add(Aspect.getAspect("potentia"), 2).add(Aspect.getAspect("electrum"), 2)
-                        .add(Aspect.getAspect("tenebrae"), 1));
+                new AspectList().add(Aspect.ENERGY, 2).add(TCAspects.ELECTRUM.getAspect(), 2).add(Aspect.DARKNESS, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.canister", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("vitreus"), 1));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.CRYSTAL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.canister", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("permutatio"), 1)
-                        .add(Aspect.getAspect("fabrico"), 1));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.EXCHANGE, 1).add(Aspect.CRAFT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.steelPole", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 5).add(Aspect.getAspect("ordo"), 5));
+                new AspectList().add(Aspect.METAL, 5).add(Aspect.ORDER, 5));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.heavyPlating", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("ordo"), 2)
-                        .add(Aspect.getAspect("volatus"), 2).add(Aspect.getAspect("instrumentum"), 1));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.ORDER, 2).add(Aspect.FLIGHT, 2).add(Aspect.TOOL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.null", 1, 3),
-                new AspectList().add(Aspect.getAspect("metallum"), 8).add(Aspect.getAspect("ordo"), 2)
-                        .add(Aspect.getAspect("volatus"), 2).add(Aspect.getAspect("instrumentum"), 1)
-                        .add(Aspect.getAspect("magneto"), 2));
+                new AspectList().add(Aspect.METAL, 8).add(Aspect.ORDER, 2).add(Aspect.FLIGHT, 2).add(Aspect.TOOL, 1)
+                        .add(TCAspects.MAGNETO.getAspect(), 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.itemBasicAsteroids", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 10).add(Aspect.getAspect("ordo"), 2)
-                        .add(Aspect.getAspect("volatus"), 2).add(Aspect.getAspect("instrumentum"), 1)
-                        .add(Aspect.getAspect("magneto"), 2).add(Aspect.getAspect("vacuos"), 2)
-                        .add(Aspect.getAspect("tenebrae"), 2));
+                new AspectList().add(Aspect.METAL, 10).add(Aspect.ORDER, 2).add(Aspect.FLIGHT, 2).add(Aspect.TOOL, 1)
+                        .add(TCAspects.MAGNETO.getAspect(), 2).add(Aspect.VOID, 2).add(Aspect.DARKNESS, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.oxygenMask", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 2).add(Aspect.getAspect("gelum"), 1)
-                        .add(Aspect.getAspect("vitreus"), 1).add(Aspect.getAspect("metallum"), 1));
+                new AspectList().add(Aspect.ARMOR, 2).add(Aspect.COLD, 1).add(Aspect.CRYSTAL, 1).add(Aspect.METAL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.battery", 1, 0),
-                new AspectList().add(Aspect.getAspect("electrum"), 6).add(Aspect.getAspect("metallum"), 2)
-                        .add(Aspect.getAspect("vacuos"), 1));
+                new AspectList().add(TCAspects.ELECTRUM.getAspect(), 6).add(Aspect.METAL, 2).add(Aspect.VOID, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 15),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("vitreus"), 1)
-                        .add(Aspect.getAspect("messis"), 3));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.CRYSTAL, 1).add(Aspect.CROP, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 16),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("vitreus"), 1)
-                        .add(Aspect.getAspect("messis"), 2));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.CRYSTAL, 1).add(Aspect.CROP, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 17),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("vitreus"), 1)
-                        .add(Aspect.getAspect("messis"), 1));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.CRYSTAL, 1).add(Aspect.CROP, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.basicItem", 1, 18),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("vitreus"), 1)
-                        .add(Aspect.getAspect("messis"), 2));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.CRYSTAL, 1).add(Aspect.CROP, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.meteoricIronRaw", 1, 0),
-                new AspectList().add(Aspect.getAspect("magneto"), 2).add(Aspect.getAspect("metallum"), 2));
+                new AspectList().add(TCAspects.MAGNETO.getAspect(), 2).add(Aspect.METAL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.thermalPadding", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 12).add(Aspect.getAspect("bestia"), 6)
-                        .add(Aspect.getAspect("fabrico"), 3).add(Aspect.getAspect("aqua"), 2)
-                        .add(Aspect.getAspect("ordo"), 2).add(Aspect.getAspect("perditio"), 2));
+                new AspectList().add(Aspect.CLOTH, 12).add(Aspect.BEAST, 6).add(Aspect.CRAFT, 3).add(Aspect.WATER, 2)
+                        .add(Aspect.ORDER, 2).add(Aspect.ENTROPY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.thermalPadding", 1, 1),
-                new AspectList().add(Aspect.getAspect("pannus"), 18).add(Aspect.getAspect("bestia"), 9)
-                        .add(Aspect.getAspect("fabrico"), 5).add(Aspect.getAspect("aqua"), 3)
-                        .add(Aspect.getAspect("ordo"), 3).add(Aspect.getAspect("perditio"), 3));
+                new AspectList().add(Aspect.CLOTH, 18).add(Aspect.BEAST, 9).add(Aspect.CRAFT, 5).add(Aspect.WATER, 3)
+                        .add(Aspect.ORDER, 3).add(Aspect.ENTROPY, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.thermalPadding", 1, 2),
-                new AspectList().add(Aspect.getAspect("pannus"), 15).add(Aspect.getAspect("bestia"), 7)
-                        .add(Aspect.getAspect("fabrico"), 4).add(Aspect.getAspect("aqua"), 3)
-                        .add(Aspect.getAspect("ordo"), 3).add(Aspect.getAspect("perditio"), 2));
+                new AspectList().add(Aspect.CLOTH, 15).add(Aspect.BEAST, 7).add(Aspect.CRAFT, 4).add(Aspect.WATER, 3)
+                        .add(Aspect.ORDER, 3).add(Aspect.ENTROPY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.thermalPadding", 1, 3),
-                new AspectList().add(Aspect.getAspect("pannus"), 9).add(Aspect.getAspect("bestia"), 5)
-                        .add(Aspect.getAspect("fabrico"), 2).add(Aspect.getAspect("aqua"), 1)
-                        .add(Aspect.getAspect("ordo"), 1).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.CLOTH, 9).add(Aspect.BEAST, 5).add(Aspect.CRAFT, 2).add(Aspect.WATER, 1)
+                        .add(Aspect.ORDER, 1).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.null", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("tenebrae"), 1));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.DARKNESS, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.hydrogenPipe", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("gelum"), 1)
-                        .add(Aspect.getAspect("vitreus"), 1).add(Aspect.getAspect("permutatio"), 1));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.COLD, 1).add(Aspect.CRYSTAL, 1)
+                        .add(Aspect.EXCHANGE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.bucketSludge", 1, 0),
-                new AspectList().add(Aspect.getAspect("venenum"), 4).add(Aspect.getAspect("aqua"), 2)
-                        .add(Aspect.getAspect("alienis"), 2).add(Aspect.getAspect("metallum"), 3));
+                new AspectList().add(Aspect.POISON, 4).add(Aspect.WATER, 2).add(Aspect.ELDRITCH, 2)
+                        .add(Aspect.METAL, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.oilCanisterPartial", 1, 1001),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("ordo"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.ORDER, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.methaneCanisterPartial", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("ordo"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.ORDER, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.canisterPartialLOX", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("ordo"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.ORDER, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "item.canisterPartialLN2", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("ordo"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.ORDER, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftCore.ID, "item.fuelCanisterPartial", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("ordo"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.ORDER, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.creeperEgg", 1, 0),
-                new AspectList().add(Aspect.getAspect("alienis"), 10).add(Aspect.getAspect("perditio"), 5));
+                new AspectList().add(Aspect.ELDRITCH, 10).add(Aspect.ENTROPY, 5));
         ThaumcraftApi.registerObjectTag(
                 getModItem(GalacticraftMars.ID, "tile.denseIce", 1, 0),
-                new AspectList().add(Aspect.getAspect("alienis"), 5).add(Aspect.getAspect("gelum"), 5));
+                new AspectList().add(Aspect.ELDRITCH, 5).add(Aspect.COLD, 5));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockMetal", 1, 5),
-                new AspectList().add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("ordo"), 5));
+                new AspectList().add(Aspect.METAL, 18).add(Aspect.ORDER, 5));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemPartCircuitAdv", 1, 0),
-                new AspectList().add(Aspect.getAspect("fabrico"), 9).add(Aspect.getAspect("ordo"), 7)
-                        .add(Aspect.getAspect("machina"), 6).add(Aspect.getAspect("instrumentum"), 5)
-                        .add(Aspect.getAspect("metallum"), 5).add(Aspect.getAspect("lux"), 4));
+                new AspectList().add(Aspect.CRAFT, 9).add(Aspect.ORDER, 7).add(Aspect.MECHANISM, 6).add(Aspect.TOOL, 5)
+                        .add(Aspect.METAL, 5).add(Aspect.LIGHT, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemPartAlloy", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("vacuos"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.VOID, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemIngot", 1, 4),
-                new AspectList().add(Aspect.getAspect("metallum"), 3));
+                new AspectList().add(Aspect.METAL, 3));
         ThaumcraftApi.registerObjectTag(
                 NHItemList.ReinforcedGlassPlate.get(),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("gelum"), 1));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.COLD, 1));
         ThaumcraftApi.registerObjectTag(
                 NHItemList.ReinforcedGlassPlate.get(),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("gelum"), 1)
-                        .add(Aspect.getAspect("vitreus"), 1));
+                new AspectList().add(Aspect.METAL, 1).add(Aspect.COLD, 1).add(Aspect.CRYSTAL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockAlloy", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("ordo"), 3)
-                        .add(Aspect.getAspect("terra"), 2).add(Aspect.getAspect("fabrico"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.ORDER, 3).add(Aspect.EARTH, 2).add(Aspect.CRAFT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockMetal", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.EXCHANGE, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockMetal", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("vitreus"), 3));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.CRYSTAL, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockMetal", 1, 2),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("instrumentum"), 3));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.TOOL, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockMetal", 1, 4),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("ordo"), 3));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.ORDER, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockMetal", 1, 3),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("venenum"), 2)
-                        .add(Aspect.getAspect("potentia"), 2).add(Aspect.getAspect("radio"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.POISON, 2).add(Aspect.ENERGY, 2)
+                        .add(TCAspects.RADIO.getAspect(), 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockGenerator", 1, 6),
-                new AspectList().add(Aspect.getAspect("metallum"), 40).add(Aspect.getAspect("fabrico"), 30)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("tutamen"), 2));
+                new AspectList().add(Aspect.METAL, 40).add(Aspect.CRAFT, 30).add(Aspect.ORDER, 15)
+                        .add(Aspect.ARMOR, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockHeatGenerator", 1, 2),
-                new AspectList().add(Aspect.getAspect("metallum"), 30).add(Aspect.getAspect("fabrico"), 18)
-                        .add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("permutatio"), 2));
+                new AspectList().add(Aspect.METAL, 30).add(Aspect.CRAFT, 18).add(Aspect.ORDER, 8)
+                        .add(Aspect.EXCHANGE, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockreactorvessel", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 5).add(Aspect.getAspect("fabrico"), 3)
-                        .add(Aspect.getAspect("ordo"), 3).add(Aspect.getAspect("terra"), 1));
+                new AspectList().add(Aspect.METAL, 5).add(Aspect.CRAFT, 3).add(Aspect.ORDER, 3).add(Aspect.EARTH, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockReactorFluidPort", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 5).add(Aspect.getAspect("fabrico"), 3)
-                        .add(Aspect.getAspect("iter"), 3).add(Aspect.getAspect("aqua"), 2));
+                new AspectList().add(Aspect.METAL, 5).add(Aspect.CRAFT, 3).add(Aspect.TRAVEL, 3).add(Aspect.WATER, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockReactorAccessHatch", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 5).add(Aspect.getAspect("fabrico"), 3)
-                        .add(Aspect.getAspect("iter"), 3).add(Aspect.getAspect("machina"), 2));
+                new AspectList().add(Aspect.METAL, 5).add(Aspect.CRAFT, 3).add(Aspect.TRAVEL, 3)
+                        .add(Aspect.MECHANISM, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockReactorRedstonePort", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 5).add(Aspect.getAspect("fabrico"), 3)
-                        .add(Aspect.getAspect("sensus"), 2).add(Aspect.getAspect("machina"), 1));
+                new AspectList().add(Aspect.METAL, 5).add(Aspect.CRAFT, 3).add(Aspect.SENSES, 2)
+                        .add(Aspect.MECHANISM, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockElectric", 1, 3),
-                new AspectList().add(Aspect.getAspect("metallum"), 11).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.METAL, 11).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.MOTION, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockElectric", 1, 4),
-                new AspectList().add(Aspect.getAspect("metallum"), 11).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("volatus"), 3));
+                new AspectList().add(Aspect.METAL, 11).add(Aspect.CRAFT, 4).add(Aspect.FLIGHT, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockElectric", 1, 5),
-                new AspectList().add(Aspect.getAspect("fabrico"), 5).add(Aspect.getAspect("machina"), 4)
-                        .add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("ignis"), 4));
+                new AspectList().add(Aspect.CRAFT, 5).add(Aspect.MECHANISM, 4).add(Aspect.METAL, 4)
+                        .add(Aspect.FIRE, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockElectric", 1, 6),
-                new AspectList().add(Aspect.getAspect("metallum"), 7).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("tutamen"), 3).add(Aspect.getAspect("motus"), 2));
+                new AspectList().add(Aspect.METAL, 7).add(Aspect.CRAFT, 4).add(Aspect.ARMOR, 3).add(Aspect.MOTION, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockMachine", 1, 6),
-                new AspectList().add(Aspect.getAspect("metallum"), 64).add(Aspect.getAspect("fabrico"), 64)
-                        .add(Aspect.getAspect("ordo"), 64).add(Aspect.getAspect("instrumentum"), 50));
+                new AspectList().add(Aspect.METAL, 64).add(Aspect.CRAFT, 64).add(Aspect.ORDER, 64)
+                        .add(Aspect.TOOL, 50));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemPartCarbonPlate", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("ignis"), 4)
-                        .add(Aspect.getAspect("vitreus"), 4));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.FIRE, 4).add(Aspect.CRYSTAL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockMachine", 1, 12),
-                new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("fabrico"), 8)
-                        .add(Aspect.getAspect("vacuos"), 4).add(Aspect.getAspect("ignis"), 2));
+                new AspectList().add(Aspect.METAL, 32).add(Aspect.CRAFT, 8).add(Aspect.VOID, 4).add(Aspect.FIRE, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemHarz", 1, 0),
-                new AspectList().add(Aspect.getAspect("limus"), 2).add(Aspect.getAspect("motus"), 2));
+                new AspectList().add(Aspect.SLIME, 2).add(Aspect.MOTION, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockMiningPipe", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 4));
+                new AspectList().add(Aspect.METAL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockLuminatorDark", 1, 0),
-                new AspectList().add(Aspect.getAspect("lux"), 4).add(Aspect.getAspect("ignis"), 2)
-                        .add(Aspect.getAspect("tenebrae"), 2));
+                new AspectList().add(Aspect.LIGHT, 4).add(Aspect.FIRE, 2).add(Aspect.DARKNESS, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "blockITNT", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 4).add(Aspect.getAspect("perditio"), 8)
-                        .add(Aspect.getAspect("potentia"), 2));
+                new AspectList().add(Aspect.FIRE, 4).add(Aspect.ENTROPY, 8).add(Aspect.ENERGY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 11),
-                new AspectList().add(Aspect.getAspect("metallum"), 27));
+                new AspectList().add(Aspect.METAL, 27));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 12),
-                new AspectList().add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("ordo"), 5));
+                new AspectList().add(Aspect.METAL, 18).add(Aspect.ORDER, 5));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 17).add(Aspect.getAspect("fabrico"), 3)
-                        .add(Aspect.getAspect("instrumentum"), 2).add(Aspect.getAspect("magneto"), 1));
+                new AspectList().add(Aspect.METAL, 17).add(Aspect.CRAFT, 3).add(Aspect.TOOL, 2)
+                        .add(TCAspects.MAGNETO.getAspect(), 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 1),
-                new AspectList().add(Aspect.getAspect("machina"), 1).add(Aspect.getAspect("electrum"), 1)
-                        .add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.MECHANISM, 1).add(TCAspects.ELECTRUM.getAspect(), 1).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 1),
-                new AspectList().add(Aspect.getAspect("sensus"), 1).add(Aspect.getAspect("fabrico"), 2));
+                new AspectList().add(Aspect.SENSES, 1).add(Aspect.CRAFT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemRecipePart", 1, 1),
-                new AspectList().add(Aspect.getAspect("fabrico"), 2).add(Aspect.getAspect("metallum"), 1)
-                        .add(Aspect.getAspect("sano"), 1).add(Aspect.getAspect("tenebrae"), 1));
+                new AspectList().add(Aspect.CRAFT, 2).add(Aspect.METAL, 1).add(Aspect.HEAL, 1).add(Aspect.DARKNESS, 1));
         ThaumcraftApi.registerObjectTag(
                 ItemList.IC2_Uranium_Fuel.get(1),
-                new AspectList().add(Aspect.getAspect("vitreus"), 14).add(Aspect.getAspect("gelum"), 6)
-                        .add(Aspect.getAspect("radio"), 3).add(Aspect.getAspect("permutatio"), 6));
+                new AspectList().add(Aspect.CRYSTAL, 14).add(Aspect.COLD, 6).add(TCAspects.RADIO.getAspect(), 3)
+                        .add(Aspect.EXCHANGE, 6));
         ThaumcraftApi.registerObjectTag(
                 ItemList.IC2_MOX_Fuel.get(1),
-                new AspectList().add(Aspect.getAspect("radio"), 3).add(Aspect.getAspect("metallum"), 3)
-                        .add(Aspect.getAspect("permutatio"), 6).add(Aspect.getAspect("vitreus"), 10));
+                new AspectList().add(TCAspects.RADIO.getAspect(), 3).add(Aspect.METAL, 3).add(Aspect.EXCHANGE, 6)
+                        .add(Aspect.CRYSTAL, 10));
         ThaumcraftApi.registerObjectTag(
                 ItemList.IC2_Plutonium.get(1),
-                new AspectList().add(Aspect.getAspect("radio"), 3).add(Aspect.getAspect("metallum"), 3));
-        ThaumcraftApi.registerObjectTag(
-                ItemList.IC2_Plutonium_Small.get(1),
-                new AspectList().add(Aspect.getAspect("metallum"), 1));
+                new AspectList().add(TCAspects.RADIO.getAspect(), 3).add(Aspect.METAL, 3));
+        ThaumcraftApi.registerObjectTag(ItemList.IC2_Plutonium_Small.get(1), new AspectList().add(Aspect.METAL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemDust2", 1, 2),
-                new AspectList().add(Aspect.getAspect("lucrum"), 4).add(Aspect.getAspect("potentia"), 3)
-                        .add(Aspect.getAspect("machina"), 2).add(Aspect.getAspect("vitreus"), 3));
+                new AspectList().add(Aspect.GREED, 4).add(Aspect.ENERGY, 3).add(Aspect.MECHANISM, 2)
+                        .add(Aspect.CRYSTAL, 3));
         ThaumcraftApi.registerObjectTag(
                 ItemList.IC2_Uranium_235_Small.get(1),
-                new AspectList().add(Aspect.getAspect("metallum"), 3).add(Aspect.getAspect("radio"), 3));
+                new AspectList().add(Aspect.METAL, 3).add(TCAspects.RADIO.getAspect(), 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemContainmentbox", 1, 0),
-                new AspectList().add(Aspect.getAspect("fabrico"), 3).add(Aspect.getAspect("instrumentum"), 3)
-                        .add(Aspect.getAspect("ordo"), 3).add(Aspect.getAspect("metallum"), 3));
+                new AspectList().add(Aspect.CRAFT, 3).add(Aspect.TOOL, 3).add(Aspect.ORDER, 3).add(Aspect.METAL, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemRTGPellet", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("fabrico"), 6)
-                        .add(Aspect.getAspect("radio"), 15));
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.CRAFT, 6).add(TCAspects.RADIO.getAspect(), 15));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemFuelRod", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("instrumentum"), 2).add(Aspect.getAspect("ordo"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.CRAFT, 4).add(Aspect.TOOL, 2).add(Aspect.ORDER, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemPartCarbonFibre", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 3).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("vitreus"), 3));
+                new AspectList().add(Aspect.METAL, 3).add(Aspect.FIRE, 3).add(Aspect.CRYSTAL, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemPartCarbonMesh", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 2).add(Aspect.getAspect("ignis"), 2)
-                        .add(Aspect.getAspect("vitreus"), 2));
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.FIRE, 2).add(Aspect.CRYSTAL, 2));
         ThaumcraftApi.registerObjectTag(
                 ItemList.ToolBox.get(1L),
-                new AspectList().add(Aspect.getAspect("fabrico"), 3).add(Aspect.getAspect("metallum"), 3)
-                        .add(Aspect.getAspect("instrumentum"), 2).add(Aspect.getAspect("ordo"), 2));
+                new AspectList().add(Aspect.CRAFT, 3).add(Aspect.METAL, 3).add(Aspect.TOOL, 2).add(Aspect.ORDER, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemShardIridium", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 1));
+                new AspectList().add(Aspect.METAL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemPartIridium", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 8).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("machina"), 4).add(Aspect.getAspect("vitreus"), 4));
+                new AspectList().add(Aspect.METAL, 8).add(Aspect.CRAFT, 4).add(Aspect.MECHANISM, 4)
+                        .add(Aspect.CRYSTAL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolMEter", 1, 0),
-                new AspectList().add(Aspect.getAspect("fabrico"), 15).add(Aspect.getAspect("instrumentum"), 6)
-                        .add(Aspect.getAspect("cognitio"), 2).add(Aspect.getAspect("lux"), 2));
+                new AspectList().add(Aspect.CRAFT, 15).add(Aspect.TOOL, 6).add(Aspect.MIND, 2).add(Aspect.LIGHT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemScanner", 1, 0),
-                new AspectList().add(Aspect.getAspect("fabrico"), 18).add(Aspect.getAspect("instrumentum"), 8)
-                        .add(Aspect.getAspect("cognitio"), 4).add(Aspect.getAspect("lux"), 4));
+                new AspectList().add(Aspect.CRAFT, 18).add(Aspect.TOOL, 8).add(Aspect.MIND, 4).add(Aspect.LIGHT, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemScannerAdv", 1, 0),
-                new AspectList().add(Aspect.getAspect("fabrico"), 10).add(Aspect.getAspect("instrumentum"), 10)
-                        .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("lux"), 6));
+                new AspectList().add(Aspect.CRAFT, 10).add(Aspect.TOOL, 10).add(Aspect.MIND, 6).add(Aspect.LIGHT, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "obscurator", 1, 0),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 6).add(Aspect.getAspect("lux"), 4)
-                        .add(Aspect.getAspect("machina"), 4).add(Aspect.getAspect("tenebrae"), 2));
+                new AspectList().add(Aspect.TOOL, 6).add(Aspect.LIGHT, 4).add(Aspect.MECHANISM, 4)
+                        .add(Aspect.DARKNESS, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemFreq", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("sensus"), 4).add(Aspect.getAspect("electrum"), 2));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.TOOL, 4).add(Aspect.SENSES, 4)
+                        .add(TCAspects.ELECTRUM.getAspect(), 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemBatREDischarged", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 1).add(Aspect.getAspect("electrum"), 1)
-                        .add(Aspect.getAspect("vacuos"), 1));
+                new AspectList().add(Aspect.METAL, 1).add(TCAspects.ELECTRUM.getAspect(), 1).add(Aspect.VOID, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemBatCrystal", 1, 0),
-                new AspectList().add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("vitreus"), 4));
+                new AspectList().add(Aspect.GREED, 6).add(Aspect.ENERGY, 9).add(Aspect.CRYSTAL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemBatLamaCrystal", 1, 0),
-                new AspectList().add(Aspect.getAspect("lucrum"), 8).add(Aspect.getAspect("potentia"), 11)
-                        .add(Aspect.getAspect("sensus"), 5));
+                new AspectList().add(Aspect.GREED, 8).add(Aspect.ENERGY, 11).add(Aspect.SENSES, 5));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemAdvBat", 1, 0),
-                new AspectList().add(Aspect.getAspect("electrum"), 2).add(Aspect.getAspect("metallum"), 2)
-                        .add(Aspect.getAspect("vacuos"), 2).add(Aspect.getAspect("potentia"), 1));
+                new AspectList().add(TCAspects.ELECTRUM.getAspect(), 2).add(Aspect.METAL, 2).add(Aspect.VOID, 2)
+                        .add(Aspect.ENERGY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemBatChargeRE", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 2).add(Aspect.getAspect("electrum"), 2)
-                        .add(Aspect.getAspect("vacuos"), 2));
+                new AspectList().add(Aspect.METAL, 2).add(TCAspects.ELECTRUM.getAspect(), 2).add(Aspect.VOID, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemBatChargeAdv", 1, 0),
-                new AspectList().add(Aspect.getAspect("electrum"), 3).add(Aspect.getAspect("metallum"), 3)
-                        .add(Aspect.getAspect("vacuos"), 3).add(Aspect.getAspect("potentia"), 2));
+                new AspectList().add(TCAspects.ELECTRUM.getAspect(), 3).add(Aspect.METAL, 3).add(Aspect.VOID, 3)
+                        .add(Aspect.ENERGY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemBatChargeCrystal", 1, 0),
-                new AspectList().add(Aspect.getAspect("lucrum"), 10).add(Aspect.getAspect("potentia"), 14)
-                        .add(Aspect.getAspect("sensus"), 6));
+                new AspectList().add(Aspect.GREED, 10).add(Aspect.ENERGY, 14).add(Aspect.SENSES, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemBatChargeLamaCrystal", 1, 0),
-                new AspectList().add(Aspect.getAspect("lucrum"), 12).add(Aspect.getAspect("potentia"), 16)
-                        .add(Aspect.getAspect("sensus"), 7));
+                new AspectList().add(Aspect.GREED, 12).add(Aspect.ENERGY, 16).add(Aspect.SENSES, 7));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemGrinPowder", 1, 0),
-                new AspectList().add(Aspect.getAspect("venenum"), 3).add(Aspect.getAspect("messis"), 2));
+                new AspectList().add(Aspect.POISON, 3).add(Aspect.CROP, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemFuelPlantBall", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 4));
+                new AspectList().add(Aspect.PLANT, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemBiochaff", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 2));
+                new AspectList().add(Aspect.PLANT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemPartCoalBall", 1, 0),
-                new AspectList().add(Aspect.getAspect("potentia"), 2).add(Aspect.getAspect("ignis"), 2)
-                        .add(Aspect.getAspect("terra"), 1).add(Aspect.getAspect("instrumentum"), 1));
+                new AspectList().add(Aspect.ENERGY, 2).add(Aspect.FIRE, 2).add(Aspect.EARTH, 1).add(Aspect.TOOL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemPartCoalBlock", 1, 0),
-                new AspectList().add(Aspect.getAspect("potentia"), 4).add(Aspect.getAspect("ignis"), 4)
-                        .add(Aspect.getAspect("terra"), 2).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.ENERGY, 4).add(Aspect.FIRE, 4).add(Aspect.EARTH, 2).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemPartCoalBlock", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 2).add(Aspect.getAspect("terra"), 2)
-                        .add(Aspect.getAspect("tenebrae"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.ENTROPY, 2).add(Aspect.EARTH, 2).add(Aspect.DARKNESS, 1)
+                        .add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemScrap", 1, 0),
-                new AspectList().add(Aspect.getAspect("strontio"), 2));
+                new AspectList().add(TCAspects.STRONTIO.getAspect(), 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemScrapbox", 1, 0),
-                new AspectList().add(Aspect.getAspect("strontio"), 4));
+                new AspectList().add(TCAspects.STRONTIO.getAspect(), 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterBlack", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterCloud", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterMagenta", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterOrange", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterWhite", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterRed", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterGreen", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterBrown", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterBlue", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterLime", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterYellow", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterPink", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterDarkGrey", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterLightGrey", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterCyan", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemToolPainterPurple", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.CLOTH, 10).add(Aspect.CRAFT, 4).add(Aspect.ORDER, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorVent", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("volatus"), 4).add(Aspect.getAspect("gelum"), 2));
+                new AspectList().add(Aspect.METAL, 12).add(Aspect.CRAFT, 4).add(Aspect.FLIGHT, 4).add(Aspect.COLD, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorVentCore", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 20).add(Aspect.getAspect("fabrico"), 8)
-                        .add(Aspect.getAspect("lucrum"), 4).add(Aspect.getAspect("gelum"), 4));
+                new AspectList().add(Aspect.METAL, 20).add(Aspect.CRAFT, 8).add(Aspect.GREED, 4).add(Aspect.COLD, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorVentGold", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 24).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("gelum"), 6));
+                new AspectList().add(Aspect.METAL, 24).add(Aspect.CRAFT, 12).add(Aspect.GREED, 9).add(Aspect.COLD, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorVentDiamond", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 26).add(Aspect.getAspect("fabrico"), 14)
-                        .add(Aspect.getAspect("lucrum"), 10).add(Aspect.getAspect("gelum"), 7));
+                new AspectList().add(Aspect.METAL, 26).add(Aspect.CRAFT, 14).add(Aspect.GREED, 10).add(Aspect.COLD, 7));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorHeatSwitch", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("permutatio"), 4).add(Aspect.getAspect("gelum"), 2));
+                new AspectList().add(Aspect.METAL, 12).add(Aspect.CRAFT, 4).add(Aspect.EXCHANGE, 4)
+                        .add(Aspect.COLD, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorHeatSwitchCore", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 20).add(Aspect.getAspect("fabrico"), 8)
-                        .add(Aspect.getAspect("permutatio"), 4).add(Aspect.getAspect("gelum"), 4));
+                new AspectList().add(Aspect.METAL, 20).add(Aspect.CRAFT, 8).add(Aspect.EXCHANGE, 4)
+                        .add(Aspect.COLD, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorHeatSwitchSpread", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 24).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("gelum"), 6));
+                new AspectList().add(Aspect.METAL, 24).add(Aspect.CRAFT, 12).add(Aspect.EXCHANGE, 9)
+                        .add(Aspect.COLD, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorHeatSwitchDiamond", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 26).add(Aspect.getAspect("fabrico"), 14)
-                        .add(Aspect.getAspect("permutatio"), 10).add(Aspect.getAspect("gelum"), 7));
+                new AspectList().add(Aspect.METAL, 26).add(Aspect.CRAFT, 14).add(Aspect.EXCHANGE, 10)
+                        .add(Aspect.COLD, 7));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemwoodrotor", 1, 1),
-                new AspectList().add(Aspect.getAspect("tempestas"), 2).add(Aspect.getAspect("arbor"), 4)
-                        .add(Aspect.getAspect("metallum"), 2).add(Aspect.getAspect("permutatio"), 2));
+                new AspectList().add(Aspect.WEATHER, 2).add(Aspect.TREE, 4).add(Aspect.METAL, 2)
+                        .add(Aspect.EXCHANGE, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemironrotor", 1, 1),
-                new AspectList().add(Aspect.getAspect("tempestas"), 4).add(Aspect.getAspect("metallum"), 4)
-                        .add(Aspect.getAspect("instrumentum"), 2).add(Aspect.getAspect("permutatio"), 4));
+                new AspectList().add(Aspect.WEATHER, 4).add(Aspect.METAL, 4).add(Aspect.TOOL, 2)
+                        .add(Aspect.EXCHANGE, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemsteelrotor", 1, 1),
-                new AspectList().add(Aspect.getAspect("tempestas"), 6).add(Aspect.getAspect("metallum"), 6)
-                        .add(Aspect.getAspect("instrumentum"), 4).add(Aspect.getAspect("permutatio"), 6));
+                new AspectList().add(Aspect.WEATHER, 6).add(Aspect.METAL, 6).add(Aspect.TOOL, 4)
+                        .add(Aspect.EXCHANGE, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemwcarbonrotor", 1, 1),
-                new AspectList().add(Aspect.getAspect("tempestas"), 8).add(Aspect.getAspect("metallum"), 8)
-                        .add(Aspect.getAspect("instrumentum"), 6).add(Aspect.getAspect("permutatio"), 8));
+                new AspectList().add(Aspect.WEATHER, 8).add(Aspect.METAL, 8).add(Aspect.TOOL, 6)
+                        .add(Aspect.EXCHANGE, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorReflector", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("ignis"), 4)
-                        .add(Aspect.getAspect("vitreus"), 2).add(Aspect.getAspect("fabrico"), 2));
+                new AspectList().add(Aspect.METAL, 4).add(Aspect.FIRE, 4).add(Aspect.CRYSTAL, 2).add(Aspect.CRAFT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorReflectorThick", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 8).add(Aspect.getAspect("ignis"), 4)
-                        .add(Aspect.getAspect("lucrum"), 4).add(Aspect.getAspect("fabrico"), 4));
+                new AspectList().add(Aspect.METAL, 8).add(Aspect.FIRE, 4).add(Aspect.GREED, 4).add(Aspect.CRAFT, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorCondensator", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 24).add(Aspect.getAspect("fabrico"), 16)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("gelum"), 8));
+                new AspectList().add(Aspect.METAL, 24).add(Aspect.CRAFT, 16).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.COLD, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorCondensatorLap", 1, 1),
-                new AspectList().add(Aspect.getAspect("metallum"), 24).add(Aspect.getAspect("fabrico"), 16)
-                        .add(Aspect.getAspect("permutatio"), 16).add(Aspect.getAspect("gelum"), 16));
+                new AspectList().add(Aspect.METAL, 24).add(Aspect.CRAFT, 16).add(Aspect.EXCHANGE, 16)
+                        .add(Aspect.COLD, 16));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 0),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 4).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("motus"), 4));
+                new AspectList().add(Aspect.TOOL, 4).add(Aspect.CRAFT, 4).add(Aspect.METAL, 4).add(Aspect.MOTION, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 1),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 4).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("electrum"), 4));
+                new AspectList().add(Aspect.TOOL, 4).add(Aspect.CRAFT, 4).add(Aspect.METAL, 4)
+                        .add(TCAspects.ELECTRUM.getAspect(), 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 2),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 4).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("lucrum"), 4));
+                new AspectList().add(Aspect.TOOL, 4).add(Aspect.CRAFT, 4).add(Aspect.METAL, 4).add(Aspect.GREED, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 3),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 4).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("permutatio"), 4));
+                new AspectList().add(Aspect.TOOL, 4).add(Aspect.CRAFT, 4).add(Aspect.METAL, 4).add(Aspect.EXCHANGE, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 4),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 4).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("aqua"), 4));
+                new AspectList().add(Aspect.TOOL, 4).add(Aspect.CRAFT, 4).add(Aspect.METAL, 4).add(Aspect.WATER, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 5),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 4).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("cognitio"), 4));
+                new AspectList().add(Aspect.TOOL, 4).add(Aspect.CRAFT, 4).add(Aspect.METAL, 4).add(Aspect.MIND, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "upgradeModule", 1, 6),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 4).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("metallum"), 4).add(Aspect.getAspect("ignis"), 4));
+                new AspectList().add(Aspect.TOOL, 4).add(Aspect.CRAFT, 4).add(Aspect.METAL, 4).add(Aspect.FIRE, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemBoat", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 8).add(Aspect.getAspect("ignis"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.METAL, 8).add(Aspect.FIRE, 8).add(Aspect.CRYSTAL, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemBoat", 1, 2),
-                new AspectList().add(Aspect.getAspect("fabrico"), 1).add(Aspect.getAspect("limus"), 1)
-                        .add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.CRAFT, 1).add(Aspect.SLIME, 1).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemCoin", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 1));
+                new AspectList().add(Aspect.METAL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemDynamite", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("strontio"), 4));
+                new AspectList().add(Aspect.ENTROPY, 8).add(TCAspects.STRONTIO.getAspect(), 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemDynamiteSticky", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("limus"), 2)
-                        .add(Aspect.getAspect("strontio"), 4));
+                new AspectList().add(Aspect.ENTROPY, 8).add(Aspect.SLIME, 2).add(TCAspects.STRONTIO.getAspect(), 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemRemote", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("instrumentum"), 4)
-                        .add(Aspect.getAspect("sensus"), 4).add(Aspect.getAspect("perditio"), 2));
+                new AspectList().add(Aspect.METAL, 6).add(Aspect.TOOL, 4).add(Aspect.SENSES, 4).add(Aspect.ENTROPY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemCellEmpty", 1, 0),
-                new AspectList().add(Aspect.getAspect("fabrico"), 2).add(Aspect.getAspect("metallum"), 2)
-                        .add(Aspect.getAspect("vitreus"), 2));
+                new AspectList().add(Aspect.CRAFT, 2).add(Aspect.METAL, 2).add(Aspect.CRYSTAL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemTinCan", 1, 0),
-                new AspectList().add(Aspect.getAspect("fabrico"), 1).add(Aspect.getAspect("metallum"), 1)
-                        .add(Aspect.getAspect("vitreus"), 1));
+                new AspectList().add(Aspect.CRAFT, 1).add(Aspect.METAL, 1).add(Aspect.CRYSTAL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemTinCanFilled", 1, 0),
-                new AspectList().add(Aspect.getAspect("fabrico"), 2).add(Aspect.getAspect("metallum"), 2)
-                        .add(Aspect.getAspect("vitreus"), 2).add(Aspect.getAspect("victus"), 4));
+                new AspectList().add(Aspect.CRAFT, 2).add(Aspect.METAL, 2).add(Aspect.CRYSTAL, 2).add(Aspect.LIFE, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "itemCellHydrant", 1, 1),
-                new AspectList().add(Aspect.getAspect("aqua"), 8).add(Aspect.getAspect("metallum"), 2));
+                new AspectList().add(Aspect.WATER, 8).add(Aspect.METAL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorCoolantSimple", 1, 1),
-                new AspectList().add(Aspect.getAspect("gelum"), 4).add(Aspect.getAspect("metallum"), 2)
-                        .add(Aspect.getAspect("vitreus"), 2));
+                new AspectList().add(Aspect.COLD, 4).add(Aspect.METAL, 2).add(Aspect.CRYSTAL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorCoolantTriple", 1, 1),
-                new AspectList().add(Aspect.getAspect("gelum"), 8).add(Aspect.getAspect("metallum"), 4)
-                        .add(Aspect.getAspect("vitreus"), 4));
+                new AspectList().add(Aspect.COLD, 8).add(Aspect.METAL, 4).add(Aspect.CRYSTAL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(IndustrialCraft2.ID, "reactorCoolantSix", 1, 1),
-                new AspectList().add(Aspect.getAspect("gelum"), 16).add(Aspect.getAspect("metallum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.COLD, 16).add(Aspect.METAL, 8).add(Aspect.CRYSTAL, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(MalisisDoors.ID, "trapdoor_acacia", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(MalisisDoors.ID, "trapdoor_birch", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(MalisisDoors.ID, "trapdoor_dark_oak", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(MalisisDoors.ID, "trapdoor_jungle", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(MalisisDoors.ID, "trapdoor_spruce", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Minecraft.ID, "blaze_powder", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("praecantatio"), 4)
-                        .add(Aspect.getAspect("instrumentum"), 2));
+                new AspectList().add(Aspect.FIRE, 6).add(Aspect.MAGIC, 4).add(Aspect.TOOL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Minecraft.ID, "blaze_rod", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 10).add(Aspect.getAspect("praecantatio"), 4));
+                new AspectList().add(Aspect.FIRE, 10).add(Aspect.MAGIC, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Minecraft.ID, "paper", 1, 0),
-                new AspectList().add(Aspect.getAspect("cognitio"), 4).add(Aspect.getAspect("aqua"), 2)
-                        .add(Aspect.getAspect("arbor"), 1));
+                new AspectList().add(Aspect.MIND, 4).add(Aspect.WATER, 2).add(Aspect.TREE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Minecraft.ID, "book", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 1).add(Aspect.getAspect("cognitio"), 1));
+                new AspectList().add(Aspect.CLOTH, 1).add(Aspect.MIND, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Minecraft.ID, "enchanted_book", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 1).add(Aspect.getAspect("cognitio"), 1)
-                        .add(Aspect.getAspect("metallum"), 1));
+                new AspectList().add(Aspect.CLOTH, 1).add(Aspect.MIND, 1).add(Aspect.METAL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Minecraft.ID, "hopper", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("arbor"), 4)
-                        .add(Aspect.getAspect("vacuos"), 3).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("permutatio"), 1));
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.TREE, 4).add(Aspect.VOID, 3).add(Aspect.MECHANISM, 1)
+                        .add(Aspect.EXCHANGE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Minecraft.ID, "furnace", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("perditio"), 6)
-                        .add(Aspect.getAspect("ignis"), 1));
+                new AspectList().add(Aspect.EARTH, 6).add(Aspect.ENTROPY, 6).add(Aspect.FIRE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Minecraft.ID, "stone_pressure_plate", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.MECHANISM, 1).add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Minecraft.ID, "redstone_torch", 1, 0),
-                new AspectList().add(Aspect.getAspect("potentia"), 1).add(Aspect.getAspect("machina"), 1));
+                new AspectList().add(Aspect.ENERGY, 1).add(Aspect.MECHANISM, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.eucalyptus", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.sakura", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.ghostwood", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.redwood", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.bloodwood", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.hopseed", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.maple", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.amaranth", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.silverbell", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.willow", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.darkwood", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Natura.ID, "trapdoor.fusewood", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("motus"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MOTION, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 4),
-                new AspectList().add(Aspect.getAspect("corpus"), 4).add(Aspect.getAspect("praecantatio"), 2)
-                        .add(Aspect.getAspect("mortuus"), 2));
+                new AspectList().add(Aspect.FLESH, 4).add(Aspect.MAGIC, 2).add(Aspect.DEATH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Thaumcraft.ID, "blockCandle", 1, 0),
-                new AspectList().add(Aspect.getAspect("lux"), 5).add(Aspect.getAspect("praecantatio"), 2)
-                        .add(Aspect.getAspect("pannus"), 1));
+                new AspectList().add(Aspect.LIGHT, 5).add(Aspect.MAGIC, 2).add(Aspect.CLOTH, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFRoots", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2));
+                new AspectList().add(Aspect.TREE, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFRoots", 1, 1),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("praecantatio"), 2));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MAGIC, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.liveRoot", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("praecantatio"), 1));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MAGIC, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFFirefly", 1, 0),
-                new AspectList().add(Aspect.getAspect("victus"), 1).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.LIFE, 1).add(Aspect.FLIGHT, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFCicada", 1, 0),
-                new AspectList().add(Aspect.getAspect("victus"), 1).add(Aspect.getAspect("volatus"), 1));
+                new AspectList().add(Aspect.LIFE, 1).add(Aspect.FLIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPortal", 1, 0),
-                new AspectList().add(Aspect.getAspect("tempus"), 4).add(Aspect.getAspect("praecantatio"), 4)
-                        .add(Aspect.getAspect("iter"), 4));
+                new AspectList().add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 4).add(Aspect.MAGIC, 4)
+                        .add(Aspect.TRAVEL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 3),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 4),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 5),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 6),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 7),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFHedge", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFFireflyJar", 1, 0),
-                new AspectList().add(Aspect.getAspect("vitreus"), 2).add(Aspect.getAspect("arbor"), 1));
+                new AspectList().add(Aspect.CRYSTAL, 2).add(Aspect.TREE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 3),
-                new AspectList().add(Aspect.getAspect("herba"), 2).add(Aspect.getAspect("victus"), 1));
+                new AspectList().add(Aspect.PLANT, 2).add(Aspect.LIFE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 4),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 8),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 9),
-                new AspectList().add(Aspect.getAspect("herba"), 2));
+                new AspectList().add(Aspect.PLANT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 10),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 11),
-                new AspectList().add(Aspect.getAspect("herba"), 1).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.PLANT, 1).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 13),
-                new AspectList().add(Aspect.getAspect("herba"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.PLANT, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 14),
-                new AspectList().add(Aspect.getAspect("arbor"), 1));
+                new AspectList().add(Aspect.TREE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFFireJet", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 2).add(Aspect.getAspect("aer"), 2)
-                        .add(Aspect.getAspect("machina"), 1));
+                new AspectList().add(Aspect.FIRE, 2).add(Aspect.AIR, 2).add(Aspect.MECHANISM, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFFireJet", 1, 8),
-                new AspectList().add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("motus"), 2)
-                        .add(Aspect.getAspect("machina"), 1));
+                new AspectList().add(Aspect.FIRE, 6).add(Aspect.MOTION, 2).add(Aspect.MECHANISM, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFNagastone", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.EARTH, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFNagastone", 1, 13),
-                new AspectList().add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.EARTH, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFSapling", 1, 5),
-                new AspectList().add(Aspect.getAspect("herba"), 4).add(Aspect.getAspect("arbor"), 2)
-                        .add(Aspect.getAspect("tempus"), 1));
+                new AspectList().add(Aspect.PLANT, 4).add(Aspect.TREE, 2)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFSapling", 1, 6),
-                new AspectList().add(Aspect.getAspect("herba"), 4).add(Aspect.getAspect("arbor"), 2)
-                        .add(Aspect.getAspect("praecantatio"), 1));
+                new AspectList().add(Aspect.PLANT, 4).add(Aspect.TREE, 2).add(Aspect.MAGIC, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFSapling", 1, 7),
-                new AspectList().add(Aspect.getAspect("herba"), 4).add(Aspect.getAspect("arbor"), 2)
-                        .add(Aspect.getAspect("perfodio"), 1));
+                new AspectList().add(Aspect.PLANT, 4).add(Aspect.TREE, 2).add(Aspect.MINE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFSapling", 1, 9),
-                new AspectList().add(Aspect.getAspect("herba"), 4).add(Aspect.getAspect("arbor"), 2)
-                        .add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.PLANT, 4).add(Aspect.TREE, 2).add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMoonworm", 1, 0),
-                new AspectList().add(Aspect.getAspect("victus"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.LIFE, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMagicLogSpecial", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 4).add(Aspect.getAspect("praecantatio"), 2)
-                        .add(Aspect.getAspect("tempus"), 2).add(Aspect.getAspect("herba"), 2)
-                        .add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.TREE, 4).add(Aspect.MAGIC, 2)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 2).add(Aspect.PLANT, 2)
+                        .add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMagicLogSpecial", 1, 1),
-                new AspectList().add(Aspect.getAspect("arbor"), 4).add(Aspect.getAspect("praecantatio"), 2)
-                        .add(Aspect.getAspect("aer"), 2).add(Aspect.getAspect("herba"), 2)
-                        .add(Aspect.getAspect("invidia"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.TREE, 4).add(Aspect.MAGIC, 2).add(Aspect.AIR, 2).add(Aspect.PLANT, 2)
+                        .add(DarkAspects.ENVY, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMagicLogSpecial", 1, 2),
-                new AspectList().add(Aspect.getAspect("arbor"), 4).add(Aspect.getAspect("praecantatio"), 2)
-                        .add(Aspect.getAspect("perfodio"), 2).add(Aspect.getAspect("herba"), 2)
-                        .add(Aspect.getAspect("lucrum"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.TREE, 4).add(Aspect.MAGIC, 2).add(Aspect.MINE, 2).add(Aspect.PLANT, 2)
+                        .add(Aspect.GREED, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMagicLogSpecial", 1, 3),
-                new AspectList().add(Aspect.getAspect("arbor"), 4).add(Aspect.getAspect("praecantatio"), 2)
-                        .add(Aspect.getAspect("motus"), 2).add(Aspect.getAspect("herba"), 2)
-                        .add(Aspect.getAspect("cognitio"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.TREE, 4).add(Aspect.MAGIC, 2).add(Aspect.MOTION, 2).add(Aspect.PLANT, 2)
+                        .add(Aspect.MIND, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 2),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("potentia"), 1));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 1).add(Aspect.ENERGY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 4),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("potentia"), 2));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 1).add(Aspect.ENERGY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 5),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("potentia"), 2));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 1).add(Aspect.ENERGY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 6),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("potentia"), 2).add(Aspect.getAspect("iter"), 1));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 1).add(Aspect.ENERGY, 2)
+                        .add(Aspect.TRAVEL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 9),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 2)
-                        .add(Aspect.getAspect("potentia"), 4).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 2).add(Aspect.ENERGY, 4)
+                        .add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 10),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 2)
-                        .add(Aspect.getAspect("potentia"), 4).add(Aspect.getAspect("vinculum"), 1));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 2).add(Aspect.ENERGY, 4)
+                        .add(Aspect.TRAP, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFShield", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("machina"), 1));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.MECHANISM, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTrophyPedestal", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 7).add(Aspect.getAspect("ordo"), 4)
-                        .add(Aspect.getAspect("lucrum"), 4).add(Aspect.getAspect("instrumentum"), 4));
+                new AspectList().add(Aspect.EARTH, 7).add(Aspect.ORDER, 4).add(Aspect.GREED, 4).add(Aspect.TOOL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTrophyPedestal", 1, 15),
-                new AspectList().add(Aspect.getAspect("terra"), 7).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("lucrum"), 12).add(Aspect.getAspect("instrumentum"), 4));
+                new AspectList().add(Aspect.EARTH, 7).add(Aspect.ORDER, 12).add(Aspect.GREED, 12).add(Aspect.TOOL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFAuroraBrick", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFUnderBrick", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFUnderBrick", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFUnderBrick", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFThorns", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("fabrico"), 1)
-                        .add(Aspect.getAspect("telum"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.CRAFT, 1).add(Aspect.WEAPON, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFThorns", 1, 1),
-                new AspectList().add(Aspect.getAspect("herba"), 3).add(Aspect.getAspect("fabrico"), 1)
-                        .add(Aspect.getAspect("telum"), 1).add(Aspect.getAspect("aqua"), 1));
+                new AspectList().add(Aspect.PLANT, 3).add(Aspect.CRAFT, 1).add(Aspect.WEAPON, 1).add(Aspect.WATER, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFBurntThorns", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFThornRose", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 2));
+                new AspectList().add(Aspect.PLANT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFLeaves3", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFLeaves3", 1, 1),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFDeadrock", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 8).add(Aspect.getAspect("ignis"), 6));
+                new AspectList().add(Aspect.EARTH, 8).add(Aspect.FIRE, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFDeadrock", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 8).add(Aspect.getAspect("ignis"), 6));
+                new AspectList().add(Aspect.EARTH, 8).add(Aspect.FIRE, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFDeadrock", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 8).add(Aspect.getAspect("ignis"), 6));
+                new AspectList().add(Aspect.EARTH, 8).add(Aspect.FIRE, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.DarkLeaves", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.AuroraPillar", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.AuroraSlab", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 2).add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.EARTH, 2).add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.AuroraDoubleSlab", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TrollSteinn", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("potentia"), 2));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.ENERGY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.WispyCloud", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 1).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("aqua"), 1).add(Aspect.getAspect("tempestas"), 1));
+                new AspectList().add(Aspect.AIR, 1).add(Aspect.FLIGHT, 1).add(Aspect.WATER, 1).add(Aspect.WEATHER, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.FluffyCloud", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 1).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("pannus"), 1).add(Aspect.getAspect("tempestas"), 1));
+                new AspectList().add(Aspect.AIR, 1).add(Aspect.FLIGHT, 1).add(Aspect.CLOTH, 1).add(Aspect.WEATHER, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.HugeStalk", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 4));
+                new AspectList().add(Aspect.PLANT, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.GiantCobble", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("perditio"), 16));
+                new AspectList().add(Aspect.EARTH, 16).add(Aspect.ENTROPY, 16));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.GiantLog", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 16));
+                new AspectList().add(Aspect.TREE, 16));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.GiantLeaves", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 16));
+                new AspectList().add(Aspect.PLANT, 16));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.GiantObsidian", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("ignis"), 16)
-                        .add(Aspect.getAspect("tenebrae"), 8));
+                new AspectList().add(Aspect.EARTH, 16).add(Aspect.FIRE, 16).add(Aspect.DARKNESS, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.UberousSoil", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("aqua"), 4)
-                        .add(Aspect.getAspect("herba"), 4).add(Aspect.getAspect("victus"), 10));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.WATER, 4).add(Aspect.PLANT, 4).add(Aspect.LIFE, 10));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.HugeGloomBlock", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("tenebrae"), 2)
-                        .add(Aspect.getAspect("herba"), 2));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.DARKNESS, 2).add(Aspect.PLANT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.KnightmetalBlock", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("lucrum"), 9));
+                new AspectList().add(Aspect.METAL, 18).add(Aspect.GREED, 9));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.UnripeTrollBer", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1).add(Aspect.getAspect("terra"), 1)
-                        .add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.PLANT, 1).add(Aspect.EARTH, 1).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TrollBer", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1).add(Aspect.getAspect("terra"), 1)
-                        .add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.PLANT, 1).add(Aspect.EARTH, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.HugeLilyPad", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 8).add(Aspect.getAspect("aqua"), 4));
+                new AspectList().add(Aspect.PLANT, 8).add(Aspect.WATER, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.HugeWaterLily", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 3));
+                new AspectList().add(Aspect.PLANT, 3));
         ThaumcraftApi.registerObjectTag(getModItem(TwilightForest.ID, "tile.Slider", 1, 0), new AspectList());
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.CastleBrick", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.CastleBrick", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.CastleBrick", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("perditio"), 2));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3).add(Aspect.ENTROPY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.CastleBrick", 1, 3),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("tenebrae"), 1));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3).add(Aspect.DARKNESS, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.CastleMagic", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("praecantatio"), 2));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3).add(Aspect.MAGIC, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.CastleMagic", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("praecantatio"), 2));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3).add(Aspect.MAGIC, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.CastleMagic", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("praecantatio"), 2));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3).add(Aspect.MAGIC, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.CastleMagic", 1, 3),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("praecantatio"), 2));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3).add(Aspect.MAGIC, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.nagaScale", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 3).add(Aspect.getAspect("tutamen"), 2)
-                        .add(Aspect.getAspect("bestia"), 2));
+                new AspectList().add(Aspect.CLOTH, 3).add(Aspect.ARMOR, 2).add(Aspect.BEAST, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.plateNaga", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 24).add(Aspect.getAspect("tutamen"), 16)
-                        .add(Aspect.getAspect("bestia"), 16).add(Aspect.getAspect("superbia"), 4));
+                new AspectList().add(Aspect.CLOTH, 24).add(Aspect.ARMOR, 16).add(Aspect.BEAST, 16)
+                        .add(DarkAspects.PRIDE, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.legsNaga", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 21).add(Aspect.getAspect("tutamen"), 14)
-                        .add(Aspect.getAspect("bestia"), 14).add(Aspect.getAspect("superbia"), 3));
+                new AspectList().add(Aspect.CLOTH, 21).add(Aspect.ARMOR, 14).add(Aspect.BEAST, 14)
+                        .add(DarkAspects.PRIDE, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.scepterTwilight", 1, 0),
-                new AspectList().add(Aspect.getAspect("alienis"), 40).add(Aspect.getAspect("iter"), 35)
-                        .add(Aspect.getAspect("praecantatio"), 25).add(Aspect.getAspect("mortuus"), 20)
-                        .add(Aspect.getAspect("corpus"), 10));
+                new AspectList().add(Aspect.ELDRITCH, 40).add(Aspect.TRAVEL, 35).add(Aspect.MAGIC, 25)
+                        .add(Aspect.DEATH, 20).add(Aspect.FLESH, 10));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.scepterLifeDrain", 1, 0),
-                new AspectList().add(Aspect.getAspect("alienis"), 40).add(Aspect.getAspect("victus"), 15)
-                        .add(Aspect.getAspect("gula"), 20).add(Aspect.getAspect("praecantatio"), 25)
-                        .add(Aspect.getAspect("mortuus"), 20).add(Aspect.getAspect("corpus"), 10));
+                new AspectList().add(Aspect.ELDRITCH, 40).add(Aspect.LIFE, 15).add(DarkAspects.GLUTTONY, 20)
+                        .add(Aspect.MAGIC, 25).add(Aspect.DEATH, 20).add(Aspect.FLESH, 10));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.scepterZombie", 1, 0),
-                new AspectList().add(Aspect.getAspect("alienis"), 40).add(Aspect.getAspect("exanimis"), 35)
-                        .add(Aspect.getAspect("praecantatio"), 25).add(Aspect.getAspect("mortuus"), 20)
-                        .add(Aspect.getAspect("corpus"), 10));
+                new AspectList().add(Aspect.ELDRITCH, 40).add(Aspect.UNDEAD, 35).add(Aspect.MAGIC, 25)
+                        .add(Aspect.DEATH, 20).add(Aspect.FLESH, 10));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.scepterTwilight", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("alienis"), 40).add(Aspect.getAspect("iter"), 35)
-                        .add(Aspect.getAspect("praecantatio"), 25).add(Aspect.getAspect("mortuus"), 20)
-                        .add(Aspect.getAspect("corpus"), 10));
+                new AspectList().add(Aspect.ELDRITCH, 40).add(Aspect.TRAVEL, 35).add(Aspect.MAGIC, 25)
+                        .add(Aspect.DEATH, 20).add(Aspect.FLESH, 10));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.scepterLifeDrain", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("alienis"), 40).add(Aspect.getAspect("victus"), 15)
-                        .add(Aspect.getAspect("gula"), 20).add(Aspect.getAspect("praecantatio"), 25)
-                        .add(Aspect.getAspect("mortuus"), 20).add(Aspect.getAspect("corpus"), 10));
+                new AspectList().add(Aspect.ELDRITCH, 40).add(Aspect.LIFE, 15).add(DarkAspects.GLUTTONY, 20)
+                        .add(Aspect.MAGIC, 25).add(Aspect.DEATH, 20).add(Aspect.FLESH, 10));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.scepterZombie", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("alienis"), 40).add(Aspect.getAspect("exanimis"), 35)
-                        .add(Aspect.getAspect("praecantatio"), 25).add(Aspect.getAspect("mortuus"), 20)
-                        .add(Aspect.getAspect("corpus"), 10));
+                new AspectList().add(Aspect.ELDRITCH, 40).add(Aspect.UNDEAD, 35).add(Aspect.MAGIC, 25)
+                        .add(Aspect.DEATH, 20).add(Aspect.FLESH, 10));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.tfFeather", 1, 0),
-                new AspectList().add(Aspect.getAspect("volatus"), 2).add(Aspect.getAspect("aer"), 1)
-                        .add(Aspect.getAspect("tenebrae"), 1));
+                new AspectList().add(Aspect.FLIGHT, 2).add(Aspect.AIR, 1).add(Aspect.DARKNESS, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.magicMapFocus", 1, 0),
-                new AspectList().add(Aspect.getAspect("volatus"), 2).add(Aspect.getAspect("aer"), 1)
-                        .add(Aspect.getAspect("tenebrae"), 1).add(Aspect.getAspect("lux"), 1)
-                        .add(Aspect.getAspect("praecantatio"), 1));
+                new AspectList().add(Aspect.FLIGHT, 2).add(Aspect.AIR, 1).add(Aspect.DARKNESS, 1).add(Aspect.LIGHT, 1)
+                        .add(Aspect.MAGIC, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.venisonRaw", 1, 0),
-                new AspectList().add(Aspect.getAspect("mortuus"), 3).add(Aspect.getAspect("victus"), 2)
-                        .add(Aspect.getAspect("bestia"), 1));
+                new AspectList().add(Aspect.DEATH, 3).add(Aspect.LIFE, 2).add(Aspect.BEAST, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.venisonCooked", 1, 0),
-                new AspectList().add(Aspect.getAspect("mortuus"), 4).add(Aspect.getAspect("fames"), 3)
-                        .add(Aspect.getAspect("fabrico"), 1));
+                new AspectList().add(Aspect.DEATH, 4).add(Aspect.HUNGER, 3).add(Aspect.CRAFT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.hydraChop", 1, 0),
-                new AspectList().add(Aspect.getAspect("mortuus"), 9).add(Aspect.getAspect("victus"), 6)
-                        .add(Aspect.getAspect("bestia"), 2));
+                new AspectList().add(Aspect.DEATH, 9).add(Aspect.LIFE, 6).add(Aspect.BEAST, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.fieryBlood", 1, 0),
-                new AspectList().add(Aspect.getAspect("vacuos"), 1).add(Aspect.getAspect("victus"), 4)
-                        .add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.VOID, 1).add(Aspect.LIFE, 4).add(Aspect.WATER, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.trophy", 1, 0),
-                new AspectList().add(Aspect.getAspect("lucrum"), 10).add(Aspect.getAspect("luxuria"), 1)
-                        .add(Aspect.getAspect("superbia"), 2).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("ignis"), 8));
+                new AspectList().add(Aspect.GREED, 10).add(DarkAspects.LUST, 1).add(DarkAspects.PRIDE, 2)
+                        .add(Aspect.CRAFT, 4).add(Aspect.FIRE, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.trophy", 1, 1),
-                new AspectList().add(Aspect.getAspect("lucrum"), 10).add(Aspect.getAspect("luxuria"), 1)
-                        .add(Aspect.getAspect("superbia"), 2).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("terra"), 8));
+                new AspectList().add(Aspect.GREED, 10).add(DarkAspects.LUST, 1).add(DarkAspects.PRIDE, 2)
+                        .add(Aspect.CRAFT, 4).add(Aspect.EARTH, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.trophy", 1, 2),
-                new AspectList().add(Aspect.getAspect("lucrum"), 10).add(Aspect.getAspect("luxuria"), 1)
-                        .add(Aspect.getAspect("superbia"), 2).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("exanimis"), 8));
+                new AspectList().add(Aspect.GREED, 10).add(DarkAspects.LUST, 1).add(DarkAspects.PRIDE, 2)
+                        .add(Aspect.CRAFT, 4).add(Aspect.UNDEAD, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.trophy", 1, 3),
-                new AspectList().add(Aspect.getAspect("lucrum"), 10).add(Aspect.getAspect("luxuria"), 1)
-                        .add(Aspect.getAspect("superbia"), 2).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("infernus"), 8));
+                new AspectList().add(Aspect.GREED, 10).add(DarkAspects.LUST, 1).add(DarkAspects.PRIDE, 2)
+                        .add(Aspect.CRAFT, 4).add(DarkAspects.NETHER, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.trophy", 1, 4),
-                new AspectList().add(Aspect.getAspect("lucrum"), 10).add(Aspect.getAspect("luxuria"), 1)
-                        .add(Aspect.getAspect("superbia"), 2).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("gelum"), 8));
+                new AspectList().add(Aspect.GREED, 10).add(DarkAspects.LUST, 1).add(DarkAspects.PRIDE, 2)
+                        .add(Aspect.CRAFT, 4).add(Aspect.COLD, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.minotaurAxe", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 10).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("telum"), 8).add(Aspect.getAspect("instrumentum"), 8)
-                        .add(Aspect.getAspect("superbia"), 4));
+                new AspectList().add(Aspect.METAL, 10).add(Aspect.CRAFT, 4).add(Aspect.WEAPON, 8).add(Aspect.TOOL, 8)
+                        .add(DarkAspects.PRIDE, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.transformPowder", 1, 0),
-                new AspectList().add(Aspect.getAspect("mortuus"), 4).add(Aspect.getAspect("fames"), 3)
-                        .add(Aspect.getAspect("fabrico"), 1));
+                new AspectList().add(Aspect.DEATH, 4).add(Aspect.HUNGER, 3).add(Aspect.CRAFT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.meefRaw", 1, 0),
-                new AspectList().add(Aspect.getAspect("mortuus"), 3).add(Aspect.getAspect("victus"), 2)
-                        .add(Aspect.getAspect("bestia"), 1));
+                new AspectList().add(Aspect.DEATH, 3).add(Aspect.LIFE, 2).add(Aspect.BEAST, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.meefSteak", 1, 0),
-                new AspectList().add(Aspect.getAspect("mortuus"), 4).add(Aspect.getAspect("fames"), 3)
-                        .add(Aspect.getAspect("fabrico"), 1));
+                new AspectList().add(Aspect.DEATH, 4).add(Aspect.HUNGER, 3).add(Aspect.CRAFT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.meefStroganoff", 1, 0),
-                new AspectList().add(Aspect.getAspect("mortuus"), 4).add(Aspect.getAspect("fames"), 4)
-                        .add(Aspect.getAspect("fabrico"), 2).add(Aspect.getAspect("arbor"), 1));
+                new AspectList().add(Aspect.DEATH, 4).add(Aspect.HUNGER, 4).add(Aspect.CRAFT, 2).add(Aspect.TREE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.mazeWafer", 1, 0),
-                new AspectList().add(Aspect.getAspect("messis"), 4).add(Aspect.getAspect("fames"), 3)
-                        .add(Aspect.getAspect("fabrico"), 1).add(Aspect.getAspect("sano"), 1));
+                new AspectList().add(Aspect.CROP, 4).add(Aspect.HUNGER, 3).add(Aspect.CRAFT, 1).add(Aspect.HEAL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.oreMagnet", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("magneto"), 4)
-                        .add(Aspect.getAspect("perfodio"), 1));
+                new AspectList().add(Aspect.METAL, 6).add(TCAspects.MAGNETO.getAspect(), 4).add(Aspect.MINE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.oreMagnet", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("metallum"), 6).add(Aspect.getAspect("magneto"), 4)
-                        .add(Aspect.getAspect("perfodio"), 1));
+                new AspectList().add(Aspect.METAL, 6).add(TCAspects.MAGNETO.getAspect(), 4).add(Aspect.MINE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.crumbleHorn", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 18).add(Aspect.getAspect("praecantatio"), 14)
-                        .add(Aspect.getAspect("ordo"), 12).add(Aspect.getAspect("auram"), 8));
+                new AspectList().add(Aspect.TREE, 18).add(Aspect.MAGIC, 14).add(Aspect.ORDER, 12).add(Aspect.AURA, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.crumbleHorn", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("arbor"), 18).add(Aspect.getAspect("praecantatio"), 14)
-                        .add(Aspect.getAspect("ordo"), 12).add(Aspect.getAspect("auram"), 8));
+                new AspectList().add(Aspect.TREE, 18).add(Aspect.MAGIC, 14).add(Aspect.ORDER, 12).add(Aspect.AURA, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.peacockFan", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 18).add(Aspect.getAspect("volatus"), 10)
-                        .add(Aspect.getAspect("motus"), 10).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("arbor"), 4));
+                new AspectList().add(Aspect.AIR, 18).add(Aspect.FLIGHT, 10).add(Aspect.MOTION, 10).add(Aspect.MAGIC, 6)
+                        .add(Aspect.TREE, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.peacockFan", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("aer"), 18).add(Aspect.getAspect("volatus"), 10)
-                        .add(Aspect.getAspect("motus"), 10).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("arbor"), 4));
+                new AspectList().add(Aspect.AIR, 18).add(Aspect.FLIGHT, 10).add(Aspect.MOTION, 10).add(Aspect.MAGIC, 6)
+                        .add(Aspect.TREE, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.moonwormQueen", 1, 0),
-                new AspectList().add(Aspect.getAspect("victus"), 10).add(Aspect.getAspect("lux"), 10)
-                        .add(Aspect.getAspect("motus"), 4));
+                new AspectList().add(Aspect.LIFE, 10).add(Aspect.LIGHT, 10).add(Aspect.MOTION, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.moonwormQueen", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("victus"), 10).add(Aspect.getAspect("lux"), 10)
-                        .add(Aspect.getAspect("motus"), 4));
+                new AspectList().add(Aspect.LIFE, 10).add(Aspect.LIGHT, 10).add(Aspect.MOTION, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.charmOfLife1", 1, 0),
-                new AspectList().add(Aspect.getAspect("sano"), 16).add(Aspect.getAspect("ordo"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 8).add(Aspect.getAspect("victus"), 8)
-                        .add(Aspect.getAspect("lucrum"), 1));
+                new AspectList().add(Aspect.HEAL, 16).add(Aspect.ORDER, 16).add(Aspect.MAGIC, 8).add(Aspect.LIFE, 8)
+                        .add(Aspect.GREED, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.charmOfLife2", 1, 0),
-                new AspectList().add(Aspect.getAspect("sano"), 64).add(Aspect.getAspect("ordo"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("victus"), 32)
-                        .add(Aspect.getAspect("lucrum"), 4));
+                new AspectList().add(Aspect.HEAL, 64).add(Aspect.ORDER, 64).add(Aspect.MAGIC, 32).add(Aspect.LIFE, 32)
+                        .add(Aspect.GREED, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.charmOfKeeping1", 1, 0),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 4).add(Aspect.getAspect("ordo"), 4)
-                        .add(Aspect.getAspect("praecantatio"), 3).add(Aspect.getAspect("tutamen"), 3)
-                        .add(Aspect.getAspect("lucrum"), 1));
+                new AspectList().add(Aspect.TOOL, 4).add(Aspect.ORDER, 4).add(Aspect.MAGIC, 3).add(Aspect.ARMOR, 3)
+                        .add(Aspect.GREED, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.charmOfKeeping2", 1, 0),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 16).add(Aspect.getAspect("ordo"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 8).add(Aspect.getAspect("tutamen"), 8)
-                        .add(Aspect.getAspect("lucrum"), 4));
+                new AspectList().add(Aspect.TOOL, 16).add(Aspect.ORDER, 16).add(Aspect.MAGIC, 8).add(Aspect.ARMOR, 8)
+                        .add(Aspect.GREED, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.charmOfKeeping3", 1, 0),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 64).add(Aspect.getAspect("ordo"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("tutamen"), 32)
-                        .add(Aspect.getAspect("lucrum"), 16));
+                new AspectList().add(Aspect.TOOL, 64).add(Aspect.ORDER, 64).add(Aspect.MAGIC, 32).add(Aspect.ARMOR, 32)
+                        .add(Aspect.GREED, 16));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.towerKey", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 2).add(Aspect.getAspect("lucrum"), 2)
-                        .add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.GREED, 2).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.borerEssence", 1, 0),
-                new AspectList().add(Aspect.getAspect("praecantatio"), 2).add(Aspect.getAspect("lucrum"), 2)
-                        .add(Aspect.getAspect("ordo"), 1));
+                new AspectList().add(Aspect.MAGIC, 2).add(Aspect.GREED, 2).add(Aspect.ORDER, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.experiment115", 1, 0),
-                new AspectList().add(Aspect.getAspect("messis"), 5).add(Aspect.getAspect("fames"), 4)
-                        .add(Aspect.getAspect("fabrico"), 2).add(Aspect.getAspect("alienis"), 1));
+                new AspectList().add(Aspect.CROP, 5).add(Aspect.HUNGER, 4).add(Aspect.CRAFT, 2)
+                        .add(Aspect.ELDRITCH, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.phantomHelm", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 5).add(Aspect.getAspect("fabrico"), 3)
-                        .add(Aspect.getAspect("metallum"), 7).add(Aspect.getAspect("spiritus"), 5)
-                        .add(Aspect.getAspect("instrumentum"), 1));
+                new AspectList().add(Aspect.ARMOR, 5).add(Aspect.CRAFT, 3).add(Aspect.METAL, 7).add(Aspect.SOUL, 5)
+                        .add(Aspect.TOOL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.phantomPlate", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 8).add(Aspect.getAspect("fabrico"), 5)
-                        .add(Aspect.getAspect("metallum"), 11).add(Aspect.getAspect("spiritus"), 8)
-                        .add(Aspect.getAspect("instrumentum"), 1));
+                new AspectList().add(Aspect.ARMOR, 8).add(Aspect.CRAFT, 5).add(Aspect.METAL, 11).add(Aspect.SOUL, 8)
+                        .add(Aspect.TOOL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.lampOfCinders", 1, 0),
-                new AspectList().add(Aspect.getAspect("lucrum"), 16).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("fabrico"), 6).add(Aspect.getAspect("praecantatio"), 8)
-                        .add(Aspect.getAspect("instrumentum"), 4).add(Aspect.getAspect("luxuria"), 1));
+                new AspectList().add(Aspect.GREED, 16).add(Aspect.FIRE, 10).add(Aspect.CRAFT, 6).add(Aspect.MAGIC, 8)
+                        .add(Aspect.TOOL, 4).add(DarkAspects.LUST, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.fieryTears", 1, 0),
-                new AspectList().add(Aspect.getAspect("vacuos"), 1).add(Aspect.getAspect("ira"), 4)
-                        .add(Aspect.getAspect("exanimis"), 4).add(Aspect.getAspect("spiritus"), 4)
-                        .add(Aspect.getAspect("praecantatio"), 2).add(Aspect.getAspect("aqua"), 1));
+                new AspectList().add(Aspect.VOID, 1).add(DarkAspects.WRATH, 4).add(Aspect.UNDEAD, 4).add(Aspect.SOUL, 4)
+                        .add(Aspect.MAGIC, 2).add(Aspect.WATER, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.alphaFur", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 6).add(Aspect.getAspect("gelum"), 3)
-                        .add(Aspect.getAspect("bestia"), 2));
+                new AspectList().add(Aspect.CLOTH, 6).add(Aspect.COLD, 3).add(Aspect.BEAST, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.arcticFur", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("gelum"), 1)
-                        .add(Aspect.getAspect("bestia"), 1));
+                new AspectList().add(Aspect.CLOTH, 2).add(Aspect.COLD, 1).add(Aspect.BEAST, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.iceBomb", 1, 0),
-                new AspectList().add(Aspect.getAspect("gelum"), 8).add(Aspect.getAspect("motus"), 8)
-                        .add(Aspect.getAspect("fabrico"), 1));
+                new AspectList().add(Aspect.COLD, 8).add(Aspect.MOTION, 8).add(Aspect.CRAFT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.arcticHelm", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 3).add(Aspect.getAspect("fabrico"), 2)
-                        .add(Aspect.getAspect("pannus"), 6).add(Aspect.getAspect("gelum"), 2)
-                        .add(Aspect.getAspect("instrumentum"), 1));
+                new AspectList().add(Aspect.ARMOR, 3).add(Aspect.CRAFT, 2).add(Aspect.CLOTH, 6).add(Aspect.COLD, 2)
+                        .add(Aspect.TOOL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.arcticPlate", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 7).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("pannus"), 14).add(Aspect.getAspect("gelum"), 4)
-                        .add(Aspect.getAspect("instrumentum"), 1));
+                new AspectList().add(Aspect.ARMOR, 7).add(Aspect.CRAFT, 4).add(Aspect.CLOTH, 14).add(Aspect.COLD, 4)
+                        .add(Aspect.TOOL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.arcticLegs", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 5).add(Aspect.getAspect("fabrico"), 3)
-                        .add(Aspect.getAspect("pannus"), 10).add(Aspect.getAspect("gelum"), 3)
-                        .add(Aspect.getAspect("instrumentum"), 1));
+                new AspectList().add(Aspect.ARMOR, 5).add(Aspect.CRAFT, 3).add(Aspect.CLOTH, 10).add(Aspect.COLD, 3)
+                        .add(Aspect.TOOL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.arcticBoots", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 2).add(Aspect.getAspect("fabrico"), 2)
-                        .add(Aspect.getAspect("pannus"), 4).add(Aspect.getAspect("gelum"), 2)
-                        .add(Aspect.getAspect("instrumentum"), 1));
+                new AspectList().add(Aspect.ARMOR, 2).add(Aspect.CRAFT, 2).add(Aspect.CLOTH, 4).add(Aspect.COLD, 2)
+                        .add(Aspect.TOOL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.yetiHelm", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 4).add(Aspect.getAspect("fabrico"), 2)
-                        .add(Aspect.getAspect("pannus"), 12).add(Aspect.getAspect("gelum"), 4)
-                        .add(Aspect.getAspect("instrumentum"), 1).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.ARMOR, 4).add(Aspect.CRAFT, 2).add(Aspect.CLOTH, 12).add(Aspect.COLD, 4)
+                        .add(Aspect.TOOL, 1).add(Aspect.MAGIC, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.yetiPlate", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 8).add(Aspect.getAspect("fabrico"), 4)
-                        .add(Aspect.getAspect("pannus"), 24).add(Aspect.getAspect("gelum"), 8)
-                        .add(Aspect.getAspect("instrumentum"), 1).add(Aspect.getAspect("praecantatio"), 4));
+                new AspectList().add(Aspect.ARMOR, 8).add(Aspect.CRAFT, 4).add(Aspect.CLOTH, 24).add(Aspect.COLD, 8)
+                        .add(Aspect.TOOL, 1).add(Aspect.MAGIC, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.yetiLegs", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 6).add(Aspect.getAspect("fabrico"), 3)
-                        .add(Aspect.getAspect("pannus"), 18).add(Aspect.getAspect("gelum"), 6)
-                        .add(Aspect.getAspect("instrumentum"), 1).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.ARMOR, 6).add(Aspect.CRAFT, 3).add(Aspect.CLOTH, 18).add(Aspect.COLD, 6)
+                        .add(Aspect.TOOL, 1).add(Aspect.MAGIC, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.yetiBoots", 1, 0),
-                new AspectList().add(Aspect.getAspect("tutamen"), 3).add(Aspect.getAspect("fabrico"), 2)
-                        .add(Aspect.getAspect("pannus"), 9).add(Aspect.getAspect("gelum"), 3)
-                        .add(Aspect.getAspect("instrumentum"), 1).add(Aspect.getAspect("praecantatio"), 2));
+                new AspectList().add(Aspect.ARMOR, 3).add(Aspect.CRAFT, 2).add(Aspect.CLOTH, 9).add(Aspect.COLD, 3)
+                        .add(Aspect.TOOL, 1).add(Aspect.MAGIC, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.magicBeans", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 16).add(Aspect.getAspect("praecantatio"), 8)
-                        .add(Aspect.getAspect("sensus"), 4));
+                new AspectList().add(Aspect.PLANT, 16).add(Aspect.MAGIC, 8).add(Aspect.SENSES, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.giantPick", 1, 0),
-                new AspectList().add(Aspect.getAspect("perfodio"), 32).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("arbor"), 8));
+                new AspectList().add(Aspect.MINE, 32).add(Aspect.EARTH, 16).add(Aspect.ENTROPY, 16)
+                        .add(Aspect.TREE, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.giantSword", 1, 0),
-                new AspectList().add(Aspect.getAspect("telum"), 32).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("arbor"), 8));
+                new AspectList().add(Aspect.WEAPON, 32).add(Aspect.EARTH, 16).add(Aspect.ENTROPY, 16)
+                        .add(Aspect.TREE, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.enderBow", 1, 0),
-                new AspectList().add(Aspect.getAspect("telum"), 3).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 2)
-                        .add(Aspect.getAspect("alienis"), 2));
+                new AspectList().add(Aspect.WEAPON, 3).add(Aspect.FLIGHT, 1).add(Aspect.CLOTH, 2).add(Aspect.BEAST, 2)
+                        .add(Aspect.ELDRITCH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.iceBow", 1, 0),
-                new AspectList().add(Aspect.getAspect("telum"), 3).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 2)
-                        .add(Aspect.getAspect("gelum"), 2));
+                new AspectList().add(Aspect.WEAPON, 3).add(Aspect.FLIGHT, 1).add(Aspect.CLOTH, 2).add(Aspect.BEAST, 2)
+                        .add(Aspect.COLD, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.tripleBow", 1, 0),
-                new AspectList().add(Aspect.getAspect("telum"), 6).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 2)
-                        .add(Aspect.getAspect("arbor"), 1));
+                new AspectList().add(Aspect.WEAPON, 6).add(Aspect.FLIGHT, 1).add(Aspect.CLOTH, 2).add(Aspect.BEAST, 2)
+                        .add(Aspect.TREE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.seekerBow", 1, 0),
-                new AspectList().add(Aspect.getAspect("telum"), 3).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 2)
-                        .add(Aspect.getAspect("iter"), 2));
+                new AspectList().add(Aspect.WEAPON, 3).add(Aspect.FLIGHT, 1).add(Aspect.CLOTH, 2).add(Aspect.BEAST, 2)
+                        .add(Aspect.TRAVEL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.iceSword", 1, 0),
-                new AspectList().add(Aspect.getAspect("telum"), 4).add(Aspect.getAspect("lucrum"), 2)
-                        .add(Aspect.getAspect("praecantatio"), 2).add(Aspect.getAspect("gelum"), 6));
+                new AspectList().add(Aspect.WEAPON, 4).add(Aspect.GREED, 2).add(Aspect.MAGIC, 2).add(Aspect.COLD, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.glassSword", 1, 0),
-                new AspectList().add(Aspect.getAspect("telum"), 14).add(Aspect.getAspect("vitreus"), 20)
-                        .add(Aspect.getAspect("lucrum"), 1));
+                new AspectList().add(Aspect.WEAPON, 14).add(Aspect.CRYSTAL, 20).add(Aspect.GREED, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.giantPick", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("perfodio"), 32).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("arbor"), 8));
+                new AspectList().add(Aspect.MINE, 32).add(Aspect.EARTH, 16).add(Aspect.ENTROPY, 16)
+                        .add(Aspect.TREE, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.giantSword", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("telum"), 32).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("arbor"), 8));
+                new AspectList().add(Aspect.WEAPON, 32).add(Aspect.EARTH, 16).add(Aspect.ENTROPY, 16)
+                        .add(Aspect.TREE, 8));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.enderBow", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("telum"), 3).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 2)
-                        .add(Aspect.getAspect("alienis"), 2));
+                new AspectList().add(Aspect.WEAPON, 3).add(Aspect.FLIGHT, 1).add(Aspect.CLOTH, 2).add(Aspect.BEAST, 2)
+                        .add(Aspect.ELDRITCH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.iceBow", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("telum"), 3).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 2)
-                        .add(Aspect.getAspect("gelum"), 2));
+                new AspectList().add(Aspect.WEAPON, 3).add(Aspect.FLIGHT, 1).add(Aspect.CLOTH, 2).add(Aspect.BEAST, 2)
+                        .add(Aspect.COLD, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.tripleBow", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("telum"), 6).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 2)
-                        .add(Aspect.getAspect("arbor"), 1));
+                new AspectList().add(Aspect.WEAPON, 6).add(Aspect.FLIGHT, 1).add(Aspect.CLOTH, 2).add(Aspect.BEAST, 2)
+                        .add(Aspect.TREE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.seekerBow", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("telum"), 3).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 2)
-                        .add(Aspect.getAspect("iter"), 2));
+                new AspectList().add(Aspect.WEAPON, 3).add(Aspect.FLIGHT, 1).add(Aspect.CLOTH, 2).add(Aspect.BEAST, 2)
+                        .add(Aspect.TRAVEL, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.iceSword", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("telum"), 4).add(Aspect.getAspect("lucrum"), 2)
-                        .add(Aspect.getAspect("praecantatio"), 2).add(Aspect.getAspect("gelum"), 6));
+                new AspectList().add(Aspect.WEAPON, 4).add(Aspect.GREED, 2).add(Aspect.MAGIC, 2).add(Aspect.COLD, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.glassSword", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("telum"), 14).add(Aspect.getAspect("vitreus"), 20)
-                        .add(Aspect.getAspect("lucrum"), 1));
+                new AspectList().add(Aspect.WEAPON, 14).add(Aspect.CRYSTAL, 20).add(Aspect.GREED, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.knightmetalRing", 1, 0),
-                new AspectList().add(Aspect.getAspect("instrumentum"), 3).add(Aspect.getAspect("ordo"), 3)
-                        .add(Aspect.getAspect("fabrico"), 3));
+                new AspectList().add(Aspect.TOOL, 3).add(Aspect.ORDER, 3).add(Aspect.CRAFT, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.chainBlock", 1, 0),
-                new AspectList().add(Aspect.getAspect("telum"), 10).add(Aspect.getAspect("metallum"), 20)
-                        .add(Aspect.getAspect("motus"), 4).add(Aspect.getAspect("lucrum"), 8)
-                        .add(Aspect.getAspect("instrumentum"), 10));
+                new AspectList().add(Aspect.WEAPON, 10).add(Aspect.METAL, 20).add(Aspect.MOTION, 4).add(Aspect.GREED, 8)
+                        .add(Aspect.TOOL, 10));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.chainBlock", 1, wildcard),
-                new AspectList().add(Aspect.getAspect("telum"), 10).add(Aspect.getAspect("metallum"), 20)
-                        .add(Aspect.getAspect("motus"), 4).add(Aspect.getAspect("lucrum"), 8)
-                        .add(Aspect.getAspect("instrumentum"), 10));
+                new AspectList().add(Aspect.WEAPON, 10).add(Aspect.METAL, 20).add(Aspect.MOTION, 4).add(Aspect.GREED, 8)
+                        .add(Aspect.TOOL, 10));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Forestry.ID, "grafter", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 2).add(Aspect.getAspect("arbor"), 1)
-                        .add(Aspect.getAspect("instrumentum"), 1));
+                new AspectList().add(Aspect.METAL, 2).add(Aspect.TREE, 1).add(Aspect.TOOL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(Forestry.ID, "scoop", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 4).add(Aspect.getAspect("pannus"), 3)
-                        .add(Aspect.getAspect("instrumentum"), 1));
+                new AspectList().add(Aspect.TREE, 4).add(Aspect.CLOTH, 3).add(Aspect.TOOL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(ThaumicBases.ID, "tobaccoPowder", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1).add(Aspect.getAspect("humanus"), 1)
-                        .add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.PLANT, 1).add(Aspect.MAN, 1).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 NHItemList.NANCertificate.get(1),
                 new AspectList().add(Aspect.METAL, 64).add(Aspect.CRAFT, 64).add(Aspect.CRYSTAL, 64));

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicBases.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicBases.java
@@ -19,7 +19,6 @@ import static gregtech.api.recipe.RecipeMaps.compressorRecipes;
 import static gregtech.api.recipe.RecipeMaps.cutterRecipes;
 import static gregtech.api.recipe.RecipeMaps.fluidExtractionRecipes;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
-import static thaumcraft.api.aspects.Aspect.getAspect;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,10 +30,12 @@ import com.dreammaster.item.NHItemList;
 import com.dreammaster.oredict.OreDictHelper;
 import com.dreammaster.thaumcraft.TCHelper;
 
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.enums.TCAspects;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTModHandler;
 import gtPlusPlus.xmod.gregtech.api.enums.GregtechItemList;
@@ -163,8 +164,7 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Relocator",
                 getModItem(ThaumicBases.ID, "relocator", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("aqua"), 5),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.EARTH, 10).add(Aspect.WATER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -189,8 +189,7 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Relocator",
                 getModItem(ThaumicBases.ID, "relocator", 1, 6),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("aqua"), 5),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.EARTH, 10).add(Aspect.WATER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -216,9 +215,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.AdvAlc",
                 getModItem(ThaumicBases.ID, "advAlchFurnace", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("ignis"), 48).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("machina"), 16).add(Aspect.getAspect("metallum"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 24),
+                new AspectList().add(Aspect.FIRE, 48).add(Aspect.ENERGY, 32).add(Aspect.MECHANISM, 16)
+                        .add(Aspect.METAL, 16).add(Aspect.MAGIC, 24),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 0),
                 getModItem(Railcraft.ID, "machine.beta", 1, 4),
                 OrePrefixes.plateDense.get(Materials.Steel),
@@ -230,9 +228,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.ThaumicAnvil",
                 getModItem(ThaumicBases.ID, "thaumicAnvil", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("aqua"), 50).add(Aspect.getAspect("terra"), 50)
-                        .add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("perditio"), 50),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.FIRE, 50).add(Aspect.WATER, 50).add(Aspect.EARTH, 50)
+                        .add(Aspect.ORDER, 50).add(Aspect.ENTROPY, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -258,9 +255,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "ROD_tbthaumium",
                 getModItem(ThaumicBases.ID, "resource", 1, 3),
                 6,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("auram"), 16)
-                        .add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("vitreus"), 16)
-                        .add(Aspect.getAspect("instrumentum"), 32),
+                new AspectList().add(Aspect.MAGIC, 32).add(Aspect.AURA, 16).add(Aspect.METAL, 16)
+                        .add(Aspect.CRYSTAL, 16).add(Aspect.TOOL, 32),
                 OrePrefixes.stick.get(Materials.Thaumium),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 OrePrefixes.dust.get(Materials.Thaumium),
@@ -277,8 +273,7 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.BloodyRobes",
                 getModItem(ThaumicBases.ID, "bloodyChest", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 25).add(Aspect.getAspect("ignis"), 25)
-                        .add(Aspect.getAspect("aqua"), 25).add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.AIR, 25).add(Aspect.FIRE, 25).add(Aspect.WATER, 25).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -303,8 +298,7 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.BloodyRobes",
                 getModItem(ThaumicBases.ID, "bloodyLeggings", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 25).add(Aspect.getAspect("ignis"), 25)
-                        .add(Aspect.getAspect("aqua"), 25).add(Aspect.getAspect("perditio"), 25),
+                new AspectList().add(Aspect.AIR, 25).add(Aspect.FIRE, 25).add(Aspect.WATER, 25).add(Aspect.ENTROPY, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -329,8 +323,7 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.BloodyRobes",
                 getModItem(ThaumicBases.ID, "bloodyBoots", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 25).add(Aspect.getAspect("ignis"), 25)
-                        .add(Aspect.getAspect("aqua"), 25).add(Aspect.getAspect("terra"), 25),
+                new AspectList().add(Aspect.AIR, 25).add(Aspect.FIRE, 25).add(Aspect.WATER, 25).add(Aspect.EARTH, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -349,8 +342,7 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Spike.Iron",
                 getModItem(ThaumicBases.ID, "spike", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 20).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("terra"), 10),
+                new AspectList().add(Aspect.ENTROPY, 20).add(Aspect.FIRE, 20).add(Aspect.AIR, 15).add(Aspect.EARTH, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -373,8 +365,7 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Spike.Thaumic",
                 getModItem(ThaumicBases.ID, "spike", 1, 2),
-                new AspectList().add(Aspect.getAspect("perditio"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("terra"), 20),
+                new AspectList().add(Aspect.ENTROPY, 50).add(Aspect.FIRE, 50).add(Aspect.AIR, 30).add(Aspect.EARTH, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -398,9 +389,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.Spike.Void",
                 getModItem(ThaumicBases.ID, "spike", 1, 4),
                 5,
-                new AspectList().add(getAspect("telum"), 32).add(getAspect("instrumentum"), 32)
-                        .add(getAspect("tenebrae"), 16).add(getAspect("alienis"), 16).add(getAspect("metallum"), 16)
-                        .add(getAspect("mortuus"), 16),
+                new AspectList().add(Aspect.WEAPON, 32).add(Aspect.TOOL, 32).add(Aspect.DARKNESS, 16)
+                        .add(Aspect.ELDRITCH, 16).add(Aspect.METAL, 16).add(Aspect.DEATH, 16),
                 getModItem(ThaumicBases.ID, "spike", 1, 2),
                 plate.get(Void),
                 createItemStack(TinkersGregworks.ID, "tGregToolPartArrowHead", 1, 1520, "{material:\"Titanium\"}"),
@@ -415,10 +405,9 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.VoidAnvil",
                 getModItem(ThaumicBases.ID, "voidAnvil", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("telum"), 32).add(Aspect.getAspect("instrumentum"), 32)
-                        .add(Aspect.getAspect("fabrico"), 32).add(Aspect.getAspect("alienis"), 32)
-                        .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("vacuos"), 16)
-                        .add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("praecantatio"), 16),
+                new AspectList().add(Aspect.WEAPON, 32).add(Aspect.TOOL, 32).add(Aspect.CRAFT, 32)
+                        .add(Aspect.ELDRITCH, 32).add(Aspect.DARKNESS, 16).add(Aspect.VOID, 16).add(Aspect.METAL, 16)
+                        .add(Aspect.MAGIC, 16),
                 getModItem(ThaumicBases.ID, "thaumicAnvil", 1, 0),
                 OrePrefixes.plate.get(Materials.Void),
                 getModItem(ThaumicBases.ID, "voidBlock", 1, 0),
@@ -433,11 +422,9 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.VoidSeed",
                 getModItem(ThaumicBases.ID, "voidSeed", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("messis"), 64).add(Aspect.getAspect("herba"), 64)
-                        .add(Aspect.getAspect("victus"), 32).add(Aspect.getAspect("auram"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("alienis"), 16)
-                        .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("desidia"), 8)
-                        .add(Aspect.getAspect("nebrisum"), 8),
+                new AspectList().add(Aspect.CROP, 64).add(Aspect.PLANT, 64).add(Aspect.LIFE, 32).add(Aspect.AURA, 32)
+                        .add(Aspect.MAGIC, 16).add(Aspect.ELDRITCH, 16).add(Aspect.DARKNESS, 16)
+                        .add(DarkAspects.SLOTH, 8).add(TCAspects.NEBRISUM.getAspect(), 8),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 17),
                 getModItem(ThaumicBases.ID, "lazulliaSeeds", 1, 0),
                 getModItem(ThaumicBases.ID, "lucriteSeeds", 1, 0),
@@ -455,9 +442,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "CAP_thauminite",
                 getModItem(ThaumicBases.ID, "resource", 1, 2),
                 6,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("auram"), 16)
-                        .add(Aspect.getAspect("metallum"), 16).add(Aspect.getAspect("vitreus"), 16)
-                        .add(Aspect.getAspect("instrumentum"), 32),
+                new AspectList().add(Aspect.MAGIC, 32).add(Aspect.AURA, 16).add(Aspect.METAL, 16)
+                        .add(Aspect.CRYSTAL, 16).add(Aspect.TOOL, 32),
                 getModItem(Thaumcraft.ID, "WandCap", 1, 2),
                 getModItem(ThaumicBases.ID, "resource", 1, 1),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
@@ -472,8 +458,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.Foci.Experience",
                 getModItem(ThaumicBases.ID, "fociExperience", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("lucrum"), 32).add(Aspect.getAspect("vitreus"), 32)
-                        .add(Aspect.getAspect("cognitio"), 16).add(Aspect.getAspect("permutatio"), 16),
+                new AspectList().add(Aspect.GREED, 32).add(Aspect.CRYSTAL, 32).add(Aspect.MIND, 16)
+                        .add(Aspect.EXCHANGE, 16),
                 OrePrefixes.lens.get(Materials.Emerald),
                 getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3),
@@ -486,8 +472,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.Foci.Activation",
                 getModItem(ThaumicBases.ID, "fociActivation", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("motus"), 32).add(Aspect.getAspect("vitreus"), 32)
-                        .add(Aspect.getAspect("iter"), 16).add(Aspect.getAspect("sensus"), 16),
+                new AspectList().add(Aspect.MOTION, 32).add(Aspect.CRYSTAL, 32).add(Aspect.TRAVEL, 16)
+                        .add(Aspect.SENSES, 16),
                 OrePrefixes.lens.get(Materials.InfusedOrder),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4),
                 ItemList.Emitter_LV.get(1L),
@@ -499,8 +485,7 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.Foci.Drain",
                 getModItem(ThaumicBases.ID, "fociDrain", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("perditio"), 32)
-                        .add(Aspect.getAspect("aqua"), 16),
+                new AspectList().add(Aspect.VOID, 32).add(Aspect.ENTROPY, 32).add(Aspect.WATER, 16),
                 OrePrefixes.lens.get(Materials.InfusedWater),
                 getModItem(Minecraft.ID, "bucket", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2),
@@ -514,9 +499,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.Foci.Flux",
                 getModItem(ThaumicBases.ID, "fociFlux", 1, 0),
                 7,
-                new AspectList().add(Aspect.getAspect("vitium"), 32).add(Aspect.getAspect("perditio"), 32)
-                        .add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("sano"), 16),
+                new AspectList().add(Aspect.TAINT, 32).add(Aspect.ENTROPY, 32).add(Aspect.ORDER, 16)
+                        .add(Aspect.MAGIC, 16).add(Aspect.HEAL, 16),
                 OrePrefixes.lens.get(Materials.EnderEye),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6),
                 getModItem(Thaumcraft.ID, "blockCustomPlant", 1, 4),
@@ -529,8 +513,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.CryingObs",
                 getModItem(ThaumicBases.ID, "cryingObsidian", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("iter"), 32).add(Aspect.getAspect("vinculum"), 32)
-                        .add(Aspect.getAspect("desidia"), 16).add(Aspect.getAspect("sensus"), 16),
+                new AspectList().add(Aspect.TRAVEL, 32).add(Aspect.TRAP, 32).add(DarkAspects.SLOTH, 16)
+                        .add(Aspect.SENSES, 16),
                 GregtechItemList.DoubleCompressedObsidian.get(1),
                 getModItem(IndustrialCraft2.ID, "itemDensePlates", 1, 8),
                 getModItem(CarpentersBlocks.ID, "itemCarpentersBed", 1, 0),
@@ -540,8 +524,7 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.TaintFlask",
                 getModItem(ThaumicBases.ID, "concentratedTaint", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("vitium"), 64).add(Aspect.getAspect("venenum"), 32)
-                        .add(Aspect.getAspect("perditio"), 16),
+                new AspectList().add(Aspect.TAINT, 64).add(Aspect.POISON, 32).add(Aspect.ENTROPY, 16),
                 getModItem(Thaumcraft.ID, "ItemBottleTaint", 1, 0),
                 getModItem(ThaumicBases.ID, "knoseFragment", 1, 7),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
@@ -552,8 +535,7 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.EntityDec",
                 getModItem(ThaumicBases.ID, "entityDeconstructor", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("cognitio"), 32).add(Aspect.getAspect("spiritus"), 24)
-                        .add(Aspect.getAspect("mortuus"), 16).add(Aspect.getAspect("praecantatio"), 16),
+                new AspectList().add(Aspect.MIND, 32).add(Aspect.SOUL, 24).add(Aspect.DEATH, 16).add(Aspect.MAGIC, 16),
                 getModItem(Thaumcraft.ID, "blockTable", 1, 14),
                 getModItem(Minecraft.ID, "light_weighted_pressure_plate", 1, 0),
                 OrePrefixes.lens.get(Materials.InfusedAir),
@@ -567,9 +549,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "ROD_tbvoid",
                 getModItem(ThaumicBases.ID, "resource", 1, 4),
                 8,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("auram"), 32)
-                        .add(Aspect.getAspect("vitreus"), 16).add(Aspect.getAspect("instrumentum"), 32)
-                        .add(Aspect.getAspect("potentia"), 40).add(Aspect.getAspect("vacuos"), 24),
+                new AspectList().add(Aspect.MAGIC, 64).add(Aspect.AURA, 32).add(Aspect.CRYSTAL, 16).add(Aspect.TOOL, 32)
+                        .add(Aspect.ENERGY, 40).add(Aspect.VOID, 24),
                 getModItem(ThaumicBases.ID, "resource", 1, 3),
                 getModItem(ThaumicBases.ID, "knoseFragment", 1, 7),
                 getModItem(ThaumicBases.ID, "crystalBlock", 1, 7),
@@ -584,9 +565,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeMan",
                 getModItem(ThaumicBases.ID, "nodeManipulator", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("auram"), 48)
-                        .add(Aspect.getAspect("praecantatio"), 40).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("tenebrae"), 24),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.AURA, 48).add(Aspect.MAGIC, 40)
+                        .add(Aspect.ENERGY, 32).add(Aspect.VOID, 32).add(Aspect.DARKNESS, 24),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11),
                 getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0),
                 ItemList.Emitter_EV.get(1L),
@@ -604,9 +584,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeLinker",
                 getModItem(ThaumicBases.ID, "nodeLinker", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("machina"), 48)
-                        .add(Aspect.getAspect("instrumentum"), 40).add(Aspect.getAspect("ordo"), 32)
-                        .add(Aspect.getAspect("electrum"), 32),
+                new AspectList().add(Aspect.ENERGY, 64).add(Aspect.MECHANISM, 48).add(Aspect.TOOL, 40)
+                        .add(Aspect.ORDER, 32).add(TCAspects.ELECTRUM.getAspect(), 32),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 14),
                 ItemList.Emitter_MV.get(1L),
@@ -621,11 +600,9 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.Overchanter",
                 getModItem(ThaumicBases.ID, "overchanter", 1, 0),
                 15,
-                new AspectList().add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("aqua"), 32)
-                        .add(Aspect.getAspect("terra"), 32).add(Aspect.getAspect("ignis"), 32)
-                        .add(Aspect.getAspect("ordo"), 32).add(Aspect.getAspect("perditio"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("machina"), 32)
-                        .add(Aspect.getAspect("cognitio"), 32),
+                new AspectList().add(Aspect.AIR, 32).add(Aspect.WATER, 32).add(Aspect.EARTH, 32).add(Aspect.FIRE, 32)
+                        .add(Aspect.ORDER, 32).add(Aspect.ENTROPY, 32).add(Aspect.MAGIC, 32).add(Aspect.MECHANISM, 32)
+                        .add(Aspect.MIND, 32),
                 getModItem(Minecraft.ID, "enchanting_table", 1, 0),
                 getModItem(ThaumicBases.ID, "crystalBlock", 1, 0),
                 getModItem(ThaumicBases.ID, "crystalBlock", 1, 1),
@@ -641,9 +618,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Iron",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("aqua"), 30).add(Aspect.getAspect("terra"), 30)
-                        .add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("perditio"), 30),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.FIRE, 30).add(Aspect.WATER, 30).add(Aspect.EARTH, 30)
+                        .add(Aspect.ORDER, 30).add(Aspect.ENTROPY, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -668,9 +644,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Gold",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 60).add(Aspect.getAspect("ignis"), 60)
-                        .add(Aspect.getAspect("aqua"), 60).add(Aspect.getAspect("terra"), 60)
-                        .add(Aspect.getAspect("ordo"), 60).add(Aspect.getAspect("perditio"), 60),
+                new AspectList().add(Aspect.AIR, 60).add(Aspect.FIRE, 60).add(Aspect.WATER, 60).add(Aspect.EARTH, 60)
+                        .add(Aspect.ORDER, 60).add(Aspect.ENTROPY, 60),
                 "abc",
                 "def",
                 "ghi",
@@ -695,9 +670,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Greatwood",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 90).add(Aspect.getAspect("ignis"), 90)
-                        .add(Aspect.getAspect("aqua"), 90).add(Aspect.getAspect("terra"), 90)
-                        .add(Aspect.getAspect("ordo"), 90).add(Aspect.getAspect("perditio"), 90),
+                new AspectList().add(Aspect.AIR, 90).add(Aspect.FIRE, 90).add(Aspect.WATER, 90).add(Aspect.EARTH, 90)
+                        .add(Aspect.ORDER, 90).add(Aspect.ENTROPY, 90),
                 "abc",
                 "def",
                 "ghi",
@@ -722,9 +696,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Reed",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 5),
-                new AspectList().add(Aspect.getAspect("aer"), 120).add(Aspect.getAspect("ignis"), 120)
-                        .add(Aspect.getAspect("aqua"), 120).add(Aspect.getAspect("terra"), 120)
-                        .add(Aspect.getAspect("ordo"), 120).add(Aspect.getAspect("perditio"), 120),
+                new AspectList().add(Aspect.AIR, 120).add(Aspect.FIRE, 120).add(Aspect.WATER, 120)
+                        .add(Aspect.EARTH, 120).add(Aspect.ORDER, 120).add(Aspect.ENTROPY, 120),
                 "abc",
                 "def",
                 "ghi",
@@ -749,9 +722,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Bone",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 6),
-                new AspectList().add(Aspect.getAspect("aer"), 120).add(Aspect.getAspect("ignis"), 120)
-                        .add(Aspect.getAspect("aqua"), 120).add(Aspect.getAspect("terra"), 120)
-                        .add(Aspect.getAspect("ordo"), 120).add(Aspect.getAspect("perditio"), 120),
+                new AspectList().add(Aspect.AIR, 120).add(Aspect.FIRE, 120).add(Aspect.WATER, 120)
+                        .add(Aspect.EARTH, 120).add(Aspect.ORDER, 120).add(Aspect.ENTROPY, 120),
                 "abc",
                 "def",
                 "ghi",
@@ -776,9 +748,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Obsidian",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 7),
-                new AspectList().add(Aspect.getAspect("aer"), 120).add(Aspect.getAspect("ignis"), 120)
-                        .add(Aspect.getAspect("aqua"), 120).add(Aspect.getAspect("terra"), 120)
-                        .add(Aspect.getAspect("ordo"), 120).add(Aspect.getAspect("perditio"), 120),
+                new AspectList().add(Aspect.AIR, 120).add(Aspect.FIRE, 120).add(Aspect.WATER, 120)
+                        .add(Aspect.EARTH, 120).add(Aspect.ORDER, 120).add(Aspect.ENTROPY, 120),
                 "abc",
                 "def",
                 "ghi",
@@ -803,9 +774,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Blaze",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 8),
-                new AspectList().add(Aspect.getAspect("aer"), 120).add(Aspect.getAspect("ignis"), 120)
-                        .add(Aspect.getAspect("aqua"), 120).add(Aspect.getAspect("terra"), 120)
-                        .add(Aspect.getAspect("ordo"), 120).add(Aspect.getAspect("perditio"), 120),
+                new AspectList().add(Aspect.AIR, 120).add(Aspect.FIRE, 120).add(Aspect.WATER, 120)
+                        .add(Aspect.EARTH, 120).add(Aspect.ORDER, 120).add(Aspect.ENTROPY, 120),
                 "abc",
                 "def",
                 "ghi",
@@ -830,9 +800,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Ice",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 9),
-                new AspectList().add(Aspect.getAspect("aer"), 120).add(Aspect.getAspect("ignis"), 120)
-                        .add(Aspect.getAspect("aqua"), 120).add(Aspect.getAspect("terra"), 120)
-                        .add(Aspect.getAspect("ordo"), 120).add(Aspect.getAspect("perditio"), 120),
+                new AspectList().add(Aspect.AIR, 120).add(Aspect.FIRE, 120).add(Aspect.WATER, 120)
+                        .add(Aspect.EARTH, 120).add(Aspect.ORDER, 120).add(Aspect.ENTROPY, 120),
                 "abc",
                 "def",
                 "ghi",
@@ -857,9 +826,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Quartz",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 10),
-                new AspectList().add(Aspect.getAspect("aer"), 120).add(Aspect.getAspect("ignis"), 120)
-                        .add(Aspect.getAspect("aqua"), 120).add(Aspect.getAspect("terra"), 120)
-                        .add(Aspect.getAspect("ordo"), 120).add(Aspect.getAspect("perditio"), 120),
+                new AspectList().add(Aspect.AIR, 120).add(Aspect.FIRE, 120).add(Aspect.WATER, 120)
+                        .add(Aspect.EARTH, 120).add(Aspect.ORDER, 120).add(Aspect.ENTROPY, 120),
                 "abc",
                 "def",
                 "ghi",
@@ -884,9 +852,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Thaumium",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 3),
-                new AspectList().add(Aspect.getAspect("aer"), 135).add(Aspect.getAspect("ignis"), 135)
-                        .add(Aspect.getAspect("aqua"), 135).add(Aspect.getAspect("terra"), 135)
-                        .add(Aspect.getAspect("ordo"), 135).add(Aspect.getAspect("perditio"), 135),
+                new AspectList().add(Aspect.AIR, 135).add(Aspect.FIRE, 135).add(Aspect.WATER, 135)
+                        .add(Aspect.EARTH, 135).add(Aspect.ORDER, 135).add(Aspect.ENTROPY, 135),
                 "abc",
                 "def",
                 "ghi",
@@ -911,9 +878,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Silverwood",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 4),
-                new AspectList().add(Aspect.getAspect("aer"), 150).add(Aspect.getAspect("ignis"), 150)
-                        .add(Aspect.getAspect("aqua"), 150).add(Aspect.getAspect("terra"), 150)
-                        .add(Aspect.getAspect("ordo"), 150).add(Aspect.getAspect("perditio"), 150),
+                new AspectList().add(Aspect.AIR, 150).add(Aspect.FIRE, 150).add(Aspect.WATER, 150)
+                        .add(Aspect.EARTH, 150).add(Aspect.ORDER, 150).add(Aspect.ENTROPY, 150),
                 "abc",
                 "def",
                 "ghi",
@@ -938,9 +904,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TB.Bracelet.Void",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 11),
-                new AspectList().add(Aspect.getAspect("aer"), 150).add(Aspect.getAspect("ignis"), 150)
-                        .add(Aspect.getAspect("aqua"), 150).add(Aspect.getAspect("terra"), 150)
-                        .add(Aspect.getAspect("ordo"), 150).add(Aspect.getAspect("perditio"), 150),
+                new AspectList().add(Aspect.AIR, 150).add(Aspect.FIRE, 150).add(Aspect.WATER, 150)
+                        .add(Aspect.EARTH, 150).add(Aspect.ORDER, 150).add(Aspect.ENTROPY, 150),
                 "abc",
                 "def",
                 "ghi",
@@ -966,10 +931,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.Bracelet.Primal",
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 12),
                 10,
-                new AspectList().add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("ignis"), 64)
-                        .add(Aspect.getAspect("aqua"), 64).add(Aspect.getAspect("terra"), 64)
-                        .add(Aspect.getAspect("ordo"), 64).add(Aspect.getAspect("perditio"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("alienis"), 32),
+                new AspectList().add(Aspect.AIR, 64).add(Aspect.FIRE, 64).add(Aspect.WATER, 64).add(Aspect.EARTH, 64)
+                        .add(Aspect.ORDER, 64).add(Aspect.ENTROPY, 64).add(Aspect.MAGIC, 32).add(Aspect.ELDRITCH, 32),
                 getModItem(ThaumicBases.ID, "castingBracelet", 1, 4),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 4),
                 NHItemList.SnowQueenBlood.get(),
@@ -987,9 +950,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeFoci.Bright",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("auram"), 256).add(Aspect.getAspect("lux"), 192)
-                        .add(Aspect.getAspect("potentia"), 128).add(Aspect.getAspect("superbia"), 64)
-                        .add(Aspect.getAspect("nebrisum"), 32),
+                new AspectList().add(Aspect.AURA, 256).add(Aspect.LIGHT, 192).add(Aspect.ENERGY, 128)
+                        .add(DarkAspects.PRIDE, 64).add(TCAspects.NEBRISUM.getAspect(), 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3),
                 getModItem(ThaumicBases.ID, "blockSalisMundus", 1, 0),
@@ -1003,8 +965,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeFoci.Destr",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 1),
                 8,
-                new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("perditio"), 96)
-                        .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("mortuus"), 32),
+                new AspectList().add(Aspect.AURA, 128).add(Aspect.ENTROPY, 96).add(Aspect.VOID, 64)
+                        .add(Aspect.DEATH, 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
                 getModItem(Thaumcraft.ID, "FocusPrimal", 1, 0),
                 getModItem(ThaumicBases.ID, "crystalBlock", 1, 5),
@@ -1018,8 +980,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeFoci.Efficiency",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 2),
                 7,
-                new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("potentia"), 96)
-                        .add(Aspect.getAspect("electrum"), 64).add(Aspect.getAspect("machina"), 64),
+                new AspectList().add(Aspect.AURA, 128).add(Aspect.ENERGY, 96).add(TCAspects.ELECTRUM.getAspect(), 64)
+                        .add(Aspect.MECHANISM, 64),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
                 getModItem(Minecraft.ID, "glowstone_dust", 1, 0),
                 getModItem(ThaumicBases.ID, "crystalBlock", 1, 1),
@@ -1033,9 +995,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeFoci.Hunger",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 3),
                 10,
-                new AspectList().add(Aspect.getAspect("auram"), 256).add(Aspect.getAspect("fames"), 192)
-                        .add(Aspect.getAspect("lucrum"), 128).add(Aspect.getAspect("vacuos"), 96)
-                        .add(Aspect.getAspect("gula"), 64),
+                new AspectList().add(Aspect.AURA, 256).add(Aspect.HUNGER, 192).add(Aspect.GREED, 128)
+                        .add(Aspect.VOID, 96).add(DarkAspects.GLUTTONY, 64),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 0),
                 getModItem(ThaumicBases.ID, "voidBlock", 1, 0),
@@ -1049,8 +1010,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeFoci.Unstable",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 4),
                 8,
-                new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("alienis"), 96)
-                        .add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("perditio"), 32),
+                new AspectList().add(Aspect.AURA, 128).add(Aspect.ELDRITCH, 96).add(Aspect.VOID, 64)
+                        .add(Aspect.ENTROPY, 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
                 getModItem(Minecraft.ID, "ender_pearl", 1, 0),
                 getModItem(ThaumicBases.ID, "crystalBlock", 1, 2),
@@ -1064,8 +1025,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeFoci.Purity",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 5),
                 8,
-                new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("sano"), 96)
-                        .add(Aspect.getAspect("victus"), 64).add(Aspect.getAspect("vitreus"), 32),
+                new AspectList().add(Aspect.AURA, 128).add(Aspect.HEAL, 96).add(Aspect.LIFE, 64)
+                        .add(Aspect.CRYSTAL, 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 3),
                 getModItem(ThaumicBases.ID, "crystalBlock", 1, 6),
@@ -1079,8 +1040,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeFoci.Sinister",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 6),
                 9,
-                new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("tenebrae"), 96)
-                        .add(Aspect.getAspect("exanimis"), 64).add(Aspect.getAspect("spiritus"), 32),
+                new AspectList().add(Aspect.AURA, 128).add(Aspect.DARKNESS, 96).add(Aspect.UNDEAD, 64)
+                        .add(Aspect.SOUL, 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
                 getModItem(Thaumcraft.ID, "ItemCompassStone", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 1),
@@ -1094,8 +1055,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeFoci.Speed",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 7),
                 8,
-                new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("potentia"), 96)
-                        .add(Aspect.getAspect("motus"), 64).add(Aspect.getAspect("aer"), 32),
+                new AspectList().add(Aspect.AURA, 128).add(Aspect.ENERGY, 96).add(Aspect.MOTION, 64)
+                        .add(Aspect.AIR, 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
                 getModItem(Minecraft.ID, "sugar", 1, 0),
                 getModItem(ThaumicBases.ID, "crystalBlock", 1, 0),
@@ -1109,8 +1070,7 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeFoci.Stability",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 8),
                 7,
-                new AspectList().add(Aspect.getAspect("auram"), 128).add(Aspect.getAspect("cognitio"), 96)
-                        .add(Aspect.getAspect("instrumentum"), 64).add(Aspect.getAspect("ordo"), 32),
+                new AspectList().add(Aspect.AURA, 128).add(Aspect.MIND, 96).add(Aspect.TOOL, 64).add(Aspect.ORDER, 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 10),
                 getModItem(ThaumicBases.ID, "crystalBlock", 1, 4),
@@ -1124,9 +1084,8 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.NodeFoci.Taint",
                 getModItem(ThaumicBases.ID, "nodeFoci", 1, 9),
                 10,
-                new AspectList().add(Aspect.getAspect("auram"), 256).add(Aspect.getAspect("vitium"), 192)
-                        .add(Aspect.getAspect("venenum"), 128).add(Aspect.getAspect("perditio"), 64)
-                        .add(Aspect.getAspect("strontio"), 32),
+                new AspectList().add(Aspect.AURA, 256).add(Aspect.TAINT, 192).add(Aspect.POISON, 128)
+                        .add(Aspect.ENTROPY, 64).add(TCAspects.STRONTIO.getAspect(), 32),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 12),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 11),
                 getModItem(ThaumicBases.ID, "crystalBlock", 1, 7),
@@ -1140,44 +1099,38 @@ public class ScriptThaumicBases implements IScriptLoader {
                 "TB.SM",
                 getModItem(Thaumcraft.ID, "ItemResource", 2, 14),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
-                new AspectList().add(Aspect.getAspect("aer"), 4).add(Aspect.getAspect("aqua"), 4)
-                        .add(Aspect.getAspect("ignis"), 4).add(Aspect.getAspect("praecantatio"), 4)
-                        .add(Aspect.getAspect("ordo"), 4).add(Aspect.getAspect("perditio"), 4)
-                        .add(Aspect.getAspect("terra"), 4));
+                new AspectList().add(Aspect.AIR, 4).add(Aspect.WATER, 4).add(Aspect.FIRE, 4).add(Aspect.MAGIC, 4)
+                        .add(Aspect.ORDER, 4).add(Aspect.ENTROPY, 4).add(Aspect.EARTH, 4));
         ThaumcraftApi.addCrucibleRecipe(
                 "TB.Amber",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 6),
                 getModItem(Minecraft.ID, "sapling", 1, 1),
-                new AspectList().add(Aspect.getAspect("vinculum"), 4));
+                new AspectList().add(Aspect.TRAP, 4));
         ThaumcraftApi.addCrucibleRecipe(
                 "TB.Quicksilver",
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 3),
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 1),
-                new AspectList().add(Aspect.getAspect("ordo"), 1).add(Aspect.getAspect("venenum"), 1));
+                new AspectList().add(Aspect.ORDER, 1).add(Aspect.POISON, 1));
         CrucibleRecipe leatherHelmetBP = ThaumcraftApi.addCrucibleRecipe(
                 "TB.Backprocessing",
                 getModItem(Minecraft.ID, "leather", 5),
                 getModItem(Minecraft.ID, "leather_helmet", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 1)
-                        .add(Aspect.getAspect("tutamen"), 1).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.CLOTH, 2).add(Aspect.BEAST, 1).add(Aspect.ARMOR, 1).add(Aspect.ENTROPY, 1));
         CrucibleRecipe leatherChestplateBP = ThaumcraftApi.addCrucibleRecipe(
                 "TB.Backprocessing",
                 getModItem(Minecraft.ID, "leather", 8),
                 getModItem(Minecraft.ID, "leather_chestplate", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 1)
-                        .add(Aspect.getAspect("tutamen"), 1).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.CLOTH, 2).add(Aspect.BEAST, 1).add(Aspect.ARMOR, 1).add(Aspect.ENTROPY, 1));
         CrucibleRecipe leatherLeggingsBP = ThaumcraftApi.addCrucibleRecipe(
                 "TB.Backprocessing",
                 getModItem(Minecraft.ID, "leather", 7),
                 getModItem(Minecraft.ID, "leather_leggings", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 1)
-                        .add(Aspect.getAspect("tutamen"), 1).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.CLOTH, 2).add(Aspect.BEAST, 1).add(Aspect.ARMOR, 1).add(Aspect.ENTROPY, 1));
         CrucibleRecipe leatherBootsBP = ThaumcraftApi.addCrucibleRecipe(
                 "TB.Backprocessing",
                 getModItem(Minecraft.ID, "leather", 4),
                 getModItem(Minecraft.ID, "leather_boots", 1, 0),
-                new AspectList().add(Aspect.getAspect("pannus"), 2).add(Aspect.getAspect("bestia"), 1)
-                        .add(Aspect.getAspect("tutamen"), 1).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.CLOTH, 2).add(Aspect.BEAST, 1).add(Aspect.ARMOR, 1).add(Aspect.ENTROPY, 1));
 
         TCHelper.addResearchPage("TB.Backprocessing", new ResearchPage(Objects.requireNonNull(leatherHelmetBP)));
         TCHelper.addResearchPage("TB.Backprocessing", new ResearchPage(Objects.requireNonNull(leatherChestplateBP)));
@@ -1291,8 +1244,8 @@ public class ScriptThaumicBases implements IScriptLoader {
         new ResearchItem(
                 "TB.TaintFlask",
                 "THAUMICBASES",
-                new AspectList().add(Aspect.getAspect("vitium"), 10).add(Aspect.getAspect("alienis"), 15)
-                        .add(Aspect.getAspect("perditio"), 8).add(Aspect.getAspect("permutatio"), 12),
+                new AspectList().add(Aspect.TAINT, 10).add(Aspect.ELDRITCH, 15).add(Aspect.ENTROPY, 8)
+                        .add(Aspect.EXCHANGE, 12),
                 1,
                 -1,
                 3,

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicBases.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicBases.java
@@ -5,6 +5,7 @@ import static com.dreammaster.scripts.IngredientFactory.getModItem;
 import static gregtech.api.enums.Materials.Void;
 import static gregtech.api.enums.Mods.CarpentersBlocks;
 import static gregtech.api.enums.Mods.ExtraUtilities;
+import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.IronTanks;
 import static gregtech.api.enums.Mods.Minecraft;
@@ -58,6 +59,7 @@ public class ScriptThaumicBases implements IScriptLoader {
         return Arrays.asList(
                 CarpentersBlocks.ID,
                 ExtraUtilities.ID,
+                ForbiddenMagic.ID,
                 IndustrialCraft2.ID,
                 IronTanks.ID,
                 Railcraft.ID,

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
@@ -243,10 +243,8 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 "thaumicenergistics.TEESSPROV",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.essentia.provider", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("machina"), 64).add(Aspect.getAspect("praecantatio"), 48)
-                        .add(Aspect.getAspect("ordo"), 32).add(Aspect.getAspect("permutatio"), 24)
-                        .add(Aspect.getAspect("aqua"), 16).add(Aspect.getAspect("cognitio"), 8)
-                        .add(Aspect.getAspect("lucrum"), 4),
+                new AspectList().add(Aspect.MECHANISM, 64).add(Aspect.MAGIC, 48).add(Aspect.ORDER, 32)
+                        .add(Aspect.EXCHANGE, 24).add(Aspect.WATER, 16).add(Aspect.MIND, 8).add(Aspect.GREED, 4),
                 getModItem(AppliedEnergistics2.ID, "tile.BlockInterface", 1, 0),
                 getModItem(Thaumcraft.ID, "blockTube", 1, 3),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2),
@@ -260,16 +258,13 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEESSPROV",
-                new AspectList().add(Aspect.getAspect("sensus"), 21).add(Aspect.getAspect("praecantatio"), 18)
-                        .add(Aspect.getAspect("lucrum"), 15).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("machina"), 3));
+                new AspectList().add(Aspect.SENSES, 21).add(Aspect.MAGIC, 18).add(Aspect.GREED, 15)
+                        .add(Aspect.METAL, 12).add(Aspect.ORDER, 9).add(Aspect.ENERGY, 6).add(Aspect.MECHANISM, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEESSPROV", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEIRONGEARBOX",
                 IronGear,
-                new AspectList().add(Aspect.getAspect("terra"), 10).add(Aspect.getAspect("ignis"), 5)
-                        .add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.EARTH, 10).add(Aspect.FIRE, 5).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -294,8 +289,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEIRONGEARBOX",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.gear.box", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ignis"), 15)
-                        .add(Aspect.getAspect("ordo"), 15),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.FIRE, 15).add(Aspect.ORDER, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -319,15 +313,14 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 6));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEIRONGEARBOX",
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("metallum"), 15)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("permutatio"), 6));
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.METAL, 15).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.EXCHANGE, 6));
         TCHelper.setResearchComplexity("thaumicenergistics.TEIRONGEARBOX", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEARCANETERM",
                 getModItem(ThaumicEnergistics.ID, "part.base", 1, 5),
-                new AspectList().add(Aspect.getAspect("aqua"), 25).add(Aspect.getAspect("ignis"), 25)
-                        .add(Aspect.getAspect("aer"), 25).add(Aspect.getAspect("terra"), 25)
-                        .add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("perditio"), 25),
+                new AspectList().add(Aspect.WATER, 25).add(Aspect.FIRE, 25).add(Aspect.AIR, 25).add(Aspect.EARTH, 25)
+                        .add(Aspect.ORDER, 25).add(Aspect.ENTROPY, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -351,19 +344,18 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 GTOreDictUnificator.get(OrePrefixes.plate, Materials.InfusedEarth, 1L));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEARCANETERM",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("machina"), 6)
-                        .add(Aspect.getAspect("vacuos"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.CRAFT, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.MECHANISM, 6).add(Aspect.VOID, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEARCANETERM", 3);
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TECERTUSDUPE",
-                new AspectList().add(Aspect.getAspect("vitreus"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("lucrum"), 9).add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.CRYSTAL, 9).add(Aspect.MAGIC, 6).add(Aspect.GREED, 9)
+                        .add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TECERTUSDUPE", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TECORES",
                 DiffusionCore,
-                new AspectList().add(Aspect.getAspect("aqua"), 20).add(Aspect.getAspect("perditio"), 20),
+                new AspectList().add(Aspect.WATER, 20).add(Aspect.ENTROPY, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -388,7 +380,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TECORES",
                 CoalescenceCore,
-                new AspectList().add(Aspect.getAspect("aqua"), 20).add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.WATER, 20).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -412,15 +404,14 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 3));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TECORES",
-                new AspectList().add(Aspect.getAspect("cognitio"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("machina"), 6).add(Aspect.getAspect("limus"), 9)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.MIND, 12).add(Aspect.MAGIC, 9).add(Aspect.MECHANISM, 6).add(Aspect.SLIME, 9)
+                        .add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TECORES", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEESSVIBCMBR",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.essentia.vibration.chamber", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 35).add(Aspect.getAspect("ordo"), 35)
-                        .add(Aspect.getAspect("perditio"), 35).add(Aspect.getAspect("aqua"), 35),
+                new AspectList().add(Aspect.FIRE, 35).add(Aspect.ORDER, 35).add(Aspect.ENTROPY, 35)
+                        .add(Aspect.WATER, 35),
                 "abc",
                 "def",
                 "ghi",
@@ -444,15 +435,13 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 "plateInfusedEntropy");
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEESSVIBCMBR",
-                new AspectList().add(Aspect.getAspect("vitreus"), 18).add(Aspect.getAspect("machina"), 15)
-                        .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.CRYSTAL, 18).add(Aspect.MECHANISM, 15).add(Aspect.ENERGY, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.MOTION, 6).add(Aspect.WATER, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEESSVIBCMBR", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEIO",
                 getModItem(ThaumicEnergistics.ID, "part.base", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("terra"), 15),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.WATER, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -477,8 +466,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEIO",
                 getModItem(ThaumicEnergistics.ID, "part.base", 1, 3),
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("aqua"), 15)
-                        .add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("terra"), 15),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.WATER, 15).add(Aspect.FIRE, 15).add(Aspect.EARTH, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -503,8 +491,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEIO",
                 getModItem(ThaumicEnergistics.ID, "part.base", 1, 2),
-                new AspectList().add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("aqua"), 20)
-                        .add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("terra"), 20),
+                new AspectList().add(Aspect.ORDER, 20).add(Aspect.WATER, 20).add(Aspect.FIRE, 20).add(Aspect.EARTH, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -528,15 +515,13 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockTube", 1, 3));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEIO",
-                new AspectList().add(Aspect.getAspect("motus"), 18).add(Aspect.getAspect("machina"), 15)
-                        .add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("vitreus"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.MOTION, 18).add(Aspect.MECHANISM, 15).add(Aspect.METAL, 12)
+                        .add(Aspect.CRYSTAL, 9).add(Aspect.AIR, 6).add(Aspect.WATER, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEIO", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEDISTILLATIONPATTERNENCODER",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.distillation.encoder", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("perditio"), 25)
-                        .add(Aspect.getAspect("ignis"), 25),
+                new AspectList().add(Aspect.ORDER, 25).add(Aspect.ENTROPY, 25).add(Aspect.FIRE, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -560,16 +545,13 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 "plateInfusedOrder");
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEDISTILLATIONPATTERNENCODER",
-                new AspectList().add(Aspect.getAspect("ordo"), 21).add(Aspect.getAspect("fabrico"), 18)
-                        .add(Aspect.getAspect("permutatio"), 15).add(Aspect.getAspect("perditio"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.ORDER, 21).add(Aspect.CRAFT, 18).add(Aspect.EXCHANGE, 15)
+                        .add(Aspect.ENTROPY, 12).add(Aspect.MECHANISM, 9).add(Aspect.GREED, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEDISTILLATIONPATTERNENCODER", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEFOCUSWRENCH",
                 getModItem(ThaumicEnergistics.ID, "focus.aewrench", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("aer"), 25)
-                        .add(Aspect.getAspect("ignis"), 25),
+                new AspectList().add(Aspect.ORDER, 25).add(Aspect.AIR, 25).add(Aspect.FIRE, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -593,15 +575,13 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEFOCUSWRENCH",
-                new AspectList().add(Aspect.getAspect("ignis"), 18).add(Aspect.getAspect("aer"), 15)
-                        .add(Aspect.getAspect("machina"), 12).add(Aspect.getAspect("instrumentum"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("metallum"), 3));
+                new AspectList().add(Aspect.FIRE, 18).add(Aspect.AIR, 15).add(Aspect.MECHANISM, 12).add(Aspect.TOOL, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.METAL, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEFOCUSWRENCH", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEGOLEMWIFIBACKPACK",
                 getModItem(ThaumicEnergistics.ID, "golem.wifi.backpack", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("aer"), 30)
-                        .add(Aspect.getAspect("ignis"), 30),
+                new AspectList().add(Aspect.ORDER, 30).add(Aspect.AIR, 30).add(Aspect.FIRE, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -625,10 +605,8 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 9));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEGOLEMWIFIBACKPACK",
-                new AspectList().add(Aspect.getAspect("vacuos"), 21).add(Aspect.getAspect("potentia"), 18)
-                        .add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("cognitio"), 12)
-                        .add(Aspect.getAspect("tutamen"), 9).add(Aspect.getAspect("motus"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.VOID, 21).add(Aspect.ENERGY, 18).add(Aspect.AURA, 15).add(Aspect.MIND, 12)
+                        .add(Aspect.ARMOR, 9).add(Aspect.MOTION, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEGOLEMWIFIBACKPACK", 3);
         TCHelper.clearPages("thaumicenergistics.TESTORAGE");
         TCHelper.addResearchPage(
@@ -640,8 +618,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 EssentialComponent1K,
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("aqua"), 10),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.FIRE, 10).add(Aspect.WATER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -669,8 +646,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 EssentialComponent4K,
-                new AspectList().add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("aqua"), 20),
+                new AspectList().add(Aspect.ORDER, 20).add(Aspect.FIRE, 20).add(Aspect.WATER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -698,8 +674,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 EssentialComponent16K,
-                new AspectList().add(Aspect.getAspect("ordo"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("aqua"), 30),
+                new AspectList().add(Aspect.ORDER, 30).add(Aspect.FIRE, 30).add(Aspect.WATER, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -727,8 +702,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 EssentialComponent64K,
-                new AspectList().add(Aspect.getAspect("ordo"), 40).add(Aspect.getAspect("ignis"), 40)
-                        .add(Aspect.getAspect("aqua"), 40),
+                new AspectList().add(Aspect.ORDER, 40).add(Aspect.FIRE, 40).add(Aspect.WATER, 40),
                 "abc",
                 "def",
                 "ghi",
@@ -756,8 +730,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 EssentialComponent256K,
-                new AspectList().add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("ignis"), 50)
-                        .add(Aspect.getAspect("aqua"), 50),
+                new AspectList().add(Aspect.ORDER, 50).add(Aspect.FIRE, 50).add(Aspect.WATER, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -785,8 +758,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 EssentialComponent1024K,
-                new AspectList().add(Aspect.getAspect("ordo"), 60).add(Aspect.getAspect("ignis"), 60)
-                        .add(Aspect.getAspect("aqua"), 60),
+                new AspectList().add(Aspect.ORDER, 60).add(Aspect.FIRE, 60).add(Aspect.WATER, 60),
                 "abc",
                 "def",
                 "ghi",
@@ -814,8 +786,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 EssentialComponent4096K,
-                new AspectList().add(Aspect.getAspect("ordo"), 70).add(Aspect.getAspect("ignis"), 70)
-                        .add(Aspect.getAspect("aqua"), 70),
+                new AspectList().add(Aspect.ORDER, 70).add(Aspect.FIRE, 70).add(Aspect.WATER, 70),
                 "abc",
                 "def",
                 "ghi",
@@ -843,8 +814,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 EssentialComponent16384K,
-                new AspectList().add(Aspect.getAspect("ordo"), 80).add(Aspect.getAspect("ignis"), 80)
-                        .add(Aspect.getAspect("aqua"), 80),
+                new AspectList().add(Aspect.ORDER, 80).add(Aspect.FIRE, 80).add(Aspect.WATER, 80),
                 "abc",
                 "def",
                 "ghi",
@@ -872,8 +842,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.casing", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("aqua"), 10),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.EARTH, 10).add(Aspect.WATER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -901,8 +870,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("aqua"), 15),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -927,8 +895,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 5).add(Aspect.getAspect("terra"), 5)
-                        .add(Aspect.getAspect("aqua"), 5),
+                new AspectList().add(Aspect.ORDER, 5).add(Aspect.EARTH, 5).add(Aspect.WATER, 5),
                 getModItem(ThaumicEnergistics.ID, "storage.casing", 1, 0),
                 EssentialComponent1K);
         TCHelper.addResearchPage(
@@ -938,8 +905,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 1),
-                new AspectList().add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("terra"), 25)
-                        .add(Aspect.getAspect("aqua"), 25),
+                new AspectList().add(Aspect.ORDER, 25).add(Aspect.EARTH, 25).add(Aspect.WATER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -964,8 +930,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 1),
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("aqua"), 15),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.EARTH, 15).add(Aspect.WATER, 15),
                 getModItem(ThaumicEnergistics.ID, "storage.casing", 1, 0),
                 EssentialComponent4K);
         TCHelper.addResearchPage(
@@ -975,8 +940,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 2),
-                new AspectList().add(Aspect.getAspect("ordo"), 35).add(Aspect.getAspect("terra"), 35)
-                        .add(Aspect.getAspect("aqua"), 35),
+                new AspectList().add(Aspect.ORDER, 35).add(Aspect.EARTH, 35).add(Aspect.WATER, 35),
                 "abc",
                 "def",
                 "ghi",
@@ -1001,8 +965,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 2),
-                new AspectList().add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("terra"), 25)
-                        .add(Aspect.getAspect("aqua"), 25),
+                new AspectList().add(Aspect.ORDER, 25).add(Aspect.EARTH, 25).add(Aspect.WATER, 25),
                 getModItem(ThaumicEnergistics.ID, "storage.casing", 1, 0),
                 EssentialComponent16K);
         TCHelper.addResearchPage(
@@ -1012,8 +975,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 3),
-                new AspectList().add(Aspect.getAspect("ordo"), 45).add(Aspect.getAspect("terra"), 45)
-                        .add(Aspect.getAspect("aqua"), 45),
+                new AspectList().add(Aspect.ORDER, 45).add(Aspect.EARTH, 45).add(Aspect.WATER, 45),
                 "abc",
                 "def",
                 "ghi",
@@ -1038,8 +1000,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 3),
-                new AspectList().add(Aspect.getAspect("ordo"), 35).add(Aspect.getAspect("terra"), 35)
-                        .add(Aspect.getAspect("aqua"), 35),
+                new AspectList().add(Aspect.ORDER, 35).add(Aspect.EARTH, 35).add(Aspect.WATER, 35),
                 getModItem(ThaumicEnergistics.ID, "storage.casing", 1, 0),
                 EssentialComponent64K);
         TCHelper.addResearchPage(
@@ -1049,8 +1010,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 5),
-                new AspectList().add(Aspect.getAspect("ordo"), 55).add(Aspect.getAspect("terra"), 55)
-                        .add(Aspect.getAspect("aqua"), 55),
+                new AspectList().add(Aspect.ORDER, 55).add(Aspect.EARTH, 55).add(Aspect.WATER, 55),
                 "abc",
                 "def",
                 "ghi",
@@ -1075,8 +1035,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 5),
-                new AspectList().add(Aspect.getAspect("ordo"), 45).add(Aspect.getAspect("terra"), 45)
-                        .add(Aspect.getAspect("aqua"), 45),
+                new AspectList().add(Aspect.ORDER, 45).add(Aspect.EARTH, 45).add(Aspect.WATER, 45),
                 getModItem(ThaumicEnergistics.ID, "storage.casing", 1, 0),
                 EssentialComponent256K);
         TCHelper.addResearchPage(
@@ -1086,8 +1045,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 6),
-                new AspectList().add(Aspect.getAspect("ordo"), 65).add(Aspect.getAspect("terra"), 65)
-                        .add(Aspect.getAspect("aqua"), 65),
+                new AspectList().add(Aspect.ORDER, 65).add(Aspect.EARTH, 65).add(Aspect.WATER, 65),
                 "abc",
                 "def",
                 "ghi",
@@ -1112,8 +1070,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 6),
-                new AspectList().add(Aspect.getAspect("ordo"), 55).add(Aspect.getAspect("terra"), 55)
-                        .add(Aspect.getAspect("aqua"), 55),
+                new AspectList().add(Aspect.ORDER, 55).add(Aspect.EARTH, 55).add(Aspect.WATER, 55),
                 getModItem(ThaumicEnergistics.ID, "storage.casing", 1, 0),
                 EssentialComponent1024K);
         TCHelper.addResearchPage(
@@ -1123,8 +1080,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 7),
-                new AspectList().add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("aqua"), 75),
+                new AspectList().add(Aspect.ORDER, 75).add(Aspect.EARTH, 75).add(Aspect.WATER, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -1149,8 +1105,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 7),
-                new AspectList().add(Aspect.getAspect("ordo"), 65).add(Aspect.getAspect("terra"), 65)
-                        .add(Aspect.getAspect("aqua"), 65),
+                new AspectList().add(Aspect.ORDER, 65).add(Aspect.EARTH, 65).add(Aspect.WATER, 65),
                 getModItem(ThaumicEnergistics.ID, "storage.casing", 1, 0),
                 EssentialComponent4096K);
         TCHelper.addResearchPage(
@@ -1160,8 +1115,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 8),
-                new AspectList().add(Aspect.getAspect("ordo"), 85).add(Aspect.getAspect("terra"), 85)
-                        .add(Aspect.getAspect("aqua"), 85),
+                new AspectList().add(Aspect.ORDER, 85).add(Aspect.EARTH, 85).add(Aspect.WATER, 85),
                 "abc",
                 "def",
                 "ghi",
@@ -1186,8 +1140,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addShapelessArcaneCraftingRecipe(
                 "thaumicenergistics.TESTORAGE",
                 getModItem(ThaumicEnergistics.ID, "storage.essentia", 1, 8),
-                new AspectList().add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("aqua"), 75),
+                new AspectList().add(Aspect.ORDER, 75).add(Aspect.EARTH, 75).add(Aspect.WATER, 75),
                 getModItem(ThaumicEnergistics.ID, "storage.casing", 1, 0),
                 EssentialComponent16384K);
         TCHelper.addResearchPage(
@@ -1220,17 +1173,14 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
 
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TESTORAGE",
-                new AspectList().add(Aspect.getAspect("vacuos"), 21).add(Aspect.getAspect("potentia"), 18)
-                        .add(Aspect.getAspect("vitreus"), 15).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("aqua"), 6)
-                        .add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.VOID, 21).add(Aspect.ENERGY, 18).add(Aspect.CRYSTAL, 15)
+                        .add(Aspect.METAL, 12).add(Aspect.MIND, 9).add(Aspect.WATER, 6).add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TESTORAGE", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEVISINT",
                 getModItem(ThaumicEnergistics.ID, "part.base", 1, 6),
-                new AspectList().add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("aqua"), 20)
-                        .add(Aspect.getAspect("perditio"), 20).add(Aspect.getAspect("aer"), 20),
+                new AspectList().add(Aspect.ORDER, 20).add(Aspect.EARTH, 20).add(Aspect.FIRE, 20).add(Aspect.WATER, 20)
+                        .add(Aspect.ENTROPY, 20).add(Aspect.AIR, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -1254,29 +1204,26 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 "plateInfusedOrder");
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEVISINT",
-                new AspectList().add(Aspect.getAspect("vacuos"), 21).add(Aspect.getAspect("potentia"), 18)
-                        .add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("metallum"), 12)
-                        .add(Aspect.getAspect("cognitio"), 9).add(Aspect.getAspect("machina"), 6)
-                        .add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.VOID, 21).add(Aspect.ENERGY, 18).add(Aspect.AURA, 15).add(Aspect.METAL, 12)
+                        .add(Aspect.MIND, 9).add(Aspect.MECHANISM, 6).add(Aspect.WATER, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEVISINT", 3);
         ThaumcraftApi.addCrucibleRecipe(
                 "thaumicenergistics.TETHAUMGBOX",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.golem.gear.box", 1, 0),
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.gear.box", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("praecantatio"), 32));
+                new AspectList().add(Aspect.METAL, 32).add(Aspect.MAGIC, 32));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TETHAUMGBOX",
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("machina"), 12)
-                        .add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("permutatio"), 3));
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.MECHANISM, 12).add(Aspect.METAL, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.EXCHANGE, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TETHAUMGBOX", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "thaumicenergistics.TEARCANEASSEMBLER",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.arcane.assembler", 1, 0),
                 16,
-                new AspectList().add(getAspect("auram"), 16).add(getAspect("fabrico"), 64).add(getAspect("metallum"), 8)
-                        .add(getAspect("permutatio"), 32).add(getAspect("lucrum"), 16)
-                        .add(getAspect("praecantatio"), 48).add(getAspect("vitreus"), 16),
+                new AspectList().add(Aspect.AURA, 16).add(Aspect.CRAFT, 64).add(Aspect.METAL, 8)
+                        .add(getAspect("permutatio"), 32).add(Aspect.GREED, 16).add(getAspect("praecantatio"), 48)
+                        .add(Aspect.CRYSTAL, 16),
                 getModItem(AppliedEnergistics2.ID, "tile.BlockMolecularAssembler", 1, 0),
                 createItemStack(
                         Thaumcraft.ID,
@@ -1293,16 +1240,14 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 6));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEARCANEASSEMBLER",
-                new AspectList().add(Aspect.getAspect("lucrum"), 24).add(Aspect.getAspect("fabrico"), 21)
-                        .add(Aspect.getAspect("machina"), 18).add(Aspect.getAspect("cognitio"), 15)
-                        .add(Aspect.getAspect("permutatio"), 12).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.GREED, 24).add(Aspect.CRAFT, 21).add(Aspect.MECHANISM, 18)
+                        .add(Aspect.MIND, 15).add(Aspect.EXCHANGE, 12).add(Aspect.AURA, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.WATER, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEARCANEASSEMBLER", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEKNOWLEDGEINSCRIBER",
                 getModItem(ThaumicEnergistics.ID, "knowledge.core", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("aqua"), 10),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.EARTH, 10).add(Aspect.WATER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -1327,9 +1272,8 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "thaumicenergistics.TEKNOWLEDGEINSCRIBER",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.knowledge.inscriber", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("aqua"), 20)
-                        .add(Aspect.getAspect("perditio"), 20).add(Aspect.getAspect("aer"), 20),
+                new AspectList().add(Aspect.ORDER, 20).add(Aspect.EARTH, 20).add(Aspect.FIRE, 20).add(Aspect.WATER, 20)
+                        .add(Aspect.ENTROPY, 20).add(Aspect.AIR, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -1353,17 +1297,15 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 "plateThaumium");
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEKNOWLEDGEINSCRIBER",
-                new AspectList().add(Aspect.getAspect("cognitio"), 18).add(Aspect.getAspect("machina"), 15)
-                        .add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("permutatio"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.MIND, 18).add(Aspect.MECHANISM, 15).add(Aspect.CRAFT, 12)
+                        .add(Aspect.EXCHANGE, 9).add(Aspect.MAGIC, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEKNOWLEDGEINSCRIBER", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "thaumicenergistics.TEINFPROV",
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.infusion.provider", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("machina"), 64).add(Aspect.getAspect("ordo"), 48)
-                        .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("alienis"), 24).add(Aspect.getAspect("spiritus"), 8),
+                new AspectList().add(Aspect.MECHANISM, 64).add(Aspect.ORDER, 48).add(Aspect.EXCHANGE, 32)
+                        .add(Aspect.MAGIC, 16).add(Aspect.ELDRITCH, 24).add(Aspect.SOUL, 8),
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.essentia.provider", 1, 0),
                 getModItem(Thaumcraft.ID, "blockMirror", 1, 6),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
@@ -1377,10 +1319,8 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0));
         TCHelper.setResearchAspects(
                 "thaumicenergistics.TEINFPROV",
-                new AspectList().add(Aspect.getAspect("permutatio"), 21).add(Aspect.getAspect("motus"), 18)
-                        .add(Aspect.getAspect("sensus"), 15).add(Aspect.getAspect("machina"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("spiritus"), 3));
+                new AspectList().add(Aspect.EXCHANGE, 21).add(Aspect.MOTION, 18).add(Aspect.SENSES, 15)
+                        .add(Aspect.MECHANISM, 12).add(Aspect.MAGIC, 9).add(Aspect.ELDRITCH, 6).add(Aspect.SOUL, 3));
         TCHelper.setResearchComplexity("thaumicenergistics.TEINFPROV", 3);
 
         TCHelper.addInfusionCraftingRecipe(

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicEnergistics.java
@@ -14,7 +14,6 @@ import static gregtech.api.enums.Mods.ThaumicInsurgence;
 import static gregtech.api.enums.Mods.TinkerConstruct;
 import static gregtech.api.recipe.RecipeMaps.circuitAssemblerRecipes;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
-import static thaumcraft.api.aspects.Aspect.getAspect;
 
 import java.util.Arrays;
 import java.util.List;
@@ -1222,8 +1221,7 @@ public class ScriptThaumicEnergistics implements IScriptLoader {
                 getModItem(ThaumicEnergistics.ID, "thaumicenergistics.block.arcane.assembler", 1, 0),
                 16,
                 new AspectList().add(Aspect.AURA, 16).add(Aspect.CRAFT, 64).add(Aspect.METAL, 8)
-                        .add(getAspect("permutatio"), 32).add(Aspect.GREED, 16).add(getAspect("praecantatio"), 48)
-                        .add(Aspect.CRYSTAL, 16),
+                        .add(Aspect.EXCHANGE, 32).add(Aspect.GREED, 16).add(Aspect.MAGIC, 48).add(Aspect.CRYSTAL, 16),
                 getModItem(AppliedEnergistics2.ID, "tile.BlockMolecularAssembler", 1, 0),
                 createItemStack(
                         Thaumcraft.ID,

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicExploration.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicExploration.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 
 import com.dreammaster.thaumcraft.TCHelper;
 
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
@@ -130,8 +131,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "DiacountringsGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("vitreus"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 12).add(Aspect.MAGIC, 9).add(Aspect.GREED, 6)
+                        .add(Aspect.ELDRITCH, 3),
                 1,
                 3,
                 2,
@@ -140,7 +141,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DiacountringsGTNH",
                 getModItem(ThaumicExploration.ID, "discountRing", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 25),
+                new AspectList().add(Aspect.AIR, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -168,7 +169,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DiacountringsGTNH",
                 getModItem(ThaumicExploration.ID, "discountRing", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 25),
+                new AspectList().add(Aspect.EARTH, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -196,7 +197,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DiacountringsGTNH",
                 getModItem(ThaumicExploration.ID, "discountRing", 1, 2),
-                new AspectList().add(Aspect.getAspect("ignis"), 25),
+                new AspectList().add(Aspect.FIRE, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -224,7 +225,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DiacountringsGTNH",
                 getModItem(ThaumicExploration.ID, "discountRing", 1, 3),
-                new AspectList().add(Aspect.getAspect("aqua"), 25),
+                new AspectList().add(Aspect.WATER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -252,7 +253,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DiacountringsGTNH",
                 getModItem(ThaumicExploration.ID, "discountRing", 1, 4),
-                new AspectList().add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -280,7 +281,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DiacountringsGTNH",
                 getModItem(ThaumicExploration.ID, "discountRing", 1, 5),
-                new AspectList().add(Aspect.getAspect("perditio"), 25),
+                new AspectList().add(Aspect.ENTROPY, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -310,9 +311,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "JarsealGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("vinculum"), 18).add(Aspect.getAspect("alienis"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("iter"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("aqua"), 3),
+                new AspectList().add(Aspect.TRAP, 18).add(Aspect.ELDRITCH, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.TRAVEL, 9).add(Aspect.EARTH, 6).add(Aspect.WATER, 3),
                 -7,
                 -2,
                 3,
@@ -325,8 +325,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 15),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -352,9 +351,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 15),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 15),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 15))));
@@ -364,8 +362,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -391,9 +388,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 0),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 0),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 0))));
@@ -403,8 +399,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -430,9 +425,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 1),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 1),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 1))));
@@ -442,8 +436,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -469,9 +462,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 2),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 2),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 2))));
@@ -481,8 +473,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 3),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -508,9 +499,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 3),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 3),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 3))));
@@ -520,8 +510,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 4),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -547,9 +536,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 4),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 4),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 4))));
@@ -559,8 +547,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 5),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -586,9 +573,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 5),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 5),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 5))));
@@ -598,8 +584,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 6),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -625,9 +610,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 6),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 6),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 6))));
@@ -637,8 +621,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 7),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -664,9 +647,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 7),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 7),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 7))));
@@ -676,8 +658,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 8),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -703,9 +684,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 8),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 8),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 8))));
@@ -715,8 +695,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 9),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -742,9 +721,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 9),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 9),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 9))));
@@ -754,8 +732,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 10),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -781,9 +758,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 10),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 10),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 10))));
@@ -793,8 +769,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 11),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -820,9 +795,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 11),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 11),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 11))));
@@ -832,8 +806,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 12),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -859,9 +832,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 12),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 12),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 12))));
@@ -871,8 +843,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 13),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -898,9 +869,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 13),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 13),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 13))));
@@ -910,8 +880,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 14),
-                new AspectList().add(Aspect.getAspect("aer"), 5).add(Aspect.getAspect("aqua"), 5)
-                        .add(Aspect.getAspect("ignis"), 5).add(Aspect.getAspect("terra"), 5),
+                new AspectList().add(Aspect.AIR, 5).add(Aspect.WATER, 5).add(Aspect.FIRE, 5).add(Aspect.EARTH, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -937,9 +906,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "JarsealGTNH",
                 getModItem(ThaumicExploration.ID, "jarSeal", 1, 14),
                 getModItem(ThaumicExploration.ID, "blankSeal", 1, 14),
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("vinculum"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.TRAVEL, 12).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.TRAP, 8).add(Aspect.CRYSTAL, 8));
         TCHelper.addResearchPage(
                 "JarsealGTNH",
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicExploration.ID, "blankSeal", 1, 14))));
@@ -951,8 +919,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "FloatingcandleGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("aer"), 12).add(Aspect.getAspect("pannus"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("volatus"), 3),
+                new AspectList().add(Aspect.AIR, 12).add(Aspect.CLOTH, 9).add(Aspect.MAGIC, 6).add(Aspect.FLIGHT, 3),
                 -7,
                 -9,
                 2,
@@ -961,7 +928,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -983,7 +950,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1005,7 +972,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 2),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1027,7 +994,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 3),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1049,7 +1016,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 4),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1071,7 +1038,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 5),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1093,7 +1060,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 6),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1115,7 +1082,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 7),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1137,7 +1104,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 8),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1159,7 +1126,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 9),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1181,7 +1148,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 10),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1203,7 +1170,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 11),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1225,7 +1192,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 12),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1247,7 +1214,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 13),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1269,7 +1236,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 14),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1291,7 +1258,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FloatingcandleGTNH",
                 getModItem(ThaumicExploration.ID, "floatCandle", 3, 15),
-                new AspectList().add(Aspect.getAspect("aer"), 15),
+                new AspectList().add(Aspect.AIR, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -1315,9 +1282,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "ReplicatorGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("lucrum"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("machina"), 9).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.GREED, 15).add(Aspect.CRAFT, 12).add(Aspect.MECHANISM, 9)
+                        .add(Aspect.ORDER, 6).add(Aspect.MAGIC, 3),
                 4,
                 -5,
                 3,
@@ -1329,9 +1295,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "ReplicatorGTNH",
                 getModItem(ThaumicExploration.ID, "replicator", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("fabrico"), 64).add(Aspect.getAspect("instrumentum"), 48)
-                        .add(Aspect.getAspect("machina"), 48).add(Aspect.getAspect("ordo"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("lucrum"), 16),
+                new AspectList().add(Aspect.CRAFT, 64).add(Aspect.TOOL, 48).add(Aspect.MECHANISM, 48)
+                        .add(Aspect.ORDER, 32).add(Aspect.MAGIC, 24).add(Aspect.GREED, 16),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 2),
                 getModItem(Thaumcraft.ID, "blockTable", 1, 15),
                 OrePrefixes.plate.get(Materials.Gold),
@@ -1352,9 +1317,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "TrashjarGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("perditio"), 15).add(Aspect.getAspect("vacuos"), 12)
-                        .add(Aspect.getAspect("fames"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.ENTROPY, 15).add(Aspect.VOID, 12).add(Aspect.HUNGER, 9)
+                        .add(Aspect.ELDRITCH, 6).add(Aspect.MAGIC, 3),
                 5,
                 -9,
                 3,
@@ -1366,9 +1330,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "TrashjarGTNH",
                 getModItem(ThaumicExploration.ID, "trashJar", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("alienis"), 16).add(Aspect.getAspect("fames"), 14)
-                        .add(Aspect.getAspect("perditio"), 24).add(Aspect.getAspect("vacuos"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("tenebrae"), 8),
+                new AspectList().add(Aspect.ELDRITCH, 16).add(Aspect.HUNGER, 14).add(Aspect.ENTROPY, 24)
+                        .add(Aspect.VOID, 32).add(Aspect.MAGIC, 12).add(Aspect.DARKNESS, 8),
                 getModItem(Thaumcraft.ID, "blockJar", 1, 3),
                 getModItem(Thaumcraft.ID, "blockChestHungry", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCosmeticOpaque", 1, 2),
@@ -1391,9 +1354,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "MeteorbootsGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("iter"), 15).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("volatus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.TRAVEL, 15).add(Aspect.FIRE, 12).add(Aspect.ENERGY, 9).add(Aspect.FLIGHT, 6)
+                        .add(Aspect.MAGIC, 3),
                 2,
                 -1,
                 3,
@@ -1404,9 +1366,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "MeteorbootsGTNH",
                 getModItem(ThaumicExploration.ID, "bootsMeteor", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("ignis"), 32).add(Aspect.getAspect("iter"), 32)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("volatus"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 16),
+                new AspectList().add(Aspect.FIRE, 32).add(Aspect.TRAVEL, 32).add(Aspect.ENERGY, 32)
+                        .add(Aspect.FLIGHT, 32).add(Aspect.MAGIC, 16),
                 getModItem(Thaumcraft.ID, "BootsTraveller", 1, wildcard),
                 getModItem(Thaumcraft.ID, "FocusFire", 1, 0),
                 OrePrefixes.plate.get(Materials.Firestone),
@@ -1424,9 +1385,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "CometsbootsGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("iter"), 15).add(Aspect.getAspect("aqua"), 12)
-                        .add(Aspect.getAspect("gelum"), 9).add(Aspect.getAspect("motus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.TRAVEL, 15).add(Aspect.WATER, 12).add(Aspect.COLD, 9).add(Aspect.MOTION, 6)
+                        .add(Aspect.MAGIC, 3),
                 5,
                 -3,
                 3,
@@ -1437,9 +1397,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "CometsbootsGTNH",
                 getModItem(ThaumicExploration.ID, "bootsComet", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("gelum"), 32).add(Aspect.getAspect("iter"), 32)
-                        .add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("motus"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 16),
+                new AspectList().add(Aspect.COLD, 32).add(Aspect.TRAVEL, 32).add(Aspect.WATER, 32)
+                        .add(Aspect.MOTION, 32).add(Aspect.MAGIC, 16),
                 getModItem(Thaumcraft.ID, "BootsTraveller", 1, wildcard),
                 getModItem(Thaumcraft.ID, "FocusFrost", 1, 0),
                 getModItem(BiomesOPlenty.ID, "hardIce", 1, 0),
@@ -1457,9 +1416,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "SoulbraizerGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("mortuus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.AURA, 15).add(Aspect.ELDRITCH, 12).add(Aspect.DARKNESS, 9)
+                        .add(Aspect.DEATH, 6).add(Aspect.MAGIC, 3),
                 -6,
                 -10,
                 3,
@@ -1470,9 +1428,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "SoulbraizerGTNH",
                 getModItem(ThaumicExploration.ID, "soulBrazier", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("auram"), 64).add(Aspect.getAspect("mortuus"), 48)
-                        .add(Aspect.getAspect("tenebrae"), 48).add(Aspect.getAspect("alienis"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 16),
+                new AspectList().add(Aspect.AURA, 64).add(Aspect.DEATH, 48).add(Aspect.DARKNESS, 48)
+                        .add(Aspect.ELDRITCH, 32).add(Aspect.MAGIC, 16),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemSanitySoap", 1, 0),
@@ -1492,9 +1449,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "UrnGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("vacuos"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.MAGIC, 12).add(Aspect.VOID, 9).add(Aspect.ELDRITCH, 6)
+                        .add(Aspect.GREED, 3),
                 3,
                 -10,
                 3,
@@ -1504,9 +1460,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "UrnGTNH",
                 getModItem(ThaumicExploration.ID, "everfullUrn", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("aqua"), 64).add(Aspect.getAspect("praecantatio"), 48)
-                        .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("alienis"), 32)
-                        .add(Aspect.getAspect("lucrum"), 16),
+                new AspectList().add(Aspect.WATER, 64).add(Aspect.MAGIC, 48).add(Aspect.VOID, 32)
+                        .add(Aspect.ELDRITCH, 32).add(Aspect.GREED, 16),
                 getModItem(Minecraft.ID, "flower_pot", 1, 0),
                 getModItem(Minecraft.ID, "water_bucket", 1, 0),
                 getModItem(Minecraft.ID, "netherbrick", 1, 0),
@@ -1528,9 +1483,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "BurnGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("vacuos"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.MAGIC, 12).add(Aspect.VOID, 9).add(Aspect.ELDRITCH, 6)
+                        .add(Aspect.GREED, 3),
                 4,
                 -11,
                 3,
@@ -1540,9 +1494,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "BurnGTNH",
                 getModItem(ThaumicExploration.ID, "everburnUrn", 1, 0),
                 9,
-                new AspectList().add(Aspect.getAspect("ignis"), 64).add(Aspect.getAspect("praecantatio"), 48)
-                        .add(Aspect.getAspect("vacuos"), 32).add(Aspect.getAspect("alienis"), 32)
-                        .add(Aspect.getAspect("lucrum"), 16),
+                new AspectList().add(Aspect.FIRE, 64).add(Aspect.MAGIC, 48).add(Aspect.VOID, 32)
+                        .add(Aspect.ELDRITCH, 32).add(Aspect.GREED, 16),
                 getModItem(Minecraft.ID, "flower_pot", 1, 0),
                 getModItem(Minecraft.ID, "lava_bucket", 1, 0),
                 getModItem(Minecraft.ID, "netherbrick", 1, 0),
@@ -1568,9 +1521,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "CAP_SOJOURNER",
                 "TX",
-                new AspectList().add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("permutatio"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("instrumentum"), 3),
+                new AspectList().add(Aspect.AURA, 15).add(Aspect.EXCHANGE, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.GREED, 6).add(Aspect.TOOL, 3),
                 -5,
                 -8,
                 3,
@@ -1580,8 +1532,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_SOJOURNER",
                 getModItem(ThaumicExploration.ID, "sojournerCapUncharged", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 35).add(Aspect.getAspect("perditio"), 35)
-                        .add(Aspect.getAspect("ordo"), 35).add(Aspect.getAspect("aqua"), 35),
+                new AspectList().add(Aspect.AIR, 35).add(Aspect.ENTROPY, 35).add(Aspect.ORDER, 35)
+                        .add(Aspect.WATER, 35),
                 "abc",
                 "def",
                 "ghi",
@@ -1611,9 +1563,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "CAP_SOJOURNER",
                 getModItem(ThaumicExploration.ID, "sojournerCap", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("auram"), 48).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("permutatio"), 24).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AURA, 48).add(Aspect.MAGIC, 32).add(Aspect.EXCHANGE, 24)
+                        .add(Aspect.ENERGY, 32).add(Aspect.AIR, 16).add(Aspect.ORDER, 16),
                 getModItem(ThaumicExploration.ID, "sojournerCapUncharged", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 OrePrefixes.dust.get(Materials.Diamond),
@@ -1629,9 +1580,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "CAP_MECHANIST",
                 "TX",
-                new AspectList().add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("machina"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("lucrum"), 6)
-                        .add(Aspect.getAspect("instrumentum"), 3),
+                new AspectList().add(Aspect.AURA, 15).add(Aspect.MECHANISM, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.GREED, 6).add(Aspect.TOOL, 3),
                 -9,
                 -6,
                 3,
@@ -1641,8 +1591,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_MECHANIST",
                 getModItem(ThaumicExploration.ID, "mechanistCapUncharged", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 35).add(Aspect.getAspect("perditio"), 35)
-                        .add(Aspect.getAspect("ordo"), 35).add(Aspect.getAspect("aqua"), 35),
+                new AspectList().add(Aspect.AIR, 35).add(Aspect.ENTROPY, 35).add(Aspect.ORDER, 35)
+                        .add(Aspect.WATER, 35),
                 "abc",
                 "def",
                 "ghi",
@@ -1672,9 +1622,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "CAP_MECHANIST",
                 getModItem(ThaumicExploration.ID, "mechanistCap", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("auram"), 48).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("machina"), 24).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.AURA, 48).add(Aspect.MAGIC, 32).add(Aspect.MECHANISM, 24)
+                        .add(Aspect.ENERGY, 32).add(Aspect.AIR, 16).add(Aspect.ORDER, 16),
                 getModItem(ThaumicExploration.ID, "mechanistCapUncharged", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 getModItem(Minecraft.ID, "redstone", 1, 0),
@@ -1690,9 +1639,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "StabilizerbeltGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("ordo"), 18).add(Aspect.getAspect("terra"), 15)
-                        .add(Aspect.getAspect("iter"), 12).add(Aspect.getAspect("superbia"), 9)
-                        .add(Aspect.getAspect("tutamen"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.ORDER, 18).add(Aspect.EARTH, 15).add(Aspect.TRAVEL, 12)
+                        .add(DarkAspects.PRIDE, 9).add(Aspect.ARMOR, 6).add(Aspect.MAGIC, 3),
                 1,
                 -10,
                 3,
@@ -1702,9 +1650,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "StabilizerbeltGTNH",
                 getModItem(ThaumicExploration.ID, "stabilizerBelt", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("ordo"), 48).add(Aspect.getAspect("terra"), 32)
-                        .add(Aspect.getAspect("iter"), 12).add(Aspect.getAspect("superbia"), 24)
-                        .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("praecantatio"), 16),
+                new AspectList().add(Aspect.ORDER, 48).add(Aspect.EARTH, 32).add(Aspect.TRAVEL, 12)
+                        .add(DarkAspects.PRIDE, 24).add(Aspect.ARMOR, 32).add(Aspect.MAGIC, 16),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 2),
                 ItemList.Electric_Piston_LV.get(1L),
                 OrePrefixes.springSmall.get(Materials.Thaumium),
@@ -1720,23 +1667,20 @@ public class ScriptThaumicExploration implements IScriptLoader {
                         TCHelper.findInfusionRecipe(getModItem(ThaumicExploration.ID, "stabilizerBelt", 1, 0))));
         TCHelper.setResearchAspects(
                 "ENCHBINDING",
-                new AspectList().add(Aspect.getAspect("vinculum"), 15).add(Aspect.getAspect("perditio"), 12)
-                        .add(Aspect.getAspect("iter"), 9).add(Aspect.getAspect("superbia"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.TRAP, 15).add(Aspect.ENTROPY, 12).add(Aspect.TRAVEL, 9)
+                        .add(DarkAspects.PRIDE, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("ENCHBINDING", 3);
         ThaumcraftApi.addWarpToResearch("ENCHBINDING", 1);
         TCHelper.setResearchAspects(
                 "ENCHNIGHTVISION",
-                new AspectList().add(Aspect.getAspect("sensus"), 15).add(Aspect.getAspect("lux"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("ignis"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.SENSES, 15).add(Aspect.LIGHT, 12).add(Aspect.DARKNESS, 9)
+                        .add(Aspect.FIRE, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("ENCHNIGHTVISION", 3);
         ThaumcraftApi.addWarpToResearch("ENCHNIGHTVISION", 1);
         TCHelper.setResearchAspects(
                 "ENCHDISARM",
-                new AspectList().add(Aspect.getAspect("vinculum"), 15).add(Aspect.getAspect("limus"), 12)
-                        .add(Aspect.getAspect("telum"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.TRAP, 15).add(Aspect.SLIME, 12).add(Aspect.WEAPON, 9).add(Aspect.MAGIC, 6)
+                        .add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("ENCHDISARM", 3);
         ThaumcraftApi.addWarpToResearch("ENCHDISARM", 1);
         TCHelper.orphanResearch("FLESHCURE");
@@ -1744,9 +1688,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "FleshcureGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("pannus"), 15).add(Aspect.getAspect("tutamen"), 12)
-                        .add(Aspect.getAspect("corpus"), 9).add(Aspect.getAspect("permutatio"), 6)
-                        .add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.CLOTH, 15).add(Aspect.ARMOR, 12).add(Aspect.FLESH, 9)
+                        .add(Aspect.EXCHANGE, 6).add(Aspect.ELDRITCH, 3),
                 -4,
                 -10,
                 2,
@@ -1756,8 +1699,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "FleshcureGTNH",
                 getModItem(Minecraft.ID, "leather", 1, 0),
                 getModItem(Minecraft.ID, "rotten_flesh", 1, 0),
-                new AspectList().add(Aspect.getAspect("corpus"), 4).add(Aspect.getAspect("pannus"), 4)
-                        .add(Aspect.getAspect("permutatio"), 4));
+                new AspectList().add(Aspect.FLESH, 4).add(Aspect.CLOTH, 4).add(Aspect.EXCHANGE, 4));
         TCHelper.addResearchPage(
                 "FleshcureGTNH",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(Minecraft.ID, "leather", 1, 0))));
@@ -1766,9 +1708,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "BraincureGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("ordo"), 18).add(Aspect.getAspect("cognitio"), 15)
-                        .add(Aspect.getAspect("humanus"), 12).add(Aspect.getAspect("exanimis"), 9)
-                        .add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("permutatio"), 3),
+                new AspectList().add(Aspect.ORDER, 18).add(Aspect.MIND, 15).add(Aspect.MAN, 12).add(Aspect.UNDEAD, 9)
+                        .add(Aspect.ELDRITCH, 6).add(Aspect.EXCHANGE, 3),
                 -2,
                 -8,
                 3,
@@ -1779,9 +1720,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "BraincureGTNH",
                 getModItem(ThaumicExploration.ID, "pureZombieBrain", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("ordo"), 32).add(Aspect.getAspect("sano"), 12)
-                        .add(Aspect.getAspect("humanus"), 12).add(Aspect.getAspect("alienis"), 24)
-                        .add(Aspect.getAspect("cognitio"), 16).add(Aspect.getAspect("praecantatio"), 8),
+                new AspectList().add(Aspect.ORDER, 32).add(Aspect.HEAL, 12).add(Aspect.MAN, 12).add(Aspect.ELDRITCH, 24)
+                        .add(Aspect.MIND, 16).add(Aspect.MAGIC, 8),
                 getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0),
                 getModItem(Minecraft.ID, "water_bucket", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
@@ -1798,9 +1738,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "TalismanfoodtGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("fames"), 18).add(Aspect.getAspect("pannus"), 15)
-                        .add(Aspect.getAspect("messis"), 12).add(Aspect.getAspect("sano"), 9)
-                        .add(Aspect.getAspect("permutatio"), 6).add(Aspect.getAspect("ordo"), 3),
+                new AspectList().add(Aspect.HUNGER, 18).add(Aspect.CLOTH, 15).add(Aspect.CROP, 12).add(Aspect.HEAL, 9)
+                        .add(Aspect.EXCHANGE, 6).add(Aspect.ORDER, 3),
                 -1,
                 -11,
                 3,
@@ -1811,9 +1750,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "TalismanfoodtGTNH",
                 getModItem(ThaumicExploration.ID, "talismanFood", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("fames"), 64).add(Aspect.getAspect("pannus"), 48)
-                        .add(Aspect.getAspect("messis"), 24).add(Aspect.getAspect("sano"), 24)
-                        .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.HUNGER, 64).add(Aspect.CLOTH, 48).add(Aspect.CROP, 24).add(Aspect.HEAL, 24)
+                        .add(Aspect.EXCHANGE, 32).add(Aspect.ORDER, 16),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 15),
                 OrePrefixes.gemExquisite.get(Materials.Ruby),
                 getModItem(PamsHarvestCraft.ID, "heartybreakfastItem", 1, 0),
@@ -1832,9 +1770,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "TalismanfoodtGTNH",
                 getModItem(ThaumicExploration.ID, "taintBerry", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("aqua"), 20)
-                        .add(Aspect.getAspect("ignis"), 20).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("perditio"), 25),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.WATER, 20).add(Aspect.FIRE, 20).add(Aspect.EARTH, 20)
+                        .add(Aspect.ORDER, 25).add(Aspect.ENTROPY, 25),
                 "tft",
                 "gbg",
                 "ggg",
@@ -1851,9 +1788,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "DreamcatcherGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("vitium"), 15).add(Aspect.getAspect("cognitio"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("metallum"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.TAINT, 15).add(Aspect.MIND, 12).add(Aspect.TOOL, 9).add(Aspect.METAL, 6)
+                        .add(Aspect.MAGIC, 3),
                 -7,
                 2,
                 3,
@@ -1862,8 +1798,7 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DreamcatcherGTNH",
                 getModItem(ThaumicExploration.ID, "charmNoTaint", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("perditio"), 25)
-                        .add(Aspect.getAspect("terra"), 25),
+                new AspectList().add(Aspect.ORDER, 25).add(Aspect.ENTROPY, 25).add(Aspect.EARTH, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -1893,9 +1828,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "CrucsoulGTNH",
                 "TX",
-                new AspectList().add(Aspect.getAspect("spiritus"), 18).add(Aspect.getAspect("mortuus"), 15)
-                        .add(Aspect.getAspect("fames"), 12).add(Aspect.getAspect("exanimis"), 9)
-                        .add(Aspect.getAspect("telum"), 6).add(Aspect.getAspect("alienis"), 3),
+                new AspectList().add(Aspect.SOUL, 18).add(Aspect.DEATH, 15).add(Aspect.HUNGER, 12).add(Aspect.UNDEAD, 9)
+                        .add(Aspect.WEAPON, 6).add(Aspect.ELDRITCH, 3),
                 5,
                 -7,
                 3,
@@ -1909,10 +1843,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "CrucsoulGTNH",
                 getModItem(ThaumicExploration.ID, "crucibleSouls", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("exanimis"), 24).add(Aspect.getAspect("fames"), 48)
-                        .add(Aspect.getAspect("spiritus"), 32).add(Aspect.getAspect("mortuus"), 64)
-                        .add(Aspect.getAspect("telum"), 24).add(Aspect.getAspect("vinculum"), 16)
-                        .add(Aspect.getAspect("alienis"), 8),
+                new AspectList().add(Aspect.UNDEAD, 24).add(Aspect.HUNGER, 48).add(Aspect.SOUL, 32)
+                        .add(Aspect.DEATH, 64).add(Aspect.WEAPON, 24).add(Aspect.TRAP, 16).add(Aspect.ELDRITCH, 8),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 0),
                 getModItem(Thaumcraft.ID, "blockMetalDevice", 1, 0),
                 getModItem(Minecraft.ID, "rotten_flesh", 1, 0),
@@ -1937,10 +1869,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "CrucsoulGTNH",
                 getModItem(EnderIO.ID, "itemBrokenSpawner", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("exanimis"), 34).add(Aspect.getAspect("fames"), 18)
-                        .add(Aspect.getAspect("spiritus"), 62).add(Aspect.getAspect("mortuus"), 64)
-                        .add(Aspect.getAspect("telum"), 24).add(Aspect.getAspect("vinculum"), 46)
-                        .add(Aspect.getAspect("alienis"), 28),
+                new AspectList().add(Aspect.UNDEAD, 34).add(Aspect.HUNGER, 18).add(Aspect.SOUL, 62)
+                        .add(Aspect.DEATH, 64).add(Aspect.WEAPON, 24).add(Aspect.TRAP, 46).add(Aspect.ELDRITCH, 28),
                 getModItem(ThaumicExploration.ID, "crucibleSouls", 1, 0),
                 getModItem(Botania.ID, "cocoon", 1, 0),
                 getModItem(EnderIO.ID, "itemMaterial", 1, 9),
@@ -1963,9 +1893,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         TCHelper.addResearchPrereq("TENTACLERING", "BraincureGTNH", true);
         TCHelper.setResearchAspects(
                 "TENTACLERING",
-                new AspectList().add(Aspect.getAspect("vitium"), 15).add(Aspect.getAspect("telum"), 12)
-                        .add(Aspect.getAspect("tutamen"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TAINT, 15).add(Aspect.WEAPON, 12).add(Aspect.ARMOR, 9)
+                        .add(Aspect.ELDRITCH, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("TENTACLERING", 3);
         ThaumcraftApi.addWarpToResearch("TENTACLERING", 2);
         TCHelper.orphanResearch("ROD_TRANSMUTATION");
@@ -1973,9 +1902,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "ROD_TRANSMUTATION",
                 "TX",
-                new AspectList().add(Aspect.getAspect("permutatio"), 15).add(Aspect.getAspect("instrumentum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("alienis"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.EXCHANGE, 15).add(Aspect.TOOL, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.ELDRITCH, 6).add(Aspect.EARTH, 3),
                 -1,
                 -1,
                 3,
@@ -1986,9 +1914,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "ROD_TRANSMUTATION",
                 getModItem(ThaumicExploration.ID, "transmutationCore", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("permutatio"), 32)
-                        .add(Aspect.getAspect("auram"), 24).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("arbor"), 8).add(Aspect.getAspect("alienis"), 8),
+                new AspectList().add(Aspect.MAGIC, 32).add(Aspect.EXCHANGE, 32).add(Aspect.AURA, 24)
+                        .add(Aspect.EARTH, 16).add(Aspect.TREE, 8).add(Aspect.ELDRITCH, 8),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
@@ -2007,9 +1934,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "ROD_TRANSMUTATION_staff",
                 "TX",
-                new AspectList().add(Aspect.getAspect("permutatio"), 18).add(Aspect.getAspect("instrumentum"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("arbor"), 3),
+                new AspectList().add(Aspect.EXCHANGE, 18).add(Aspect.TOOL, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.EARTH, 6).add(Aspect.TREE, 3),
                 0,
                 0,
                 3,
@@ -2019,9 +1945,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_TRANSMUTATION_staff",
                 getModItem(ThaumicExploration.ID, "transmutationStaffCore", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 85).add(Aspect.getAspect("perditio"), 85)
-                        .add(Aspect.getAspect("terra"), 85).add(Aspect.getAspect("aqua"), 85)
-                        .add(Aspect.getAspect("ignis"), 85).add(Aspect.getAspect("aer"), 85),
+                new AspectList().add(Aspect.ORDER, 85).add(Aspect.ENTROPY, 85).add(Aspect.EARTH, 85)
+                        .add(Aspect.WATER, 85).add(Aspect.FIRE, 85).add(Aspect.AIR, 85),
                 "abc",
                 "def",
                 "ghi",
@@ -2052,9 +1977,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "ROD_AMBER",
                 "TX",
-                new AspectList().add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("instrumentum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("vinculum"), 6)
-                        .add(Aspect.getAspect("vitreus"), 3),
+                new AspectList().add(Aspect.AURA, 15).add(Aspect.TOOL, 12).add(Aspect.MAGIC, 9).add(Aspect.TRAP, 6)
+                        .add(Aspect.CRYSTAL, 3),
                 -5,
                 -1,
                 3,
@@ -2064,9 +1988,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "ROD_AMBER",
                 getModItem(ThaumicExploration.ID, "amberCore", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("vinculum"), 32)
-                        .add(Aspect.getAspect("auram"), 24).add(Aspect.getAspect("vitreus"), 16)
-                        .add(Aspect.getAspect("arbor"), 8).add(Aspect.getAspect("alienis"), 8),
+                new AspectList().add(Aspect.MAGIC, 32).add(Aspect.TRAP, 32).add(Aspect.AURA, 24).add(Aspect.CRYSTAL, 16)
+                        .add(Aspect.TREE, 8).add(Aspect.ELDRITCH, 8),
                 OrePrefixes.stick.get(Materials.Amber),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 6),
@@ -2088,9 +2011,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "ROD_AMBER_staff",
                 "TX",
-                new AspectList().add(Aspect.getAspect("vinculum"), 18).add(Aspect.getAspect("instrumentum"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("alienis"), 12)
-                        .add(Aspect.getAspect("auram"), 6),
+                new AspectList().add(Aspect.TRAP, 18).add(Aspect.TOOL, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.ELDRITCH, 12).add(Aspect.AURA, 6),
                 -6,
                 0,
                 3,
@@ -2100,9 +2022,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ROD_AMBER_staff",
                 getModItem(ThaumicExploration.ID, "amberStaffCore", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 85).add(Aspect.getAspect("perditio"), 85)
-                        .add(Aspect.getAspect("terra"), 85).add(Aspect.getAspect("aqua"), 85)
-                        .add(Aspect.getAspect("ignis"), 85).add(Aspect.getAspect("aer"), 85),
+                new AspectList().add(Aspect.ORDER, 85).add(Aspect.ENTROPY, 85).add(Aspect.EARTH, 85)
+                        .add(Aspect.WATER, 85).add(Aspect.FIRE, 85).add(Aspect.AIR, 85),
                 "abc",
                 "def",
                 "ghi",
@@ -2132,10 +2053,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
         new ResearchItem(
                 "ROD_NECROMANCER_staff",
                 "TX",
-                new AspectList().add(Aspect.getAspect("mortuus"), 21).add(Aspect.getAspect("instrumentum"), 18)
-                        .add(Aspect.getAspect("perditio"), 15).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("spiritus"), 9).add(Aspect.getAspect("exanimis"), 6)
-                        .add(Aspect.getAspect("cognitio"), 3),
+                new AspectList().add(Aspect.DEATH, 21).add(Aspect.TOOL, 18).add(Aspect.ENTROPY, 15).add(Aspect.AURA, 12)
+                        .add(Aspect.SOUL, 9).add(Aspect.UNDEAD, 6).add(Aspect.MIND, 3),
                 -3,
                 1,
                 3,
@@ -2146,10 +2065,8 @@ public class ScriptThaumicExploration implements IScriptLoader {
                 "ROD_NECROMANCER_staff",
                 getModItem(ThaumicExploration.ID, "necroStaffCore", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("mortuus"), 64).add(Aspect.getAspect("instrumentum"), 24)
-                        .add(Aspect.getAspect("perditio"), 48).add(Aspect.getAspect("auram"), 32)
-                        .add(Aspect.getAspect("spiritus"), 32).add(Aspect.getAspect("exanimis"), 16)
-                        .add(Aspect.getAspect("cognitio"), 16),
+                new AspectList().add(Aspect.DEATH, 64).add(Aspect.TOOL, 24).add(Aspect.ENTROPY, 48).add(Aspect.AURA, 32)
+                        .add(Aspect.SOUL, 32).add(Aspect.UNDEAD, 16).add(Aspect.MIND, 16),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 57),
                 getModItem(Minecraft.ID, "skull", 1, 1),
                 getModItem(ThaumicExploration.ID, "pureZombieBrain", 1, 0),

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicHorizons.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicHorizons.java
@@ -76,9 +76,8 @@ public class ScriptThaumicHorizons implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "planarTheory",
                 getModItem(ThaumicHorizons.ID, "planarConduit", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("aqua"), 75)
-                        .add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.WATER, 75).add(Aspect.FIRE, 75).add(Aspect.EARTH, 75)
+                        .add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -102,17 +101,15 @@ public class ScriptThaumicHorizons implements IScriptLoader {
                 "plateVoid");
         TCHelper.setResearchAspects(
                 "planarTheory",
-                new AspectList().add(Aspect.getAspect("vacuos"), 18).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("perditio"), 6).add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.VOID, 18).add(Aspect.MAGIC, 15).add(Aspect.ELDRITCH, 12).add(Aspect.AURA, 9)
+                        .add(Aspect.ENTROPY, 6).add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("planarTheory", 4);
         ThaumcraftApi.addWarpToResearch("planarTheory", 1);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "transductionAmplifier",
                 getModItem(ThaumicHorizons.ID, "transductionAmplifier", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("ignis"), 75)
-                        .add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("terra"), 75)
-                        .add(Aspect.getAspect("aqua"), 75).add(Aspect.getAspect("perditio"), 75),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.FIRE, 75).add(Aspect.ORDER, 75).add(Aspect.EARTH, 75)
+                        .add(Aspect.WATER, 75).add(Aspect.ENTROPY, 75),
                 "abc",
                 "def",
                 "ghi",
@@ -136,17 +133,16 @@ public class ScriptThaumicHorizons implements IScriptLoader {
                 "plateRedstoneAlloy");
         TCHelper.setResearchAspects(
                 "transductionAmplifier",
-                new AspectList().add(Aspect.getAspect("auram"), 18).add(Aspect.getAspect("potentia"), 15)
-                        .add(Aspect.getAspect("vacuos"), 12).add(Aspect.getAspect("alienis"), 9));
+                new AspectList().add(Aspect.AURA, 18).add(Aspect.ENERGY, 15).add(Aspect.VOID, 12)
+                        .add(Aspect.ELDRITCH, 9));
         TCHelper.setResearchComplexity("transductionAmplifier", 4);
         ThaumcraftApi.addWarpToResearch("transductionAmplifier", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "vortexStabilizer",
                 getModItem(ThaumicHorizons.ID, "vortexStabilizer", 1, 0),
                 7,
-                new AspectList().add(Aspect.getAspect("auram"), 64).add(Aspect.getAspect("fames"), 32)
-                        .add(Aspect.getAspect("machina"), 48).add(Aspect.getAspect("ordo"), 32)
-                        .add(Aspect.getAspect("potentia"), 48).add(Aspect.getAspect("vinculum"), 32),
+                new AspectList().add(Aspect.AURA, 64).add(Aspect.HUNGER, 32).add(Aspect.MECHANISM, 48)
+                        .add(Aspect.ORDER, 32).add(Aspect.ENERGY, 48).add(Aspect.TRAP, 32),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 10),
                 getModItem(ThaumicHorizons.ID, "planarConduit", 1, 0),
                 OrePrefixes.plate.get(Materials.Thaumium),
@@ -158,18 +154,16 @@ public class ScriptThaumicHorizons implements IScriptLoader {
                 OrePrefixes.plate.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "vortexStabilizer",
-                new AspectList().add(Aspect.getAspect("auram"), 21).add(Aspect.getAspect("fames"), 18)
-                        .add(Aspect.getAspect("machina"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("vinculum"), 6));
+                new AspectList().add(Aspect.AURA, 21).add(Aspect.HUNGER, 18).add(Aspect.MECHANISM, 15)
+                        .add(Aspect.ORDER, 12).add(Aspect.ENERGY, 9).add(Aspect.TRAP, 6));
         TCHelper.setResearchComplexity("vortexStabilizer", 4);
         ThaumcraftApi.addWarpToResearch("vortexStabilizer", 2);
         TCHelper.addInfusionCraftingRecipe(
                 "recombinator",
                 getModItem(ThaumicHorizons.ID, "recombinator", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("permutatio"), 64).add(Aspect.getAspect("auram"), 48)
-                        .add(Aspect.getAspect("fabrico"), 32).add(Aspect.getAspect("potentia"), 32)
-                        .add(Aspect.getAspect("sensus"), 16).add(Aspect.getAspect("praecantatio"), 24),
+                new AspectList().add(Aspect.EXCHANGE, 64).add(Aspect.AURA, 48).add(Aspect.CRAFT, 32)
+                        .add(Aspect.ENERGY, 32).add(Aspect.SENSES, 16).add(Aspect.MAGIC, 24),
                 getModItem(Thaumcraft.ID, "ItemEldritchObject", 1, 3),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 11),
                 OrePrefixes.gemExquisite.get(Materials.Amber),
@@ -185,9 +179,8 @@ public class ScriptThaumicHorizons implements IScriptLoader {
                 OrePrefixes.gemExquisite.get(Materials.Amber));
         TCHelper.setResearchAspects(
                 "recombinator",
-                new AspectList().add(Aspect.getAspect("auram"), 21).add(Aspect.getAspect("permutatio"), 18)
-                        .add(Aspect.getAspect("fabrico"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("potentia"), 9).add(Aspect.getAspect("sensus"), 6));
+                new AspectList().add(Aspect.AURA, 21).add(Aspect.EXCHANGE, 18).add(Aspect.CRAFT, 15)
+                        .add(Aspect.MAGIC, 12).add(Aspect.ENERGY, 9).add(Aspect.SENSES, 6));
         TCHelper.setResearchComplexity("recombinator", 4);
         ThaumcraftApi.addWarpToResearch("recombinator", 3);
         TCHelper.refreshResearchPages("greatwoodBoat");

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicMachina.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicMachina.java
@@ -38,14 +38,12 @@ public class ScriptThaumicMachina implements IScriptLoader {
         TCHelper.removeResearch("@WAND_AUGMENTATION_TAINT_CAPPING");
         TCHelper.setResearchAspects(
                 "@WAND_STABILITY",
-                new AspectList().add(Aspect.getAspect("perditio"), 3).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 6).add(Aspect.getAspect("praecantatio"), 9));
+                new AspectList().add(Aspect.ENTROPY, 3).add(Aspect.ORDER, 12).add(Aspect.TOOL, 6).add(Aspect.MAGIC, 9));
         TCHelper.setResearchComplexity("@WAND_STABILITY", 3);
         TCHelper.setResearchAspects(
                 "@WAND_STUDIES",
-                new AspectList().add(Aspect.getAspect("perditio"), 3).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 6));
+                new AspectList().add(Aspect.ENTROPY, 3).add(Aspect.AURA, 9).add(Aspect.MIND, 15).add(Aspect.ORDER, 12)
+                        .add(Aspect.TOOL, 6));
         TCHelper.setResearchComplexity("@WAND_STUDIES", 3);
         TCHelper.clearPages("@WAND_AUGMENTATION");
         TCHelper.addResearchPrereq("@WAND_AUGMENTATION", "MIRROR", false);
@@ -56,7 +54,7 @@ public class ScriptThaumicMachina implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "@WAND_AUGMENTATION",
                 getModItem(ThaumicMachina.ID, "wandAugmentationCore", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 35).add(Aspect.getAspect("perditio"), 35),
+                new AspectList().add(Aspect.ORDER, 35).add(Aspect.ENTROPY, 35),
                 "abc",
                 "def",
                 "ghi",
@@ -84,86 +82,72 @@ public class ScriptThaumicMachina implements IScriptLoader {
                         TCHelper.findArcaneRecipe(getModItem(ThaumicMachina.ID, "wandAugmentationCore", 1, 0))));
         TCHelper.setResearchAspects(
                 "@WAND_AUGMENTATION",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 3).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("machina"), 12)
-                        .add(Aspect.getAspect("perditio"), 15));
+                new AspectList().add(Aspect.TOOL, 3).add(Aspect.MAGIC, 6).add(Aspect.ORDER, 9).add(Aspect.MECHANISM, 12)
+                        .add(Aspect.ENTROPY, 15));
         TCHelper.setResearchComplexity("@WAND_AUGMENTATION", 3);
         TCHelper.setResearchAspects(
                 "@VIS",
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("auram"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.AURA, 9).add(Aspect.MAGIC, 6));
         TCHelper.setResearchComplexity("@VIS", 2);
         TCHelper.setResearchAspects(
                 "@VIS_STUDIES",
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 15));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.AURA, 12).add(Aspect.MIND, 6).add(Aspect.ENERGY, 9)
+                        .add(Aspect.MAGIC, 15));
         TCHelper.setResearchComplexity("@VIS_STUDIES", 3);
         TCHelper.setResearchAspects(
                 "@VIS_CHARGE",
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 15));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.AURA, 12).add(Aspect.ENERGY, 6)
+                        .add(Aspect.ENTROPY, 9).add(Aspect.MAGIC, 15));
         TCHelper.setResearchComplexity("@VIS_CHARGE", 3);
         TCHelper.setResearchAspects(
                 "@NODAL_STUDIES",
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("praecantatio"), 15));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.AURA, 12).add(Aspect.MIND, 15)
+                        .add(Aspect.MAGIC, 15));
         TCHelper.setResearchComplexity("@NODAL_STUDIES", 3);
         TCHelper.setResearchAspects(
                 "@AURA_FIELD",
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("vacuos"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 15));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.AURA, 12).add(Aspect.ENERGY, 6).add(Aspect.VOID, 9)
+                        .add(Aspect.MAGIC, 15));
         TCHelper.setResearchComplexity("@AURA_FIELD", 3);
         TCHelper.setResearchAspects(
                 "@CRIMSON_ASTRONOMY",
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("vacuos"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 15));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.AURA, 12).add(Aspect.DARKNESS, 6)
+                        .add(Aspect.VOID, 9).add(Aspect.MAGIC, 15));
         TCHelper.setResearchComplexity("@CRIMSON_ASTRONOMY", 3);
         TCHelper.setResearchAspects(
                 "@CRIMSON_REALISATION",
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("potentia"), 15));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.AURA, 12).add(Aspect.DARKNESS, 6)
+                        .add(Aspect.MAGIC, 9).add(Aspect.ENERGY, 15));
         TCHelper.setResearchComplexity("@CRIMSON_REALISATION", 3);
         TCHelper.setResearchAspects(
                 "@CRIMSON_CELESTIAL_FIELD",
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("vacuos"), 18));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.AURA, 12).add(Aspect.DARKNESS, 6)
+                        .add(Aspect.MAGIC, 9).add(Aspect.ORDER, 15).add(Aspect.VOID, 18));
         TCHelper.setResearchComplexity("@CRIMSON_CELESTIAL_FIELD", 3);
         TCHelper.setResearchAspects(
                 "@CRIMSON_THAUMATURGY",
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("instrumentum"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 6).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("ordo"), 15));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.TOOL, 12).add(Aspect.DARKNESS, 6)
+                        .add(Aspect.MAGIC, 9).add(Aspect.ORDER, 15));
         TCHelper.setResearchComplexity("@CRIMSON_THAUMATURGY", 3);
         TCHelper.setResearchAspects(
                 "@CRIMSON_WAND_AUGMENTATION",
-                new AspectList().add(Aspect.getAspect("alienis"), 3).add(Aspect.getAspect("tenebrae"), 6)
-                        .add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("machina"), 18)
-                        .add(Aspect.getAspect("cognitio"), 21));
+                new AspectList().add(Aspect.ELDRITCH, 3).add(Aspect.DARKNESS, 6).add(Aspect.TOOL, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.ORDER, 15).add(Aspect.MECHANISM, 18).add(Aspect.MIND, 21));
         TCHelper.setResearchComplexity("@CRIMSON_WAND_AUGMENTATION", 3);
         TCHelper.setResearchAspects(
                 "@WAND_AUGMENTATION_CHARGE_BUFFER",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 3).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("vacuos"), 9)
-                        .add(Aspect.getAspect("tenebrae"), 15).add(Aspect.getAspect("alienis"), 18));
+                new AspectList().add(Aspect.TOOL, 3).add(Aspect.MAGIC, 6).add(Aspect.ENERGY, 12).add(Aspect.VOID, 9)
+                        .add(Aspect.DARKNESS, 15).add(Aspect.ELDRITCH, 18));
         TCHelper.setResearchComplexity("@WAND_AUGMENTATION_CHARGE_BUFFER", 3);
         TCHelper.setResearchAspects(
                 "@WAND_AUGMENTATION_VIS_CHANNEL",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 3).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("alienis"), 15));
+                new AspectList().add(Aspect.TOOL, 3).add(Aspect.MAGIC, 6).add(Aspect.WATER, 9).add(Aspect.DARKNESS, 12)
+                        .add(Aspect.ELDRITCH, 15));
         TCHelper.setResearchComplexity("@WAND_AUGMENTATION_VIS_CHANNEL", 3);
         TCHelper.setResearchAspects(
                 "@WAND_AUGMENTATION_CONTACT_DISCHARGE",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 3).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("tenebrae"), 15)
-                        .add(Aspect.getAspect("alienis"), 18).add(Aspect.getAspect("telum"), 21));
+                new AspectList().add(Aspect.TOOL, 3).add(Aspect.MAGIC, 6).add(Aspect.ENERGY, 12)
+                        .add(Aspect.DARKNESS, 15).add(Aspect.ELDRITCH, 18).add(Aspect.WEAPON, 21));
         TCHelper.setResearchComplexity("@WAND_AUGMENTATION_CONTACT_DISCHARGE", 3);
         ThaumcraftApi.addWarpToResearch("@WAND_AUGMENTATION_CONTACT_DISCHARGE", 5);
     }

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
@@ -12,6 +12,7 @@ import static gregtech.api.enums.Mods.ExtraUtilities;
 import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.Forestry;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
+import static gregtech.api.enums.Mods.MagicBees;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.PamsHarvestCraft;
 import static gregtech.api.enums.Mods.StevesCarts2;
@@ -67,6 +68,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 ForbiddenMagic.ID,
                 Forestry.ID,
                 IndustrialCraft2.ID,
+                MagicBees.ID,
                 PamsHarvestCraft.ID,
                 StevesCarts2.ID,
                 Thaumcraft.ID,

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
@@ -24,7 +24,6 @@ import static gregtech.api.recipe.RecipeMaps.cutterRecipes;
 import static gregtech.api.recipe.RecipeMaps.laserEngraverRecipes;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeBuilder.TICKS;
-import static thaumcraft.api.aspects.Aspect.getAspect;
 
 import java.util.Arrays;
 import java.util.List;
@@ -602,7 +601,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "fireChaos", 1, 0),
                 16,
                 new AspectList().add(Aspect.ENTROPY, 10).add(Aspect.LIGHT, 10).add(Aspect.AIR, 10)
-                        .add(getAspect("praecantatio"), 10),
+                        .add(Aspect.MAGIC, 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"perditio\"}]}"),
                 getModItem(Botania.ID, "manaResource", 1, 23),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5),
@@ -617,8 +616,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "INFUSEDSEED",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.ENTROPY, 15).add(Aspect.LIGHT, 12).add(Aspect.AIR, 9)
-                        .add(getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.ENTROPY, 15).add(Aspect.LIGHT, 12).add(Aspect.AIR, 9).add(Aspect.MAGIC, 3),
                 7,
                 -5,
                 3,

--- a/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptThaumicTinkerer.java
@@ -32,6 +32,7 @@ import net.minecraftforge.fluids.FluidRegistry;
 
 import com.dreammaster.thaumcraft.TCHelper;
 
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -40,6 +41,7 @@ import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTModHandler;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.api.util.GTUtility;
+import magicbees.api.MagicBeesAPI;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -211,9 +213,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "SHARETOME",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("instrumentum"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.MIND, 15).add(Aspect.MAGIC, 12).add(Aspect.EXCHANGE, 9).add(Aspect.TOOL, 6)
+                        .add(Aspect.EARTH, 3),
                 0,
                 -1,
                 3,
@@ -223,8 +224,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "SHARETOME",
                 getModItem(ThaumicTinkerer.ID, "shareBook", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("cognitio"), 32).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("pannus"), 16),
+                new AspectList().add(Aspect.MIND, 32).add(Aspect.MAGIC, 16).add(Aspect.EXCHANGE, 32)
+                        .add(Aspect.CLOTH, 16),
                 getModItem(Minecraft.ID, "skull", 1, 3),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 getModItem(Minecraft.ID, "paper", 1, 0),
@@ -248,7 +249,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DARKQUARTZ",
                 getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 8),
+                new AspectList().add(Aspect.ENTROPY, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -273,7 +274,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DARKQUARTZ",
                 getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 8),
+                new AspectList().add(Aspect.ENTROPY, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -314,8 +315,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "INTERFACE",
                 getModItem(ThaumicTinkerer.ID, "interface", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 32).add(Aspect.getAspect("perditio"), 32)
-                        .add(Aspect.getAspect("terra"), 16),
+                new AspectList().add(Aspect.ORDER, 32).add(Aspect.ENTROPY, 32).add(Aspect.EARTH, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -340,7 +340,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "INTERFACE",
                 getModItem(ThaumicTinkerer.ID, "connector", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.ORDER, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -360,14 +360,13 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemShard", 1, 3));
         TCHelper.setResearchAspects(
                 "INTERFACE",
-                new AspectList().add(Aspect.getAspect("ordo"), 12).add(Aspect.getAspect("perditio"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.ORDER, 12).add(Aspect.ENTROPY, 9).add(Aspect.ENERGY, 6)
+                        .add(Aspect.WATER, 3));
         TCHelper.setResearchComplexity("INTERFACE", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DISLOCATOR",
                 getModItem(ThaumicTinkerer.ID, "dislocator", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 48).add(Aspect.getAspect("perditio"), 48)
-                        .add(Aspect.getAspect("terra"), 24),
+                new AspectList().add(Aspect.ORDER, 48).add(Aspect.ENTROPY, 48).add(Aspect.EARTH, 24),
                 "abc",
                 "def",
                 "ghi",
@@ -391,39 +390,33 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "screwThaumium");
         TCHelper.setResearchAspects(
                 "DISLOCATOR",
-                new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("perditio"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("aqua"), 3));
+                new AspectList().add(Aspect.MIND, 15).add(Aspect.ORDER, 12).add(Aspect.ENTROPY, 9).add(Aspect.ENERGY, 6)
+                        .add(Aspect.WATER, 3));
         TCHelper.setResearchComplexity("DISLOCATOR", 4);
         ThaumcraftApi.addCrucibleRecipe(
                 "GASEOUS_LIGHT",
                 getModItem(ThaumicTinkerer.ID, "gaseousLightItem", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemEssence", 1, 0),
-                new AspectList().add(Aspect.getAspect("lux"), 16).add(Aspect.getAspect("aer"), 12)
-                        .add(Aspect.getAspect("motus"), 10));
+                new AspectList().add(Aspect.LIGHT, 16).add(Aspect.AIR, 12).add(Aspect.MOTION, 10));
         TCHelper.setResearchAspects(
                 "GASEOUS_LIGHT",
-                new AspectList().add(Aspect.getAspect("lux"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("motus"), 3).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.LIGHT, 9).add(Aspect.AIR, 6).add(Aspect.MOTION, 3).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("GASEOUS_LIGHT", 2);
         ResearchCategories.getResearch("GASEOUS_SHADOW").setConcealed();
         ThaumcraftApi.addCrucibleRecipe(
                 "GASEOUS_SHADOW",
                 getModItem(ThaumicTinkerer.ID, "gaseousShadowItem", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemEssence", 1, 0),
-                new AspectList().add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("aer"), 12)
-                        .add(Aspect.getAspect("motus"), 10));
+                new AspectList().add(Aspect.DARKNESS, 16).add(Aspect.AIR, 12).add(Aspect.MOTION, 10));
         TCHelper.setResearchAspects(
                 "GASEOUS_SHADOW",
-                new AspectList().add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("motus"), 3).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.DARKNESS, 9).add(Aspect.AIR, 6).add(Aspect.MOTION, 3).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("GASEOUS_SHADOW", 2);
         ResearchCategories.getResearch("GAS_REMOVER").setConcealed();
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "GAS_REMOVER",
                 getModItem(ThaumicTinkerer.ID, "gasRemover", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("aer"), 12)
-                        .add(Aspect.getAspect("perditio"), 8),
+                new AspectList().add(Aspect.ORDER, 16).add(Aspect.AIR, 12).add(Aspect.ENTROPY, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -447,30 +440,26 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0));
         TCHelper.setResearchAspects(
                 "GASEOUS_SHADOW",
-                new AspectList().add(Aspect.getAspect("ignis"), 12).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("motus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.FIRE, 12).add(Aspect.DARKNESS, 12).add(Aspect.AIR, 9).add(Aspect.MOTION, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("GASEOUS_SHADOW", 3);
         TCHelper.addResearchPrereq("BRIGHT_NITOR", "INFUSION", false);
         ThaumcraftApi.addCrucibleRecipe(
                 "BRIGHT_NITOR",
                 getModItem(ThaumicTinkerer.ID, "brightNitor", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 1),
-                new AspectList().add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("aer"), 16)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("lux"), 32));
+                new AspectList().add(Aspect.FIRE, 16).add(Aspect.AIR, 16).add(Aspect.ENERGY, 32).add(Aspect.LIGHT, 32));
         TCHelper.setResearchAspects(
                 "BRIGHT_NITOR",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("lux"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.LIGHT, 12).add(Aspect.AIR, 9).add(Aspect.ENERGY, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("BRIGHT_NITOR", 3);
         TCHelper.orphanResearch("FIRE_IGNIS");
         TCHelper.removeResearch("FIRE_IGNIS");
         new ResearchItem(
                 "FIREIGNIS",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("lux"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.LIGHT, 12).add(Aspect.AIR, 9).add(Aspect.MAGIC, 3),
                 4,
                 -4,
                 3,
@@ -481,8 +470,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "FIREIGNIS",
                 getModItem(ThaumicTinkerer.ID, "fireFire", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("ignis"), 10).add(Aspect.getAspect("lux"), 10)
-                        .add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("praecantatio"), 10),
+                new AspectList().add(Aspect.FIRE, 10).add(Aspect.LIGHT, 10).add(Aspect.AIR, 10).add(Aspect.MAGIC, 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"ignis\"}]}"),
                 getModItem(Botania.ID, "manaResource", 1, 23),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1),
@@ -497,8 +485,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "FIREAQUA",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("lux"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.LIGHT, 12).add(Aspect.AIR, 9).add(Aspect.MAGIC, 3),
                 2,
                 -2,
                 3,
@@ -509,8 +496,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "FIREAQUA",
                 getModItem(ThaumicTinkerer.ID, "fireWater", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("aqua"), 10).add(Aspect.getAspect("lux"), 10)
-                        .add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("praecantatio"), 10),
+                new AspectList().add(Aspect.WATER, 10).add(Aspect.LIGHT, 10).add(Aspect.AIR, 10).add(Aspect.MAGIC, 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"aqua\"}]}"),
                 getModItem(Botania.ID, "manaResource", 1, 23),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2),
@@ -525,8 +511,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "FIRETERRA",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("lux"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.LIGHT, 12).add(Aspect.AIR, 9).add(Aspect.MAGIC, 3),
                 4,
                 -6,
                 3,
@@ -537,8 +522,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "FIRETERRA",
                 getModItem(ThaumicTinkerer.ID, "fireEarth", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("terra"), 10).add(Aspect.getAspect("lux"), 10)
-                        .add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("praecantatio"), 10),
+                new AspectList().add(Aspect.EARTH, 10).add(Aspect.LIGHT, 10).add(Aspect.AIR, 10).add(Aspect.MAGIC, 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"terra\"}]}"),
                 getModItem(Botania.ID, "manaResource", 1, 23),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3),
@@ -553,8 +537,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "FIREORDO",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("lux"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.LIGHT, 12).add(Aspect.AIR, 9).add(Aspect.MAGIC, 3),
                 3,
                 -3,
                 3,
@@ -565,8 +548,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "FIREORDO",
                 getModItem(ThaumicTinkerer.ID, "fireOrder", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("ordo"), 10).add(Aspect.getAspect("lux"), 10)
-                        .add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("praecantatio"), 10),
+                new AspectList().add(Aspect.ORDER, 10).add(Aspect.LIGHT, 10).add(Aspect.AIR, 10).add(Aspect.MAGIC, 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"ordo\"}]}"),
                 getModItem(Botania.ID, "manaResource", 1, 23),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4),
@@ -581,8 +563,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "FIREAER",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("lux"), 12)
-                        .add(Aspect.getAspect("motus"), 9).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.LIGHT, 12).add(Aspect.MOTION, 9).add(Aspect.MAGIC, 3),
                 3,
                 -7,
                 3,
@@ -592,8 +573,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "FIREAER",
                 getModItem(ThaumicTinkerer.ID, "fireAir", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("lux"), 10)
-                        .add(Aspect.getAspect("motus"), 10).add(Aspect.getAspect("praecantatio"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.LIGHT, 10).add(Aspect.MOTION, 10).add(Aspect.MAGIC, 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"aer\"}]}"),
                 getModItem(Botania.ID, "manaResource", 1, 23),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
@@ -608,8 +588,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "FIREPERDITIO",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.getAspect("perditio"), 15).add(Aspect.getAspect("lux"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.ENTROPY, 15).add(Aspect.LIGHT, 12).add(Aspect.AIR, 9).add(Aspect.MAGIC, 3),
                 2,
                 -8,
                 3,
@@ -620,7 +599,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "FIREPERDITIO",
                 getModItem(ThaumicTinkerer.ID, "fireChaos", 1, 0),
                 16,
-                new AspectList().add(getAspect("perditio"), 10).add(getAspect("lux"), 10).add(getAspect("aer"), 10)
+                new AspectList().add(Aspect.ENTROPY, 10).add(Aspect.LIGHT, 10).add(Aspect.AIR, 10)
                         .add(getAspect("praecantatio"), 10),
                 createItemStack(Thaumcraft.ID, "ItemEssence", 1, 1, "{Aspects:[0:{amount:8,key:\"perditio\"}]}"),
                 getModItem(Botania.ID, "manaResource", 1, 23),
@@ -636,7 +615,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "INFUSEDSEED",
                 "TT_CATEGORY",
-                new AspectList().add(getAspect("perditio"), 15).add(getAspect("lux"), 12).add(getAspect("aer"), 9)
+                new AspectList().add(Aspect.ENTROPY, 15).add(Aspect.LIGHT, 12).add(Aspect.AIR, 9)
                         .add(getAspect("praecantatio"), 3),
                 7,
                 -5,
@@ -671,7 +650,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         0,
                         "{mainAspect:{Aspects:[0:{amount:1,key:\"aer\"}]},aspectTendencies:{Aspects:[]}}"),
                 4,
-                new AspectList().add(getAspect("messis"), 32).add(getAspect("meto"), 32).add(getAspect("aer"), 16),
+                new AspectList().add(Aspect.CROP, 32).add(Aspect.HARVEST, 32).add(Aspect.AIR, 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
@@ -696,7 +675,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         0,
                         "{mainAspect:{Aspects:[0:{amount:1,key:\"ignis\"}]},aspectTendencies:{Aspects:[]}}"),
                 4,
-                new AspectList().add(getAspect("messis"), 32).add(getAspect("meto"), 32).add(getAspect("ignis"), 16),
+                new AspectList().add(Aspect.CROP, 32).add(Aspect.HARVEST, 32).add(Aspect.FIRE, 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 1),
@@ -711,7 +690,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         0,
                         "{mainAspect:{Aspects:[0:{amount:1,key:\"aqua\"}]},aspectTendencies:{Aspects:[]}}"),
                 4,
-                new AspectList().add(getAspect("messis"), 32).add(getAspect("meto"), 32).add(getAspect("aqua"), 16),
+                new AspectList().add(Aspect.CROP, 32).add(Aspect.HARVEST, 32).add(Aspect.WATER, 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 2),
@@ -726,7 +705,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         0,
                         "{mainAspect:{Aspects:[0:{amount:1,key:\"terra\"}]},aspectTendencies:{Aspects:[]}}"),
                 4,
-                new AspectList().add(getAspect("messis"), 32).add(getAspect("meto"), 32).add(getAspect("terra"), 16),
+                new AspectList().add(Aspect.CROP, 32).add(Aspect.HARVEST, 32).add(Aspect.EARTH, 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 3),
@@ -741,7 +720,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         0,
                         "{mainAspect:{Aspects:[0:{amount:1,key:\"ordo\"}]},aspectTendencies:{Aspects:[]}}"),
                 4,
-                new AspectList().add(getAspect("messis"), 32).add(getAspect("meto"), 32).add(getAspect("ordo"), 16),
+                new AspectList().add(Aspect.CROP, 32).add(Aspect.HARVEST, 32).add(Aspect.ORDER, 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4),
@@ -756,7 +735,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         0,
                         "{mainAspect:{Aspects:[0:{amount:1,key:\"perditio\"}]},aspectTendencies:{Aspects:[]}}"),
                 4,
-                new AspectList().add(getAspect("messis"), 32).add(getAspect("meto"), 32).add(getAspect("perditio"), 16),
+                new AspectList().add(Aspect.CROP, 32).add(Aspect.HARVEST, 32).add(Aspect.ENTROPY, 16),
                 getModItem(Minecraft.ID, "wheat_seeds", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 5),
@@ -767,9 +746,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "INFUSEDPOTIONS",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.getAspect("auram"), 15).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("aer"), 9).add(Aspect.getAspect("aqua"), 9)
-                        .add(Aspect.getAspect("terra"), 9),
+                new AspectList().add(Aspect.AURA, 15).add(Aspect.FIRE, 12).add(Aspect.AIR, 9).add(Aspect.WATER, 9)
+                        .add(Aspect.EARTH, 9),
                 9,
                 -5,
                 3,
@@ -783,8 +761,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "INFUSEDPOTIONS",
                 getModItem(ThaumicTinkerer.ID, "infusedPotion", 1, 0),
                 getModItem(ThaumicTinkerer.ID, "infusedGrain", 1, 0),
-                new AspectList().add(Aspect.getAspect("auram"), 16).add(Aspect.getAspect("aer"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 8));
+                new AspectList().add(Aspect.AURA, 16).add(Aspect.AIR, 16).add(Aspect.MAGIC, 8));
         TCHelper.addResearchPage(
                 "INFUSEDPOTIONS",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ThaumicTinkerer.ID, "infusedPotion", 1, 0))));
@@ -792,8 +769,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "INFUSEDPOTIONS",
                 getModItem(ThaumicTinkerer.ID, "infusedPotion", 1, 1),
                 getModItem(ThaumicTinkerer.ID, "infusedGrain", 1, 1),
-                new AspectList().add(Aspect.getAspect("auram"), 16).add(Aspect.getAspect("ignis"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 8));
+                new AspectList().add(Aspect.AURA, 16).add(Aspect.FIRE, 16).add(Aspect.MAGIC, 8));
         TCHelper.addResearchPage(
                 "INFUSEDPOTIONS",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ThaumicTinkerer.ID, "infusedPotion", 1, 1))));
@@ -801,8 +777,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "INFUSEDPOTIONS",
                 getModItem(ThaumicTinkerer.ID, "infusedPotion", 1, 2),
                 getModItem(ThaumicTinkerer.ID, "infusedGrain", 1, 2),
-                new AspectList().add(Aspect.getAspect("auram"), 16).add(Aspect.getAspect("terra"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 8));
+                new AspectList().add(Aspect.AURA, 16).add(Aspect.EARTH, 16).add(Aspect.MAGIC, 8));
         TCHelper.addResearchPage(
                 "INFUSEDPOTIONS",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ThaumicTinkerer.ID, "infusedPotion", 1, 2))));
@@ -810,8 +785,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "INFUSEDPOTIONS",
                 getModItem(ThaumicTinkerer.ID, "infusedPotion", 1, 3),
                 getModItem(ThaumicTinkerer.ID, "infusedGrain", 1, 3),
-                new AspectList().add(Aspect.getAspect("auram"), 16).add(Aspect.getAspect("aqua"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 8));
+                new AspectList().add(Aspect.AURA, 16).add(Aspect.WATER, 16).add(Aspect.MAGIC, 8));
         TCHelper.addResearchPage(
                 "INFUSEDPOTIONS",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(ThaumicTinkerer.ID, "infusedPotion", 1, 3))));
@@ -820,8 +794,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FUNNEL",
                 getModItem(ThaumicTinkerer.ID, "funnel", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 8).add(Aspect.getAspect("perditio"), 8)
-                        .add(Aspect.getAspect("aqua"), 8),
+                new AspectList().add(Aspect.ORDER, 8).add(Aspect.ENTROPY, 8).add(Aspect.WATER, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -839,18 +812,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "plateThaumium");
         TCHelper.setResearchAspects(
                 "FUNNEL",
-                new AspectList().add(Aspect.getAspect("iter"), 15).add(Aspect.getAspect("instrumentum"), 12)
-                        .add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("metallum"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TRAVEL, 15).add(Aspect.TOOL, 12).add(Aspect.WATER, 9).add(Aspect.METAL, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("FUNNEL", 3);
         TCHelper.addResearchPrereq("REPAIRER", "INFUSION", false);
         TCHelper.addInfusionCraftingRecipe(
                 "REPAIRER",
                 getModItem(ThaumicTinkerer.ID, "repairer", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("fabrico"), 32).add(Aspect.getAspect("instrumentum"), 32)
-                        .add(Aspect.getAspect("ordo"), 16).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("potentia"), 8),
+                new AspectList().add(Aspect.CRAFT, 32).add(Aspect.TOOL, 32).add(Aspect.ORDER, 16).add(Aspect.MAGIC, 16)
+                        .add(Aspect.ENERGY, 8),
                 OrePrefixes.block.get(Materials.Thaumium),
                 OrePrefixes.plate.get(Materials.Thaumium),
                 OrePrefixes.plate.get(Materials.Iron),
@@ -862,15 +833,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 OrePrefixes.plate.get(Materials.Gold));
         TCHelper.setResearchAspects(
                 "REPAIRER",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.CRAFT, 12).add(Aspect.ORDER, 9).add(Aspect.ENERGY, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("REPAIRER", 4);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MAGNETS",
                 getModItem(ThaumicTinkerer.ID, "magnet", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("terra"), 25)
-                        .add(Aspect.getAspect("ordo"), 20).add(Aspect.getAspect("perditio"), 15),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.EARTH, 25).add(Aspect.ORDER, 20)
+                        .add(Aspect.ENTROPY, 15),
                 "abc",
                 "def",
                 "ghi",
@@ -894,16 +864,15 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockMagicalLog", 1, 0));
         TCHelper.setResearchAspects(
                 "MAGNETS",
-                new AspectList().add(Aspect.getAspect("bestia"), 15).add(Aspect.getAspect("machina"), 15)
-                        .add(Aspect.getAspect("motus"), 12).add(Aspect.getAspect("sensus"), 9)
-                        .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("spiritus"), 3));
+                new AspectList().add(Aspect.BEAST, 15).add(Aspect.MECHANISM, 15).add(Aspect.MOTION, 12)
+                        .add(Aspect.SENSES, 9).add(Aspect.ORDER, 6).add(Aspect.SOUL, 3));
         TCHelper.setResearchComplexity("MAGNETS", 4);
         ThaumcraftApi.addWarpToResearch("MAGNETS", 2);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "MAGNETS",
                 getModItem(ThaumicTinkerer.ID, "magnet", 1, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 25).add(Aspect.getAspect("terra"), 30)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("perditio"), 20),
+                new AspectList().add(Aspect.AIR, 25).add(Aspect.EARTH, 30).add(Aspect.ORDER, 15)
+                        .add(Aspect.ENTROPY, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -929,14 +898,12 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "MAGNETS",
                 getModItem(ThaumicTinkerer.ID, "soulMould", 1, 0),
                 getModItem(Minecraft.ID, "ender_eye", 1, 0),
-                new AspectList().add(Aspect.getAspect("bestia"), 8).add(Aspect.getAspect("cognitio"), 8)
-                        .add(Aspect.getAspect("sensus"), 8).add(Aspect.getAspect("spiritus"), 8));
+                new AspectList().add(Aspect.BEAST, 8).add(Aspect.MIND, 8).add(Aspect.SENSES, 8).add(Aspect.SOUL, 8));
         ResearchCategories.getResearch("ANIMATION_TABLET").setConcealed();
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ANIMATION_TABLET",
                 getModItem(ThaumicTinkerer.ID, "animationTablet", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 35).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.AIR, 35).add(Aspect.FIRE, 30).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -960,9 +927,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "screwThaumium");
         TCHelper.setResearchAspects(
                 "ANIMATION_TABLET",
-                new AspectList().add(Aspect.getAspect("machina"), 15).add(Aspect.getAspect("metallum"), 15)
-                        .add(Aspect.getAspect("motus"), 12).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("exanimis"), 3));
+                new AspectList().add(Aspect.MECHANISM, 15).add(Aspect.METAL, 15).add(Aspect.MOTION, 12)
+                        .add(Aspect.ENERGY, 9).add(Aspect.ORDER, 6).add(Aspect.UNDEAD, 3));
         TCHelper.setResearchComplexity("ANIMATION_TABLET", 4);
         ThaumcraftApi.addWarpToResearch("ANIMATION_TABLET", 3);
         ResearchCategories.getResearch("LEVITATOR_LOCOMOTIVE").setConcealed();
@@ -970,9 +936,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "LEVITATOR_LOCOMOTIVE",
                 getModItem(ThaumicTinkerer.ID, "Levitational Locomotive", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("motus"), 30).add(Aspect.getAspect("ordo"), 20)
-                        .add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("aer"), 25)
-                        .add(Aspect.getAspect("potentia"), 10),
+                new AspectList().add(Aspect.MOTION, 30).add(Aspect.ORDER, 20).add(Aspect.MAGIC, 15).add(Aspect.AIR, 25)
+                        .add(Aspect.ENERGY, 10),
                 getModItem(Thaumcraft.ID, "blockLifter", 1, 0),
                 OrePrefixes.plate.get(Materials.Obsidian),
                 OrePrefixes.screw.get(Materials.Iron),
@@ -984,15 +949,13 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 OrePrefixes.screw.get(Materials.Iron));
         TCHelper.setResearchAspects(
                 "LEVITATOR_LOCOMOTIVE",
-                new AspectList().add(Aspect.getAspect("motus"), 15).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("machina"), 12).add(Aspect.getAspect("aer"), 9)
-                        .add(Aspect.getAspect("potentia"), 6).add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.MOTION, 15).add(Aspect.ORDER, 15).add(Aspect.MECHANISM, 12)
+                        .add(Aspect.AIR, 9).add(Aspect.ENERGY, 6).add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("LEVITATOR_LOCOMOTIVE", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "LEVITATOR_LOCOMOTIVE",
                 getModItem(ThaumicTinkerer.ID, "Levitational Locomotive Relay", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("terra"), 20)
-                        .add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.EARTH, 20).add(Aspect.ORDER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -1022,8 +985,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "CLEANSING_TALISMAN",
                 getModItem(ThaumicTinkerer.ID, "cleansingTalisman", 1, 0),
                 4,
-                new AspectList().add(Aspect.getAspect("humanus"), 32).add(Aspect.getAspect("instrumentum"), 24)
-                        .add(Aspect.getAspect("sano"), 16).add(Aspect.getAspect("victus"), 16),
+                new AspectList().add(Aspect.MAN, 32).add(Aspect.TOOL, 24).add(Aspect.HEAL, 16).add(Aspect.LIFE, 16),
                 getModItem(Minecraft.ID, "ender_eye", 1, 0),
                 getModItem(ThaumicTinkerer.ID, "darkQuartzItem", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 1),
@@ -1035,15 +997,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 1));
         TCHelper.setResearchAspects(
                 "CLEANSING_TALISMAN",
-                new AspectList().add(Aspect.getAspect("sano"), 15).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("mortuus"), 9).add(Aspect.getAspect("victus"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.HEAL, 15).add(Aspect.ORDER, 12).add(Aspect.DEATH, 9).add(Aspect.LIFE, 6)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("CLEANSING_TALISMAN", 3);
         ResearchCategories.getResearch("INFUSEDPOTIONS").setConcealed();
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "PLATFORM",
                 getModItem(ThaumicTinkerer.ID, "platform", 2, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 10).add(Aspect.getAspect("perditio"), 10),
+                new AspectList().add(Aspect.AIR, 10).add(Aspect.ENTROPY, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -1061,18 +1022,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockWoodenDevice", 1, 6));
         TCHelper.setResearchAspects(
                 "PLATFORM",
-                new AspectList().add(Aspect.getAspect("sensus"), 12).add(Aspect.getAspect("arbor"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("iter"), 3)
-                        .add(Aspect.getAspect("praecantatio"), 3));
+                new AspectList().add(Aspect.SENSES, 12).add(Aspect.TREE, 9).add(Aspect.MOTION, 6).add(Aspect.TRAVEL, 3)
+                        .add(Aspect.MAGIC, 3));
         TCHelper.setResearchComplexity("PLATFORM", 3);
         ResearchCategories.getResearch("BLOOD_SWORD").setConcealed();
         TCHelper.addInfusionCraftingRecipe(
                 "BLOOD_SWORD",
                 getModItem(ThaumicTinkerer.ID, "bloodSword", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("fames"), 32).add(Aspect.getAspect("humanus"), 8)
-                        .add(Aspect.getAspect("spiritus"), 16).add(Aspect.getAspect("tenebrae"), 24)
-                        .add(Aspect.getAspect("telum"), 16),
+                new AspectList().add(Aspect.HUNGER, 32).add(Aspect.MAN, 8).add(Aspect.SOUL, 16).add(Aspect.DARKNESS, 24)
+                        .add(Aspect.WEAPON, 16),
                 getModItem(Thaumcraft.ID, "ItemSwordThaumium", 1, 0),
                 OrePrefixes.gemFlawless.get(Materials.Diamond),
                 getModItem(Minecraft.ID, "ghast_tear", 1, 0),
@@ -1088,17 +1047,15 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Minecraft.ID, "chicken", 1, 0));
         TCHelper.setResearchAspects(
                 "BLOOD_SWORD",
-                new AspectList().add(Aspect.getAspect("fames"), 15).add(Aspect.getAspect("telum"), 12)
-                        .add(Aspect.getAspect("corpus"), 9).add(Aspect.getAspect("spiritus"), 6)
-                        .add(Aspect.getAspect("tenebrae"), 3));
+                new AspectList().add(Aspect.HUNGER, 15).add(Aspect.WEAPON, 12).add(Aspect.FLESH, 9).add(Aspect.SOUL, 6)
+                        .add(Aspect.DARKNESS, 3));
         TCHelper.setResearchComplexity("BLOOD_SWORD", 4);
         ThaumcraftApi.addWarpToResearch("BLOOD_SWORD", 3);
         ResearchCategories.getResearch("SUMMON").setConcealed();
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SUMMON",
                 getModItem(ThaumicTinkerer.ID, "spawner", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 75).add(Aspect.getAspect("perditio"), 75)
-                        .add(Aspect.getAspect("terra"), 50),
+                new AspectList().add(Aspect.ORDER, 75).add(Aspect.ENTROPY, 75).add(Aspect.EARTH, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -1122,16 +1079,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "screwThaumium");
         TCHelper.setResearchAspects(
                 "SUMMON",
-                new AspectList().add(Aspect.getAspect("telum"), 15).add(Aspect.getAspect("bestia"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("spiritus"), 6)
-                        .add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.WEAPON, 15).add(Aspect.BEAST, 12).add(Aspect.MAGIC, 9).add(Aspect.SOUL, 6)
+                        .add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("SUMMON", 4);
         ThaumcraftApi.addWarpToResearch("SUMMON", 5);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCUS_SMELT",
                 getModItem(ThaumicTinkerer.ID, "focusSmelt", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 16).add(Aspect.getAspect("perditio"), 12)
-                        .add(Aspect.getAspect("ordo"), 12).add(Aspect.getAspect("aer"), 8),
+                new AspectList().add(Aspect.FIRE, 16).add(Aspect.ENTROPY, 12).add(Aspect.ORDER, 12).add(Aspect.AIR, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -1155,17 +1110,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14));
         TCHelper.setResearchAspects(
                 "FOCUS_SMELT",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("aer"), 6)
-                        .add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.ENERGY, 12).add(Aspect.MAGIC, 9).add(Aspect.AIR, 6)
+                        .add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("FOCUS_SMELT", 3);
         TCHelper.addResearchPrereq("FOCUS_FLIGHT", "FOCUSFIRE", false);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_FLIGHT",
                 getModItem(ThaumicTinkerer.ID, "focusFlight", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 48).add(Aspect.getAspect("iter"), 24)
-                        .add(Aspect.getAspect("motus"), 32).add(Aspect.getAspect("volatus"), 24),
+                new AspectList().add(Aspect.AIR, 48).add(Aspect.TRAVEL, 24).add(Aspect.MOTION, 32)
+                        .add(Aspect.FLIGHT, 24),
                 getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0),
                 OrePrefixes.rotor.get(Materials.Thaumium),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 7),
@@ -1175,18 +1129,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 OrePrefixes.dust.get(Materials.EnderPearl));
         TCHelper.setResearchAspects(
                 "FOCUS_FLIGHT",
-                new AspectList().add(Aspect.getAspect("motus"), 15).add(Aspect.getAspect("aer"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("volatus"), 6)
-                        .add(Aspect.getAspect("iter"), 3));
+                new AspectList().add(Aspect.MOTION, 15).add(Aspect.AIR, 12).add(Aspect.MAGIC, 9).add(Aspect.FLIGHT, 6)
+                        .add(Aspect.TRAVEL, 3));
         TCHelper.setResearchComplexity("FOCUS_FLIGHT", 4);
         TCHelper.addResearchPrereq("FOCUS_DEFLECT", "FOCUS_FLIGHT", false);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_DEFLECT",
                 getModItem(ThaumicTinkerer.ID, "focusDeflect", 1, 0),
                 6,
-                new AspectList().add(Aspect.getAspect("aer"), 32).add(Aspect.getAspect("ordo"), 24)
-                        .add(Aspect.getAspect("tutamen"), 32).add(Aspect.getAspect("auram"), 24)
-                        .add(Aspect.getAspect("alienis"), 16),
+                new AspectList().add(Aspect.AIR, 32).add(Aspect.ORDER, 24).add(Aspect.ARMOR, 32).add(Aspect.AURA, 24)
+                        .add(Aspect.ELDRITCH, 16),
                 getModItem(ThaumicTinkerer.ID, "focusFlight", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 10),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 3),
@@ -1196,15 +1148,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 4));
         TCHelper.setResearchAspects(
                 "FOCUS_DEFLECT",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("auram"), 6)
-                        .add(Aspect.getAspect("aer"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.MAGIC, 12).add(Aspect.EXCHANGE, 9)
+                        .add(Aspect.AURA, 6).add(Aspect.AIR, 3));
         TCHelper.setResearchComplexity("FOCUS_DEFLECT", 4);
         TCHelper.addResearchPrereq("FOCUS_ENDER_CHEST", "ENDERCHEST", false);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FOCUS_ENDER_CHEST",
                 getModItem(ThaumicTinkerer.ID, "focusEnderChest", 1, 0),
-                new AspectList().add(Aspect.getAspect("perditio"), 50).add(Aspect.getAspect("ordo"), 50),
+                new AspectList().add(Aspect.ENTROPY, 50).add(Aspect.ORDER, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -1228,18 +1179,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14));
         TCHelper.setResearchAspects(
                 "FOCUS_ENDER_CHEST",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("vacuos"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("tenebrae"), 6)
-                        .add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.VOID, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.DARKNESS, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("FOCUS_ENDER_CHEST", 4);
         ThaumcraftApi.addWarpToResearch("ANIMATION_TABLET", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_TELEKINESIS",
                 getModItem(ThaumicTinkerer.ID, "focusTelekinesis", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("cognitio"), 32)
-                        .add(Aspect.getAspect("motus"), 32).add(Aspect.getAspect("perditio"), 24)
-                        .add(Aspect.getAspect("lucrum"), 16),
+                new AspectList().add(Aspect.AIR, 24).add(Aspect.MIND, 32).add(Aspect.MOTION, 32).add(Aspect.ENTROPY, 24)
+                        .add(Aspect.GREED, 16),
                 getModItem(ThaumicTinkerer.ID, "focusFlight", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCrystal", 1, 0),
                 OrePrefixes.plate.get(Materials.NetherQuartz),
@@ -1251,18 +1200,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 OrePrefixes.plate.get(Materials.NetherQuartz));
         TCHelper.setResearchAspects(
                 "FOCUS_TELEKINESIS",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("motus"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("cognitio"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6));
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.MOTION, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.MIND, 9).add(Aspect.GREED, 6));
         TCHelper.setResearchComplexity("FOCUS_TELEKINESIS", 4);
         TCHelper.addResearchPrereq("FOCUS_DISLOCATION", "FOCUSTRADE", false);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_DISLOCATION",
                 getModItem(ThaumicTinkerer.ID, "focusDislocation", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("tenebrae"), 32).add(Aspect.getAspect("vacuos"), 32)
-                        .add(Aspect.getAspect("vitium"), 16).add(Aspect.getAspect("permutatio"), 16),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.MAGIC, 32).add(Aspect.DARKNESS, 32)
+                        .add(Aspect.VOID, 32).add(Aspect.TAINT, 16).add(Aspect.EXCHANGE, 16),
                 getModItem(Thaumcraft.ID, "FocusTrade", 1, 0),
                 OrePrefixes.gemFlawless.get(Materials.Diamond),
                 OrePrefixes.plate.get(Materials.NetherQuartz),
@@ -1274,17 +1221,15 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 OrePrefixes.plate.get(Materials.NetherQuartz));
         TCHelper.setResearchAspects(
                 "FOCUS_DISLOCATION",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("permutatio"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("tenebrae"), 9)
-                        .add(Aspect.getAspect("vacuos"), 6).add(Aspect.getAspect("vitium"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.EXCHANGE, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.DARKNESS, 9).add(Aspect.VOID, 6).add(Aspect.TAINT, 3));
         TCHelper.setResearchComplexity("FOCUS_DISLOCATION", 4);
         ThaumcraftApi.addWarpToResearch("FOCUS_DISLOCATION", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_HEAL",
                 getModItem(ThaumicTinkerer.ID, "focusHeal", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("sano"), 24).add(Aspect.getAspect("spiritus"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 32).add(Aspect.getAspect("victus"), 24),
+                new AspectList().add(Aspect.HEAL, 24).add(Aspect.SOUL, 32).add(Aspect.MAGIC, 32).add(Aspect.LIFE, 24),
                 getModItem(Thaumcraft.ID, "FocusPech", 1, 0),
                 getModItem(Minecraft.ID, "golden_apple", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14),
@@ -1296,9 +1241,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 14));
         TCHelper.setResearchAspects(
                 "FOCUS_HEAL",
-                new AspectList().add(Aspect.getAspect("sano"), 15).add(Aspect.getAspect("victus"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("spiritus"), 9)
-                        .add(Aspect.getAspect("cognitio"), 6));
+                new AspectList().add(Aspect.HEAL, 15).add(Aspect.LIFE, 15).add(Aspect.MAGIC, 12).add(Aspect.SOUL, 9)
+                        .add(Aspect.MIND, 6));
         TCHelper.setResearchComplexity("FOCUS_HEAL", 4);
         TCHelper.addResearchPrereq("ENCHANTER", "ENCHANTINGTABLE", false);
         TCHelper.addResearchPrereq("ENCHANTER", "INFUSION", false);
@@ -1307,9 +1251,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "ENCHANTER",
                 getModItem(ThaumicTinkerer.ID, "enchanter", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("cognitio"), 64)
-                        .add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("auram"), 64).add(Aspect.getAspect("vacuos"), 64),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.MIND, 64).add(Aspect.ENERGY, 64)
+                        .add(Aspect.MAGIC, 64).add(Aspect.AURA, 64).add(Aspect.VOID, 64),
                 getModItem(Minecraft.ID, "enchanting_table", 1, 0),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0),
                 OrePrefixes.plate.get(Materials.Thaumium),
@@ -1325,10 +1268,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 0));
         TCHelper.setResearchAspects(
                 "ENCHANTER",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("vacuos"), 9).add(Aspect.getAspect("cognitio"), 6)
-                        .add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.MAGIC, 15).add(Aspect.AURA, 12)
+                        .add(Aspect.DARKNESS, 12).add(Aspect.VOID, 9).add(Aspect.MIND, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("ENCHANTER", 4);
         ThaumcraftApi.addWarpToResearch("ENCHANTER", 3);
         TCHelper.addResearchPrereq("SPELL_CLOTH", "INFUSION", false);
@@ -1337,20 +1278,19 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "SPELL_CLOTH",
                 getModItem(ThaumicTinkerer.ID, "spellCloth", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 7),
-                new AspectList().add(Aspect.getAspect("perditio"), 16).add(Aspect.getAspect("praecantatio"), 16)
-                        .add(Aspect.getAspect("permutatio"), 8).add(Aspect.getAspect("alienis"), 8));
+                new AspectList().add(Aspect.ENTROPY, 16).add(Aspect.MAGIC, 16).add(Aspect.EXCHANGE, 8)
+                        .add(Aspect.ELDRITCH, 8));
         TCHelper.setResearchAspects(
                 "SPELL_CLOTH",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("pannus"), 9)
-                        .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.MAGIC, 12).add(Aspect.CLOTH, 9).add(Aspect.AURA, 6)
+                        .add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("SPELL_CLOTH", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "XP_TALISMAN",
                 getModItem(ThaumicTinkerer.ID, "xpTalisman", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("bestia"), 24).add(Aspect.getAspect("lucrum"), 32)
-                        .add(Aspect.getAspect("machina"), 16).add(Aspect.getAspect("permutatio"), 16)
-                        .add(Aspect.getAspect("humanus"), 8),
+                new AspectList().add(Aspect.BEAST, 24).add(Aspect.GREED, 32).add(Aspect.MECHANISM, 16)
+                        .add(Aspect.EXCHANGE, 16).add(Aspect.MAN, 8),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 0),
                 getModItem(Thaumcraft.ID, "ItemZombieBrain", 1, 0),
                 OrePrefixes.plate.get(Materials.NetherQuartz),
@@ -1362,16 +1302,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 OrePrefixes.plate.get(Materials.Diamond));
         TCHelper.setResearchAspects(
                 "XP_TALISMAN",
-                new AspectList().add(Aspect.getAspect("lucrum"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("humanus"), 9).add(Aspect.getAspect("auram"), 6)
-                        .add(Aspect.getAspect("machina"), 3));
+                new AspectList().add(Aspect.GREED, 15).add(Aspect.MAGIC, 12).add(Aspect.MAN, 9).add(Aspect.AURA, 6)
+                        .add(Aspect.MECHANISM, 3));
         TCHelper.setResearchComplexity("XP_TALISMAN", 4);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "REVEALING_HELM",
                 getModItem(ThaumicTinkerer.ID, "revealingHelm", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 35).add(Aspect.getAspect("aqua"), 35)
-                        .add(Aspect.getAspect("terra"), 35).add(Aspect.getAspect("ignis"), 35)
-                        .add(Aspect.getAspect("ordo"), 35).add(Aspect.getAspect("perditio"), 35),
+                new AspectList().add(Aspect.AIR, 35).add(Aspect.WATER, 35).add(Aspect.EARTH, 35).add(Aspect.FIRE, 35)
+                        .add(Aspect.ORDER, 35).add(Aspect.ENTROPY, 35),
                 "abc",
                 "def",
                 "ghi",
@@ -1391,108 +1329,92 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemHelmetThaumium", 1, 0));
         TCHelper.setResearchAspects(
                 "REVEALING_HELM",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("auram"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("metallum"), 6)
-                        .add(Aspect.getAspect("sensus"), 3));
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.AURA, 12).add(Aspect.MAGIC, 9).add(Aspect.METAL, 6)
+                        .add(Aspect.SENSES, 3));
         TCHelper.setResearchComplexity("REVEALING_HELM", 4);
         ResearchCategories.getResearch("TTENCH_ASCENT_BOOST").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_ASCENT_BOOST",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("motus"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("auram"), 6)
-                        .add(Aspect.getAspect("tempus"), 3));
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.MOTION, 12).add(Aspect.MAGIC, 9).add(Aspect.AURA, 6)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 3));
         TCHelper.setResearchComplexity("TTENCH_ASCENT_BOOST", 3);
         ResearchCategories.getResearch("TTENCH_SLOW_FALL").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_SLOW_FALL",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("motus"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("auram"), 6)
-                        .add(Aspect.getAspect("tempus"), 3));
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.MOTION, 12).add(Aspect.MAGIC, 9).add(Aspect.AURA, 6)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 3));
         TCHelper.setResearchComplexity("TTENCH_SLOW_FALL", 3);
         ResearchCategories.getResearch("TTENCH_AUTO_SMELT").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_AUTO_SMELT",
-                new AspectList().add(Aspect.getAspect("ignis"), 15).add(Aspect.getAspect("perditio"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("auram"), 6)
-                        .add(Aspect.getAspect("metallum"), 3));
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.ENTROPY, 12).add(Aspect.MAGIC, 9).add(Aspect.AURA, 6)
+                        .add(Aspect.METAL, 3));
         TCHelper.setResearchComplexity("TTENCH_AUTO_SMELT", 3);
         ResearchCategories.getResearch("TTENCH_DESINTEGRATE").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_DESINTEGRATE",
-                new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("perditio"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("auram"), 6)
-                        .add(Aspect.getAspect("tempus"), 3));
+                new AspectList().add(Aspect.VOID, 15).add(Aspect.ENTROPY, 12).add(Aspect.MAGIC, 9).add(Aspect.AURA, 6)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 3));
         TCHelper.setResearchComplexity("TTENCH_DESINTEGRATE", 3);
         ResearchCategories.getResearch("TTENCH_QUICK_DRAW").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_QUICK_DRAW",
-                new AspectList().add(Aspect.getAspect("telum"), 15).add(Aspect.getAspect("sensus"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("auram"), 6)
-                        .add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.WEAPON, 15).add(Aspect.SENSES, 12).add(Aspect.MAGIC, 9).add(Aspect.AURA, 6)
+                        .add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("TTENCH_QUICK_DRAW", 3);
         ResearchCategories.getResearch("TTENCH_VAMPIRISM").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_VAMPIRISM",
-                new AspectList().add(Aspect.getAspect("fames"), 15).add(Aspect.getAspect("telum"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("auram"), 6)
-                        .add(Aspect.getAspect("lucrum"), 3));
+                new AspectList().add(Aspect.HUNGER, 15).add(Aspect.WEAPON, 12).add(Aspect.MAGIC, 9).add(Aspect.AURA, 6)
+                        .add(Aspect.GREED, 3));
         TCHelper.setResearchComplexity("TTENCH_VAMPIRISM", 3);
         ResearchCategories.getResearch("TTENCH_POUNCE").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_POUNCE",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("tutamen"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("volatus"), 3));
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.ORDER, 15).add(Aspect.ARMOR, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.AURA, 6).add(Aspect.FLIGHT, 3));
         TCHelper.setResearchComplexity("TTENCH_POUNCE", 4);
         ResearchCategories.getResearch("TTENCH_SHOCKWAVE").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_SHOCKWAVE",
-                new AspectList().add(Aspect.getAspect("aer"), 15).add(Aspect.getAspect("perditio"), 15)
-                        .add(Aspect.getAspect("tutamen"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("volatus"), 3));
+                new AspectList().add(Aspect.AIR, 15).add(Aspect.ENTROPY, 15).add(Aspect.ARMOR, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.AURA, 6).add(Aspect.FLIGHT, 3));
         TCHelper.setResearchComplexity("TTENCH_SHOCKWAVE", 4);
         ResearchCategories.getResearch("TTENCH_TUNNEL").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_TUNNEL",
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("perfodio"), 3));
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.ORDER, 15).add(Aspect.TOOL, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.AURA, 6).add(Aspect.MINE, 3));
         TCHelper.setResearchComplexity("TTENCH_TUNNEL", 4);
         ResearchCategories.getResearch("TTENCH_SHATTER").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_SHATTER",
-                new AspectList().add(Aspect.getAspect("terra"), 15).add(Aspect.getAspect("perditio"), 15)
-                        .add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("perfodio"), 3));
+                new AspectList().add(Aspect.EARTH, 15).add(Aspect.ENTROPY, 15).add(Aspect.TOOL, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.AURA, 6).add(Aspect.MINE, 3));
         TCHelper.setResearchComplexity("TTENCH_SHATTER", 4);
         ResearchCategories.getResearch("TTENCH_FOCUSED").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_FOCUSED",
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("telum"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("bestia"), 3));
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.WEAPON, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.AURA, 6).add(Aspect.BEAST, 3));
         TCHelper.setResearchComplexity("TTENCH_FOCUSED", 4);
         ResearchCategories.getResearch("TTENCH_DISPERSED").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_DISPERSED",
-                new AspectList().add(Aspect.getAspect("perditio"), 15).add(Aspect.getAspect("telum"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("bestia"), 3));
+                new AspectList().add(Aspect.ENTROPY, 15).add(Aspect.WEAPON, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.AURA, 6).add(Aspect.BEAST, 3));
         TCHelper.setResearchComplexity("TTENCH_DISPERSED", 4);
         ResearchCategories.getResearch("TTENCH_VALIANCE").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_VALIANCE",
-                new AspectList().add(Aspect.getAspect("sano"), 15).add(Aspect.getAspect("telum"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("alienis"), 9)
-                        .add(Aspect.getAspect("auram"), 6).add(Aspect.getAspect("bestia"), 3));
+                new AspectList().add(Aspect.HEAL, 15).add(Aspect.WEAPON, 15).add(Aspect.MAGIC, 12)
+                        .add(Aspect.ELDRITCH, 9).add(Aspect.AURA, 6).add(Aspect.BEAST, 3));
         TCHelper.setResearchComplexity("TTENCH_VALIANCE", 4);
         ResearchCategories.getResearch("TTENCH_FINAL").setConcealed();
         TCHelper.setResearchAspects(
                 "TTENCH_FINAL",
-                new AspectList().add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("perditio"), 15)
-                        .add(Aspect.getAspect("telum"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("auram"), 6)
-                        .add(Aspect.getAspect("superbia"), 3));
+                new AspectList().add(Aspect.ORDER, 15).add(Aspect.ENTROPY, 15).add(Aspect.WEAPON, 15)
+                        .add(Aspect.MAGIC, 12).add(Aspect.ELDRITCH, 9).add(Aspect.AURA, 6).add(DarkAspects.PRIDE, 3));
         TCHelper.setResearchComplexity("TTENCH_FINAL", 4);
         TCHelper.refreshResearchPages("INTERFACE");
         TCHelper.refreshResearchPages("DISLOCATOR");
@@ -1572,10 +1494,9 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "DIMENSIONSHARDS",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.getAspect("infernus"), 15).add(Aspect.getAspect("luxuria"), 15)
-                        .add(Aspect.getAspect("superbia"), 15).add(Aspect.getAspect("gula"), 12)
-                        .add(Aspect.getAspect("invidia"), 9).add(Aspect.getAspect("desidia"), 6)
-                        .add(Aspect.getAspect("ira"), 3),
+                new AspectList().add(DarkAspects.NETHER, 15).add(DarkAspects.LUST, 15).add(DarkAspects.PRIDE, 15)
+                        .add(DarkAspects.GLUTTONY, 12).add(DarkAspects.ENVY, 9).add(DarkAspects.SLOTH, 6)
+                        .add(DarkAspects.WRATH, 3),
                 7,
                 8,
                 3,
@@ -1585,12 +1506,10 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "DIMENSIONSHARDS",
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6),
                 8,
-                new AspectList().add(Aspect.getAspect("infernus"), 8).add(Aspect.getAspect("praecantatio"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8).add(Aspect.getAspect("vitium"), 8)
-                        .add(Aspect.getAspect("luxuria"), 8).add(Aspect.getAspect("superbia"), 8)
-                        .add(Aspect.getAspect("gula"), 8).add(Aspect.getAspect("invidia"), 8)
-                        .add(Aspect.getAspect("desidia"), 8).add(Aspect.getAspect("ira"), 8)
-                        .add(Aspect.getAspect("alienis"), 8),
+                new AspectList().add(DarkAspects.NETHER, 8).add(Aspect.MAGIC, 8).add(Aspect.CRYSTAL, 8)
+                        .add(Aspect.TAINT, 8).add(DarkAspects.LUST, 8).add(DarkAspects.PRIDE, 8)
+                        .add(DarkAspects.GLUTTONY, 8).add(DarkAspects.ENVY, 8).add(DarkAspects.SLOTH, 8)
+                        .add(DarkAspects.WRATH, 8).add(Aspect.ELDRITCH, 8),
                 getModItem(Minecraft.ID, "blaze_rod", 1, 0),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1),
@@ -1611,12 +1530,10 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "DIMENSIONSHARDS",
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7),
                 8,
-                new AspectList().add(Aspect.getAspect("infernus"), 8).add(Aspect.getAspect("praecantatio"), 8)
-                        .add(Aspect.getAspect("vitreus"), 8).add(Aspect.getAspect("vitium"), 8)
-                        .add(Aspect.getAspect("luxuria"), 8).add(Aspect.getAspect("superbia"), 8)
-                        .add(Aspect.getAspect("gula"), 8).add(Aspect.getAspect("invidia"), 8)
-                        .add(Aspect.getAspect("desidia"), 8).add(Aspect.getAspect("ira"), 8)
-                        .add(Aspect.getAspect("alienis"), 8),
+                new AspectList().add(DarkAspects.NETHER, 8).add(Aspect.MAGIC, 8).add(Aspect.CRYSTAL, 8)
+                        .add(Aspect.TAINT, 8).add(DarkAspects.LUST, 8).add(DarkAspects.PRIDE, 8)
+                        .add(DarkAspects.GLUTTONY, 8).add(DarkAspects.ENVY, 8).add(DarkAspects.SLOTH, 8)
+                        .add(DarkAspects.WRATH, 8).add(Aspect.ELDRITCH, 8),
                 getModItem(Minecraft.ID, "ender_eye", 1, 0),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 0),
                 getModItem(ForbiddenMagic.ID, "NetherShard", 1, 1),
@@ -1644,9 +1561,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "ICHOR",
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 2, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("humanus"), 32).add(Aspect.getAspect("lux"), 32)
-                        .add(Aspect.getAspect("spiritus"), 64).add(Aspect.getAspect("alienis"), 16)
-                        .add(Aspect.getAspect("ordo"), 16),
+                new AspectList().add(Aspect.MAN, 32).add(Aspect.LIGHT, 32).add(Aspect.SOUL, 64).add(Aspect.ELDRITCH, 16)
+                        .add(Aspect.ORDER, 16),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 OrePrefixes.gemFlawless.get(Materials.Diamond),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6),
@@ -1654,18 +1570,15 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7));
         TCHelper.setResearchAspects(
                 "ICHOR",
-                new AspectList().add(Aspect.getAspect("humanus"), 15).add(Aspect.getAspect("spiritus"), 15)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("vitium"), 12).add(Aspect.getAspect("lux"), 9)
-                        .add(Aspect.getAspect("infernus"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.MAN, 15).add(Aspect.SOUL, 15).add(Aspect.ORDER, 15).add(Aspect.MAGIC, 15)
+                        .add(Aspect.TAINT, 12).add(Aspect.LIGHT, 9).add(DarkAspects.NETHER, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("ICHOR", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR", 5);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ICHOR_CLOTH",
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 2, 1),
-                new AspectList().add(Aspect.getAspect("aer"), 125).add(Aspect.getAspect("aqua"), 125)
-                        .add(Aspect.getAspect("ignis"), 125).add(Aspect.getAspect("terra"), 125)
-                        .add(Aspect.getAspect("ordo"), 125).add(Aspect.getAspect("perditio"), 125),
+                new AspectList().add(Aspect.AIR, 125).add(Aspect.WATER, 125).add(Aspect.FIRE, 125)
+                        .add(Aspect.EARTH, 125).add(Aspect.ORDER, 125).add(Aspect.ENTROPY, 125),
                 "aba",
                 "cdc",
                 "ebe",
@@ -1681,9 +1594,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "gemFlawlessDiamond");
         TCHelper.setResearchAspects(
                 "ICHOR_CLOTH",
-                new AspectList().add(Aspect.getAspect("pannus"), 15).add(Aspect.getAspect("fabrico"), 15)
-                        .add(Aspect.getAspect("praecantatio"), 12).add(Aspect.getAspect("sensus"), 9)
-                        .add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.CLOTH, 15).add(Aspect.CRAFT, 15).add(Aspect.MAGIC, 12).add(Aspect.SENSES, 9)
+                        .add(Aspect.LIGHT, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("ICHOR_CLOTH", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_CLOTH", 1);
         TCHelper.clearPages("ICHORIUM");
@@ -1691,9 +1603,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ICHORIUM",
                 GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L),
-                new AspectList().add(Aspect.getAspect("aer"), 125).add(Aspect.getAspect("aqua"), 125)
-                        .add(Aspect.getAspect("ignis"), 125).add(Aspect.getAspect("terra"), 125)
-                        .add(Aspect.getAspect("ordo"), 125).add(Aspect.getAspect("perditio"), 125),
+                new AspectList().add(Aspect.AIR, 125).add(Aspect.WATER, 125).add(Aspect.FIRE, 125)
+                        .add(Aspect.EARTH, 125).add(Aspect.ORDER, 125).add(Aspect.ENTROPY, 125),
                 "abc",
                 "def",
                 "ghi",
@@ -1721,9 +1632,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                         TCHelper.findArcaneRecipe(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Ichorium, 1L))));
         TCHelper.setResearchAspects(
                 "ICHORIUM",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("fabrico"), 15)
-                        .add(Aspect.getAspect("instrumentum"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.CRAFT, 15).add(Aspect.TOOL, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.LIGHT, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("ICHORIUM", 4);
         ThaumcraftApi.addWarpToResearch("ICHORIUM", 2);
         TCHelper.clearPrereq("ICHORIUM");
@@ -1733,9 +1643,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         new ResearchItem(
                 "CAP_ICHOR",
                 "TT_CATEGORY",
-                new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("instrumentum"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.MIND, 15).add(Aspect.MAGIC, 12).add(Aspect.EXCHANGE, 9).add(Aspect.TOOL, 6)
+                        .add(Aspect.EARTH, 3),
                 11,
                 11,
                 3,
@@ -1744,9 +1653,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CAP_ICHOR",
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 2, 4),
-                new AspectList().add(Aspect.getAspect("aer"), 150).add(Aspect.getAspect("aqua"), 150)
-                        .add(Aspect.getAspect("ignis"), 150).add(Aspect.getAspect("terra"), 150)
-                        .add(Aspect.getAspect("ordo"), 150).add(Aspect.getAspect("perditio"), 150),
+                new AspectList().add(Aspect.AIR, 150).add(Aspect.WATER, 150).add(Aspect.FIRE, 150)
+                        .add(Aspect.EARTH, 150).add(Aspect.ORDER, 150).add(Aspect.ENTROPY, 150),
                 "abc",
                 "def",
                 "ghi",
@@ -1773,17 +1681,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 4))));
         TCHelper.setResearchAspects(
                 "CAP_ICHOR",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("instrumentum"), 15)
-                        .add(Aspect.getAspect("tenebrae"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.TOOL, 15).add(Aspect.DARKNESS, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.LIGHT, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("CAP_ICHOR", 4);
         ThaumcraftApi.addWarpToResearch("CAP_ICHOR", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "CAT_AMULET",
                 getModItem(ThaumicTinkerer.ID, "catAmulet", 1, 0),
                 8,
-                new AspectList().add(Aspect.getAspect("cognitio"), 16).add(Aspect.getAspect("ordo"), 32)
-                        .add(Aspect.getAspect("tenebrae"), 16).add(Aspect.getAspect("mortuus"), 16),
+                new AspectList().add(Aspect.MIND, 16).add(Aspect.ORDER, 32).add(Aspect.DARKNESS, 16)
+                        .add(Aspect.DEATH, 16),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0),
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 10),
                 OrePrefixes.ring.get(Materials.Gold),
@@ -1795,17 +1702,15 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 OrePrefixes.ring.get(Materials.Gold));
         TCHelper.setResearchAspects(
                 "CAT_AMULET",
-                new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("ordo"), 15)
-                        .add(Aspect.getAspect("tenebrae"), 12).add(Aspect.getAspect("mortuus"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.MIND, 15).add(Aspect.ORDER, 15).add(Aspect.DARKNESS, 12)
+                        .add(Aspect.DEATH, 9).add(Aspect.MOTION, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("CAT_AMULET", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "ICHOR_POUCH",
                 getModItem(ThaumicTinkerer.ID, "ichorPouch", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("vacuos"), 64).add(Aspect.getAspect("humanus"), 48)
-                        .add(Aspect.getAspect("pannus"), 48).add(Aspect.getAspect("alienis"), 48)
-                        .add(Aspect.getAspect("aer"), 64),
+                new AspectList().add(Aspect.VOID, 64).add(Aspect.MAN, 48).add(Aspect.CLOTH, 48).add(Aspect.ELDRITCH, 48)
+                        .add(Aspect.AIR, 64),
                 getModItem(Thaumcraft.ID, "FocusPouch", 1, 0),
                 getModItem(Thaumcraft.ID, "blockJar", 1, 3),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1),
@@ -1817,16 +1722,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 OrePrefixes.gemExquisite.get(Materials.Diamond));
         TCHelper.setResearchAspects(
                 "ICHOR_POUCH",
-                new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("pannus"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("humanus"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("aer"), 3));
+                new AspectList().add(Aspect.VOID, 15).add(Aspect.CLOTH, 15).add(Aspect.ELDRITCH, 12).add(Aspect.MAN, 9)
+                        .add(Aspect.MOTION, 6).add(Aspect.AIR, 3));
         TCHelper.setResearchComplexity("ICHOR_POUCH", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_POUCH", 3);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ICHORCLOTH_ARMOR",
                 getModItem(ThaumicTinkerer.ID, "ichorclothHelm", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 75).add(Aspect.getAspect("perditio"), 50)
-                        .add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.WATER, 75).add(Aspect.ENTROPY, 50).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -1847,8 +1750,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ICHORCLOTH_ARMOR",
                 getModItem(ThaumicTinkerer.ID, "ichorclothChest", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("perditio"), 50)
-                        .add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.ENTROPY, 50).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -1873,8 +1775,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ICHORCLOTH_ARMOR",
                 getModItem(ThaumicTinkerer.ID, "ichorclothLegs", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("perditio"), 50)
-                        .add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.FIRE, 75).add(Aspect.ENTROPY, 50).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -1899,8 +1800,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ICHORCLOTH_ARMOR",
                 getModItem(ThaumicTinkerer.ID, "ichorclothBoots", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 75).add(Aspect.getAspect("perditio"), 50)
-                        .add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.EARTH, 75).add(Aspect.ENTROPY, 50).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -1918,18 +1818,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1));
         TCHelper.setResearchAspects(
                 "ICHORCLOTH_ARMOR",
-                new AspectList().add(Aspect.getAspect("tutamen"), 15).add(Aspect.getAspect("pannus"), 15)
-                        .add(Aspect.getAspect("lux"), 12).add(Aspect.getAspect("perfodio"), 9)
-                        .add(Aspect.getAspect("motus"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.ARMOR, 15).add(Aspect.CLOTH, 15).add(Aspect.LIGHT, 12).add(Aspect.MINE, 9)
+                        .add(Aspect.MOTION, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("ICHORCLOTH_ARMOR", 4);
         ThaumcraftApi.addWarpToResearch("ICHORCLOTH_ARMOR", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ROD_ICHORCLOTH",
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 5),
                 10,
-                new AspectList().add(Aspect.getAspect("praecantatio"), 150).add(Aspect.getAspect("lux"), 100)
-                        .add(Aspect.getAspect("instrumentum"), 100).add(Aspect.getAspect("arbor"), 75)
-                        .add(Aspect.getAspect("alienis"), 50),
+                new AspectList().add(Aspect.MAGIC, 150).add(Aspect.LIGHT, 100).add(Aspect.TOOL, 100)
+                        .add(Aspect.TREE, 75).add(Aspect.ELDRITCH, 50),
                 getModItem(Thaumcraft.ID, "WandRod", 1, 2),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1),
@@ -1941,18 +1839,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0));
         TCHelper.setResearchAspects(
                 "ROD_ICHORCLOTH",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("pannus"), 15)
-                        .add(Aspect.getAspect("lux"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("arbor"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.CLOTH, 15).add(Aspect.LIGHT, 12).add(Aspect.MAGIC, 9)
+                        .add(Aspect.TREE, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("ROD_ICHORCLOTH", 4);
         ThaumcraftApi.addWarpToResearch("ROD_ICHORCLOTH", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_SHADOWBEAM",
                 getModItem(ThaumicTinkerer.ID, "focusShadowbeam", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("telum"), 64).add(Aspect.getAspect("tenebrae"), 64)
-                        .add(Aspect.getAspect("tempestas"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.MAGIC, 64).add(Aspect.WEAPON, 64)
+                        .add(Aspect.DARKNESS, 64).add(Aspect.WEATHER, 32),
                 getModItem(Thaumcraft.ID, "FocusShock", 1, 0),
                 OrePrefixes.ring.get(Materials.Ichorium),
                 getModItem(ThaumicTinkerer.ID, "focusDeflect", 1, 0),
@@ -1963,17 +1859,15 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "FocusExcavation", 1, 0));
         TCHelper.setResearchAspects(
                 "FOCUS_SHADOWBEAM",
-                new AspectList().add(Aspect.getAspect("tenebrae"), 15).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("telum"), 9)
-                        .add(Aspect.getAspect("tempestas"), 6).add(Aspect.getAspect("motus"), 3));
+                new AspectList().add(Aspect.DARKNESS, 15).add(Aspect.MAGIC, 15).add(Aspect.ELDRITCH, 12)
+                        .add(Aspect.WEAPON, 9).add(Aspect.WEATHER, 6).add(Aspect.MOTION, 3));
         TCHelper.setResearchComplexity("FOCUS_SHADOWBEAM", 4);
         ThaumcraftApi.addWarpToResearch("FOCUS_SHADOWBEAM", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_XP_DRAIN",
                 getModItem(ThaumicTinkerer.ID, "focusXPDrain", 1, 0),
                 12,
-                new AspectList().add(Aspect.getAspect("auram"), 64).add(Aspect.getAspect("cognitio"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("vitium"), 32),
+                new AspectList().add(Aspect.AURA, 64).add(Aspect.MIND, 64).add(Aspect.MAGIC, 64).add(Aspect.TAINT, 32),
                 getModItem(Minecraft.ID, "experience_bottle", 1, 0),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 getModItem(ThaumicTinkerer.ID, "enchanter", 1, 0),
@@ -1983,19 +1877,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "xpTalisman", 1, 0));
         TCHelper.setResearchAspects(
                 "FOCUS_XP_DRAIN",
-                new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("praecantatio"), 15)
-                        .add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("humanus"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.MIND, 15).add(Aspect.MAGIC, 15).add(Aspect.AURA, 12).add(Aspect.MAN, 9)
+                        .add(Aspect.GREED, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("FOCUS_XP_DRAIN", 4);
         ThaumcraftApi.addWarpToResearch("FOCUS_XP_DRAIN", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "ICHORCLOTH_HELM_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorclothHelmGem", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("aqua"), 64).add(Aspect.getAspect("auram"), 64)
-                        .add(Aspect.getAspect("cognitio"), 64).add(Aspect.getAspect("corpus"), 64)
-                        .add(Aspect.getAspect("fames"), 64).add(Aspect.getAspect("lux"), 64)
-                        .add(Aspect.getAspect("tutamen"), 64),
+                new AspectList().add(Aspect.WATER, 64).add(Aspect.AURA, 64).add(Aspect.MIND, 64).add(Aspect.FLESH, 64)
+                        .add(Aspect.HUNGER, 64).add(Aspect.LIGHT, 64).add(Aspect.ARMOR, 64),
                 getModItem(ThaumicTinkerer.ID, "ichorclothHelm", 1, 0),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 getModItem(Thaumcraft.ID, "ItemHelmetThaumium", 1, 0),
@@ -2011,20 +1902,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemGoggles", 1, 0));
         TCHelper.setResearchAspects(
                 "ICHORCLOTH_HELM_GEM",
-                new AspectList().add(Aspect.getAspect("aqua"), 24).add(Aspect.getAspect("sano"), 21)
-                        .add(Aspect.getAspect("fames"), 18).add(Aspect.getAspect("auram"), 15)
-                        .add(Aspect.getAspect("cognitio"), 12).add(Aspect.getAspect("corpus"), 9)
-                        .add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("tutamen"), 3));
+                new AspectList().add(Aspect.WATER, 24).add(Aspect.HEAL, 21).add(Aspect.HUNGER, 18).add(Aspect.AURA, 15)
+                        .add(Aspect.MIND, 12).add(Aspect.FLESH, 9).add(Aspect.LIGHT, 6).add(Aspect.ARMOR, 3));
         TCHelper.setResearchComplexity("ICHORCLOTH_HELM_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHORCLOTH_HELM_GEM", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "ICHORCLOTH_CHEST_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorclothChestGem", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("alienis"), 64)
-                        .add(Aspect.getAspect("lux"), 64).add(Aspect.getAspect("ordo"), 64)
-                        .add(Aspect.getAspect("sensus"), 64).add(Aspect.getAspect("tutamen"), 64)
-                        .add(Aspect.getAspect("volatus"), 64),
+                new AspectList().add(Aspect.AIR, 64).add(Aspect.ELDRITCH, 64).add(Aspect.LIGHT, 64)
+                        .add(Aspect.ORDER, 64).add(Aspect.SENSES, 64).add(Aspect.ARMOR, 64).add(Aspect.FLIGHT, 64),
                 getModItem(ThaumicTinkerer.ID, "ichorclothChest", 1, 0),
                 OrePrefixes.plate.get(Materials.Ichorium),
                 getModItem(Thaumcraft.ID, "ItemChestplateThaumium", 1, 0),
@@ -2040,20 +1927,17 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "HoverHarness", 1, 0));
         TCHelper.setResearchAspects(
                 "ICHORCLOTH_CHEST_GEM",
-                new AspectList().add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("motus"), 21)
-                        .add(Aspect.getAspect("volatus"), 18).add(Aspect.getAspect("alienis"), 15)
-                        .add(Aspect.getAspect("lux"), 12).add(Aspect.getAspect("sensus"), 9)
-                        .add(Aspect.getAspect("ordo"), 6).add(Aspect.getAspect("tutamen"), 3));
+                new AspectList().add(Aspect.AIR, 24).add(Aspect.MOTION, 21).add(Aspect.FLIGHT, 18)
+                        .add(Aspect.ELDRITCH, 15).add(Aspect.LIGHT, 12).add(Aspect.SENSES, 9).add(Aspect.ORDER, 6)
+                        .add(Aspect.ARMOR, 3));
         TCHelper.setResearchComplexity("ICHORCLOTH_CHEST_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHORCLOTH_CHEST_GEM", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "ICHORCLOTH_LEGS_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorclothLegsGem", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("ignis"), 64)
-                        .add(Aspect.getAspect("lucrum"), 64).add(Aspect.getAspect("lux"), 64)
-                        .add(Aspect.getAspect("potentia"), 64).add(Aspect.getAspect("sano"), 64)
-                        .add(Aspect.getAspect("tutamen"), 64),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.FIRE, 64).add(Aspect.GREED, 64)
+                        .add(Aspect.LIGHT, 64).add(Aspect.ENERGY, 64).add(Aspect.HEAL, 64).add(Aspect.ARMOR, 64),
                 getModItem(ThaumicTinkerer.ID, "ichorclothLegs", 1, 0),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 getModItem(Thaumcraft.ID, "ItemLeggingsThaumium", 1, 0),
@@ -2069,19 +1953,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Minecraft.ID, "lava_bucket", 1, 0));
         TCHelper.setResearchAspects(
                 "ICHORCLOTH_LEGS_GEM",
-                new AspectList().add(Aspect.getAspect("ignis"), 24).add(Aspect.getAspect("sano"), 21)
-                        .add(Aspect.getAspect("lucrum"), 18).add(Aspect.getAspect("potentia"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("aer"), 9)
-                        .add(Aspect.getAspect("lux"), 6).add(Aspect.getAspect("tutamen"), 3));
+                new AspectList().add(Aspect.FIRE, 24).add(Aspect.HEAL, 21).add(Aspect.GREED, 18).add(Aspect.ENERGY, 15)
+                        .add(Aspect.ELDRITCH, 12).add(Aspect.AIR, 9).add(Aspect.LIGHT, 6).add(Aspect.ARMOR, 3));
         TCHelper.setResearchComplexity("ICHORCLOTH_LEGS_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHORCLOTH_LEGS_GEM", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "ICHORCLOTH_BOOTS_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorclothBootsGem", 1, 0),
                 16,
-                new AspectList().add(getAspect("herba"), 64).add(getAspect("iter"), 64).add(getAspect("lux"), 64)
-                        .add(getAspect("motus"), 64).add(getAspect("perfodio"), 64).add(getAspect("terra"), 64)
-                        .add(getAspect("tutamen"), 64),
+                new AspectList().add(Aspect.PLANT, 64).add(Aspect.TRAVEL, 64).add(Aspect.LIGHT, 64)
+                        .add(Aspect.MOTION, 64).add(Aspect.MINE, 64).add(Aspect.EARTH, 64).add(Aspect.ARMOR, 64),
                 getModItem(ThaumicTinkerer.ID, "ichorclothBoots", 1, 0),
                 ingot.get(Ichorium),
                 getModItem(Thaumcraft.ID, "ItemBootsThaumium", 1, 0),
@@ -2102,19 +1983,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Minecraft.ID, "grass", 1, 0));
         TCHelper.setResearchAspects(
                 "ICHORCLOTH_BOOTS_GEM",
-                new AspectList().add(Aspect.getAspect("terra"), 24).add(Aspect.getAspect("iter"), 21)
-                        .add(Aspect.getAspect("perfodio"), 18).add(Aspect.getAspect("herba"), 15)
-                        .add(Aspect.getAspect("lux"), 12).add(Aspect.getAspect("motus"), 9)
-                        .add(Aspect.getAspect("cognitio"), 6).add(Aspect.getAspect("tutamen"), 3));
+                new AspectList().add(Aspect.EARTH, 24).add(Aspect.TRAVEL, 21).add(Aspect.MINE, 18).add(Aspect.PLANT, 15)
+                        .add(Aspect.LIGHT, 12).add(Aspect.MOTION, 9).add(Aspect.MIND, 6).add(Aspect.ARMOR, 3));
         TCHelper.setResearchComplexity("ICHORCLOTH_BOOTS_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHORCLOTH_BOOTS_GEM", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "WARP_GATE",
                 getModItem(ThaumicTinkerer.ID, "warpGate", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("iter"), 72)
-                        .add(Aspect.getAspect("volatus"), 64).add(Aspect.getAspect("terra"), 32)
-                        .add(Aspect.getAspect("aer"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.TRAVEL, 72).add(Aspect.FLIGHT, 64)
+                        .add(Aspect.EARTH, 32).add(Aspect.AIR, 32),
                 getModItem(Thaumcraft.ID, "blockCosmeticSolid", 1, 2),
                 getModItem(ThaumicTinkerer.ID, "dislocator", 1, 0),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7),
@@ -2127,9 +2005,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "WARP_GATE",
                 getModItem(ThaumicTinkerer.ID, "skyPearl", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("aer"), 24).add(Aspect.getAspect("alienis"), 32)
-                        .add(Aspect.getAspect("volatus"), 32).add(Aspect.getAspect("iter"), 32)
-                        .add(Aspect.getAspect("vitreus"), 24),
+                new AspectList().add(Aspect.AIR, 24).add(Aspect.ELDRITCH, 32).add(Aspect.FLIGHT, 32)
+                        .add(Aspect.TRAVEL, 32).add(Aspect.CRYSTAL, 24),
                 getModItem(Minecraft.ID, "ender_pearl", 1, 0),
                 getModItem(IndustrialCraft2.ID, "itemDensePlates", 1, 8),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 7),
@@ -2139,18 +2016,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 6));
         TCHelper.setResearchAspects(
                 "WARP_GATE",
-                new AspectList().add(Aspect.getAspect("iter"), 18).add(Aspect.getAspect("volatus"), 15)
-                        .add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("machina"), 9)
-                        .add(Aspect.getAspect("vitreus"), 6).add(Aspect.getAspect("aer"), 3));
+                new AspectList().add(Aspect.TRAVEL, 18).add(Aspect.FLIGHT, 15).add(Aspect.ELDRITCH, 12)
+                        .add(Aspect.MECHANISM, 9).add(Aspect.CRYSTAL, 6).add(Aspect.AIR, 3));
         TCHelper.setResearchComplexity("WARP_GATE", 4);
         ThaumcraftApi.addWarpToResearch("WARP_GATE", 4);
         TCHelper.addInfusionCraftingRecipe(
                 "FOCUS_RECALL",
                 getModItem(ThaumicTinkerer.ID, "focusRecall", 1, 0),
                 14,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("iter"), 128)
-                        .add(Aspect.getAspect("praecantatio"), 96).add(Aspect.getAspect("volatus"), 48)
-                        .add(Aspect.getAspect("aer"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.TRAVEL, 128).add(Aspect.MAGIC, 96)
+                        .add(Aspect.FLIGHT, 48).add(Aspect.AIR, 32),
                 getModItem(ThaumicTinkerer.ID, "focusEnderChest", 1, 0),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 0),
                 getModItem(ThaumicTinkerer.ID, "skyPearl", 1, 0),
@@ -2158,16 +2033,14 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(ThaumicTinkerer.ID, "skyPearl", 1, 0));
         TCHelper.setResearchAspects(
                 "FOCUS_RECALL",
-                new AspectList().add(Aspect.getAspect("iter"), 18).add(Aspect.getAspect("alienis"), 15)
-                        .add(Aspect.getAspect("volatus"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("cognitio"), 3));
+                new AspectList().add(Aspect.TRAVEL, 18).add(Aspect.ELDRITCH, 15).add(Aspect.FLIGHT, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.AIR, 6).add(Aspect.MIND, 3));
         TCHelper.setResearchComplexity("FOCUS_RECALL", 4);
         ThaumcraftApi.addWarpToResearch("FOCUS_RECALL", 4);
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ICHOR_TOOLS",
                 getModItem(ThaumicTinkerer.ID, "ichorPick", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 75).add(Aspect.getAspect("perditio"), 50)
-                        .add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.FIRE, 75).add(Aspect.ENTROPY, 50).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -2192,8 +2065,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ICHOR_TOOLS",
                 getModItem(ThaumicTinkerer.ID, "ichorShovel", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 75).add(Aspect.getAspect("perditio"), 50)
-                        .add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.EARTH, 75).add(Aspect.ENTROPY, 50).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -2214,8 +2086,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ICHOR_TOOLS",
                 getModItem(ThaumicTinkerer.ID, "ichorAxe", 1, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 75).add(Aspect.getAspect("perditio"), 50)
-                        .add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.WATER, 75).add(Aspect.ENTROPY, 50).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -2240,8 +2111,7 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ICHOR_TOOLS",
                 getModItem(ThaumicTinkerer.ID, "ichorSword", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 75).add(Aspect.getAspect("perditio"), 50)
-                        .add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.AIR, 75).add(Aspect.ENTROPY, 50).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -2261,19 +2131,17 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 "screwOsmiridium");
         TCHelper.setResearchAspects(
                 "ICHOR_TOOLS",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 18).add(Aspect.getAspect("telum"), 15)
-                        .add(Aspect.getAspect("metallum"), 12).add(Aspect.getAspect("fabrico"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6).add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.TOOL, 18).add(Aspect.WEAPON, 15).add(Aspect.METAL, 12).add(Aspect.CRAFT, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("ICHOR_TOOLS", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_TOOLS", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ICHOR_PICK_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorPickGem", 1, 0),
                 18,
-                new AspectList().add(Aspect.getAspect("ignis"), 64).add(Aspect.getAspect("lucrum"), 64)
-                        .add(Aspect.getAspect("metallum"), 64).add(Aspect.getAspect("meto"), 64)
-                        .add(Aspect.getAspect("messis"), 64).add(Aspect.getAspect("perfodio"), 64)
-                        .add(Aspect.getAspect("terra"), 64).add(Aspect.getAspect("sensus"), 64),
+                new AspectList().add(Aspect.FIRE, 64).add(Aspect.GREED, 64).add(Aspect.METAL, 64)
+                        .add(Aspect.HARVEST, 64).add(Aspect.CROP, 64).add(Aspect.MINE, 64).add(Aspect.EARTH, 64)
+                        .add(Aspect.SENSES, 64),
                 getModItem(ThaumicTinkerer.ID, "ichorPick", 1, 0),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0),
@@ -2289,20 +2157,17 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemPickaxeElemental", 1, 0));
         TCHelper.setResearchAspects(
                 "ICHOR_PICK_GEM",
-                new AspectList().add(Aspect.getAspect("ignis"), 24).add(Aspect.getAspect("lucrum"), 21)
-                        .add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("meto"), 15)
-                        .add(Aspect.getAspect("messis"), 12).add(Aspect.getAspect("perfodio"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("sensus"), 3));
+                new AspectList().add(Aspect.FIRE, 24).add(Aspect.GREED, 21).add(Aspect.METAL, 18)
+                        .add(Aspect.HARVEST, 15).add(Aspect.CROP, 12).add(Aspect.MINE, 9).add(Aspect.EARTH, 6)
+                        .add(Aspect.SENSES, 3));
         TCHelper.setResearchComplexity("ICHOR_PICK_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_PICK_GEM", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ICHOR_SHOVEL_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorShovelGem", 1, 0),
                 18,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 64).add(Aspect.getAspect("meto"), 64)
-                        .add(Aspect.getAspect("perfodio"), 64).add(Aspect.getAspect("sensus"), 64)
-                        .add(Aspect.getAspect("terra"), 64).add(Aspect.getAspect("vinculum"), 64)
-                        .add(Aspect.getAspect("ordo"), 64),
+                new AspectList().add(Aspect.TOOL, 64).add(Aspect.HARVEST, 64).add(Aspect.MINE, 64)
+                        .add(Aspect.SENSES, 64).add(Aspect.EARTH, 64).add(Aspect.TRAP, 64).add(Aspect.ORDER, 64),
                 getModItem(ThaumicTinkerer.ID, "ichorShovel", 1, 0),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0),
@@ -2318,20 +2183,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemShovelElemental", 1, 0));
         TCHelper.setResearchAspects(
                 "ICHOR_SHOVEL_GEM",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 21).add(Aspect.getAspect("meto"), 18)
-                        .add(Aspect.getAspect("perfodio"), 15).add(Aspect.getAspect("sensus"), 12)
-                        .add(Aspect.getAspect("terra"), 9).add(Aspect.getAspect("vinculum"), 6)
-                        .add(Aspect.getAspect("ordo"), 3));
+                new AspectList().add(Aspect.TOOL, 21).add(Aspect.HARVEST, 18).add(Aspect.MINE, 15)
+                        .add(Aspect.SENSES, 12).add(Aspect.EARTH, 9).add(Aspect.TRAP, 6).add(Aspect.ORDER, 3));
         TCHelper.setResearchComplexity("ICHOR_SHOVEL_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_SHOVEL_GEM", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ICHOR_AXE_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorAxeGem", 1, 0),
                 18,
-                new AspectList().add(Aspect.getAspect("aqua"), 64).add(Aspect.getAspect("arbor"), 64)
-                        .add(Aspect.getAspect("instrumentum"), 64).add(Aspect.getAspect("messis"), 64)
-                        .add(Aspect.getAspect("meto"), 64).add(Aspect.getAspect("perfodio"), 64)
-                        .add(Aspect.getAspect("sensus"), 64),
+                new AspectList().add(Aspect.WATER, 64).add(Aspect.TREE, 64).add(Aspect.TOOL, 64).add(Aspect.CROP, 64)
+                        .add(Aspect.HARVEST, 64).add(Aspect.MINE, 64).add(Aspect.SENSES, 64),
                 getModItem(ThaumicTinkerer.ID, "ichorAxe", 1, 0),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0),
@@ -2347,20 +2208,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemAxeElemental", 1, 0));
         TCHelper.setResearchAspects(
                 "ICHOR_AXE_GEM",
-                new AspectList().add(Aspect.getAspect("aqua"), 21).add(Aspect.getAspect("arbor"), 18)
-                        .add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("messis"), 12)
-                        .add(Aspect.getAspect("meto"), 9).add(Aspect.getAspect("perfodio"), 6)
-                        .add(Aspect.getAspect("sensus"), 3));
+                new AspectList().add(Aspect.WATER, 21).add(Aspect.TREE, 18).add(Aspect.TOOL, 15).add(Aspect.CROP, 12)
+                        .add(Aspect.HARVEST, 9).add(Aspect.MINE, 6).add(Aspect.SENSES, 3));
         TCHelper.setResearchComplexity("ICHOR_AXE_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_AXE_GEM", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "ICHOR_SWORD_GEM",
                 getModItem(ThaumicTinkerer.ID, "ichorSwordGem", 1, 0),
                 18,
-                new AspectList().add(Aspect.getAspect("aer"), 64).add(Aspect.getAspect("fames"), 64)
-                        .add(Aspect.getAspect("ordo"), 64).add(Aspect.getAspect("potentia"), 64)
-                        .add(Aspect.getAspect("spiritus"), 64).add(Aspect.getAspect("telum"), 64)
-                        .add(Aspect.getAspect("vitreus"), 64),
+                new AspectList().add(Aspect.AIR, 64).add(Aspect.HUNGER, 64).add(Aspect.ORDER, 64).add(Aspect.ENERGY, 64)
+                        .add(Aspect.SOUL, 64).add(Aspect.WEAPON, 64).add(Aspect.CRYSTAL, 64),
                 getModItem(ThaumicTinkerer.ID, "ichorSword", 1, 0),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0),
@@ -2376,18 +2233,15 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Thaumcraft.ID, "ItemSwordElemental", 1, 0));
         TCHelper.setResearchAspects(
                 "ICHOR_SWORD_GEM",
-                new AspectList().add(Aspect.getAspect("aer"), 21).add(Aspect.getAspect("fames"), 18)
-                        .add(Aspect.getAspect("ordo"), 15).add(Aspect.getAspect("potentia"), 12)
-                        .add(Aspect.getAspect("spiritus"), 9).add(Aspect.getAspect("telum"), 6)
-                        .add(Aspect.getAspect("vitreus"), 3));
+                new AspectList().add(Aspect.AIR, 21).add(Aspect.HUNGER, 18).add(Aspect.ORDER, 15).add(Aspect.ENERGY, 12)
+                        .add(Aspect.SOUL, 9).add(Aspect.WEAPON, 6).add(Aspect.CRYSTAL, 3));
         TCHelper.setResearchComplexity("ICHOR_SWORD_GEM", 4);
         ThaumcraftApi.addWarpToResearch("ICHOR_SWORD_GEM", 3);
         TCHelper.addInfusionCraftingRecipe(
                 "PROTOCLAY",
                 getModItem(ThaumicTinkerer.ID, "protoclay", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("instrumentum"), 32).add(Aspect.getAspect("perfodio"), 32)
-                        .add(Aspect.getAspect("terra"), 16).add(Aspect.getAspect("aer"), 16),
+                new AspectList().add(Aspect.TOOL, 32).add(Aspect.MINE, 32).add(Aspect.EARTH, 16).add(Aspect.AIR, 16),
                 getModItem(Minecraft.ID, "clay_ball", 1, 0),
                 getModItem(Minecraft.ID, "stone", 1, 0),
                 getModItem(Minecraft.ID, "dirt", 1, 0),
@@ -2399,18 +2253,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 getModItem(Minecraft.ID, "grass", 1, 0));
         TCHelper.setResearchAspects(
                 "PROTOCLAY",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 18).add(Aspect.getAspect("humanus"), 15)
-                        .add(Aspect.getAspect("machina"), 12).add(Aspect.getAspect("perfodio"), 9)
-                        .add(Aspect.getAspect("terra"), 6).add(Aspect.getAspect("aer"), 3));
+                new AspectList().add(Aspect.TOOL, 18).add(Aspect.MAN, 15).add(Aspect.MECHANISM, 12).add(Aspect.MINE, 9)
+                        .add(Aspect.EARTH, 6).add(Aspect.AIR, 3));
         TCHelper.setResearchComplexity("PROTOCLAY", 4);
         ThaumcraftApi.addWarpToResearch("PROTOCLAY", 1);
         TCHelper.addInfusionCraftingRecipe(
                 "BLOCK_TALISMAN",
                 getModItem(ThaumicTinkerer.ID, "blockTalisman", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("vacuos"), 72).add(Aspect.getAspect("tenebrae"), 48)
-                        .add(Aspect.getAspect("spiritus"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.MAGIC, 64).add(Aspect.VOID, 72)
+                        .add(Aspect.DARKNESS, 48).add(Aspect.SOUL, 32),
                 getModItem(Thaumcraft.ID, "FocusPortableHole", 1, 0),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 OrePrefixes.gemExquisite.get(Materials.Diamond),
@@ -2422,18 +2274,16 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 OrePrefixes.gemExquisite.get(Materials.Emerald));
         TCHelper.setResearchAspects(
                 "BLOCK_TALISMAN",
-                new AspectList().add(Aspect.getAspect("vacuos"), 15).add(Aspect.getAspect("tenebrae"), 12)
-                        .add(Aspect.getAspect("alienis"), 9).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("spiritus"), 3));
+                new AspectList().add(Aspect.VOID, 15).add(Aspect.DARKNESS, 12).add(Aspect.ELDRITCH, 9)
+                        .add(Aspect.MAGIC, 6).add(Aspect.SOUL, 3));
         TCHelper.setResearchComplexity("BLOCK_TALISMAN", 4);
         ThaumcraftApi.addWarpToResearch("BLOCK_TALISMAN", 6);
         TCHelper.addInfusionCraftingRecipe(
                 "PLACEMENT_MIRROR",
                 getModItem(ThaumicTinkerer.ID, "placementMirror", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("cognitio"), 64).add(Aspect.getAspect("fabrico"), 72)
-                        .add(Aspect.getAspect("praecantatio"), 64).add(Aspect.getAspect("vitreus"), 48)
-                        .add(Aspect.getAspect("alienis"), 32),
+                new AspectList().add(Aspect.MIND, 64).add(Aspect.CRAFT, 72).add(Aspect.MAGIC, 64)
+                        .add(Aspect.CRYSTAL, 48).add(Aspect.ELDRITCH, 32),
                 getModItem(ThaumicTinkerer.ID, "blockTalisman", 1, 0),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 OrePrefixes.gemExquisite.get(Materials.Diamond),
@@ -2445,9 +2295,8 @@ public class ScriptThaumicTinkerer implements IScriptLoader {
                 OrePrefixes.gemExquisite.get(Materials.Emerald));
         TCHelper.setResearchAspects(
                 "PLACEMENT_MIRROR",
-                new AspectList().add(Aspect.getAspect("cognitio"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("praecantatio"), 9).add(Aspect.getAspect("vitreus"), 6)
-                        .add(Aspect.getAspect("alienis"), 3));
+                new AspectList().add(Aspect.MIND, 15).add(Aspect.CRAFT, 12).add(Aspect.MAGIC, 9).add(Aspect.CRYSTAL, 6)
+                        .add(Aspect.ELDRITCH, 3));
         TCHelper.setResearchComplexity("PLACEMENT_MIRROR", 4);
         ThaumcraftApi.addWarpToResearch("PLACEMENT_MIRROR", 8);
         TCHelper.refreshResearchPages("ICHOR");

--- a/src/main/java/com/dreammaster/scripts/ScriptTwilightForest.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTwilightForest.java
@@ -27,12 +27,14 @@ import net.minecraftforge.fluids.FluidStack;
 
 import com.dreammaster.item.NHItemList;
 
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
+import magicbees.api.MagicBeesAPI;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -267,266 +269,243 @@ public class ScriptTwilightForest implements IScriptLoader {
 
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFRoots", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2));
+                new AspectList().add(Aspect.TREE, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFRoots", 1, 1),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("praecantatio"), 2));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.MAGIC, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "item.liveRoot", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("praecantatio"), 1));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MAGIC, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFFirefly", 1, 0),
-                new AspectList().add(Aspect.getAspect("victus"), 1).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.LIFE, 1).add(Aspect.FLIGHT, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFCicada", 1, 0),
-                new AspectList().add(Aspect.getAspect("victus"), 1).add(Aspect.getAspect("volatus"), 1));
+                new AspectList().add(Aspect.LIFE, 1).add(Aspect.FLIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPortal", 1, 0),
-                new AspectList().add(Aspect.getAspect("tempus"), 4).add(Aspect.getAspect("praecantatio"), 4)
-                        .add(Aspect.getAspect("iter"), 4));
+                new AspectList().add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 4).add(Aspect.MAGIC, 4)
+                        .add(Aspect.TRAVEL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 3),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 4),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 5),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 6),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMazestone", 1, 7),
-                new AspectList().add(Aspect.getAspect("terra"), 2));
+                new AspectList().add(Aspect.EARTH, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFHedge", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFFireflyJar", 1, 0),
-                new AspectList().add(Aspect.getAspect("vitreus"), 2).add(Aspect.getAspect("arbor"), 1));
+                new AspectList().add(Aspect.CRYSTAL, 2).add(Aspect.TREE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 3),
-                new AspectList().add(Aspect.getAspect("herba"), 2).add(Aspect.getAspect("victus"), 1));
+                new AspectList().add(Aspect.PLANT, 2).add(Aspect.LIFE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 4),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 8),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 9),
-                new AspectList().add(Aspect.getAspect("herba"), 2));
+                new AspectList().add(Aspect.PLANT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 10),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 11),
-                new AspectList().add(Aspect.getAspect("herba"), 1).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.PLANT, 1).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 13),
-                new AspectList().add(Aspect.getAspect("herba"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.PLANT, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFPlant", 1, 14),
-                new AspectList().add(Aspect.getAspect("arbor"), 1));
+                new AspectList().add(Aspect.TREE, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFFireJet", 1, 0),
-                new AspectList().add(Aspect.getAspect("ignis"), 2).add(Aspect.getAspect("aer"), 2)
-                        .add(Aspect.getAspect("machina"), 1));
+                new AspectList().add(Aspect.FIRE, 2).add(Aspect.AIR, 2).add(Aspect.MECHANISM, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFFireJet", 1, 8),
-                new AspectList().add(Aspect.getAspect("ignis"), 6).add(Aspect.getAspect("motus"), 2)
-                        .add(Aspect.getAspect("machina"), 1));
+                new AspectList().add(Aspect.FIRE, 6).add(Aspect.MOTION, 2).add(Aspect.MECHANISM, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFNagastone", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.EARTH, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFNagastone", 1, 13),
-                new AspectList().add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.EARTH, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFSapling", 1, 5),
-                new AspectList().add(Aspect.getAspect("herba"), 4).add(Aspect.getAspect("arbor"), 2)
-                        .add(Aspect.getAspect("tempus"), 2));
+                new AspectList().add(Aspect.PLANT, 4).add(Aspect.TREE, 2)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFSapling", 1, 6),
-                new AspectList().add(Aspect.getAspect("herba"), 4).add(Aspect.getAspect("arbor"), 2)
-                        .add(Aspect.getAspect("praecantatio"), 2));
+                new AspectList().add(Aspect.PLANT, 4).add(Aspect.TREE, 2).add(Aspect.MAGIC, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFSapling", 1, 7),
-                new AspectList().add(Aspect.getAspect("herba"), 4).add(Aspect.getAspect("arbor"), 2)
-                        .add(Aspect.getAspect("perfodio"), 2));
+                new AspectList().add(Aspect.PLANT, 4).add(Aspect.TREE, 2).add(Aspect.MINE, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFSapling", 1, 9),
-                new AspectList().add(Aspect.getAspect("herba"), 4).add(Aspect.getAspect("arbor"), 2)
-                        .add(Aspect.getAspect("sensus"), 2));
+                new AspectList().add(Aspect.PLANT, 4).add(Aspect.TREE, 2).add(Aspect.SENSES, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMoonworm", 1, 0),
-                new AspectList().add(Aspect.getAspect("victus"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.LIFE, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMagicLogSpecial", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 4).add(Aspect.getAspect("praecantatio"), 2)
-                        .add(Aspect.getAspect("tempus"), 2).add(Aspect.getAspect("herba"), 2)
-                        .add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.TREE, 4).add(Aspect.MAGIC, 2)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 2).add(Aspect.PLANT, 2)
+                        .add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMagicLogSpecial", 1, 1),
-                new AspectList().add(Aspect.getAspect("arbor"), 4).add(Aspect.getAspect("praecantatio"), 2)
-                        .add(Aspect.getAspect("aer"), 2).add(Aspect.getAspect("herba"), 2)
-                        .add(Aspect.getAspect("invidia"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.TREE, 4).add(Aspect.MAGIC, 2).add(Aspect.AIR, 2).add(Aspect.PLANT, 2)
+                        .add(DarkAspects.ENVY, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMagicLogSpecial", 1, 2),
-                new AspectList().add(Aspect.getAspect("arbor"), 4).add(Aspect.getAspect("praecantatio"), 2)
-                        .add(Aspect.getAspect("perfodio"), 2).add(Aspect.getAspect("herba"), 2)
-                        .add(Aspect.getAspect("lucrum"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.TREE, 4).add(Aspect.MAGIC, 2).add(Aspect.MINE, 2).add(Aspect.PLANT, 2)
+                        .add(Aspect.GREED, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFMagicLogSpecial", 1, 3),
-                new AspectList().add(Aspect.getAspect("arbor"), 4).add(Aspect.getAspect("praecantatio"), 2)
-                        .add(Aspect.getAspect("motus"), 2).add(Aspect.getAspect("herba"), 2)
-                        .add(Aspect.getAspect("cognitio"), 1).add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.TREE, 4).add(Aspect.MAGIC, 2).add(Aspect.MOTION, 2).add(Aspect.PLANT, 2)
+                        .add(Aspect.MIND, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 2),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("potentia"), 1));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 1).add(Aspect.ENERGY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 4),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("potentia"), 2));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 1).add(Aspect.ENERGY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 5),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("potentia"), 2));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 1).add(Aspect.ENERGY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 6),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 1)
-                        .add(Aspect.getAspect("potentia"), 2).add(Aspect.getAspect("iter"), 1));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 1).add(Aspect.ENERGY, 2)
+                        .add(Aspect.TRAVEL, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 9),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 2)
-                        .add(Aspect.getAspect("potentia"), 4).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 2).add(Aspect.ENERGY, 4)
+                        .add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTowerDevice", 1, 10),
-                new AspectList().add(Aspect.getAspect("arbor"), 1).add(Aspect.getAspect("machina"), 2)
-                        .add(Aspect.getAspect("potentia"), 4).add(Aspect.getAspect("vinculum"), 1));
+                new AspectList().add(Aspect.TREE, 1).add(Aspect.MECHANISM, 2).add(Aspect.ENERGY, 4)
+                        .add(Aspect.TRAP, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFShield", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("machina"), 1));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.MECHANISM, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTrophyPedestal", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 7).add(Aspect.getAspect("ordo"), 4)
-                        .add(Aspect.getAspect("lucrum"), 4).add(Aspect.getAspect("instrumentum"), 4));
+                new AspectList().add(Aspect.EARTH, 7).add(Aspect.ORDER, 4).add(Aspect.GREED, 4).add(Aspect.TOOL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFTrophyPedestal", 1, 15),
-                new AspectList().add(Aspect.getAspect("terra"), 7).add(Aspect.getAspect("ordo"), 12)
-                        .add(Aspect.getAspect("lucrum"), 12).add(Aspect.getAspect("instrumentum"), 4));
+                new AspectList().add(Aspect.EARTH, 7).add(Aspect.ORDER, 12).add(Aspect.GREED, 12).add(Aspect.TOOL, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFAuroraBrick", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFUnderBrick", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFUnderBrick", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFUnderBrick", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 3).add(Aspect.getAspect("ignis"), 3)
-                        .add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.EARTH, 3).add(Aspect.FIRE, 3).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFThorns", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("fabrico"), 1)
-                        .add(Aspect.getAspect("telum"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.CRAFT, 1).add(Aspect.WEAPON, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFThorns", 1, 1),
-                new AspectList().add(Aspect.getAspect("herba"), 3).add(Aspect.getAspect("fabrico"), 1)
-                        .add(Aspect.getAspect("telum"), 1).add(Aspect.getAspect("aqua"), 1));
+                new AspectList().add(Aspect.PLANT, 3).add(Aspect.CRAFT, 1).add(Aspect.WEAPON, 1).add(Aspect.WATER, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFBurntThorns", 1, 0),
-                new AspectList().add(Aspect.getAspect("arbor"), 2).add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.TREE, 2).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFThornRose", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 2));
+                new AspectList().add(Aspect.PLANT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFLeaves3", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFLeaves3", 1, 1),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFDeadrock", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 8).add(Aspect.getAspect("ignis"), 6));
+                new AspectList().add(Aspect.EARTH, 8).add(Aspect.FIRE, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFDeadrock", 1, 1),
-                new AspectList().add(Aspect.getAspect("terra"), 8).add(Aspect.getAspect("ignis"), 6));
+                new AspectList().add(Aspect.EARTH, 8).add(Aspect.FIRE, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TFDeadrock", 1, 2),
-                new AspectList().add(Aspect.getAspect("terra"), 8).add(Aspect.getAspect("ignis"), 6));
+                new AspectList().add(Aspect.EARTH, 8).add(Aspect.FIRE, 6));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.DarkLeaves", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1));
+                new AspectList().add(Aspect.PLANT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.AuroraPillar", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.AuroraSlab", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 2).add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.EARTH, 2).add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.AuroraDoubleSlab", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("sensus"), 1));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.SENSES, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TrollSteinn", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("potentia"), 2));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.ENERGY, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.WispyCloud", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 1).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("aqua"), 1).add(Aspect.getAspect("tempestas"), 1));
+                new AspectList().add(Aspect.AIR, 1).add(Aspect.FLIGHT, 1).add(Aspect.WATER, 1).add(Aspect.WEATHER, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.FluffyCloud", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 1).add(Aspect.getAspect("volatus"), 1)
-                        .add(Aspect.getAspect("pannus"), 1).add(Aspect.getAspect("tempestas"), 1));
+                new AspectList().add(Aspect.AIR, 1).add(Aspect.FLIGHT, 1).add(Aspect.CLOTH, 1).add(Aspect.WEATHER, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.HugeStalk", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 4));
+                new AspectList().add(Aspect.PLANT, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.UberousSoil", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("aqua"), 4)
-                        .add(Aspect.getAspect("herba"), 4).add(Aspect.getAspect("victus"), 10));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.WATER, 4).add(Aspect.PLANT, 4).add(Aspect.LIFE, 10));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.HugeGloomBlock", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 4).add(Aspect.getAspect("tenebrae"), 2)
-                        .add(Aspect.getAspect("herba"), 2));
+                new AspectList().add(Aspect.EARTH, 4).add(Aspect.DARKNESS, 2).add(Aspect.PLANT, 2));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.KnightmetalBlock", 1, 0),
-                new AspectList().add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("lucrum"), 9));
+                new AspectList().add(Aspect.METAL, 18).add(Aspect.GREED, 9));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.UnripeTrollBer", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1).add(Aspect.getAspect("terra"), 1)
-                        .add(Aspect.getAspect("perditio"), 1));
+                new AspectList().add(Aspect.PLANT, 1).add(Aspect.EARTH, 1).add(Aspect.ENTROPY, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.TrollBer", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 1).add(Aspect.getAspect("terra"), 1)
-                        .add(Aspect.getAspect("lux"), 1));
+                new AspectList().add(Aspect.PLANT, 1).add(Aspect.EARTH, 1).add(Aspect.LIGHT, 1));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.HugeLilyPad", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 8).add(Aspect.getAspect("aqua"), 4));
+                new AspectList().add(Aspect.PLANT, 8).add(Aspect.WATER, 4));
         ThaumcraftApi.registerObjectTag(
                 getModItem(TwilightForest.ID, "tile.HugeWaterLily", 1, 0),
-                new AspectList().add(Aspect.getAspect("herba"), 3));
+                new AspectList().add(Aspect.PLANT, 3));
 
         ThaumcraftApi.addCrucibleRecipe(
                 "ThaumiumReinforcedWings",
                 getModItem(TwilightForest.ID, "item.tfFeather", 1, 0),
                 getModItem(ElectroMagicTools.ID, "EMTItems", 1, 13),
-                new AspectList().add(Aspect.getAspect("volatus"), 2).add(Aspect.getAspect("tenebrae"), 4)
-                        .add(Aspect.getAspect("tempus"), 4));
+                new AspectList().add(Aspect.FLIGHT, 2).add(Aspect.DARKNESS, 4)
+                        .add((Aspect) MagicBeesAPI.thaumcraftAspectTempus, 4));
 
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptTwilightForest.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTwilightForest.java
@@ -3,6 +3,7 @@ package com.dreammaster.scripts;
 import static com.dreammaster.scripts.IngredientFactory.getModItem;
 import static gregtech.api.enums.Mods.ElectroMagicTools;
 import static gregtech.api.enums.Mods.EtFuturumRequiem;
+import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.MagicBees;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
@@ -51,6 +52,7 @@ public class ScriptTwilightForest implements IScriptLoader {
         return Arrays.asList(
                 ElectroMagicTools.ID,
                 EtFuturumRequiem.ID,
+                ForbiddenMagic.ID,
                 MagicBees.ID,
                 Thaumcraft.ID,
                 TwilightForest.ID,

--- a/src/main/java/com/dreammaster/scripts/ScriptWarpTheory.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptWarpTheory.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.Mods.AppliedEnergistics2;
 import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.BloodMagic;
 import static gregtech.api.enums.Mods.CropsNH;
+import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.OpenBlocks;
 import static gregtech.api.enums.Mods.Thaumcraft;
@@ -45,6 +46,7 @@ public class ScriptWarpTheory implements IScriptLoader {
                 AppliedEnergistics2.ID,
                 BiomesOPlenty.ID,
                 BloodMagic.ID,
+                ForbiddenMagic.ID,
                 OpenBlocks.ID,
                 Thaumcraft.ID,
                 ThaumicBases.ID,

--- a/src/main/java/com/dreammaster/scripts/ScriptWarpTheory.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptWarpTheory.java
@@ -22,6 +22,7 @@ import net.minecraft.item.ItemStack;
 
 import com.dreammaster.thaumcraft.TCHelper;
 
+import fox.spiteful.forbidden.DarkAspects;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TCAspects;
@@ -68,7 +69,7 @@ public class ScriptWarpTheory implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "warptheory.paper",
                 getModItem(WarpTheory.ID, "item.warptheory.paper", 2, 0),
-                new AspectList().add(Aspect.getAspect("aqua"), 8).add(Aspect.getAspect("terra"), 8),
+                new AspectList().add(Aspect.WATER, 8).add(Aspect.EARTH, 8),
                 "abc",
                 "def",
                 "ghi",
@@ -104,9 +105,8 @@ public class ScriptWarpTheory implements IScriptLoader {
                 new ResearchPage(TCHelper.findArcaneRecipe(getModItem(WarpTheory.ID, "item.warptheory.paper", 1, 0))));
         TCHelper.setResearchAspects(
                 "warptheory.paper",
-                new AspectList().add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("aqua"), 3)
-                        .add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 6).add(Aspect.MAGIC, 6).add(Aspect.ORDER, 9).add(Aspect.WATER, 3)
+                        .add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("warptheory.paper", 2);
         TCHelper.orphanResearch("FAKESOAP");
         TCHelper.removeResearch("FAKESOAP");
@@ -116,9 +116,8 @@ public class ScriptWarpTheory implements IScriptLoader {
         TCHelper.addResearchPrereq("warptheory.something", "warptheory.paper", false);
         TCHelper.setResearchAspects(
                 "warptheory.something",
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("bestia"), 12)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("victus"), 6)
-                        .add(Aspect.getAspect("corpus"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.BEAST, 12).add(Aspect.EXCHANGE, 9)
+                        .add(Aspect.LIFE, 6).add(Aspect.FLESH, 3));
         TCHelper.setResearchComplexity("warptheory.something", 2);
         ThaumcraftApi.addWarpToResearch("warptheory.something", 3);
         TCHelper.orphanResearch("warptheory.cleanserminor");
@@ -126,9 +125,8 @@ public class ScriptWarpTheory implements IScriptLoader {
         new ResearchItem(
                 "PURETEARMINOR",
                 "WT_Category",
-                new AspectList().add(Aspect.getAspect("alienis"), 6).add(Aspect.getAspect("praecantatio"), 6)
-                        .add(Aspect.getAspect("permutatio"), 4).add(Aspect.getAspect("sano"), 3)
-                        .add(Aspect.getAspect("terra"), 2),
+                new AspectList().add(Aspect.ELDRITCH, 6).add(Aspect.MAGIC, 6).add(Aspect.EXCHANGE, 4)
+                        .add(Aspect.HEAL, 3).add(Aspect.EARTH, 2),
                 -1,
                 -2,
                 2,
@@ -139,10 +137,8 @@ public class ScriptWarpTheory implements IScriptLoader {
                 "PURETEARMINOR",
                 getModItem(WarpTheory.ID, "item.warptheory.cleanserminor", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("auram"), 64).add(Aspect.getAspect("desidia"), 16)
-                        .add(Aspect.getAspect("fames"), 16).add(Aspect.getAspect("gelum"), 16)
-                        .add(Aspect.getAspect("permutatio"), 32).add(Aspect.getAspect("praecantatio"), 32)
-                        .add(Aspect.getAspect("venenum"), 32),
+                new AspectList().add(Aspect.AURA, 64).add(DarkAspects.SLOTH, 16).add(Aspect.HUNGER, 16)
+                        .add(Aspect.COLD, 16).add(Aspect.EXCHANGE, 32).add(Aspect.MAGIC, 32).add(Aspect.POISON, 32),
                 getModItem(BiomesOPlenty.ID, "hardIce", 1, 0),
                 getModItem(ThaumicBases.ID, "resource", 1, 5),
                 getModItem(CropsNH.ID, "berry", 1, 2),
@@ -165,9 +161,8 @@ public class ScriptWarpTheory implements IScriptLoader {
         new ResearchItem(
                 "PURETEAR",
                 "WT_Category",
-                new AspectList().add(Aspect.getAspect("alienis"), 12).add(Aspect.getAspect("praecantatio"), 12)
-                        .add(Aspect.getAspect("permutatio"), 9).add(Aspect.getAspect("sano"), 6)
-                        .add(Aspect.getAspect("terra"), 3),
+                new AspectList().add(Aspect.ELDRITCH, 12).add(Aspect.MAGIC, 12).add(Aspect.EXCHANGE, 9)
+                        .add(Aspect.HEAL, 6).add(Aspect.EARTH, 3),
                 -4,
                 -1,
                 3,
@@ -178,8 +173,8 @@ public class ScriptWarpTheory implements IScriptLoader {
                 "PURETEAR",
                 getModItem(WarpTheory.ID, "item.warptheory.cleanser", 1, 0),
                 10,
-                new AspectList().add(Aspect.getAspect("alienis"), 32).add(Aspect.getAspect("permutatio"), 32)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("sano"), 16),
+                new AspectList().add(Aspect.ELDRITCH, 32).add(Aspect.EXCHANGE, 32).add(Aspect.MAGIC, 16)
+                        .add(Aspect.HEAL, 16),
                 getModItem(Minecraft.ID, "nether_star", 1, 0),
                 OrePrefixes.ingot.get(Materials.Ichorium),
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 10),
@@ -202,9 +197,8 @@ public class ScriptWarpTheory implements IScriptLoader {
                 "warptheory.amulet",
                 getModItem(WarpTheory.ID, "item.warptheory.amulet", 1, 0),
                 16,
-                new AspectList().add(Aspect.getAspect("alienis"), 64).add(Aspect.getAspect("auram"), 32)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("praecantatio"), 64)
-                        .add(Aspect.getAspect("permutatio"), 32),
+                new AspectList().add(Aspect.ELDRITCH, 64).add(Aspect.AURA, 32).add(Aspect.ENERGY, 32)
+                        .add(Aspect.MAGIC, 64).add(Aspect.EXCHANGE, 32),
                 getModItem(Thaumcraft.ID, "ItemBaubleBlanks", 1, 0),
                 getModItem(WarpTheory.ID, "item.warptheory.cleanser", 1, 0),
                 OrePrefixes.screw.get(Materials.Thaumium),
@@ -222,9 +216,8 @@ public class ScriptWarpTheory implements IScriptLoader {
                 OrePrefixes.screw.get(Materials.Thaumium));
         TCHelper.setResearchAspects(
                 "warptheory.amulet",
-                new AspectList().add(Aspect.getAspect("alienis"), 15).add(Aspect.getAspect("auram"), 15)
-                        .add(Aspect.getAspect("potentia"), 12).add(Aspect.getAspect("praecantatio"), 9)
-                        .add(Aspect.getAspect("permutatio"), 6).add(Aspect.getAspect("terra"), 3));
+                new AspectList().add(Aspect.ELDRITCH, 15).add(Aspect.AURA, 15).add(Aspect.ENERGY, 12)
+                        .add(Aspect.MAGIC, 9).add(Aspect.EXCHANGE, 6).add(Aspect.EARTH, 3));
         TCHelper.setResearchComplexity("warptheory.amulet", 4);
 
         TCHelper.orphanResearch("warptheory.portableshower");
@@ -234,11 +227,9 @@ public class ScriptWarpTheory implements IScriptLoader {
                 "warptheory.portableshower",
                 getModItem(WarpTheory.ID, "item.warptheory.portableshower", 1, 0),
                 64,
-                new AspectList().add(Aspect.getAspect("custom1"), 16).add(Aspect.getAspect("custom5"), 16)
-                        .add(Aspect.getAspect("aer"), 1024).add(Aspect.getAspect("aqua"), 1024)
-                        .add(Aspect.getAspect("praecantatio"), 256).add(Aspect.getAspect("tutamen"), 256)
-                        .add(Aspect.getAspect("cognitio"), 256).add(Aspect.getAspect("tutamen"), 256)
-                        .add(Aspect.getAspect("sano"), 1024),
+                new AspectList().add(TCAspects.AEQUALITAS.getAspect(), 16).add(TCAspects.GLORIA.getAspect(), 16)
+                        .add(Aspect.AIR, 1024).add(Aspect.WATER, 1024).add(Aspect.MAGIC, 256).add(Aspect.ARMOR, 512)
+                        .add(Aspect.MIND, 256).add(Aspect.HEAL, 1024),
                 getModItem(WarpTheory.ID, "item.warptheory.amulet", 1, 0),
                 getModItem(ThaumicTinkerer.ID, "kamiResource", 1, 1),
                 getModItem(Thaumcraft.ID, "blockStoneDevice", 1, 12),
@@ -251,9 +242,8 @@ public class ScriptWarpTheory implements IScriptLoader {
                 OrePrefixes.plateSuperdense.get(Materials.Ichorium));
         TCHelper.setResearchAspects(
                 "warptheory.portableshower",
-                new AspectList().add(Aspect.getAspect("custom1"), 5).add(Aspect.getAspect("custom3"), 5)
-                        .add(Aspect.getAspect("potentia"), 32).add(Aspect.getAspect("praecantatio"), 20)
-                        .add(Aspect.getAspect("aqua"), 32).add(Aspect.getAspect("aer"), 32));
+                new AspectList().add(TCAspects.AEQUALITAS.getAspect(), 5).add(TCAspects.PRIMORDIUM.getAspect(), 5)
+                        .add(Aspect.ENERGY, 32).add(Aspect.MAGIC, 20).add(Aspect.WATER, 32).add(Aspect.AIR, 32));
         TCHelper.setResearchComplexity("warptheory.portableshower", 4);
         TCHelper.refreshResearchPages("warptheory.paper");
         TCHelper.refreshResearchPages("warptheory.something");

--- a/src/main/java/com/dreammaster/scripts/ScriptWitchery.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptWitchery.java
@@ -317,8 +317,7 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "ANOINTINGPASTE",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("aqua"), 9)
-                        .add(Aspect.getAspect("praecantatio"), 6),
+                new AspectList().add(Aspect.CRAFT, 12).add(Aspect.WATER, 9).add(Aspect.MAGIC, 6),
                 0,
                 -4,
                 2,
@@ -327,8 +326,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ANOINTINGPASTE",
                 getModItem(Witchery.ID, "cauldron", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 2).add(Aspect.getAspect("ignis"), 2)
-                        .add(Aspect.getAspect("terra"), 2),
+                new AspectList().add(Aspect.ORDER, 2).add(Aspect.FIRE, 2).add(Aspect.EARTH, 2),
                 "aba",
                 "aca",
                 "aaa",
@@ -343,8 +341,8 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "OVEN",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("machina"), 6),
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.CRAFT, 12).add(Aspect.TOOL, 9)
+                        .add(Aspect.MECHANISM, 6),
                 -2,
                 2,
                 3,
@@ -356,8 +354,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "OVEN",
                 getModItem(Witchery.ID, "witchesovenidle", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 20).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("terra"), 20),
+                new AspectList().add(Aspect.AIR, 20).add(Aspect.FIRE, 20).add(Aspect.EARTH, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -386,8 +383,7 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "ATTUNEDSTONE",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("instrumentum"), 15).add(Aspect.getAspect("vitreus"), 12)
-                        .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("praecantatio"), 6),
+                new AspectList().add(Aspect.TOOL, 15).add(Aspect.CRYSTAL, 12).add(Aspect.ORDER, 9).add(Aspect.MAGIC, 6),
                 2,
                 0,
                 3,
@@ -396,8 +392,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ATTUNEDSTONE",
                 getModItem(Witchery.ID, "ingredient", 1, 10),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("terra"), 30).add(Aspect.getAspect("ordo"), 30),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.FIRE, 30).add(Aspect.EARTH, 30).add(Aspect.ORDER, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -413,9 +408,8 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "QUARTZSPHERE",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("vitreus"), 15).add(Aspect.getAspect("instrumentum"), 12)
-                        .add(Aspect.getAspect("auram"), 9).add(Aspect.getAspect("ordo"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.CRYSTAL, 15).add(Aspect.TOOL, 12).add(Aspect.AURA, 9).add(Aspect.ORDER, 6)
+                        .add(Aspect.MAGIC, 3),
                 2,
                 -2,
                 3,
@@ -424,8 +418,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "QUARTZSPHERE",
                 getModItem(Witchery.ID, "ingredient", 1, 92),
-                new AspectList().add(Aspect.getAspect("aer"), 25).add(Aspect.getAspect("ignis"), 25)
-                        .add(Aspect.getAspect("terra"), 25).add(Aspect.getAspect("ordo"), 25),
+                new AspectList().add(Aspect.AIR, 25).add(Aspect.FIRE, 25).add(Aspect.EARTH, 25).add(Aspect.ORDER, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -453,8 +446,7 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "CANDELABRA",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("lux"), 12)
-                        .add(Aspect.getAspect("ordo"), 9).add(Aspect.getAspect("ignis"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.LIGHT, 12).add(Aspect.ORDER, 9).add(Aspect.FIRE, 6),
                 0,
                 -2,
                 3,
@@ -464,8 +456,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CANDELABRA",
                 getModItem(Witchery.ID, "ingredient", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 5).add(Aspect.getAspect("ignis"), 10)
-                        .add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.EARTH, 5).add(Aspect.FIRE, 10).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -493,8 +484,7 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "KETTLE",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("ignis"), 6),
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.CRAFT, 12).add(Aspect.TOOL, 9).add(Aspect.FIRE, 6),
                 4,
                 0,
                 3,
@@ -508,8 +498,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "KETTLE",
                 getModItem(Witchery.ID, "kettle", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 40).add(Aspect.getAspect("ignis"), 40)
-                        .add(Aspect.getAspect("aqua"), 40).add(Aspect.getAspect("perditio"), 40),
+                new AspectList().add(Aspect.AIR, 40).add(Aspect.FIRE, 40).add(Aspect.WATER, 40).add(Aspect.ENTROPY, 40),
                 "abc",
                 "def",
                 "ghi",
@@ -538,9 +527,8 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "SPINNINGWHEELW",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("arbor"), 18).add(Aspect.getAspect("motus"), 15)
-                        .add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("instrumentum"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.TREE, 18).add(Aspect.MOTION, 15).add(Aspect.CRAFT, 12).add(Aspect.TOOL, 9)
+                        .add(Aspect.AIR, 6).add(Aspect.MAGIC, 3),
                 6,
                 0,
                 3,
@@ -549,8 +537,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "SPINNINGWHEELW",
                 getModItem(Witchery.ID, "spinningwheel", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 60).add(Aspect.getAspect("ignis"), 60)
-                        .add(Aspect.getAspect("ordo"), 60).add(Aspect.getAspect("perditio"), 60),
+                new AspectList().add(Aspect.AIR, 60).add(Aspect.FIRE, 60).add(Aspect.ORDER, 60).add(Aspect.ENTROPY, 60),
                 "abc",
                 "def",
                 "ghi",
@@ -578,10 +565,8 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "RUBYSLIPPERS",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("auram"), 21).add(Aspect.getAspect("aer"), 18)
-                        .add(Aspect.getAspect("fames"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("vitreus"), 9).add(Aspect.getAspect("potentia"), 6)
-                        .add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.AURA, 21).add(Aspect.AIR, 18).add(Aspect.HUNGER, 15).add(Aspect.GREED, 12)
+                        .add(Aspect.CRYSTAL, 9).add(Aspect.ENERGY, 6).add(Aspect.MAGIC, 3),
                 6,
                 -2,
                 3,
@@ -595,9 +580,8 @@ public class ScriptWitchery implements IScriptLoader {
                 "RUBYSLIPPERS",
                 getModItem(Witchery.ID, "rubyslippers", 1, 0),
                 5,
-                new AspectList().add(Aspect.getAspect("auram"), 64).add(Aspect.getAspect("aer"), 64)
-                        .add(Aspect.getAspect("lucrum"), 32).add(Aspect.getAspect("potentia"), 16)
-                        .add(Aspect.getAspect("praecantatio"), 16).add(Aspect.getAspect("fames"), 32),
+                new AspectList().add(Aspect.AURA, 64).add(Aspect.AIR, 64).add(Aspect.GREED, 32).add(Aspect.ENERGY, 16)
+                        .add(Aspect.MAGIC, 16).add(Aspect.HUNGER, 32),
                 getModItem(Witchery.ID, "seepingshoes", 1, 0),
                 getModItem(Witchery.ID, "ingredient", 1, 80),
                 NHItemList.ManyullynCrystal.get(),
@@ -616,9 +600,8 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "DISTILLERY",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("metallum"), 18).add(Aspect.getAspect("motus"), 15)
-                        .add(Aspect.getAspect("fabrico"), 12).add(Aspect.getAspect("instrumentum"), 9)
-                        .add(Aspect.getAspect("aqua"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.METAL, 18).add(Aspect.MOTION, 15).add(Aspect.CRAFT, 12).add(Aspect.TOOL, 9)
+                        .add(Aspect.WATER, 6).add(Aspect.MAGIC, 3),
                 8,
                 0,
                 3,
@@ -627,9 +610,8 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "DISTILLERY",
                 getModItem(Witchery.ID, "distilleryidle", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 80).add(Aspect.getAspect("ignis"), 80)
-                        .add(Aspect.getAspect("ordo"), 80).add(Aspect.getAspect("perditio"), 80)
-                        .add(Aspect.getAspect("aqua"), 80),
+                new AspectList().add(Aspect.AIR, 80).add(Aspect.FIRE, 80).add(Aspect.ORDER, 80).add(Aspect.ENTROPY, 80)
+                        .add(Aspect.WATER, 80),
                 "abc",
                 "def",
                 "ghi",
@@ -658,9 +640,8 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "RITUALCHALK",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("sensus"), 18).add(Aspect.getAspect("motus"), 15)
-                        .add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("iter"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.SENSES, 18).add(Aspect.MOTION, 15).add(Aspect.AURA, 12)
+                        .add(Aspect.ENERGY, 9).add(Aspect.TRAVEL, 6).add(Aspect.MAGIC, 3),
                 8,
                 -2,
                 3,
@@ -673,8 +654,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "RITUALCHALK",
                 getModItem(Witchery.ID, "chalkritual", 2, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 50).add(Aspect.getAspect("terra"), 50)
-                        .add(Aspect.getAspect("ordo"), 25).add(Aspect.getAspect("ignis"), 25),
+                new AspectList().add(Aspect.AIR, 50).add(Aspect.EARTH, 50).add(Aspect.ORDER, 25).add(Aspect.FIRE, 25),
                 "abc",
                 "def",
                 "ghi",
@@ -702,9 +682,8 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "CIRCLETALISMAN",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("lucrum"), 18).add(Aspect.getAspect("motus"), 15)
-                        .add(Aspect.getAspect("auram"), 12).add(Aspect.getAspect("potentia"), 9)
-                        .add(Aspect.getAspect("aer"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.GREED, 18).add(Aspect.MOTION, 15).add(Aspect.AURA, 12).add(Aspect.ENERGY, 9)
+                        .add(Aspect.AIR, 6).add(Aspect.MAGIC, 3),
                 10,
                 -2,
                 3,
@@ -717,8 +696,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CIRCLETALISMAN",
                 getModItem(Witchery.ID, "circletalisman", 1, 0),
-                new AspectList().add(Aspect.getAspect("ordo"), 50).add(Aspect.getAspect("terra"), 50)
-                        .add(Aspect.getAspect("ignis"), 50),
+                new AspectList().add(Aspect.ORDER, 50).add(Aspect.EARTH, 50).add(Aspect.FIRE, 50),
                 "abc",
                 "def",
                 "ghi",
@@ -747,8 +725,7 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "ALTAR",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("fabrico"), 12)
-                        .add(Aspect.getAspect("arbor"), 9).add(Aspect.getAspect("terra"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.CRAFT, 12).add(Aspect.TREE, 9).add(Aspect.EARTH, 6),
                 -2,
                 0,
                 3,
@@ -762,8 +739,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ALTAR",
                 getModItem(Witchery.ID, "altar", 2, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 20).add(Aspect.getAspect("ignis"), 20)
-                        .add(Aspect.getAspect("ordo"), 20),
+                new AspectList().add(Aspect.EARTH, 20).add(Aspect.FIRE, 20).add(Aspect.ORDER, 20),
                 "abc",
                 "def",
                 "ghi",
@@ -792,8 +768,7 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "CHALICE",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("terra"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.GREED, 12).add(Aspect.METAL, 9).add(Aspect.EARTH, 6),
                 0,
                 0,
                 3,
@@ -802,8 +777,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "CHALICE",
                 getModItem(Witchery.ID, "ingredient", 1, 1),
-                new AspectList().add(Aspect.getAspect("aqua"), 15).add(Aspect.getAspect("terra"), 10)
-                        .add(Aspect.getAspect("ordo"), 5),
+                new AspectList().add(Aspect.WATER, 15).add(Aspect.EARTH, 10).add(Aspect.ORDER, 5),
                 "abc",
                 "def",
                 "ghi",
@@ -831,8 +805,7 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "ARTHANA",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("praecantatio"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("instrumentum"), 9).add(Aspect.getAspect("mortuus"), 6),
+                new AspectList().add(Aspect.MAGIC, 15).add(Aspect.GREED, 12).add(Aspect.TOOL, 9).add(Aspect.DEATH, 6),
                 -4,
                 -2,
                 3,
@@ -845,8 +818,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "ARTHANA",
                 getModItem(Witchery.ID, "arthana", 1, 0),
-                new AspectList().add(Aspect.getAspect("terra"), 20).add(Aspect.getAspect("perditio"), 15)
-                        .add(Aspect.getAspect("ordo"), 10),
+                new AspectList().add(Aspect.EARTH, 20).add(Aspect.ENTROPY, 15).add(Aspect.ORDER, 10),
                 "abc",
                 "def",
                 "ghi",
@@ -875,8 +847,8 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "WARMBLOOD",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("fames"), 15).add(Aspect.getAspect("lucrum"), 12)
-                        .add(Aspect.getAspect("aqua"), 9).add(Aspect.getAspect("exanimis"), 6),
+                new AspectList().add(Aspect.HUNGER, 15).add(Aspect.GREED, 12).add(Aspect.WATER, 9)
+                        .add(Aspect.UNDEAD, 6),
                 -2,
                 -2,
                 3,
@@ -886,8 +858,7 @@ public class ScriptWitchery implements IScriptLoader {
                 "WARMBLOOD",
                 getModItem(Witchery.ID, "ingredient", 1, 163),
                 getModItem(TinkerConstruct.ID, "jerky", 1, 7),
-                new AspectList().add(Aspect.getAspect("exanimis"), 4).add(Aspect.getAspect("fames"), 4)
-                        .add(Aspect.getAspect("lucrum"), 4));
+                new AspectList().add(Aspect.UNDEAD, 4).add(Aspect.HUNGER, 4).add(Aspect.GREED, 4));
         TCHelper.addResearchPage(
                 "WARMBLOOD",
                 new ResearchPage(TCHelper.findCrucibleRecipe(getModItem(Witchery.ID, "ingredient", 1, 163))));
@@ -895,8 +866,7 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "FUMEFUNNEL",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("ignis"), 12)
-                        .add(Aspect.getAspect("lux"), 9).add(Aspect.getAspect("sensus"), 6),
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.FIRE, 12).add(Aspect.LIGHT, 9).add(Aspect.SENSES, 6),
                 0,
                 2,
                 3,
@@ -905,8 +875,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FUMEFUNNEL",
                 getModItem(Witchery.ID, "fumefunnel", 1, 0),
-                new AspectList().add(Aspect.getAspect("aer"), 30).add(Aspect.getAspect("ignis"), 30)
-                        .add(Aspect.getAspect("terra"), 30),
+                new AspectList().add(Aspect.AIR, 30).add(Aspect.FIRE, 30).add(Aspect.EARTH, 30),
                 "abc",
                 "def",
                 "ghi",
@@ -935,8 +904,7 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "FUMEFILTER",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("metallum"), 9).add(Aspect.getAspect("vitreus"), 9)
-                        .add(Aspect.getAspect("lucrum"), 6).add(Aspect.getAspect("praecantatio"), 3),
+                new AspectList().add(Aspect.METAL, 9).add(Aspect.CRYSTAL, 9).add(Aspect.GREED, 6).add(Aspect.MAGIC, 3),
                 2,
                 2,
                 3,
@@ -946,8 +914,7 @@ public class ScriptWitchery implements IScriptLoader {
         ThaumcraftApi.addArcaneCraftingRecipe(
                 "FUMEFILTER",
                 getModItem(Witchery.ID, "ingredient", 1, 73),
-                new AspectList().add(Aspect.getAspect("aer"), 16).add(Aspect.getAspect("ordo"), 16)
-                        .add(Aspect.getAspect("terra"), 16),
+                new AspectList().add(Aspect.AIR, 16).add(Aspect.ORDER, 16).add(Aspect.EARTH, 16),
                 "abc",
                 "def",
                 "ghi",
@@ -975,8 +942,8 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "FILTEREDFUMEFUNNEL",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("metallum"), 15).add(Aspect.getAspect("vitreus"), 12)
-                        .add(Aspect.getAspect("lux"), 9).add(Aspect.getAspect("praecantatio"), 6),
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.CRYSTAL, 12).add(Aspect.LIGHT, 9)
+                        .add(Aspect.MAGIC, 6),
                 2,
                 4,
                 3,
@@ -986,8 +953,8 @@ public class ScriptWitchery implements IScriptLoader {
                 "FILTEREDFUMEFUNNEL",
                 getModItem(Witchery.ID, "filteredfumefunnel", 1, 0),
                 3,
-                new AspectList().add(Aspect.getAspect("metallum"), 32).add(Aspect.getAspect("vitreus"), 8)
-                        .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("lux"), 16),
+                new AspectList().add(Aspect.METAL, 32).add(Aspect.CRYSTAL, 8).add(Aspect.MAGIC, 24)
+                        .add(Aspect.LIGHT, 16),
                 getModItem(Witchery.ID, "fumefunnel", 1, 0),
                 BlockList.SteelBars.get(),
                 getModItem(Thaumcraft.ID, "ItemResource", 1, 8),
@@ -1002,8 +969,8 @@ public class ScriptWitchery implements IScriptLoader {
         new ResearchItem(
                 "WAYSTONE",
                 "WITCHERY",
-                new AspectList().add(Aspect.getAspect("motus"), 15).add(Aspect.getAspect("iter"), 12)
-                        .add(Aspect.getAspect("tenebrae"), 9).add(Aspect.getAspect("praecantatio"), 6),
+                new AspectList().add(Aspect.MOTION, 15).add(Aspect.TRAVEL, 12).add(Aspect.DARKNESS, 9)
+                        .add(Aspect.MAGIC, 6),
                 8,
                 -4,
                 3,
@@ -1013,9 +980,8 @@ public class ScriptWitchery implements IScriptLoader {
                 "WAYSTONE",
                 getModItem(Witchery.ID, "ingredient", 1, 12),
                 5,
-                new AspectList().add(Aspect.getAspect("motus"), 48).add(Aspect.getAspect("iter"), 64)
-                        .add(Aspect.getAspect("praecantatio"), 24).add(Aspect.getAspect("tenebrae"), 32)
-                        .add(Aspect.getAspect("aer"), 64),
+                new AspectList().add(Aspect.MOTION, 48).add(Aspect.TRAVEL, 64).add(Aspect.MAGIC, 24)
+                        .add(Aspect.DARKNESS, 32).add(Aspect.AIR, 64),
                 getModItem(Minecraft.ID, "flint", 1, 0),
                 getModItem(Witchery.ID, "chalkritual", 1, 0),
                 getModItem(Witchery.ID, "ingredient", 1, 7),

--- a/src/main/java/com/dreammaster/thaumcraft/TCMaterialAspectHelper.java
+++ b/src/main/java/com/dreammaster/thaumcraft/TCMaterialAspectHelper.java
@@ -1,9 +1,7 @@
 package com.dreammaster.thaumcraft;
 
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 
 import net.minecraftforge.oredict.OreDictionary;
@@ -200,17 +198,12 @@ public class TCMaterialAspectHelper {
     /**
      * Aspect helper method for adding TC Aspects to GT5 Materials
      *
-     * @param material       (String format of Material name)
-     * @param mainAspect     (String format of Aspect name)
-     * @param specialAspects (String format of Aspect name, Accepts multiple aspects in seperate Strings)
+     * @param material       Material name as a String.
+     * @param mainAspect     The main Aspect for this material.
+     * @param specialAspects Special Aspects for this material, accepts multiple aspects separated by commas.
      */
-    public static void registerMaterialAspects(String material, String mainAspect, String... specialAspects) {
-        Aspect main = Aspect.getAspect(mainAspect);
-
-        Aspect[] specials = Arrays.stream(specialAspects).map(Aspect::getAspect).filter(Objects::nonNull)
-                .toArray(Aspect[]::new);
-
-        RuleContext ctx = new RuleContext(main, specials);
+    public static void registerMaterialAspects(String material, Aspect mainAspect, Aspect... specialAspects) {
+        RuleContext ctx = new RuleContext(mainAspect, specialAspects);
 
         for (Map.Entry<String, Function<RuleContext, AspectList>> entry : RULES.entrySet()) {
             String key = entry.getKey() + material;

--- a/src/main/java/com/dreammaster/thaumcraft/TCMaterialAspectHelper.java
+++ b/src/main/java/com/dreammaster/thaumcraft/TCMaterialAspectHelper.java
@@ -10,6 +10,7 @@ import net.minecraftforge.oredict.OreDictionary;
 
 import com.github.bsideup.jabel.Desugar;
 
+import gregtech.api.enums.TCAspects;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -20,18 +21,7 @@ public class TCMaterialAspectHelper {
     @Desugar
     public record RuleContext(Aspect main, Aspect[] specials) {}
 
-    // Pre-cached common aspects
-    private static final Aspect PERDITIO = Aspect.getAspect("perditio");
-    private static final Aspect PERFODIO = Aspect.getAspect("perfodio");
-    private static final Aspect FABRICO = Aspect.getAspect("fabrico");
-    private static final Aspect MOTUS = Aspect.getAspect("motus");
-    private static final Aspect MACHINA = Aspect.getAspect("machina");
-    private static final Aspect INSTRUMENT = Aspect.getAspect("instrumentum");
-    private static final Aspect ORDO = Aspect.getAspect("ordo");
-    private static final Aspect METO = Aspect.getAspect("meto");
-    private static final Aspect ARBOR = Aspect.getAspect("arbor");
-    private static final Aspect ELECTRUM = Aspect.getAspect("electrum");
-    private static final Aspect TERRA = Aspect.getAspect("terra");
+    private static final Aspect ELECTRUM = TCAspects.ELECTRUM.getAspect();
 
     // Static cached rule table
     private static final Map<String, Function<RuleContext, AspectList>> RULES = new LinkedHashMap<>();
@@ -52,28 +42,31 @@ public class TCMaterialAspectHelper {
 
         // --- Declarative rules ---
         RULES.put("dust", ctx -> {
-            AspectList list = new AspectList().add(ctx.main(), 2).add(PERDITIO, 1);
+            AspectList list = new AspectList().add(ctx.main(), 2).add(Aspect.ENTROPY, 1);
             for (Aspect a : ctx.specials()) list.add(a, 1);
             return list;
         });
 
-        RULES.put("dustSmall", ctx -> new AspectList().add(PERDITIO, 1));
-        RULES.put("dustTiny", ctx -> new AspectList().add(PERDITIO, 1));
+        RULES.put("dustSmall", ctx -> new AspectList().add(Aspect.ENTROPY, 1));
+        RULES.put("dustTiny", ctx -> new AspectList().add(Aspect.ENTROPY, 1));
 
         RULES.put("ingot", main3special);
         RULES.put("ingotHot", main2special);
         RULES.put("nugget", ctx -> new AspectList().add(ctx.main(), 1));
 
-        RULES.put("stick", ctx -> new AspectList().add(ctx.main(), 2).add(INSTRUMENT, 1));
+        RULES.put("stick", ctx -> new AspectList().add(ctx.main(), 2).add(Aspect.TOOL, 1));
         RULES.put("stickLong", main2special);
 
-        RULES.put("bolt", ctx -> new AspectList().add(INSTRUMENT, 1));
-        RULES.put("screw", ctx -> new AspectList().add(INSTRUMENT, 3).add(FABRICO, 1).add(ORDO, 1));
-        RULES.put("ring", ctx -> new AspectList().add(INSTRUMENT, 3).add(FABRICO, 3).add(ORDO, 3).add(ctx.main(), 1));
-        RULES.put("foil", ctx -> new AspectList().add(FABRICO, 1));
+        RULES.put("bolt", ctx -> new AspectList().add(Aspect.TOOL, 1));
+        RULES.put("screw", ctx -> new AspectList().add(Aspect.TOOL, 3).add(Aspect.CRAFT, 1).add(Aspect.ORDER, 1));
+        RULES.put(
+                "ring",
+                ctx -> new AspectList().add(Aspect.TOOL, 3).add(Aspect.CRAFT, 3).add(Aspect.ORDER, 3)
+                        .add(ctx.main(), 1));
+        RULES.put("foil", ctx -> new AspectList().add(Aspect.CRAFT, 1));
         RULES.put("wireFine", ctx -> new AspectList().add(ELECTRUM, 1));
         RULES.put("gear", ctx -> {
-            AspectList list = new AspectList().add(ctx.main(), 2).add(MOTUS, 1).add(MACHINA, 1);
+            AspectList list = new AspectList().add(ctx.main(), 2).add(Aspect.MOTION, 1).add(Aspect.MECHANISM, 1);
             for (Aspect a : ctx.specials()) list.add(a, 2);
             return list;
         });
@@ -86,14 +79,15 @@ public class TCMaterialAspectHelper {
         RULES.put("spring", RULES.get("rotor"));
         RULES.put(
                 "springSmall",
-                ctx -> new AspectList().add(INSTRUMENT, 5).add(FABRICO, 3).add(ORDO, 3).add(METO, 1).add(ARBOR, 1));
+                ctx -> new AspectList().add(Aspect.TOOL, 5).add(Aspect.CRAFT, 3).add(Aspect.ORDER, 3)
+                        .add(Aspect.HARVEST, 1).add(Aspect.TREE, 1));
 
         // Plate variants
         String[] plateVariants = { "plate", "plateDouble", "plateTriple", "plateQuadruple", "plateQuintuple",
                 "plateDense", "plateSuperdense" };
         for (String p : plateVariants) {
             RULES.put(p, ctx -> {
-                AspectList list = new AspectList().add(ctx.main(), 2).add(FABRICO, 1);
+                AspectList list = new AspectList().add(ctx.main(), 2).add(Aspect.CRAFT, 1);
                 for (Aspect a : ctx.specials()) list.add(a, 1);
                 return list;
             });
@@ -104,26 +98,27 @@ public class TCMaterialAspectHelper {
                 "toolHeadWrench", "toolHeadBuzzSaw" };
         for (String t : toolVariants) {
             RULES.put(t, ctx -> {
-                AspectList list = new AspectList().add(ctx.main(), 2).add(INSTRUMENT, 2);
+                AspectList list = new AspectList().add(ctx.main(), 2).add(Aspect.TOOL, 2);
                 for (Aspect a : ctx.specials()) list.add(a, 1);
                 return list;
             });
         }
 
         RULES.put("rawOre", main2special);
-        RULES.put("crushed", ctx -> new AspectList().add(PERFODIO, 1));
+        RULES.put("crushed", ctx -> new AspectList().add(Aspect.MINE, 1));
         RULES.put("crushedPurified", RULES.get("crushed"));
         RULES.put("crushedCentrifuged", RULES.get("crushed"));
-        RULES.put("dustImpure", ctx -> new AspectList().add(PERDITIO, 1));
+        RULES.put("dustImpure", ctx -> new AspectList().add(Aspect.ENTROPY, 1));
         RULES.put("dustPure", RULES.get("dustImpure"));
 
         RULES.put("frameGt", ctx -> {
-            AspectList list = new AspectList().add(INSTRUMENT, 3).add(FABRICO, 3).add(ORDO, 3).add(ctx.main(), 3);
+            AspectList list = new AspectList().add(Aspect.TOOL, 3).add(Aspect.CRAFT, 3).add(Aspect.ORDER, 3)
+                    .add(ctx.main(), 3);
             for (Aspect a : ctx.specials()) list.add(a, 1);
             return list;
         });
         RULES.put("ore", ctx -> {
-            AspectList list = new AspectList().add(ctx.main(), 3).add(TERRA, 1);
+            AspectList list = new AspectList().add(ctx.main(), 3).add(Aspect.EARTH, 1);
             for (Aspect a : ctx.specials()) list.add(a, 1);
             return list;
         });
@@ -134,69 +129,70 @@ public class TCMaterialAspectHelper {
         });
 
         RULES.put("pipeTiny", ctx -> new AspectList().add(ctx.main(), 1));
-        RULES.put("pipeSmall", ctx -> new AspectList().add(FABRICO, 1).add(ctx.main(), 1));
-        RULES.put("pipeNonuple", ctx -> new AspectList().add(FABRICO, 6).add(ctx.main(), 6));
+        RULES.put("pipeSmall", ctx -> new AspectList().add(Aspect.CRAFT, 1).add(ctx.main(), 1));
+        RULES.put("pipeNonuple", ctx -> new AspectList().add(Aspect.CRAFT, 6).add(ctx.main(), 6));
 
         RULES.put(
                 "wireGt01",
-                ctx -> new AspectList().add(FABRICO, 2).add(ctx.main(), 1).add(INSTRUMENT, 1).add(ORDO, 1));
+                ctx -> new AspectList().add(Aspect.CRAFT, 2).add(ctx.main(), 1).add(Aspect.TOOL, 1)
+                        .add(Aspect.ORDER, 1));
         RULES.put("pipeMedium", ctx -> {
-            AspectList list = new AspectList().add(ctx.main(), 4).add(FABRICO, 3);
+            AspectList list = new AspectList().add(ctx.main(), 4).add(Aspect.CRAFT, 3);
             for (Aspect a : ctx.specials()) list.add(a, 2);
-            list.add(INSTRUMENT, 1);
-            list.add(ORDO, 1);
+            list.add(Aspect.TOOL, 1);
+            list.add(Aspect.ORDER, 1);
             return list;
         });
         RULES.put("pipeLarge", ctx -> {
-            AspectList list = new AspectList().add(ctx.main(), 9).add(FABRICO, 6);
+            AspectList list = new AspectList().add(ctx.main(), 9).add(Aspect.CRAFT, 6);
             for (Aspect a : ctx.specials()) list.add(a, 4);
-            list.add(INSTRUMENT, 3);
-            list.add(ORDO, 3);
-            list.add(MACHINA, 1);
+            list.add(Aspect.TOOL, 3);
+            list.add(Aspect.ORDER, 3);
+            list.add(Aspect.MECHANISM, 1);
             return list;
         });
         RULES.put("pipeHuge", RULES.get("pipeLarge"));
 
         RULES.put("pipeQuadruple", ctx -> {
-            AspectList list = new AspectList().add(ctx.main(), 12).add(FABRICO, 9);
+            AspectList list = new AspectList().add(ctx.main(), 12).add(Aspect.CRAFT, 9);
             for (Aspect a : ctx.specials()) list.add(a, 6);
-            list.add(INSTRUMENT, 3);
-            list.add(ORDO, 3);
+            list.add(Aspect.TOOL, 3);
+            list.add(Aspect.ORDER, 3);
             return list;
         });
         RULES.put("wireGt02", ctx -> {
-            AspectList list = new AspectList().add(FABRICO, 3).add(ctx.main(), 1);
+            AspectList list = new AspectList().add(Aspect.CRAFT, 3).add(ctx.main(), 1);
             for (Aspect a : ctx.specials()) list.add(a, 1);
-            list.add(INSTRUMENT, 1);
-            list.add(ORDO, 1);
+            list.add(Aspect.TOOL, 1);
+            list.add(Aspect.ORDER, 1);
             return list;
         });
         RULES.put("wireGt04", ctx -> {
-            AspectList list = new AspectList().add(FABRICO, 5).add(ctx.main(), 2);
+            AspectList list = new AspectList().add(Aspect.CRAFT, 5).add(ctx.main(), 2);
             for (Aspect a : ctx.specials()) list.add(a, 2);
-            list.add(INSTRUMENT, 2);
-            list.add(ORDO, 2);
+            list.add(Aspect.TOOL, 2);
+            list.add(Aspect.ORDER, 2);
             return list;
         });
         RULES.put("wireGt08", ctx -> {
-            AspectList list = new AspectList().add(FABRICO, 7).add(ctx.main(), 4);
+            AspectList list = new AspectList().add(Aspect.CRAFT, 7).add(ctx.main(), 4);
             for (Aspect a : ctx.specials()) list.add(a, 4);
-            list.add(INSTRUMENT, 4);
-            list.add(ORDO, 4);
+            list.add(Aspect.TOOL, 4);
+            list.add(Aspect.ORDER, 4);
             return list;
         });
         RULES.put("wireGt12", ctx -> {
-            AspectList list = new AspectList().add(FABRICO, 10).add(ctx.main(), 5);
+            AspectList list = new AspectList().add(Aspect.CRAFT, 10).add(ctx.main(), 5);
             for (Aspect a : ctx.specials()) list.add(a, 5);
-            list.add(INSTRUMENT, 5);
-            list.add(ORDO, 5);
+            list.add(Aspect.TOOL, 5);
+            list.add(Aspect.ORDER, 5);
             return list;
         });
         RULES.put("wireGt16", ctx -> {
-            AspectList list = new AspectList().add(FABRICO, 12).add(ctx.main(), 7);
+            AspectList list = new AspectList().add(Aspect.CRAFT, 12).add(ctx.main(), 7);
             for (Aspect a : ctx.specials()) list.add(a, 7);
-            list.add(INSTRUMENT, 7);
-            list.add(ORDO, 7);
+            list.add(Aspect.TOOL, 7);
+            list.add(Aspect.ORDER, 7);
             return list;
         });
     }


### PR DESCRIPTION
Aspect.getAspect("tag") needs to search through a LinkedHashMap to find the aspect. Why do that when you can just directly access them? This PR is a simple find and replace to do that.

Adds Forbidden Magic and Magic Bees as deps for direct access to their aspects.

Draft for now because I found a material registration that still uses Aspect.getAspect() while writing this.