### PR TITLE
Add End Stone Brick chisel conversions

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptEFR.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptEFR.java
@@ -1234,6 +1234,9 @@ public class ScriptEFR implements IScriptLoader {
                 .itemOutputs(getModItem(EtFuturumRequiem.ID, "crying_obsidian", 16)).duration(5 * SECONDS)
                 .eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
 
+        ChiselHelper.addVariationFromStack("endstone", getModItem(Botania.ID, "endStoneBrick", 1, 0));
+        ChiselHelper.addVariationFromStack("endstone", getModItem(EtFuturumRequiem.ID, "end_bricks", 1, 0));
+
         ChiselHelper.addVariationFromStack("EFRHoneyBlock", getModItem(BiomesOPlenty.ID, "honeyBlock", 1));
         ChiselHelper.addVariationFromStack("EFRHoneyBlock", getModItem(EtFuturumRequiem.ID, "honey_block", 1));
 


### PR DESCRIPTION
Botania and Et Futurum Requiem provide End Stone Bricks with identical crafting recipes, but the resulting blocks were not interchangeable. Depending on which recipe was selected, players could be unable to craft Et Futurum Requiem End Stone Brick Walls.

Adding both blocks to the existing Chisel group allows players to convert between them and access recipes that require the Et Futurum Requiem variant.

Fixes GTNewHorizons/GT-New-Horizons-Modpack#26227

## Checklist

- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
