### PR TITLE
Apply the Lanthanides dynamic edit directly to NHCore

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
@@ -31,6 +31,7 @@ import gregtech.api.enums.TierEU;
 import gregtech.api.util.GTOreDictUnificator;
 import gregtech.common.items.CombType;
 import gregtech.loaders.misc.GTBees;
+import gtnhlanth.common.register.WerkstoffMaterialPool;
 
 public class CentrifugeRecipes implements Runnable {
 
@@ -359,7 +360,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Lanthanum, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Caesium, 4L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Cerium, 4L))
+                        WerkstoffMaterialPool.CeriumRichMixture.get(OrePrefixes.dust, 8))
                 .outputChances(5000, 2500, 850, 750, 500, 450).duration(10 * MINUTES + 48 * SECONDS)
                 .eut(TierEU.RECIPE_IV).addTo(centrifugeRecipes);
 

--- a/src/main/java/com/dreammaster/scripts/ScriptForbiddenMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptForbiddenMagic.java
@@ -40,6 +40,8 @@ import gregtech.api.enums.OrePrefixes;
 import gregtech.api.enums.TCAspects;
 import gregtech.api.enums.ToolDictNames;
 import gregtech.api.util.GTOreDictUnificator;
+import magicbees.item.types.NuggetType;
+import magicbees.main.Config;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -93,7 +95,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         ChiselHelper.registerOredict("blockNetherStar", "blockNetherStar");
 
         GTValues.RA.stdBuilder().itemInputs(new ItemStack(Items.emerald))
-                .itemOutputs(getModItem(MagicBees.ID, "beeNugget", 9, 6)).duration(1 * MINUTES).eut(5)
+                .itemOutputs(Config.nuggets.getStackForType(NuggetType.EMERALD, 9)).duration(1 * MINUTES).eut(5)
                 .addTo(centrifugeRecipes);
         GTValues.RA.stdBuilder().itemInputs(getModItem(ForbiddenMagic.ID, "InkFlower", 1, 0))
                 .itemOutputs(ItemList.Color_00.get(2L)).duration(15 * SECONDS).eut(2).addTo(extractorRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptForbiddenMagic.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptForbiddenMagic.java
@@ -10,6 +10,7 @@ import static gregtech.api.enums.Mods.Botania;
 import static gregtech.api.enums.Mods.EnderIO;
 import static gregtech.api.enums.Mods.ForbiddenMagic;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
+import static gregtech.api.enums.Mods.MagicBees;
 import static gregtech.api.enums.Mods.Minecraft;
 import static gregtech.api.enums.Mods.Thaumcraft;
 import static gregtech.api.enums.Mods.ThaumicTinkerer;
@@ -66,6 +67,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
                 EnderIO.ID,
                 ForbiddenMagic.ID,
                 IndustrialCraft2.ID,
+                MagicBees.ID,
                 Thaumcraft.ID,
                 ThaumicTinkerer.ID,
                 TinkerConstruct.ID,
@@ -91,7 +93,7 @@ public class ScriptForbiddenMagic implements IScriptLoader {
         ChiselHelper.registerOredict("blockNetherStar", "blockNetherStar");
 
         GTValues.RA.stdBuilder().itemInputs(new ItemStack(Items.emerald))
-                .itemOutputs(getModItem(ForbiddenMagic.ID, "FMResource", 9, 0)).duration(1 * MINUTES).eut(5)
+                .itemOutputs(getModItem(MagicBees.ID, "beeNugget", 9, 6)).duration(1 * MINUTES).eut(5)
                 .addTo(centrifugeRecipes);
         GTValues.RA.stdBuilder().itemInputs(getModItem(ForbiddenMagic.ID, "InkFlower", 1, 0))
                 .itemOutputs(ItemList.Color_00.get(2L)).duration(15 * SECONDS).eut(2).addTo(extractorRecipes);

--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -1839,7 +1839,8 @@ public class ScriptGalacticraft implements IScriptLoader {
 
     private void maceratorRecipes() {
         GTValues.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "tile.fallenMeteor", 1, 0))
-                .itemOutputs(getModItem(GalacticraftCore.ID, "item.meteoricIronRaw", 2, 0)).outputChances(10000)
+                .itemOutputs(GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.MeteoricIron, 2L))
+                .outputChances(10000)
                 .duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);
     }
 

--- a/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalacticraft.java
@@ -1840,8 +1840,7 @@ public class ScriptGalacticraft implements IScriptLoader {
     private void maceratorRecipes() {
         GTValues.RA.stdBuilder().itemInputs(getModItem(GalacticraftCore.ID, "tile.fallenMeteor", 1, 0))
                 .itemOutputs(GTOreDictUnificator.get(OrePrefixes.rawOre, Materials.MeteoricIron, 2L))
-                .outputChances(10000)
-                .duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);
+                .outputChances(10000).duration(15 * SECONDS).eut(2).addTo(maceratorRecipes);
     }
 
     private void dungeonBlockRecipes() {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
This change makes static the changes done by the Lanthanides recipe scan loop of GT5U in memory.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
