### PR TITLE
Use Mutated Living Solder for Bioware Processor SoC recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -1370,7 +1370,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedLivingBioChip, 1),
                         new CircuitComponentStack(CircuitComponent.ProcessedWireNiobiumTitanium, 16),
                         new CircuitComponentStack(CircuitComponent.ProcessedBoltChromaticGlass, 4)),
-                Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(9)),
+                Arrays.asList(MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(9)),
                 CircuitComponent.BiowareProcessor,
                 3 * SECONDS,
                 2_457_600, // UEV


### PR DESCRIPTION
## What changed

- Replace 9 L of Molten Indalloy 140 with 9 L of Mutated Living Solder in the NAC Bioware Processor SoC recipe.
- Keep all item inputs, output, duration, power usage, and recipe tier unchanged.

## Why
<img width="524" height="418" alt="image" src="https://github.com/user-attachments/assets/f7bf86e8-0fc1-4ad9-8866-e54719e024c6" />
<img width="555" height="431" alt="image" src="https://github.com/user-attachments/assets/d5ec7565-255a-485d-a041-6eb56d13a86f" />
<img width="508" height="422" alt="image" src="https://github.com/user-attachments/assets/2dfa0a51-f86f-4153-97d8-d6741ca6c98d" />

Both the Assembly and Circuit Assembler recipes for this item use Mutated Living Solder when using SoC.
NAC should also be changed to use Mutated Living Solder.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge