### PR TITLE
Enable subtypes for vanilla paper

### DIFF
--- a/src/main/java/com/dreammaster/main/MainRegistry.java
+++ b/src/main/java/com/dreammaster/main/MainRegistry.java
@@ -228,6 +228,7 @@ public class MainRegistry {
         // register final list with valid items to forge
         LOGGER.debug("LOAD Register Items");
         NHItemList.registerAll();
+        Items.paper.setHasSubtypes(true);
 
         LOGGER.debug("LOAD Register Blocks");
         BlockList.registerAll();


### PR DESCRIPTION
## Summary
This sets the `hasSubtypes` flag of paper to true, allowing item stacks with meta values other than 0. This is used for the legacy Star Gate trophies, which previously did not work correctly.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
