### PR TITLE
Add space assembler recipe for neutronium compressor controller

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -451,25 +451,26 @@ public class SpaceAssemblerRecipes implements Runnable {
                         .metadata(IGRecipeMaps.MODULE_TIER, 1).duration(10 * SECONDS).eut(TierEU.RECIPE_UHV)
                         .addTo(IGRecipeMaps.spaceAssemblerRecipes);
             }
-            // Pseudo-Inversion Sigil Ritual
-            /*
-             * if (ExtraUtilities.isModLoaded()) { GTValues.RA.stdBuilder() .itemInputs(
-             * getModItem(UniversalSingularities.ID, "universal.vanilla.singularity", 1, 2), getModItem(Avaritia.ID,
-             * "Singularity", 1, 0), getModItem(UniversalSingularities.ID, "universal.general.singularity", 1, 24),
-             * getModItem(Avaritia.ID, "Singularity", 1, 3), getModItem(Avaritia.ID, "Resource", 64, 7),
-             * getModItem(Avaritia.ID, "Ultimate_Stew", 1, 0), getModItem(Avaritia.ID, "Cosmic_Meatballs", 1, 0),
-             * getModItem(StevesCarts2.ID, "CartModule", 1, 82), getModItem(ExtraUtilities.ID, "decorativeBlock1", 16,
-             * 12), getModItem(BiomesOPlenty.ID, "petals", 64, 0), getModItem(Witchery.ID, "ingredient", 64, 56),
-             * getModItem(Avaritia.ID, "Endest_Pearl", 16, 0), getModItem(EtFuturumRequiem.ID, "chorus_flower", 64, 0),
-             * getModItem(Witchery.ID, "cauldronbook", 1, 0), getModItem(AvaritiaAddons.ID, "CompressedChest", 4, 0),
-             * getModItem(ExtraUtilities.ID, "block_bedrockium", 16, 0)) .fluidInputs( new
-             * FluidStack(FluidRegistry.getFluid("ender"), 16000), new FluidStack(FluidRegistry.getFluid("endergoo"),
-             * 8000), new FluidStack(FluidRegistry.getFluid("radon"), 4000), new
-             * FluidStack(FluidRegistry.getFluid("potion.diablosauce.strong"), 2000)) .itemOutputs( new
-             * NBTItem(getModItem(ExtraUtilities.ID, "divisionSigil", 1, 0)) .setNBT("{stable:1b}"))
-             * .metadata(IGRecipeMaps.MODULE_TIER, 1).duration(10 * SECONDS).eut(TierEU.RECIPE_UV)
-             * .addTo(IGRecipeMaps.spaceAssemblerRecipes); }
-             */
+        }
+
+        if (Avaritia.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                    .itemInputs(
+                            ItemList.CompressorUV.get(1),
+                            GTOreDictUnificator.get(OrePrefixes.block, Materials.CosmicNeutronium, 12L),
+                            GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.Bedrockium, 2L),
+                            GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.BlackPlutonium, 2L),
+                            GTOreDictUnificator.get(OrePrefixes.plateQuadruple, Materials.CosmicNeutronium, 8L),
+                            GTOreDictUnificator.get(OrePrefixes.plate, Materials.Neutronium, 4L),
+                            getModItem(Avaritia.ID, "Resource", 20, 1),
+                            ItemList.Electric_Motor_UV.get(4),
+                            ItemList.Electric_Piston_UV.get(8),
+                            ItemList.Conveyor_Module_UV.get(8),
+                            GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UHV, 4L))
+                    .fluidInputs(new FluidStack(solderIndalloy, 2304))
+                    .itemOutputs(ItemList.Machine_Multi_NeutroniumCompressor.get(1))
+                    .metadata(IGRecipeMaps.MODULE_TIER, 1).duration(10 * SECONDS).eut(TierEU.RECIPE_UHV)
+                    .addTo(IGRecipeMaps.spaceAssemblerRecipes);
         }
     }
 }


### PR DESCRIPTION
This PR adds a space assembler recipe for the controller block of the neutronium compressor multi. Its almost an exact copy of the dire table recipe, except it has some added indalloy and the large plates are replaced with quad plates.
Also removed a commented-out recipe.

<img width="530" height="465" alt="image" src="https://github.com/user-attachments/assets/eeea2119-3acf-4de7-9d13-4af8e3ab403d" />
