### PR TITLE
Enhance stellar catalyst tesseract recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -432,7 +432,7 @@ public class DTPFRecipes implements Runnable {
                 // V3
                 GTValues.RA.stdBuilder()
                         .itemInputs(
-                                GTOreDictUnificator.get(OrePrefixes.stick, Materials.TranscendentMetal, 16L),
+                                GTOreDictUnificator.get(OrePrefixes.stick, Materials.TranscendentMetal, 32L),
                                 MaterialsAlloy.BLACK_TITANIUM.getPlate(24),
                                 MaterialsAlloy.ZERON_100.getScrew(16),
                                 GregtechItemList.Laser_Lens_Special.get(1))

--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -464,7 +464,7 @@ public class DTPFRecipes implements Runnable {
                                 MaterialsAlloy.BOTMIUM.getScrew(16),
                                 GTOreDictUnificator.get(OrePrefixes.circuit, Materials.ZPM, 1L))
                         .itemOutputs(ItemList.Tesseract.get(4)).fluidInputs(Materials.ExcitedDTRC.getFluid(1000))
-                        .fluidOutputs(Materials.DTR.getFluid(1000 / 2)).duration(40 * SECONDS).eut(32_000_000)
+                        .fluidOutputs(Materials.DTR.getFluid(1000 / 2)).duration(80 * SECONDS).eut(32_000_000)
                         .metadata(COIL_HEAT, infinity_heat).addTo(plasmaForgeRecipes);
             }
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/DTPFRecipes.java
@@ -432,12 +432,12 @@ public class DTPFRecipes implements Runnable {
                 // V3
                 GTValues.RA.stdBuilder()
                         .itemInputs(
-                                GTOreDictUnificator.get(OrePrefixes.stick, Materials.TranscendentMetal, 32L),
+                                GTOreDictUnificator.get(OrePrefixes.stick, Materials.TranscendentMetal, 16L),
                                 MaterialsAlloy.BLACK_TITANIUM.getPlate(24),
                                 MaterialsAlloy.ZERON_100.getScrew(16),
                                 GregtechItemList.Laser_Lens_Special.get(1))
                         .itemOutputs(ItemList.Tesseract.get(16)).fluidInputs(Materials.ExcitedDTSC.getFluid(1000))
-                        .fluidOutputs(Materials.DTR.getFluid(2000)).duration(40 * SECONDS).eut(512_000_000)
+                        .fluidOutputs(Materials.DTR.getFluid(2000)).duration(20 * SECONDS).eut(512_000_000)
                         .metadata(COIL_HEAT, eternal_heat).addTo(plasmaForgeRecipes);
 
                 // V2


### PR DESCRIPTION
## Summary
At now tesseract's stellar recipe has 4x EU cost, same time but only 2x output compared with exotic one. This PR cut down time cost by 2x. Also resplendent recipe time is doubled. So that all the three recipes should have same speed with convergence.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
