### PR TITLE
Add Assembler Recipes For Some Compressors

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2514,7 +2514,7 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.EV, 2),
                         ItemList.Hull_EV.get(1),
                         GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Aluminium, 4))
-                .itemOutputs(ItemList.CompressorEV.get(1)).duration(5 * SECONDS)
+                .itemOutputs(ItemList.Machine_EV_Compressor.get(1)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_EV).addTo(assemblerRecipes);
 
         // UIV Compressor
@@ -2530,7 +2530,7 @@ public class AssemblerRecipes implements Runnable {
         // Industrial Compressor
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        ItemList.CompressorEV.get(1),
+                        ItemList.Machine_EV_Compressor.get(1),
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.IV, 2),
                         ItemList.Electric_Piston_IV.get(2),
                         GGMaterial.incoloy903.get(OrePrefixes.plate, 4))

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2496,7 +2496,7 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.chest, Materials.Wood, 1))
                 .itemOutputs(ItemList.Automation_ChestBuffer_UEV.get(1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
-        
+
         // EV Compressor
         GTValues.RA.stdBuilder()
                 .itemInputs(
@@ -2504,8 +2504,8 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.EV, 2),
                         ItemList.Hull_EV.get(1),
                         GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Aluminium, 4))
-                .itemOutputs(ItemList.Machine_EV_Compressor.get(1)).duration(5 * SECONDS)
-                .eut(TierEU.RECIPE_EV).addTo(assemblerRecipes);
+                .itemOutputs(ItemList.Machine_EV_Compressor.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_EV)
+                .addTo(assemblerRecipes);
 
         // UV Compressor
         GTValues.RA.stdBuilder().itemInputs(
@@ -2524,8 +2524,8 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UIV, 2),
                         ItemList.Hull_UIV.get(1),
                         GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.NetherStar, 4))
-                .itemOutputs(ItemList.CompressorUIV.get(1)).duration(1 * SECONDS)
-                .eut(TierEU.RECIPE_UIV).addTo(assemblerRecipes);
+                .itemOutputs(ItemList.CompressorUIV.get(1)).duration(1 * SECONDS).eut(TierEU.RECIPE_UIV)
+                .addTo(assemblerRecipes);
 
         // Industrial Compressor
         GTValues.RA.stdBuilder()
@@ -2536,7 +2536,7 @@ public class AssemblerRecipes implements Runnable {
                         GGMaterial.incoloy903.get(OrePrefixes.plate, 4))
                 .itemOutputs(ItemList.Machine_Multi_IndustrialCompressor.get(1)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_EV).addTo(assemblerRecipes);
-        
+
         // Implosion Compressor
         GTValues.RA.stdBuilder()
                 .itemInputs(
@@ -2557,8 +2557,8 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.IV, 1),
                         ItemList.Robot_Arm_IV.get(1),
                         ItemList.Field_Generator_IV.get(1))
-                .itemOutputs(ItemList.AdvancedImplosionCompressor.get(1)).duration(5 * SECONDS)
-                .eut(TierEU.RECIPE_IV).addTo(assemblerRecipes);
+                .itemOutputs(ItemList.AdvancedImplosionCompressor.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_IV)
+                .addTo(assemblerRecipes);
 
         // UV Microwave Transmitter
         GTValues.RA.stdBuilder().itemInputs(

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2506,6 +2506,59 @@ public class AssemblerRecipes implements Runnable {
                 GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.ElectrumFlux, 4))
                 .itemOutputs(ItemList.CompressorUV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_UV)
                 .addTo(assemblerRecipes);
+        
+        // EV Compressor
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Electric_Piston_EV.get(2),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.EV, 2),
+                        ItemList.Hull_EV.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Aluminium, 4))
+                .itemOutputs(ItemList.CompressorEV.get(1)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_EV).addTo(assemblerRecipes);
+
+        // UIV Compressor
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Electric_Piston_UIV.get(2),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UIV, 2),
+                        ItemList.Hull_UIV.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.NetherStar, 4))
+                .itemOutputs(ItemList.CompressorUIV.get(1)).duration(10 * TICKS)
+                .eut(TierEU.RECIPE_UIV).addTo(assemblerRecipes);
+
+        // Industrial Compressor
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.CompressorEV.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.IV, 2),
+                        ItemList.Electric_Piston_IV.get(2),
+                        GGMaterial.incoloy903.get(OrePrefixes.plate, 4))
+                .itemOutputs(ItemList.Machine_Multi_IndustrialCompressor.get(1)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_EV).addTo(assemblerRecipes);
+        
+        // Implosion Compressor
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        ItemList.Casing_SolidSteel.get(1L),
+                        ItemList.Block_ReinforcedConcrete.get(3L),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.HV, 3),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Gold, 2))
+                .itemOutputs(ItemList.ImplosionCompressor.get(1)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
+
+        // Advanced Implosion Compressor
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        MaterialsAlloy.LEAGRISIUM.getGear(2),
+                        ItemList.Hull_IV.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.plateAlloy, Materials.Iridium, 2L),
+                        GregtechItemList.Gregtech_Computer_Cube.get(1),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.IV, 1),
+                        ItemList.Robot_Arm_IV.get(1),
+                        ItemList.Field_Generator_IV.get(1))
+                .itemOutputs(ItemList.AdvancedImplosionCompressor.get(1)).duration(5 * SECONDS)
+                .eut(TierEU.RECIPE_IV).addTo(assemblerRecipes);
 
         // UV Microwave Transmitter
         GTValues.RA.stdBuilder().itemInputs(

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2524,7 +2524,7 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UIV, 2),
                         ItemList.Hull_UIV.get(1),
                         GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.NetherStar, 4))
