### PR TITLE
Fix Small AsGa Maceration

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/MaceratorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MaceratorRecipes.java
@@ -78,11 +78,11 @@ public class MaceratorRecipes implements Runnable {
 
         GTValues.RA.stdBuilder().itemInputs(ItemList.GalliumArsenideCrystal.get(1L))
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.GalliumArsenide, 2))
-                .outputChances(10000).duration(5 * SECONDS).eut(4).addTo(maceratorRecipes);
+                .duration(5 * SECONDS).eut(4).addTo(maceratorRecipes);
 
         GTValues.RA.stdBuilder().itemInputs(ItemList.GalliumArsenideCrystalSmallPart.get(1L))
-                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dustSmall, Materials.GalliumArsenide, 1))
-                .outputChances(10000).duration(1 * SECONDS + 5 * TICKS).eut(4).addTo(maceratorRecipes);
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.dustSmall, Materials.GalliumArsenide, 2))
+                .duration(1 * SECONDS + 5 * TICKS).eut(4).addTo(maceratorRecipes);
 
         GTValues.RA.stdBuilder().itemInputs(new ItemStack(Blocks.sand, 1, wildcard))
                 .itemOutputs(


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
For some reason the small crystal only macerated to 1 small dust when it should macerate into 2 small dusts. The maceration step for the large crystal is correct (1->2) so it follows that the small crystal, which is (1 Large -> 4 Small) should macerate to 2 tiny dusts. (4 Small * 2 tiny Dust = 2 full dust)

Thanks @Auynonymous for finding this

Technically a buff, so I'll label it as such, but ultimately it's a corrected mistake.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
