### PR TITLE
Fix Unstable Ingots not exploding on shift click craft

### DIFF
--- a/src/main/java/com/dreammaster/recipes/RecipeRemover.java
+++ b/src/main/java/com/dreammaster/recipes/RecipeRemover.java
@@ -3096,11 +3096,6 @@ public class RecipeRemover {
                         getModItem(EnderZoo.ID, "enderFragment", 1, 0) },
                 new Object[] { null, getModItem(EnderZoo.ID, "enderFragment", 1, 0), null });
         removeRecipeShapedDelayed(
-                getModItem(ExtraUtilities.ID, "unstableingot", 1, 0),
-                new Object[] { getModItem(Minecraft.ID, "iron_ingot", 1, 0) },
-                new Object[] { getModItem(ExtraUtilities.ID, "divisionSigil", 1, 0) },
-                new Object[] { getModItem(Minecraft.ID, "diamond", 1, 0) });
-        removeRecipeShapedDelayed(
                 getModItem(ForbiddenMagic.ID, "FMResource", 9, 0),
                 new Object[] { getModItem(Minecraft.ID, "emerald", 1, 0) },
                 new Object[0],

--- a/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
@@ -894,18 +894,6 @@ public class ScriptExtraUtilities implements IScriptLoader {
                 null);
 
         addShapedRecipe(
-                getModItem(ExtraUtilities.ID, "unstableingot", 1, 0),
-                getModItem(Minecraft.ID, "iron_ingot", 1, 0),
-                null,
-                null,
-                new CustomItem.NBTItem(getModItem(ExtraUtilities.ID, "divisionSigil", 1, 0)).setNBT("{damage:256}")
-                        .noValues(),
-                null,
-                null,
-                getModItem(Minecraft.ID, "diamond", 1, 0),
-                null,
-                null);
-        addShapedRecipe(
                 getModItem(ExtraUtilities.ID, "unstableingot", 1, 2),
                 getModItem(Minecraft.ID, "iron_ingot", 1, 0),
                 null,


### PR DESCRIPTION
For some reason we are removing the unstable ingot recipe and then replacing it with an identical recipe (except worse, because the original recipe allows crafting in all 3 columns, while the coremod one allows only the leftmost column).

More importantly, this is the cause of the beloved bug where shift clicking the recipe output makes them not explode. Extra Utilities has its own custom recipe class and this replaces it with a generic coremod recipe class. The fix is just to use the ExU recipe as is, since we don't even modify it...

To all players - I am sorry.