### PR TITLE
Add Server 4 Item To SPASS

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -51,8 +51,7 @@ dependencies {
 
     // For testing Stargate Recipes
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:SGCraft:1.4.13-GTNH:dev")
-
-    // For testing RC and Forestry recipes
+    // runtimeOnlyNonPublishable("com.github.GTNewHorizons:OpenComputers:1.12.55-GTNH:dev")
 
     //uncomment to test RC and Forestry recipes
     //runtimeOnlyNonPublishable("com.github.GTNewHorizons:Railcraft:9.17.29:dev")
@@ -68,7 +67,7 @@ dependencies {
     // runtimeOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
 
     // For testing ctm and animation interpolation
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.53:dev') { transitive = false }
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.53:dev') { transitive = false }
 
     // Core unit testing platform
     testImplementation(platform('org.junit:junit-bom:5.9.2'))

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -67,7 +67,7 @@ dependencies {
     // runtimeOnlyNonPublishable("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev") { transitive = false }
 
     // For testing ctm and animation interpolation
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.53:dev') { transitive = false }
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Angelica:2.1.53:dev') { transitive = false }
 
     // Core unit testing platform
     testImplementation(platform('org.junit:junit-bom:5.9.2'))

--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -498,5 +498,15 @@ public class SpaceAssemblerRecipes implements Runnable {
                     .metadata(IGRecipeMaps.MODULE_TIER, 1).duration(10 * SECONDS).eut(TierEU.RECIPE_UHV)
                     .addTo(IGRecipeMaps.spaceAssemblerRecipes);
         }
+        GTValues.RA.stdBuilder()
+                .itemInputs(
+                        getModItem(OpenComputers.ID, "case3", 1, 0),
+                        getModItem(OpenComputers.ID, "item", 2, 103),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UV, 2L),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.LuV, 16L),
+                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.IV, 4L))
+                .fluidInputs(new FluidStack(solderIndalloy, 2304))
+                .itemOutputs(getModItem(OpenComputers.ID, "item", 1, 69)).metadata(IGRecipeMaps.MODULE_TIER, 1)
+                .duration(20 * SECONDS).eut(TierEU.RECIPE_UHV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
     }
 }

--- a/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/SpaceAssemblerRecipes.java
@@ -498,15 +498,17 @@ public class SpaceAssemblerRecipes implements Runnable {
                     .metadata(IGRecipeMaps.MODULE_TIER, 1).duration(10 * SECONDS).eut(TierEU.RECIPE_UHV)
                     .addTo(IGRecipeMaps.spaceAssemblerRecipes);
         }
-        GTValues.RA.stdBuilder()
-                .itemInputs(
-                        getModItem(OpenComputers.ID, "case3", 1, 0),
-                        getModItem(OpenComputers.ID, "item", 2, 103),
-                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UV, 2L),
-                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.LuV, 16L),
-                        GTOreDictUnificator.get(OrePrefixes.circuit, Materials.IV, 4L))
-                .fluidInputs(new FluidStack(solderIndalloy, 2304))
-                .itemOutputs(getModItem(OpenComputers.ID, "item", 1, 69)).metadata(IGRecipeMaps.MODULE_TIER, 1)
-                .duration(20 * SECONDS).eut(TierEU.RECIPE_UHV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
+        if (OpenComputers.isModLoaded()) {
+            GTValues.RA.stdBuilder()
+                    .itemInputs(
+                            getModItem(OpenComputers.ID, "case3", 1, 0),
+                            getModItem(OpenComputers.ID, "item", 2, 103),
+                            GTOreDictUnificator.get(OrePrefixes.circuit, Materials.UV, 2L),
+                            GTOreDictUnificator.get(OrePrefixes.circuit, Materials.LuV, 16L),
+                            GTOreDictUnificator.get(OrePrefixes.circuit, Materials.IV, 4L))
+                    .fluidInputs(new FluidStack(solderIndalloy, 2304))
+                    .itemOutputs(getModItem(OpenComputers.ID, "item", 1, 69)).metadata(IGRecipeMaps.MODULE_TIER, 1)
+                    .duration(20 * SECONDS).eut(TierEU.RECIPE_UHV).addTo(IGRecipeMaps.spaceAssemblerRecipes);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Adds the OpenComputers Server 4 to SPASS. This item is used in high amounts for Circuit Arrays in Stargate, yet it was stuck as a dire table recipe. Same cost as dire table, just adds some soldering.

Added Recipe
<img width="510" height="464" alt="image" src="https://github.com/user-attachments/assets/8ae7dfab-e9fd-4bb3-92d1-98389e8b7a81" />

Dire Recipe (same cost)
<img width="708" height="643" alt="image" src="https://github.com/user-attachments/assets/b2b2228d-7a2b-4c3a-a56a-de79d5b1a755" />


15k Server 4s needed for gate 😨 
<img width="623" height="232" alt="image" src="https://github.com/user-attachments/assets/427e4de6-b449-4e8e-8506-88ff9a8e59bd" />



## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
