### PR TITLE
Make sulfur from cloud recipe less restrictive (3x3 into 2x2)

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptNatura.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNatura.java
@@ -2490,13 +2490,8 @@ public class ScriptNatura implements IScriptLoader {
                 GTOreDictUnificator.get(OrePrefixes.dust, Materials.Sulfur, 1),
                 getModItem(Natura.ID, "Cloud", 1, 3),
                 getModItem(Natura.ID, "Cloud", 1, 3),
-                null,
                 getModItem(Natura.ID, "Cloud", 1, 3),
-                getModItem(Natura.ID, "Cloud", 1, 3),
-                null,
-                null,
-                null,
-                null);
+                getModItem(Natura.ID, "Cloud", 1, 3));
 
         if (Chisel.isModLoaded()) {
             ChiselHelper.addVariationFromStack("bookshelf", getModItem(Natura.ID, "Natura.bookshelf", 1, 0));


### PR DESCRIPTION
On @tiffit request

Tested ingame (full pack):
<img width="435" height="398" alt="image" src="https://github.com/user-attachments/assets/d286f184-45de-4e17-ae41-a1576dda35c4" />
