### PR TITLE
Restore Celestial Magnetic Chassis recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/BECRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BECRecipes.java
@@ -1,6 +1,5 @@
 package com.dreammaster.gthandler.recipes;
 
-import static gregtech.api.enums.Mods.DraconicEvolution;
 import static gregtech.api.enums.Mods.EternalSingularity;
 import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.UniversalSingularities;
@@ -9,8 +8,6 @@ import static gregtech.api.util.GTRecipeBuilder.INGOTS;
 import static gregtech.api.util.GTRecipeBuilder.SECONDS;
 import static gregtech.api.util.GTRecipeConstants.NANITE_TIERS;
 import static gtPlusPlus.core.material.MaterialsElements.STANDALONE.HYPOGEN;
-import static kekztech.common.Blocks.lscLapotronicEnergyUnit;
-import static tectech.thing.CustomItemList.Godforge_SingularityShieldingCasing;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
@@ -52,35 +49,6 @@ public class BECRecipes implements Runnable {
     public void runLate() {
         if (EternalSingularity.isModLoaded()) {
             addSGRecipes();
-
-            if (DraconicEvolution.isModLoaded()) {
-                // Exo-Foundry Chassis Tier 3
-                addBec(
-                        ItemList.Magnetic_Chassis_T3_ExoFoundry.get(1),
-                        new ItemStack[] { ItemRefer.Field_Restriction_Coil_T4.get(1),
-                                Godforge_SingularityShieldingCasing.get(4),
-                                new ItemStack(lscLapotronicEnergyUnit, 1, 5), ItemList.SpaceElevatorMotorT5.get(2),
-                                IngredientFactory.getModItem(DraconicEvolution.ID, "chaoticCore", 2),
-                                IngredientFactory.getModItem(EternalSingularity.ID, "combined_singularity", 64, 15),
-                                GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UXV, 16),
-                                ItemList.Field_Generator_UMV.get(8),
-                                GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.SpaceTime, 64),
-                                GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.SuperconductorUMVBase, 64),
-                                GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.Eternity, 64),
-                                GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.MagMatter, 64),
-                                GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.SpaceTime, 16),
-                                GTOreDictUnificator
-                                        .get(OrePrefixes.plateSuperdense, Materials.SuperconductorUMVBase, 16),
-                                GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.Eternity, 16),
-                                GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.MagMatter, 16) },
-                        nanites(4, 2, 3, 5, 9, 8, 10, 6, 2, 2, 3, 3, 4, 4, 5, 5),
-                        new FluidStack[] { CondensateType.QuarkGluonPlasma.getEntangled(1_024_000),
-                                CondensateType.PhononMedium.getEntangled(256_000),
-                                CondensateType.MagMatter.getEntangled(4_096 * INGOTS),
-                                CondensateType.MHDCSM.getEntangled(1_024 * INGOTS) },
-                        600 * SECONDS,
-                        TierEU.RECIPE_UXV);
-            }
         }
     }
 

--- a/src/main/java/com/dreammaster/scripts/ScriptFoundryRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptFoundryRecipes.java
@@ -17,6 +17,8 @@ import static gregtech.api.util.GTRecipeConstants.RESEARCH_ITEM;
 import static gregtech.api.util.GTRecipeConstants.SCANNING;
 import static gtPlusPlus.core.material.MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN;
 import static gtPlusPlus.core.material.MaterialsElements.STANDALONE.RHUGNOR;
+import static kekztech.common.Blocks.lscLapotronicEnergyUnit;
+import static tectech.thing.CustomItemList.Godforge_SingularityShieldingCasing;
 
 import java.util.Arrays;
 import java.util.List;
@@ -325,5 +327,33 @@ public class ScriptFoundryRecipes implements IScriptLoader {
                 ItemList.Magnetic_Chassis_T2_ExoFoundry.get(1),
                 45 * SECONDS,
                 (int) TierEU.RECIPE_UIV);
+
+        // Exo-Foundry Chassis Tier 3
+        TTRecipeAdder.addResearchableAssemblylineRecipe(
+                ItemList.Magnetic_Chassis_T2_ExoFoundry.get(1),
+                4_000_000,
+                8_192,
+                (int) TierEU.RECIPE_UXV,
+                256,
+                new Object[] { ItemRefer.Field_Restriction_Coil_T4.get(1), Godforge_SingularityShieldingCasing.get(4),
+                        new ItemStack(lscLapotronicEnergyUnit, 1, 5),
+                        GTOreDictUnificator.get(OrePrefixes.screw, Materials.Universium, 4),
+                        getModItem(DraconicEvolution.ID, "chaoticCore", 2),
+                        getModItem(EternalSingularity.ID, "combined_singularity", 64, 15),
+                        new Object[] { OrePrefixes.circuit.get(Materials.UXV), 16L },
+                        ItemList.Field_Generator_UMV.get(8),
+                        GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.SpaceTime, 64),
+                        GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.SuperconductorUMVBase, 64),
+                        GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.Eternity, 64),
+                        GTOreDictUnificator.get(OrePrefixes.stickLong, Materials.MagMatter, 64),
+                        GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.SpaceTime, 16),
+                        GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.SuperconductorUMVBase, 16),
+                        GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.Eternity, 16),
+                        GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.MagMatter, 16) },
+                new FluidStack[] { Materials.MoltenProtoHalkoniteBase.getFluid(INGOTS * 4096),
+                        Materials.QuarkGluonPlasma.getFluid(100_000), Materials.MagMatter.getMolten(INGOTS * 40) },
+                ItemList.Magnetic_Chassis_T3_ExoFoundry.get(1),
+                60 * SECONDS,
+                (int) TierEU.RECIPE_UXV);
     }
 }


### PR DESCRIPTION
## What changed

Restored the Celestial Magnetic Chassis / Exo-Foundry Chassis Tier 3 recipe to the previous Assembly Line recipe.

Removed the newer BEC recipe for this item so it no longer requires Condensate Assembler processing.

## Why
After #1833  was merged, crafting one T3 Foundry would require:

500M Condensed Raw Stellar Plasma Mixture
266M Degenerate Quark Gluon Plasma
194M Molten Magmatter
38M Molten Universium
I don’t think anyone would spend 40M Universium on this before producing a large number of AA

<img width="606" height="579" alt="image" src="https://github.com/user-attachments/assets/0333b858-cc0e-452a-8188-31388b213b67" />

This cost is far too unreasonable, so this PR temporarily reverts the recipe back to the previous version.

## Area affected

- src/main/java/com/dreammaster/gthandler/recipes/BECRecipes.java
- src/main/java/com/dreammaster/scripts/ScriptFoundryRecipes.java

## Testing

- ./gradlew.bat spotlessJavaCheck --no-configuration-cache --console=plain
- ./gradlew.bat compileJava --no-configuration-cache --console=plain
