### PR TITLE
Change Watering Can assembler circuits

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptExtraUtilities.java
@@ -494,7 +494,7 @@ public class ScriptExtraUtilities implements IScriptLoader {
                         GTOreDictUnificator.get(OrePrefixes.stick, Materials.Iron, 1),
                         GTOreDictUnificator.get(OrePrefixes.ring, Materials.Steel, 1),
                         GTOreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 1))
-                .circuit(3).itemOutputs(getModItem(ExtraUtilities.ID, "watering_can", 1, 1)).duration(4 * SECONDS)
+                .circuit(11).itemOutputs(getModItem(ExtraUtilities.ID, "watering_can", 1, 1)).duration(4 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(
@@ -502,7 +502,7 @@ public class ScriptExtraUtilities implements IScriptLoader {
                         GTOreDictUnificator.get(OrePrefixes.stick, Materials.Iron, 1),
                         GTOreDictUnificator.get(OrePrefixes.ring, Materials.Steel, 1),
                         GTOreDictUnificator.get(OrePrefixes.screw, Materials.Steel, 1))
-                .circuit(5).fluidInputs(Materials.Water.getFluid(1000))
+                .circuit(12).fluidInputs(Materials.Water.getFluid(1000))
                 .itemOutputs(getModItem(ExtraUtilities.ID, "watering_can", 1, 0)).duration(4 * SECONDS)
                 .eut(TierEU.RECIPE_MV).addTo(assemblerRecipes);
         addShapedRecipe(


### PR DESCRIPTION
## What changed

- Change the empty Watering Can assembler recipe from integrated circuit 3 to circuit 11.
- Change the filled Watering Can assembler recipe from integrated circuit 5 to circuit 12.

## Why

The existing circuit configurations conflict with other assembler recipes that use overlapping inputs. This can cause the assembler to select an unintended recipe while crafting or filling a Watering Can.

Using circuits 11 and 12 gives both Watering Can recipes distinct configurations and prevents these recipe conflicts.

Fixes GTNewHorizons/GT-New-Horizons-Modpack#25918

## Checklist

- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge