### PR TITLE
Convert MAX circuit parts to use cosmic solder

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -1592,7 +1592,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.CasingEternity, 4),
                         new CircuitComponentStack(CircuitComponent.ProcessedFoilShirabon, 64)),
                 Arrays.asList(
-                        MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(16 * INGOTS),
+                        Materials.BoundlessCosmicSolder.getFluid(8 * INGOTS),
                         Materials.RadoxPolymer.getMolten(16 * INGOTS),
                         Materials.PrimordialMatter.getFluid(1000),
                         Materials.ExcitedDTSC.getFluid(4000)),
@@ -1616,7 +1616,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedBoltWhiteDwarfMatter, 32),
                         new CircuitComponentStack(CircuitComponent.ProcessedCoiledThermalSuperconductor, 8)),
                 Arrays.asList(
-                        MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(64 * INGOTS),
+                        Materials.BoundlessCosmicSolder.getFluid(32 * INGOTS),
                         Materials.PrimordialMatter.getFluid(4000),
                         Materials.Space.getMolten(4000),
                         Materials.PhononMedium.getFluid(1000)),


### PR DESCRIPTION
Updates the MAX circuit (Planck) to use cosmic solder, at half as much as the previous living solder.