### PR TITLE
Fix missing coremod cutting recipes in nei

### DIFF
--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -7,7 +7,6 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import java.util.List;
 import java.util.Random;
 
-import gregtech.loaders.postload.recipes.FakeCuttingRecipes;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -97,6 +96,7 @@ import gregtech.api.enums.GTValues;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Mods;
 import gregtech.common.items.MetaGeneratedItem01;
+import gregtech.loaders.postload.recipes.FakeCuttingRecipes;
 
 @Mod(
         modid = Refstrings.MODID,

--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -7,6 +7,7 @@ import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import java.util.List;
 import java.util.Random;
 
+import gregtech.loaders.postload.recipes.FakeCuttingRecipes;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -405,6 +406,8 @@ public class MainRegistry {
             FMLCommonHandler.instance().bus().register(handler);
             handleAchievements = true;
         }
+
+        new FakeCuttingRecipes().run(); // nei cutting recipes display
     }
 
     /**


### PR DESCRIPTION
Loads fake recipes from coremod side
merge together with https://github.com/GTNewHorizons/GT5-Unofficial/pull/7234

<img width="617" height="515" alt="{ADB3ADCA-12C5-4B92-BB5A-BA17F7C9D96F}" src="https://github.com/user-attachments/assets/57aaef2d-ee53-45b9-a1cd-5163d018a2d9" />
