### PR TITLE
Readd Sunnarium Autoclave Recipes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,20 +1,20 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.06:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.15:dev")
     api("com.github.GTNewHorizons:Yamcl:0.7.5:dev")
     api("com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev")
 
-    implementation("com.github.GTNewHorizons:GTNHLib:0.11.18:dev")
+    implementation("com.github.GTNewHorizons:GTNHLib:0.11.23:dev")
 
     implementation("net.glease:tc4recipelib:1.5.37:dev")
 
     compileOnly("com.github.GTNewHorizons:AkashicTome:1.2.7:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Avaritia:1.97:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Irontanks:1.4.6:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Irontanks:1.4.7:dev") { transitive = false }
     compileOnly("secondderivative.irontankminecarts:IronTankMinecarts:1.0.5:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:twilightforest:2.7.35:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Mantle:0.5.3:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:twilightforest:2.7.36:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Mantle:0.5.4:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.14.93-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:WitcheryExtras:1.4.16:dev") { transitive = false }
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
@@ -25,16 +25,16 @@ dependencies {
     compileOnly rfg.deobf("curse.maven:extra-utilities-225561:2264384")
     compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.26:deobf") { transitive = false }
     compileOnly("com.github.GTNewHorizons:amunra:0.8.13:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Galacticraft:3.4.29-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:ForestryMC:4.11.27:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:HoloInventory:2.5.14-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:MatterManipulator:0.1.42-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:IguanaTweaksTConstruct:2.7.9:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.5.17-GTNH:dev")
-    compileOnly("com.github.GTNewHorizons:Backhand:1.8.10:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Backhand:1.8.10:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Galacticraft:3.4.31-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.11.30:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:HoloInventory:2.5.15-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:MatterManipulator:0.1.46-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:IguanaTweaksTConstruct:2.7.10:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.5.18-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:Backhand:1.8.11:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Backhand:1.8.11:dev") { transitive = false }
     compileOnly("com.cubefury.vendingmachine:VendingMachine:0.4.82:dev")
-    compileOnly("com.github.GTNewHorizons:BetterQuesting:3.8.71-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:BetterQuesting:3.8.72-GTNH:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")
     //compileOnly("com.github.Roadhog360:Et-Futurum-Requiem:2.6.2:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev") { transitive = false }
@@ -43,7 +43,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:GTNH-TC-Wands:1.4.14:dev") { transitive = false }
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:WailaHarvestability:1.3.6-GTNH:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.29-GTNH:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.31-GTNH:dev")
 
     // For testing singularities
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Eternal-Singularity:1.4.3:dev")
@@ -56,19 +56,19 @@ dependencies {
 
     //uncomment to test RC and Forestry recipes
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Railcraft:9.17.28:dev")
-    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.27:dev")
+    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.11.30:dev")
 
     // RecEx, for testing purposesF
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:RecEx:1.1.5:dev")
 
     // For building structures faster
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:MatterManipulator:0.1.42-GTNH')
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:MatterManipulator:0.1.46-GTNH')
 
     // For testing thaumcraft
     // runtimeOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
 
     // For testing ctm and animation interpolation
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.42:dev') { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.50:dev') { transitive = false }
 
     // Core unit testing platform
     testImplementation(platform('org.junit:junit-bom:5.9.2'))

--- a/src/main/java/com/dreammaster/scripts/ScriptAdvancedSolarPanel.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAdvancedSolarPanel.java
@@ -9,6 +9,7 @@ import static gregtech.api.recipe.RecipeMaps.autoclaveRecipes;
 import static gregtech.api.recipe.RecipeMaps.hammerRecipes;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
+import static gregtech.api.util.GTRecipeBuilder.TICKS;
 
 import java.util.Arrays;
 import java.util.List;
@@ -144,12 +145,12 @@ public class ScriptAdvancedSolarPanel implements IScriptLoader {
 
         GTValues.RA.stdBuilder().itemInputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 8, 2))
                 .itemOutputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 3))
-                .fluidInputs(Materials.Sunnarium.getMolten(144L)).duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM)
-                .addTo(autoclaveRecipes);
+                .fluidInputs(Materials.Sunnarium.getMolten(144L)).duration(7 * SECONDS + 10 * TICKS)
+                .eut(TierEU.RECIPE_ZPM).addTo(autoclaveRecipes);
 
         GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Uranium, 1L))
                 .itemOutputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 2))
-                .fluidInputs(Materials.Sunnarium.getMolten(144L)).duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM)
+                .fluidInputs(Materials.Sunnarium.getMolten(144L)).duration(38 * TICKS).eut(TierEU.RECIPE_ZPM)
                 .addTo(autoclaveRecipes);
 
     }

--- a/src/main/java/com/dreammaster/scripts/ScriptAdvancedSolarPanel.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAdvancedSolarPanel.java
@@ -5,6 +5,7 @@ import static gregtech.api.enums.Mods.AdvancedSolarPanel;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
+import static gregtech.api.recipe.RecipeMaps.autoclaveRecipes;
 import static gregtech.api.recipe.RecipeMaps.hammerRecipes;
 import static gregtech.api.util.GTRecipeBuilder.MINUTES;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
@@ -140,6 +141,16 @@ public class ScriptAdvancedSolarPanel implements IScriptLoader {
         GTValues.RA.stdBuilder().itemInputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 0))
                 .itemOutputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 9, 9)).duration(2 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(hammerRecipes);
+
+        GTValues.RA.stdBuilder().itemInputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 8, 2))
+                .itemOutputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 3))
+                .fluidInputs(Materials.Sunnarium.getMolten(144L)).duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM)
+                .addTo(autoclaveRecipes);
+
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Uranium, 1L))
+                .itemOutputs(getModItem(AdvancedSolarPanel.ID, "asp_crafting_items", 1, 2))
+                .fluidInputs(Materials.Sunnarium.getMolten(144L)).duration(8 * SECONDS).eut(TierEU.RECIPE_ZPM)
+                .addTo(autoclaveRecipes);
 
     }
 }


### PR DESCRIPTION
## Summary
Add back the advanced solar panels items recipes in autoclave that where removed in this pr https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1475 , addresing the part that the recipes where in batch of 64, dividing the cost so the recipe is now in a 1 to 1 item instead of 64 to 64 ( also dividing the time)


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
