### PR TITLE
Convert cosmic solder usage in MAX circuits to multiples of 1000

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -1591,7 +1591,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.CasingEternity, 4),
                         new CircuitComponentStack(CircuitComponent.ProcessedFoilShirabon, 64)),
                 Arrays.asList(
-                        Materials.BoundlessCosmicSolder.getFluid(8 * INGOTS),
+                        Materials.BoundlessCosmicSolder.getFluid(1000),
                         Materials.RadoxPolymer.getMolten(16 * INGOTS),
                         Materials.PrimordialMatter.getFluid(1000),
                         Materials.ExcitedDTSC.getFluid(4000)),
@@ -1615,7 +1615,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedBoltWhiteDwarfMatter, 32),
                         new CircuitComponentStack(CircuitComponent.ProcessedCoiledThermalSuperconductor, 8)),
                 Arrays.asList(
-                        Materials.BoundlessCosmicSolder.getFluid(32 * INGOTS),
+                        Materials.BoundlessCosmicSolder.getFluid(4000),
                         Materials.PrimordialMatter.getFluid(4000),
                         Materials.Space.getMolten(4000),
                         Materials.PhononMedium.getFluid(1000)),


### PR DESCRIPTION
## Summary
Every other use (and production) is some clean multiple of 1000. Relatively balance-neutral, just cleaner.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
