### PR TITLE
Fix Energy Core Nano recipe requiring discharged IC2 energy crystal

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/MechanicalArmorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/MechanicalArmorRecipes.java
@@ -89,7 +89,7 @@ public class MechanicalArmorRecipes {
 
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        ItemList.IC2_EnergyCrystal.get(1),
+                        ItemList.IC2_EnergyCrystal.getWildcard(1),
                         GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.EnergeticAlloy, 64),
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.HV, 1))
                 .fluidInputs(Materials.RedstoneAlloy.getMolten(INGOTS * 10)).itemOutputs(ItemList.Armor_Core_T1.get(1))


### PR DESCRIPTION
Energy Core Nano assembler recipe used `IC2_EnergyCrystal.get(1)` which resolves to damage=0 (discharged state), so only an empty crystal was accepted. Changed to `getWildcard(1)` to accept any charge level.