### PR TITLE
reduce the carbon dioxide output from steel production in the blast furnace

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/BlastFurnaceRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/BlastFurnaceRecipes.java
@@ -486,7 +486,7 @@ public class BlastFurnaceRecipes implements Runnable {
                 .circuit(11)
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.ingot, Materials.Steel, 1L), Materials.Ash.getDust(1))
                 .outputChances(10000, 1111).fluidInputs(Materials.Oxygen.getGas(1000L))
-                .fluidOutputs(Materials.CarbonDioxide.getGas(1000L)).duration(25 * SECONDS).eut(TierEU.RECIPE_MV)
+                .fluidOutputs(Materials.CarbonDioxide.getGas(250)).duration(25 * SECONDS).eut(TierEU.RECIPE_MV)
                 .metadata(COIL_HEAT, 1000).addTo(blastFurnaceRecipes);
 
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
## Summary
producing 1000 of carbon dioxide allows players to generate more oxygen through steel production, creating an infinite oxygen loop. reducing it to 250 fixes this issue

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
