### PR TITLE
Adjust radox amount in new dyson swarm module recipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptGalaxySpace.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalaxySpace.java
@@ -274,7 +274,7 @@ public class ScriptGalaxySpace implements IScriptLoader {
                         getModItem(OpenComputers.ID, "item", 64, 36),
                         ItemList.Electric_Motor_UHV.get(4),
                         GTOreDictUnificator.get(OrePrefixes.turbineBlade, Materials.CosmicNeutronium, 8),
-                        GTOreDictUnificator.get(OrePrefixes.itemCasing, Materials.RadoxPolymer, 8),
+                        GTOreDictUnificator.get(OrePrefixes.itemCasing, Materials.RadoxPolymer, 4),
                         ItemList.UHTResistantMesh.get(64))
                 .itemOutputs(ItemList.DroneCase.get(1)).duration(15 * SECONDS).eut(TierEU.RECIPE_UHV)
                 .fluidInputs(MaterialsElements.STANDALONE.CELESTIAL_TUNGSTEN.getFluidStack(2304))


### PR DESCRIPTION
## Summary
This PR changes the radox amount required for the dyson module recipe from 4 -> 2 ingots per 64 modules based on feedback. This should help alleviate some of the added cost from the new dyson recipes.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
