### PR TITLE
Add assembler recipes for EFR boats

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,7 +35,7 @@ dependencies {
     compileOnly("com.cubefury.vendingmachine:VendingMachine:0.4.82:dev")
     compileOnly("com.github.GTNewHorizons:BetterQuesting:3.8.72-GTNH:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")
-    //compileOnly("com.github.Roadhog360:Et-Futurum-Requiem:2.6.2:dev") { transitive = false }
+    //compileOnly("ganymedes01.etfuturum:Et-Futurum-Requiem:2.6.48-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Postea:1.2.5:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:ForbiddenMagic:0.9.16-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:MagicBees:2.10.9-GTNH:dev") { transitive = false }

--- a/src/main/java/com/dreammaster/scripts/ScriptEFR.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEFR.java
@@ -2017,6 +2017,64 @@ public class ScriptEFR implements IScriptLoader {
         // getSmeltingResult for mince meat is null here for some reason, so adding explicitly
         SmokerRecipes.smelting().addRecipe(MeatRaw.getDust(1), MeatCooked.getDust(1), 0);
 
+        // Boat Assembler Recipes
+        GTValues.RA.stdBuilder().itemInputs(ItemList.Plank_Oak.get(5)).circuit(5).itemOutputs(new ItemStack(Items.boat))
+                .duration(10 * SECONDS).eut(15).addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(ItemList.Plank_Spruce.get(5)).circuit(5)
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "spruce_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(ItemList.Plank_Birch.get(5)).circuit(5)
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "birch_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(ItemList.Plank_Jungle.get(5)).circuit(5)
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "jungle_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(ItemList.Plank_Acacia.get(5)).circuit(5)
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "acacia_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(ItemList.Plank_DarkOak.get(5)).circuit(5)
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "dark_oak_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        // BoP bamboo matches manual crafting recipe
+        GTValues.RA.stdBuilder().itemInputs(getModItem(BiomesOPlenty.ID, "bamboo", 5)).circuit(5)
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "bamboo_raft", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(ItemList.Plank_Cherry_EFR.get(5)).circuit(5)
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "cherry_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+
+        // Chest Boat Assembler Recipes
+        GTValues.RA.stdBuilder().itemInputs(new ItemStack(Blocks.chest), new ItemStack(Items.boat))
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "oak_chest_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(new ItemStack(Blocks.chest), getModItem(EtFuturumRequiem.ID, "spruce_boat", 1))
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "spruce_chest_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(new ItemStack(Blocks.chest), getModItem(EtFuturumRequiem.ID, "birch_boat", 1))
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "birch_chest_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(new ItemStack(Blocks.chest), getModItem(EtFuturumRequiem.ID, "jungle_boat", 1))
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "jungle_chest_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(new ItemStack(Blocks.chest), getModItem(EtFuturumRequiem.ID, "acacia_boat", 1))
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "acacia_chest_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(new ItemStack(Blocks.chest), getModItem(EtFuturumRequiem.ID, "dark_oak_boat", 1))
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "dark_oak_chest_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(new ItemStack(Blocks.chest), getModItem(EtFuturumRequiem.ID, "bamboo_raft", 1))
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "bamboo_chest_raft", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder()
+                .itemInputs(new ItemStack(Blocks.chest), getModItem(EtFuturumRequiem.ID, "cherry_boat", 1))
+                .itemOutputs(getModItem(EtFuturumRequiem.ID, "cherry_chest_boat", 1)).duration(10 * SECONDS).eut(15)
+                .addTo(assemblerRecipes);
     }
 
     // Oxidation Functions


### PR DESCRIPTION
New assembler recipes for the vanilla and vanilla-backport boats. Uses 5 of the gt plank cover items with circuit 5:
<img width="501" height="475" alt="image" src="https://github.com/user-attachments/assets/170ea341-caee-4d4a-a1d6-777a774e5b62" />

Uses bamboo sticks for the raft to match the manual crafted recipe:
<img width="675" height="463" alt="image" src="https://github.com/user-attachments/assets/aaffd6a3-7b68-42df-831f-75c264e51008" />
Manual recipe for reference, unchanged with this PR:
<img width="483" height="240" alt="image" src="https://github.com/user-attachments/assets/b7769bdd-39c6-4c42-b076-a25551b82442" />

Also recipes for chest boats: chest+boat in assembler
<img width="494" height="476" alt="image" src="https://github.com/user-attachments/assets/0ce98a2f-4135-48ad-9b32-e4f7f1de3bc2" />

Mod compat boats didn't get recipes because they don't have manual recipes or the gt plank cover items for their wood types, but they can easily be added later if we ever add those.