### PR TITLE
Add recipe for BEC LoS Hatch

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblingLineRecipes.java
@@ -1849,6 +1849,26 @@ public class AssemblingLineRecipes implements Runnable {
                 30 * SECONDS,
                 (int) TierEU.RECIPE_UIV);
 
+        // Line-of-Sight Connector Hatch
+        TTRecipeAdder.addResearchableAssemblylineRecipe(
+                getModItem(Minecraft.ID, "beacon", 1, 0),
+                24_000_000,
+                8_192,
+                (int) TierEU.RECIPE_UMV,
+                64,
+                new Object[] { ItemList.Hull_UEV.get(1), GTModHandler.getModItem(Minecraft.ID, "beacon", 1, 0),
+                        ItemList.Casing_Dim_Bridge.get(2), ItemList.Conveyor_Module_UIV.get(1),
+                        GGMaterial.tairitsu.get(OrePrefixes.wireFine, 8),
+                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Churitsu, 8),
+                        GTOreDictUnificator.get(OrePrefixes.wireFine, Materials.Shijima, 8) },
+                new FluidStack[] { MaterialsElements.STANDALONE.HYPOGEN.getFluidStack(16 * INGOTS),
+                        MaterialsElements.STANDALONE.CHRONOMATIC_GLASS.getFluidStack(32 * INGOTS),
+                        MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN.getFluidStack(16 * INGOTS),
+                        MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(8 * STACKS) },
+                CustomItemList.Hatch_BEC_Connector.get(1),
+                30 * SECONDS,
+                (int) TierEU.RECIPE_UIV);
+
         // Condensate Entanglement Apparatus (BEC Generator multi)
         TTRecipeAdder.addResearchableAssemblylineRecipe(
                 GregtechItemList.Controller_IndustrialFluidHeater.get(1),


### PR DESCRIPTION
Recipes for the hatches added in https://github.com/GTNewHorizons/GT5-Unofficial/pull/7022

Necessary for BEC multis.

<img width="252" height="188" alt="image" src="https://github.com/user-attachments/assets/853dd75d-a64a-4538-a750-8d81a2cca8b3" />
<img width="257" height="170" alt="image" src="https://github.com/user-attachments/assets/9795a190-92d6-4b84-8e98-a58fc52c26d4" />
