### PR TITLE
Add tartarite to alpha Centauri Bb stone dust products

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
@@ -381,7 +381,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Neutronium, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.BlackPlutonium, 4L),
                         getModItem(Avaritia.ID, "Resource", 36, 2),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Tartarite, 4L))
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Tartarite, 1L))
                 .outputChances(5000, 2000, 500, 2500, 150, 80).fluidOutputs(Materials.Mercury.getFluid(7200L))
                 .duration(6 * MINUTES + 28 * SECONDS + 16 * TICKS).eut(TierEU.RECIPE_LuV).addTo(centrifugeRecipes);
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
@@ -381,7 +381,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Neutronium, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.BlackPlutonium, 4L),
                         getModItem(Avaritia.ID, "Resource", 36, 2),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.InfinityCatalyst, 4L))
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Tartarite, 4L))
                 .outputChances(5000, 2000, 500, 2500, 150, 80).fluidOutputs(Materials.Mercury.getFluid(7200L))
                 .duration(6 * MINUTES + 28 * SECONDS + 16 * TICKS).eut(TierEU.RECIPE_LuV).addTo(centrifugeRecipes);
 

--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -216,7 +216,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         ItemList.Sensor_UEV.get(4), ItemList.Emitter_UEV.get(4),
                         getModItem(OpenComputers.ID, "screen3", 1, 0), getModItem(OpenComputers.ID, "keyboard", 1, 0) },
                 new FluidStack[] { MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(256 * INGOTS),
-                        new FluidStack(MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 64 * INGOTS),
+                        MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN.getFluidStack(64 * INGOTS),
                         Materials.Americium.getPlasma(64 * INGOTS),
                         new FluidStack(MaterialsElements.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 64 * INGOTS) },
                 ItemList.Machine_Multi_NanochipAssemblyComplex.get(1),

--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -216,7 +216,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         ItemList.Sensor_UEV.get(4), ItemList.Emitter_UEV.get(4),
                         getModItem(OpenComputers.ID, "screen3", 1, 0), getModItem(OpenComputers.ID, "keyboard", 1, 0) },
                 new FluidStack[] { MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(256 * INGOTS),
-                        MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN.getFluidStack(64 * INGOTS),
+                        new FluidStack(MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN.getPlasma(), 64 * INGOTS),
                         Materials.Americium.getPlasma(64 * INGOTS),
                         new FluidStack(MaterialsElements.STANDALONE.ASTRAL_TITANIUM.getPlasma(), 64 * INGOTS) },
                 ItemList.Machine_Multi_NanochipAssemblyComplex.get(1),


### PR DESCRIPTION
## Summary
Currently NAC controller needs celestial tungsten plasma, which can only be made in fusion and requires tartarite. But for rocketless players they can only get tartarite after DTPF, with space miner mkIII meteor. 
This PR fixed the problem by adding tartarite to alpha Centauri Bb stone dust products. So players can get the stone through meteor and reach tartarite befor DTPF.
(At first I changed NAC controller recipe, but reverted later. See downside discussion.)


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
