### PR TITLE
Add Packager unpacking recipes for AE2 Crafting Storage

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptAppliedEnergistics2.java
@@ -363,6 +363,9 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
             GTValues.RA.stdBuilder()
                     .itemInputs(components[i], getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1))
                     .itemOutputs(storage[i]).duration(20 * SECONDS).eut(TierEU.RECIPE_EV).addTo(assemblerRecipes);
+            GTValues.RA.stdBuilder().itemInputs(storage[i])
+                    .itemOutputs(components[i], getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1))
+                    .duration(1 * TICKS).eut(TierEU.RECIPE_EV).addTo(unpackagerRecipes);
         }
 
         // ME Block Container
@@ -2117,24 +2120,44 @@ public class ScriptAppliedEnergistics2 implements IScriptLoader {
                         getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 35))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingStorage", 1, 0))
                 .duration(20 * SECONDS).eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingStorage", 1, 0))
+                .itemOutputs(
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1, 0),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 35))
+                .duration(1 * TICKS).eut(TierEU.RECIPE_HV).addTo(unpackagerRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1, 0),
                         getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 36))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingStorage", 1, 1))
                 .duration(20 * SECONDS).eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingStorage", 1, 1))
+                .itemOutputs(
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1, 0),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 36))
+                .duration(1 * TICKS).eut(TierEU.RECIPE_HV).addTo(unpackagerRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1, 0),
                         getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 37))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingStorage", 1, 2))
                 .duration(20 * SECONDS).eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingStorage", 1, 2))
+                .itemOutputs(
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1, 0),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 37))
+                .duration(1 * TICKS).eut(TierEU.RECIPE_HV).addTo(unpackagerRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1, 0),
                         getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 38))
                 .itemOutputs(getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingStorage", 1, 3))
                 .duration(20 * SECONDS).eut(TierEU.RECIPE_HV).addTo(assemblerRecipes);
+        GTValues.RA.stdBuilder().itemInputs(getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingStorage", 1, 3))
+                .itemOutputs(
+                        getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1, 0),
+                        getModItem(AppliedEnergistics2.ID, "item.ItemMultiMaterial", 1, 38))
+                .duration(1 * TICKS).eut(TierEU.RECIPE_HV).addTo(unpackagerRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         getModItem(AppliedEnergistics2.ID, "tile.BlockCraftingUnit", 1, 0),


### PR DESCRIPTION
## Summary
Crafting Storage blocks (1k/4k/16k/64k and their Advanced counterparts) could be assembled from a Crafting Unit and a storage component, but had no way back, unlike the Co-Processing Units next to them which already had a Packager recipe in both directions.

Added the missing unpackagerRecipes entries so the Packager can split each Crafting Storage tier back into its Crafting Unit and storage component, mirroring the existing Co-Processing Unit recipes.

<img width="433" height="413" alt="image" src="https://github.com/user-attachments/assets/60407de2-382e-4e22-a809-b0975260362c" />

## Checklist
- [ ] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
