### PR TITLE
Add a welcome notice about the guide

### DIFF
--- a/src/main/java/com/dreammaster/loginhandler/LoginHandler.java
+++ b/src/main/java/com/dreammaster/loginhandler/LoginHandler.java
@@ -22,6 +22,7 @@ public class LoginHandler {
     @SubscribeEvent
     public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
         final String WELCOME             = "dreamcraft.welcome.welcome";
+        final String GUIDE               = "dreamcraft.welcome.guide";
         final String QUESTBOOK           = "dreamcraft.welcome.questbook";
         final String GTNH_WIKI           = "dreamcraft.welcome.gtnh_wiki";
         final String CLICK_WIKI          = "dreamcraft.welcome.click_wiki";
@@ -54,6 +55,7 @@ public class LoginHandler {
         event.player.addChatMessage(new ChatComponentText("-----------------------------------------------------")
                 .setChatStyle(new ChatStyle().setColor(GOLD).setStrikethrough(true)));
         event.player.addChatMessage(new ChatComponentTranslation(WELCOME, modpackVersion).setChatStyle(new ChatStyle().setBold(true)));
+        event.player.addChatMessage(new ChatComponentTranslation(GUIDE).setChatStyle(new ChatStyle().setColor(YELLOW)));
         event.player.addChatMessage(new ChatComponentTranslation(QUESTBOOK).setChatStyle(new ChatStyle().setColor(BLUE)));
         event.player.addChatMessage(new ChatComponentTranslation(GTNH_WIKI, gtnhWikiLink).setChatStyle(new ChatStyle().setColor(DARK_GREEN)));
         event.player.addChatMessage(new ChatComponentTranslation(REPORT_BUG).setChatStyle(new ChatStyle().setColor(GREEN)));

--- a/src/main/resources/assets/dreamcraft/lang/en_US.lang
+++ b/src/main/resources/assets/dreamcraft/lang/en_US.lang
@@ -1771,6 +1771,7 @@ dreamcraft.gui.quitmessage.no=No
 dreamcraft.gui.quitmessage.never=Don't Show Again!
 
 dreamcraft.welcome.welcome=Welcome to GregTech: New Horizons %s
+dreamcraft.welcome.guide=Enable the resource pack to see what's new in the guide!
 dreamcraft.welcome.questbook=The Quest Book has a shortcut key, check your keybindings.
 dreamcraft.welcome.gtnh_wiki=GTNH Wiki link: %s
 dreamcraft.welcome.click_wiki=Click to open the wiki!


### PR DESCRIPTION
Added the yellow line about the guide.

Only line I could find that:
- Mentioned the changelog
- Mentions the guide
- Instructs to enable the resource pack
- Fits in 1 line


<img width="851" height="504" alt="image" src="https://github.com/user-attachments/assets/49d97adf-5332-40b4-a83f-89d59dbfb4f9" />
