### PR TITLE
Centralize Armok Orb Recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptAvaritia.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAvaritia.java
@@ -415,6 +415,7 @@ public class ScriptAvaritia implements IScriptLoader {
                 getModItem(EternalSingularity.ID, "combined_singularity", 1, 6));
         ExtremeCraftingManager.getInstance().addExtremeShapedOreRecipe(
                 getModItem(Avaritia.ID, "Orb_Armok", 1, 0),
+                "---------",
                 "---aia---",
                 "--ababa--",
                 "--jacaj--",
@@ -422,7 +423,6 @@ public class ScriptAvaritia implements IScriptLoader {
                 "ddeafagdd",
                 "-dddhddd-",
                 "---ddd---",
-                "---------",
                 "---------",
                 'a',
                 "plateInfinity",


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
As title states:

<img width="701" height="540" alt="image" src="https://github.com/user-attachments/assets/9dd078ca-e971-42cf-a804-d264f42030f5" />

Recipe was previously shoved to the top instead of in the middle

## Checklist
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
