### PR TITLE
Allow window name config

### DIFF
--- a/src/main/java/com/dreammaster/coremod/DreamCoreMod.java
+++ b/src/main/java/com/dreammaster/coremod/DreamCoreMod.java
@@ -35,6 +35,7 @@ public class DreamCoreMod implements IEarlyMixinLoader, IFMLLoadingPlugin {
     public static boolean showConfirmExitWindow;
     static boolean downloadOnlyOnce;
     static String downloadUA;
+    public static String displayedModpackVersion;
 
     @Override
     public String[] getASMTransformerClass() {
@@ -56,6 +57,7 @@ public class DreamCoreMod implements IEarlyMixinLoader, IFMLLoadingPlugin {
         isObf = (boolean) data.get("runtimeDeobfuscationEnabled");
         coremodConfig.setProperty("showConfirmExitWindow", "true");
         coremodConfig.setProperty("downloadOnlyOnce", "true");
+        coremodConfig.setProperty("displayedModpackVersion", Refstrings.MODPACKPACK_VERSION);
         File mcLocation = (File) data.get("mcLocation");
         File configDir = new File(mcLocation, "config");
         // noinspection ResultOfMethodCallIgnored
@@ -87,6 +89,8 @@ public class DreamCoreMod implements IEarlyMixinLoader, IFMLLoadingPlugin {
         downloadUA = coremodConfig.getProperty(
                 "downloadUA",
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) Gecko/20100101 Firefox/147.0");
+        displayedModpackVersion = coremodConfig.getProperty("displayedModpackVersion", Refstrings.MODPACKPACK_VERSION);
+
     }
 
     @Override

--- a/src/main/java/com/dreammaster/mixin/mixins/early/MixinMinecraft_PackIcon.java
+++ b/src/main/java/com/dreammaster/mixin/mixins/early/MixinMinecraft_PackIcon.java
@@ -1,5 +1,6 @@
 package com.dreammaster.mixin.mixins.early;
 
+import com.dreammaster.coremod.DreamCoreMod;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.Util;
 
@@ -26,7 +27,7 @@ public class MixinMinecraft_PackIcon {
                     remap = false))
     private String dreamcraft$changeWindowTitle(String original) {
         this.dreamcraft$loadedGTNHIcon = IconLoader.setCustomIcon("assets/dreamcraft/textures/icon/GTNH_42x42.png");
-        return Refstrings.NAME + " " + Refstrings.MODPACKPACK_VERSION;
+        return Refstrings.NAME + " " + DreamCoreMod.displayedModpackVersion;
     }
 
     @ModifyExpressionValue(

--- a/src/main/java/com/dreammaster/mixin/mixins/early/MixinMinecraft_PackIcon.java
+++ b/src/main/java/com/dreammaster/mixin/mixins/early/MixinMinecraft_PackIcon.java
@@ -1,6 +1,5 @@
 package com.dreammaster.mixin.mixins.early;
 
-import com.dreammaster.coremod.DreamCoreMod;
 import net.minecraft.client.Minecraft;
 import net.minecraft.util.Util;
 
@@ -10,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 import com.dreammaster.client.util.IconLoader;
+import com.dreammaster.coremod.DreamCoreMod;
 import com.dreammaster.lib.Refstrings;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Allow the possibility to load the displayed modpack version from a config. Required for https://github.com/GTNewHorizons/DreamAssemblerXXL/pull/299

Tested on daily 645, works well:
<img width="849" height="511" alt="image" src="https://github.com/user-attachments/assets/b2d64af9-4907-4dae-abf1-313d469688f0" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
