### PR TITLE
Fix Condensates in Mk3 Foundry Chassis

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -45,9 +45,9 @@ dependencies {
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.31-GTNH:dev")
 
     // For testing singularities and foundry
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Eternal-Singularity:1.4.3:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Universal-Singularities:8.15.4:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Draconic-Evolution:1.5.18-GTNH:dev")
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Eternal-Singularity:1.4.3:dev")
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Universal-Singularities:8.15.4:dev")
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:Draconic-Evolution:1.5.18-GTNH:dev")
 
     // For testing Stargate Recipes
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:SGCraft:1.4.13-GTNH:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,9 +44,10 @@ dependencies {
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:WailaHarvestability:1.3.6-GTNH:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.31-GTNH:dev")
 
-    // For testing singularities
+    // For testing singularities and foundry
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Eternal-Singularity:1.4.3:dev")
-    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Universal-Singularities:8.15.3:dev")
+    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Universal-Singularities:8.15.4:dev")
+    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Draconic-Evolution:1.5.28-GTNH:dev")
 
     // For testing Stargate Recipes
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:SGCraft:1.4.13-GTNH:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -45,9 +45,9 @@ dependencies {
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.31-GTNH:dev")
 
     // For testing singularities and foundry
-    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Eternal-Singularity:1.4.3:dev")
-    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Universal-Singularities:8.15.4:dev")
-    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Draconic-Evolution:1.5.28-GTNH:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Eternal-Singularity:1.4.3:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Universal-Singularities:8.15.4:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:Draconic-Evolution:1.5.18-GTNH:dev")
 
     // For testing Stargate Recipes
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:SGCraft:1.4.13-GTNH:dev")

--- a/src/main/java/com/dreammaster/gthandler/recipes/BECRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BECRecipes.java
@@ -74,10 +74,10 @@ public class BECRecipes implements Runnable {
                                 GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.Eternity, 16),
                                 GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.MagMatter, 16) },
                         nanites(4, 2, 3, 5, 9, 8, 10, 6, 2, 2, 3, 3, 4, 4, 5, 5),
-                        new FluidStack[] { CondensateType.QuarkGluonPlasma.getEntangled(1_024_000),
-                                CondensateType.PhononMedium.getEntangled(256_000),
-                                CondensateType.MagMatter.getEntangled(4_096 * INGOTS),
-                                CondensateType.MHDCSM.getEntangled(1_024 * INGOTS) },
+                        new FluidStack[] { CondensateType.BoundlessCosmicSolder.getEntangled(36000),
+                        CondensateType.QuarkGluonPlasma.getEntangled(100_000),
+                        CondensateType.MagMatter.getEntangled(48 * INGOTS),
+                        CondensateType.Universium.getEntangled(72)},
                         600 * SECONDS,
                         TierEU.RECIPE_UXV);
             }

--- a/src/main/java/com/dreammaster/gthandler/recipes/BECRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BECRecipes.java
@@ -58,8 +58,8 @@ public class BECRecipes implements Runnable {
                 addBec(
                         ItemList.Magnetic_Chassis_T3_ExoFoundry.get(1),
                         new ItemStack[] { ItemRefer.Field_Restriction_Coil_T4.get(1),
+                                ItemList.SpaceElevatorMotorT5.get(1), new ItemStack(lscLapotronicEnergyUnit, 1, 5),
                                 Godforge_SingularityShieldingCasing.get(4),
-                                new ItemStack(lscLapotronicEnergyUnit, 1, 5), ItemList.SpaceElevatorMotorT5.get(2),
                                 IngredientFactory.getModItem(DraconicEvolution.ID, "chaoticCore", 2),
                                 IngredientFactory.getModItem(EternalSingularity.ID, "combined_singularity", 64, 15),
                                 GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UXV, 16),
@@ -76,8 +76,8 @@ public class BECRecipes implements Runnable {
                         nanites(4, 2, 3, 5, 9, 8, 10, 6, 2, 2, 3, 3, 4, 4, 5, 5),
                         new FluidStack[] { CondensateType.BoundlessCosmicSolder.getEntangled(36000),
                                 CondensateType.QuarkGluonPlasma.getEntangled(100_000),
-                                CondensateType.MagMatter.getEntangled(48 * INGOTS),
-                                CondensateType.Universium.getEntangled(72) },
+                                CondensateType.DimensionallyShiftedSuperfluid.getEntangled(50_000),
+                                CondensateType.MagMatter.getEntangled(48 * INGOTS) },
                         600 * SECONDS,
                         TierEU.RECIPE_UXV);
             }

--- a/src/main/java/com/dreammaster/gthandler/recipes/BECRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BECRecipes.java
@@ -75,9 +75,9 @@ public class BECRecipes implements Runnable {
                                 GTOreDictUnificator.get(OrePrefixes.plateSuperdense, Materials.MagMatter, 16) },
                         nanites(4, 2, 3, 5, 9, 8, 10, 6, 2, 2, 3, 3, 4, 4, 5, 5),
                         new FluidStack[] { CondensateType.BoundlessCosmicSolder.getEntangled(36000),
-                        CondensateType.QuarkGluonPlasma.getEntangled(100_000),
-                        CondensateType.MagMatter.getEntangled(48 * INGOTS),
-                        CondensateType.Universium.getEntangled(72)},
+                                CondensateType.QuarkGluonPlasma.getEntangled(100_000),
+                                CondensateType.MagMatter.getEntangled(48 * INGOTS),
+                                CondensateType.Universium.getEntangled(72) },
                         600 * SECONDS,
                         TierEU.RECIPE_UXV);
             }


### PR DESCRIPTION
## Summary
This unfortunately escaped review, and was not the planned recipe. It's a copy-paste of the fluids from the SG parts. This is the intended recipe (ignore the fire, devenv-specific bug, it's the singularity item):
<img width="218" height="113" alt="image" src="https://github.com/user-attachments/assets/6fe2f663-df91-468c-8917-e6b7f5a167c4" />

This does increase universium costs, from 142 ingots to 568 ingots, which I think is fine given the overall strength of exo-foundry, the reduction in other MHDCSM consumers, and the (in the grand scheme of things) small amount of uni this represents.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
