### PR TITLE
Reduce time of Computation Singularity

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/NeutroniumCompressorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/NeutroniumCompressorRecipes.java
@@ -464,7 +464,7 @@ public class NeutroniumCompressorRecipes implements Runnable {
             GTValues.RA.stdBuilder().fluidInputs(Materials.ComputationBase.getMolten(Integer.MAX_VALUE))
                     .itemInputs(NHItemList.SingularityComputationCore.get(1))
                     .itemOutputs(getModItem(UniversalSingularities.ID, "universal.circuit2.singularity", 1, 6))
-                    .duration(6400 * SECONDS).eut(TierEU.RECIPE_UXV).metadata(COMPRESSION_TIER, 2)
+                    .duration(4500 * SECONDS).eut(TierEU.RECIPE_UXV).metadata(COMPRESSION_TIER, 2)
                     .addTo(neutroniumCompressorRecipes);
         }
     }


### PR DESCRIPTION
Reduce the computation singularity to the same base time as MHDCSM Superdense Plate. That was meant to be the capstone recipe of BHC.

You need to be careful when designing recipe times for BHC due to its exponential spacetime scaling. Adding 300 seconds to this recipe seems relatively innocent until you realize it's a 4096x multiplier to the final spacetime per tick, far surpassing the hidden overflow limit of 1B. I may follow up with a validator that prevents adding recipes longer than 4500s, we should not be encouraging hitting the hidden cap.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
