### PR TITLE
Remove GraviSuite Vajra Shapeless Recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptGraviSuite.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGraviSuite.java
@@ -129,7 +129,6 @@ public class ScriptGraviSuite implements IScriptLoader {
                 "plateAlloyIridium",
                 "batteryData",
                 "plateAlloyIridium");
-        addShapelessRecipe(ItemList.Tool_Vajra.get(1), getModItem(GraviSuite.ID, "vajra", 1, wildcard));
 
     }
 }


### PR DESCRIPTION
The recipe that transferred GS vajra -> GT Vajra is no longer needed as it's been a full dev cycle since deprecation