### PR TITLE
Fix optical circuit fluid mistake in NAC

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -1473,7 +1473,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         }),
                 Arrays.asList(
                         MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(10 * INGOTS),
-                        Materials.Radon.getGas(10 * INGOTS),
+                        Materials.Radon.getPlasma(10 * INGOTS),
                         Materials.SuperCoolant.getFluid(10000),
                         WerkstoffLoader.Oganesson.getFluidOrGas(500)),
                 CircuitComponent.OpticalAssembly,
@@ -1499,7 +1499,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedFoilPolybenzimidazole, 64)),
                 Arrays.asList(
                         MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(20 * INGOTS),
-                        Materials.Radon.getGas(20 * INGOTS),
+                        Materials.Radon.getPlasma(20 * INGOTS),
                         Materials.SuperCoolant.getFluid(20000),
                         WerkstoffLoader.Oganesson.getFluidOrGas(1000)),
                 CircuitComponent.OpticalComputer,
@@ -1524,7 +1524,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         }),
                 Arrays.asList(
                         MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(40 * INGOTS),
-                        Materials.Radon.getGas(40 * INGOTS),
+                        Materials.Radon.getPlasma(40 * INGOTS),
                         Materials.SuperCoolant.getFluid(40000),
                         WerkstoffLoader.Oganesson.getFluidOrGas(2000)),
                 CircuitComponent.OpticalMainframe,


### PR DESCRIPTION
## Summary
should use radon plasma instead of radon gas.
<img width="681" height="677" alt="image" src="https://github.com/user-attachments/assets/51e32d9a-ad8f-497b-8855-3d7fbb0c9a06" />
<img width="675" height="677" alt="image" src="https://github.com/user-attachments/assets/26865d0b-aaa8-41c2-a37f-1c942737c446" />


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
