### PR TITLE
Add recipe to the GT Network Analyzer and the Super ME Replenisher

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.15:dev")
+    api("com.github.GTNewHorizons:GT5-Unofficial:5.09.54.20:dev")
     api("com.github.GTNewHorizons:Yamcl:0.7.5:dev")
     api("com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev")
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,7 +32,6 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:IguanaTweaksTConstruct:2.7.10:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.5.18-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:Backhand:1.8.11:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Backhand:1.8.11:dev") { transitive = false }
     compileOnly("com.cubefury.vendingmachine:VendingMachine:0.4.82:dev")
     compileOnly("com.github.GTNewHorizons:BetterQuesting:3.8.72-GTNH:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import com.dreammaster.recipes.ShapedUniversalRecipe;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -51,6 +50,7 @@ import com.dreammaster.item.ItemBucketList;
 import com.dreammaster.item.NHItemList;
 import com.dreammaster.mantle.MantleManualRecipeRegistry;
 import com.dreammaster.recipes.Recipe;
+import com.dreammaster.recipes.ShapedUniversalRecipe;
 
 import bartworks.common.loaders.ItemRegistry;
 import bartworks.system.material.WerkstoffLoader;
@@ -2417,10 +2417,18 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
                     getModItem(EtFuturumRequiem.ID, "cherry_log", 1, 2));
         }
 
-        GameRegistry.addRecipe(new ShapedUniversalRecipe(ItemList.NetworkAnalyzer.get(1),
-                ItemList.Sensor_LV.get(1), "paneGlassColorless", ItemList.Emitter_LV.get(1),
-                "wireFineAnyCopper", "plateSteel", "wireFineAnyCopper",
-                "componentCircuitDiode", "circuitBasic" ,"componentCircuitDiode"));
+        GameRegistry.addRecipe(
+                new ShapedUniversalRecipe(
+                        ItemList.NetworkAnalyzer.get(1),
+                        ItemList.Sensor_LV.get(1),
+                        "paneGlassColorless",
+                        ItemList.Emitter_LV.get(1),
+                        "wireFineAnyCopper",
+                        "plateSteel",
+                        "wireFineAnyCopper",
+                        "componentCircuitDiode",
+                        "circuitBasic",
+                        "componentCircuitDiode"));
     }
 
     private Consumer<Recipe> shapelessUnremovableGtRecipes() {

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.dreammaster.recipes.ShapedUniversalRecipe;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
@@ -2415,6 +2416,11 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
                     getModItem(EtFuturumRequiem.ID, "wood_planks", 4, 3),
                     getModItem(EtFuturumRequiem.ID, "cherry_log", 1, 2));
         }
+
+        GameRegistry.addRecipe(new ShapedUniversalRecipe(ItemList.NetworkAnalyzer.get(1),
+                ItemList.Sensor_LV.get(1), "paneGlassColorless", ItemList.Emitter_LV.get(1),
+                "wireFineAnyCopper", "plateSteel", "wireFineAnyCopper",
+                "componentCircuitDiode", "circuitBasic" ,"componentCircuitDiode"));
     }
 
     private Consumer<Recipe> shapelessUnremovableGtRecipes() {

--- a/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
@@ -805,7 +805,7 @@ public class ScriptAE2FC implements IScriptLoader {
 
         GameRegistry.addShapelessRecipe(AE2FC_ENERGY_CARD, AE2_ADV_CARD, AE2_NEUTRONIUM_ENERGY_CELL);
 
-        //  Super ME Replenisher
+        // Super ME Replenisher
         addShapedRecipe(
                 getModItem(AppliedEnergistics2.ID, "tile.BlockSuperMEReplenisher"),
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 60),
@@ -816,7 +816,6 @@ public class ScriptAE2FC implements IScriptLoader {
                 "circuitInfinite",
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 60),
                 getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 67),
-                getModItem(AE2FluidCraft.ID, "fluid_part", 7)
-        );
+                getModItem(AE2FluidCraft.ID, "fluid_part", 7));
     }
 }

--- a/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAE2FC.java
@@ -804,5 +804,19 @@ public class ScriptAE2FC implements IScriptLoader {
         addShapelessRecipe(AE2FC_INTERFACE_P2P, AE2FC_INTERFACE_P2P);
 
         GameRegistry.addShapelessRecipe(AE2FC_ENERGY_CARD, AE2_ADV_CARD, AE2_NEUTRONIUM_ENERGY_CELL);
+
+        //  Super ME Replenisher
+        addShapedRecipe(
+                getModItem(AppliedEnergistics2.ID, "tile.BlockSuperMEReplenisher"),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 60),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 67),
+                getModItem(AE2FluidCraft.ID, "fluid_part", 7),
+                "circuitInfinite",
+                getModItem(AE2FluidCraft.ID, "super_stock_replenisher"),
+                "circuitInfinite",
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 60),
+                getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 67),
+                getModItem(AE2FluidCraft.ID, "fluid_part", 7)
+        );
     }
 }


### PR DESCRIPTION
## Summary
The Super ME Replenisher is an upgrade of the Super Stocker, used to do temporary resource reservation, as opposed to the super stocker which does permanent reservation. Most of the cost is in the superluminal cards (2 time anomalies). For the 16384k components, if you want to do earlier than bio catalyst medium you'll have to use the recursive recipe in the crafting table. The tier of unlocking is still UV, like the Super Stocker.
<img width="395" height="210" alt="image" src="https://github.com/user-attachments/assets/8a79fece-5873-40b8-a92e-256f9553107d" />

The Network Analyzer is a new tool to see the GT enet graphs, useful to understand how the electricity work. It is targetting the start of LV.
<img width="418" height="205" alt="image" src="https://github.com/user-attachments/assets/949cc964-5eb9-4b75-8427-41046efbee6f" />

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