-                .itemOutputs(ItemList.CompressorUIV.get(1)).duration(10 * TICKS)
+                .itemOutputs(ItemList.CompressorUIV.get(1)).duration(1 * SECONDS)
                 .eut(TierEU.RECIPE_UIV).addTo(assemblerRecipes);
 
         // Industrial Compressor

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2532,7 +2532,7 @@ public class AssemblerRecipes implements Runnable {
                 .itemInputs(
                         ItemList.Machine_EV_Compressor.get(1),
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.IV, 2),
-                        ItemList.Electric_Piston_IV.get(2),
+                        ItemList.Electric_Piston_EV.get(2),
                         GGMaterial.incoloy903.get(OrePrefixes.plate, 4))
                 .itemOutputs(ItemList.Machine_Multi_IndustrialCompressor.get(1)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_EV).addTo(assemblerRecipes);

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2496,16 +2496,6 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.chest, Materials.Wood, 1))
                 .itemOutputs(ItemList.Automation_ChestBuffer_UEV.get(1L)).duration(5 * SECONDS).eut(TierEU.RECIPE_HV)
                 .addTo(assemblerRecipes);
-
-        // UV Compressor
-        GTValues.RA.stdBuilder().itemInputs(
-                ItemList.Hull_UV.get(1),
-                // UV circuit, but internal naming is SuperconductorUHV?
-                GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UV, 2),
-                ItemList.Electric_Piston_UV.get(2),
-                GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.ElectrumFlux, 4))
-                .itemOutputs(ItemList.CompressorUV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_UV)
-                .addTo(assemblerRecipes);
         
         // EV Compressor
         GTValues.RA.stdBuilder()
@@ -2516,6 +2506,16 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Aluminium, 4))
                 .itemOutputs(ItemList.Machine_EV_Compressor.get(1)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_EV).addTo(assemblerRecipes);
+
+        // UV Compressor
+        GTValues.RA.stdBuilder().itemInputs(
+                ItemList.Hull_UV.get(1),
+                // UV circuit, but internal naming is SuperconductorUHV?
+                GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UV, 2),
+                ItemList.Electric_Piston_UV.get(2),
+                GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.ElectrumFlux, 4))
+                .itemOutputs(ItemList.CompressorUV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_UV)
+                .addTo(assemblerRecipes);
 
         // UIV Compressor
         GTValues.RA.stdBuilder()

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2544,7 +2544,7 @@ public class AssemblerRecipes implements Runnable {
                         ItemList.Block_ReinforcedConcrete.get(3L),
                         GTOreDictUnificator.get(OrePrefixes.circuit, Materials.HV, 3),
                         GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Gold, 2))
-                .itemOutputs(ItemList.ImplosionCompressor.get(1)).duration(5 * SECONDS)
+                .itemOutputs(ItemList.Machine_Multi_ImplosionCompressor.get(1)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
 
         // Advanced Implosion Compressor


### PR DESCRIPTION
## Summary
Involving EV compressor, UIV compressor, multi compressor cntroller and (advanced) implosion compressor controller. These are used a lot in black-hole which gets into EoH block recipe in 2.9. So I think it necessary to add these to assembler.
(wrong piston tier in electric compressor pic, fixed in code)
<img width="681" height="684" alt="2adf15cabc2803c2c092640d245daaa0" src="https://github.com/user-attachments/assets/e3a6e2c9-d833-43f9-aa6a-a3f68da36499" />
<img width="682" height="681" alt="c210009e5aa06601c044b5df36ef4ffe" src="https://github.com/user-attachments/assets/5e253169-c9ae-487f-b3c5-bed32f935bb0" />
<img width="683" height="720" alt="60f60f27f09cfb005cb1d3bb0f974af4" src="https://github.com/user-attachments/assets/9398f825-4694-488c-bfe7-7ba2ec3f7dd8" />
<img width="683" height="711" alt="8cb4e5214fc92f90c6bc122d697690e9" src="https://github.com/user-attachments/assets/15845348-5055-4722-8764-c3ecd6df9327" />
<img width="684" height="692" alt="3ff312bb19a31bd447a3a83c3391f23a" src="https://github.com/user-attachments/assets/3a5c2eaf-0d7f-4578-87f6-81c28b8919fe" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
