### PR TITLE
Fix Quick and Dirty Portal Gen recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -912,7 +912,7 @@ public class AssemblerRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.gem, Materials.Diamond, 1L),
+                        new OreDictItemStack(OrePrefixes.gem.get(Materials.Diamond).toString(), 1),
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.LV, 4L))
                 .itemOutputs(NHItemList.TwilightCrystal.get()).duration(30 * SECONDS).eut(TierEU.RECIPE_LV / 2)
                 .addTo(assemblerRecipes);


### PR DESCRIPTION
Fixes industrial diamonds not working to make the quick and dirty portal gen. I suspect its because the industrial diamond has 2 oredicts and gemDiamond is not the first one but I have no idea.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24101