### PR TITLE
Changes antimatter tier from UMV to UIV

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -1617,7 +1617,7 @@ public class AssemblingLineRecipes implements Runnable {
                         MaterialsElements.STANDALONE.HYPOGEN.getFineWire(64),
                         MaterialsElements.STANDALONE.HYPOGEN.getFineWire(64) },
                 new FluidStack[] { Materials.Antimatter.getFluid(1000), Materials.SixPhasedCopper.getMolten(9216),
-                        Materials.TranscendentMetal.getMolten(9216), Materials.SuperconductorUMVBase.getMolten(9216) },
+                        Materials.TranscendentMetal.getMolten(9216), Materials.SuperconductorUIVBase.getMolten(9216) },
                 ItemRefer.AntimatterGenerator.get(1),
                 6 * MINUTES,
                 (int) TierEU.RECIPE_UMV);


### PR DESCRIPTION
As per the dev-vote result changes the UMV superconductor to UIV superconductor in SLAM controller recipe
Vote result:
<img width="755" height="139" alt="image" src="https://github.com/user-attachments/assets/46b19d48-e69c-47c9-a5ca-fefb767ca527" />
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24626

Old recipe:
<img width="1512" height="800" alt="image" src="https://github.com/user-attachments/assets/9245f97b-2240-4849-9578-2c6c68f65954" />
New recipe:
<img width="1354" height="1335" alt="image" src="https://github.com/user-attachments/assets/05a54464-5ed0-43b1-a348-0557cc06a033" />
