### PR TITLE
Apply the NaquadahReworkRecipeLoader dynamic edit directly to NHCore

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
@@ -151,7 +151,7 @@ public class CentrifugeRecipes implements Runnable {
                         WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 18),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Titanium, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Tungsten, 4L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 4L))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
                 .outputChances(5000, 2500, 1000, 750, 500, 150).duration(5 * MINUTES + 24 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(centrifugeRecipes);
 
@@ -162,7 +162,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Lazurite, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Oriharukon, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Barium, 4L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 4L))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
                 .outputChances(5000, 2500, 1250, 750, 500, 150).fluidOutputs(Materials.Oxygen.getGas(1800L))
                 .duration(5 * MINUTES + 24 * SECONDS).eut(TierEU.RECIPE_HV).addTo(centrifugeRecipes);
 
@@ -250,7 +250,7 @@ public class CentrifugeRecipes implements Runnable {
                         WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 18),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Ledox, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Trinium, 4L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 4L))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
                 .outputChances(5000, 3000, 1000, 750, 400, 200).fluidOutputs(Materials.Oxygen.getGas(5400L))
                 .duration(8 * MINUTES + 6 * SECONDS).eut(TierEU.RECIPE_EV).addTo(centrifugeRecipes);
 
@@ -261,7 +261,7 @@ public class CentrifugeRecipes implements Runnable {
                         WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 18),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.MysteriousCrystal, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Trinium, 4L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 4L))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
                 .outputChances(5000, 3000, 1000, 1000, 400, 100).fluidOutputs(Materials.Nitrogen.getGas(5400L))
                 .duration(8 * MINUTES + 6 * SECONDS).eut(TierEU.RECIPE_EV).addTo(centrifugeRecipes);
 
@@ -280,7 +280,7 @@ public class CentrifugeRecipes implements Runnable {
                 .itemOutputs(
                         WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 18),
                         WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 18),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 9L),
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 9),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Uranium235, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plutonium241, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Trinium, 4L))
@@ -327,7 +327,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plutonium, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.BlackPlutonium, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Ledox, 4L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 4L))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
                 .outputChances(5000, 2500, 1250, 750, 500, 400).duration(10 * MINUTES + 48 * SECONDS)
                 .eut(TierEU.RECIPE_IV).addTo(centrifugeRecipes);
 
@@ -338,7 +338,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.BlackPlutonium, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.GarnetRed, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.GarnetYellow, 4L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 4L))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
                 .outputChances(5000, 2500, 850, 500, 500, 300).duration(10 * MINUTES + 48 * SECONDS)
                 .eut(TierEU.RECIPE_IV).addTo(centrifugeRecipes);
 
@@ -356,7 +356,7 @@ public class CentrifugeRecipes implements Runnable {
         GTValues.RA.stdBuilder().itemInputs(NHItemList.HaumeaStoneDust.get(36))
                 .itemOutputs(
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.InfusedGold, 9L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 9L),
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 9),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Lanthanum, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Caesium, 4L),
@@ -367,7 +367,7 @@ public class CentrifugeRecipes implements Runnable {
         GTValues.RA.stdBuilder().itemInputs(NHItemList.CentauriASurfaceDust.get(36))
                 .itemOutputs(
                         WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 18),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.NaquadahEnriched, 9L),
+                        GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 9),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Draconium, 9L),
                         WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 8),
                         getModItem(Avaritia.ID, "Resource", 36, 2),
@@ -378,7 +378,7 @@ public class CentrifugeRecipes implements Runnable {
         GTValues.RA.stdBuilder().itemInputs(NHItemList.CentauriAStoneDust.get(36))
                 .itemOutputs(
                         WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 18),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.NaquadahEnriched, 9L),
+                        GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 9),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Neutronium, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.BlackPlutonium, 4L),
                         getModItem(Avaritia.ID, "Resource", 36, 2),
@@ -392,7 +392,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plutonium241, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Europium, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Neutronium, 4L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadria, 4L),
+                        GGMaterial.naquadriaEarth.get(OrePrefixes.dust, 4),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 4L))
                 .outputChances(5000, 3000, 1500, 800, 500, 50).duration(6 * MINUTES + 28 * SECONDS + 16 * TICKS)
                 .eut(TierEU.RECIPE_LuV).addTo(centrifugeRecipes);

--- a/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/CentrifugeRecipes.java
@@ -151,7 +151,7 @@ public class CentrifugeRecipes implements Runnable {
                         WerkstoffLoader.PTMetallicPowder.get(OrePrefixes.dust, 18),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Titanium, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Tungsten, 4L),
-                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 8))
                 .outputChances(5000, 2500, 1000, 750, 500, 150).duration(5 * MINUTES + 24 * SECONDS)
                 .eut(TierEU.RECIPE_HV).addTo(centrifugeRecipes);
 
@@ -162,7 +162,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Lazurite, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Oriharukon, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Barium, 4L),
-                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 8))
                 .outputChances(5000, 2500, 1250, 750, 500, 150).fluidOutputs(Materials.Oxygen.getGas(1800L))
                 .duration(5 * MINUTES + 24 * SECONDS).eut(TierEU.RECIPE_HV).addTo(centrifugeRecipes);
 
@@ -250,7 +250,7 @@ public class CentrifugeRecipes implements Runnable {
                         WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 18),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Ledox, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Trinium, 4L),
-                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 8))
                 .outputChances(5000, 3000, 1000, 750, 400, 200).fluidOutputs(Materials.Oxygen.getGas(5400L))
                 .duration(8 * MINUTES + 6 * SECONDS).eut(TierEU.RECIPE_EV).addTo(centrifugeRecipes);
 
@@ -261,7 +261,7 @@ public class CentrifugeRecipes implements Runnable {
                         WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 18),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.MysteriousCrystal, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Trinium, 4L),
-                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 8))
                 .outputChances(5000, 3000, 1000, 1000, 400, 100).fluidOutputs(Materials.Nitrogen.getGas(5400L))
                 .duration(8 * MINUTES + 6 * SECONDS).eut(TierEU.RECIPE_EV).addTo(centrifugeRecipes);
 
@@ -280,7 +280,7 @@ public class CentrifugeRecipes implements Runnable {
                 .itemOutputs(
                         WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 18),
                         WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 18),
-                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 9),
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 18),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Uranium235, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plutonium241, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Trinium, 4L))
@@ -327,7 +327,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plutonium, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.BlackPlutonium, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Ledox, 4L),
-                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 8))
                 .outputChances(5000, 2500, 1250, 750, 500, 400).duration(10 * MINUTES + 48 * SECONDS)
                 .eut(TierEU.RECIPE_IV).addTo(centrifugeRecipes);
 
@@ -338,7 +338,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.BlackPlutonium, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.GarnetRed, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.GarnetYellow, 4L),
-                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 4))
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 8))
                 .outputChances(5000, 2500, 850, 500, 500, 300).duration(10 * MINUTES + 48 * SECONDS)
                 .eut(TierEU.RECIPE_IV).addTo(centrifugeRecipes);
 
@@ -356,7 +356,7 @@ public class CentrifugeRecipes implements Runnable {
         GTValues.RA.stdBuilder().itemInputs(NHItemList.HaumeaStoneDust.get(36))
                 .itemOutputs(
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.InfusedGold, 9L),
-                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 9),
+                        GGMaterial.naquadahEarth.get(OrePrefixes.dust, 18),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Lanthanum, 4L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Caesium, 4L),
@@ -367,7 +367,7 @@ public class CentrifugeRecipes implements Runnable {
         GTValues.RA.stdBuilder().itemInputs(NHItemList.CentauriASurfaceDust.get(36))
                 .itemOutputs(
                         WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 18),
-                        GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 9),
+                        GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 18),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Draconium, 9L),
                         WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 8),
                         getModItem(Avaritia.ID, "Resource", 36, 2),
@@ -378,7 +378,7 @@ public class CentrifugeRecipes implements Runnable {
         GTValues.RA.stdBuilder().itemInputs(NHItemList.CentauriAStoneDust.get(36))
                 .itemOutputs(
                         WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 18),
-                        GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 9),
+                        GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 18),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Neutronium, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.BlackPlutonium, 4L),
                         getModItem(Avaritia.ID, "Resource", 36, 2),
@@ -392,7 +392,7 @@ public class CentrifugeRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Plutonium241, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Europium, 9L),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Neutronium, 4L),
-                        GGMaterial.naquadriaEarth.get(OrePrefixes.dust, 4),
+                        GGMaterial.naquadriaEarth.get(OrePrefixes.dust, 8),
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.DraconiumAwakened, 4L))
                 .outputChances(5000, 3000, 1500, 800, 500, 50).duration(6 * MINUTES + 28 * SECONDS + 16 * TICKS)
                 .eut(TierEU.RECIPE_LuV).addTo(centrifugeRecipes);

--- a/src/main/java/com/dreammaster/gthandler/recipes/MaceratorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MaceratorRecipes.java
@@ -27,6 +27,7 @@ import com.dreammaster.block.BlockList;
 import com.dreammaster.item.NHItemList;
 
 import bartworks.system.material.WerkstoffLoader;
+import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -607,7 +608,7 @@ public class MaceratorRecipes implements Runnable {
                             NHItemList.OberonStoneDust.get(),
                             WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 2),
                             WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 2),
-                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 1))
+                            GGMaterial.naquadahEarth.get(OrePrefixes.dust, 1))
                     .outputChances(10000, 500, 250, 212).duration(20 * SECONDS).eut(TierEU.RECIPE_HV)
                     .addTo(maceratorRecipes);
 
@@ -616,7 +617,7 @@ public class MaceratorRecipes implements Runnable {
                             NHItemList.OberonStoneDust.get(),
                             WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 2),
                             WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 2),
-                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 1))
+                            GGMaterial.naquadahEarth.get(OrePrefixes.dust, 1))
                     .outputChances(10000, 500, 250, 212).duration(20 * SECONDS).eut(TierEU.RECIPE_HV)
                     .addTo(maceratorRecipes);
 
@@ -625,7 +626,7 @@ public class MaceratorRecipes implements Runnable {
                             NHItemList.OberonStoneDust.get(),
                             WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 2),
                             WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 2),
-                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 1))
+                            GGMaterial.naquadahEarth.get(OrePrefixes.dust, 1))
                     .outputChances(10000, 500, 250, 212).duration(20 * SECONDS).eut(TierEU.RECIPE_HV)
                     .addTo(maceratorRecipes);
 
@@ -786,7 +787,7 @@ public class MaceratorRecipes implements Runnable {
                     .itemOutputs(
                             NHItemList.HaumeaStoneDust.get(),
                             GTOreDictUnificator.get(OrePrefixes.dust, Materials.InfusedGold, 1),
-                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 1),
+                            GGMaterial.naquadahEarth.get(OrePrefixes.dust, 1),
                             GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 1))
                     .outputChances(10000, 1250, 625, 212).duration(20 * SECONDS).eut(TierEU.RECIPE_EV)
                     .addTo(maceratorRecipes);
@@ -795,7 +796,7 @@ public class MaceratorRecipes implements Runnable {
                     .itemOutputs(
                             NHItemList.CentauriASurfaceDust.get(),
                             WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 2),
-                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.NaquadahEnriched, 1),
+                            GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 1),
                             GTOreDictUnificator.get(OrePrefixes.dust, Materials.Draconium, 1))
                     .outputChances(10000, 1250, 750, 250).duration(20 * SECONDS).eut(TierEU.RECIPE_IV / 2)
                     .addTo(maceratorRecipes);
@@ -804,7 +805,7 @@ public class MaceratorRecipes implements Runnable {
                     .itemOutputs(
                             NHItemList.CentauriAStoneDust.get(),
                             WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 2),
-                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.NaquadahEnriched, 1),
+                            GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 1),
                             GTOreDictUnificator.get(OrePrefixes.dust, Materials.Neutronium, 1))
                     .outputChances(10000, 1250, 750, 125).duration(20 * SECONDS).eut(TierEU.RECIPE_IV / 2)
                     .addTo(maceratorRecipes);

--- a/src/main/java/com/dreammaster/gthandler/recipes/MaceratorRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MaceratorRecipes.java
@@ -27,7 +27,6 @@ import com.dreammaster.block.BlockList;
 import com.dreammaster.item.NHItemList;
 
 import bartworks.system.material.WerkstoffLoader;
-import goodgenerator.items.GGMaterial;
 import gregtech.api.enums.GTValues;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
@@ -608,7 +607,7 @@ public class MaceratorRecipes implements Runnable {
                             NHItemList.OberonStoneDust.get(),
                             WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 2),
                             WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 2),
-                            GGMaterial.naquadahEarth.get(OrePrefixes.dust, 1))
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 1))
                     .outputChances(10000, 500, 250, 212).duration(20 * SECONDS).eut(TierEU.RECIPE_HV)
                     .addTo(maceratorRecipes);
 
@@ -617,7 +616,7 @@ public class MaceratorRecipes implements Runnable {
                             NHItemList.OberonStoneDust.get(),
                             WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 2),
                             WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 2),
-                            GGMaterial.naquadahEarth.get(OrePrefixes.dust, 1))
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 1))
                     .outputChances(10000, 500, 250, 212).duration(20 * SECONDS).eut(TierEU.RECIPE_HV)
                     .addTo(maceratorRecipes);
 
@@ -626,7 +625,7 @@ public class MaceratorRecipes implements Runnable {
                             NHItemList.OberonStoneDust.get(),
                             WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 2),
                             WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 2),
-                            GGMaterial.naquadahEarth.get(OrePrefixes.dust, 1))
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 1))
                     .outputChances(10000, 500, 250, 212).duration(20 * SECONDS).eut(TierEU.RECIPE_HV)
                     .addTo(maceratorRecipes);
 
@@ -787,7 +786,7 @@ public class MaceratorRecipes implements Runnable {
                     .itemOutputs(
                             NHItemList.HaumeaStoneDust.get(),
                             GTOreDictUnificator.get(OrePrefixes.dust, Materials.InfusedGold, 1),
-                            GGMaterial.naquadahEarth.get(OrePrefixes.dust, 1),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.Naquadah, 1),
                             GTOreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 1))
                     .outputChances(10000, 1250, 625, 212).duration(20 * SECONDS).eut(TierEU.RECIPE_EV)
                     .addTo(maceratorRecipes);
@@ -796,7 +795,7 @@ public class MaceratorRecipes implements Runnable {
                     .itemOutputs(
                             NHItemList.CentauriASurfaceDust.get(),
                             WerkstoffLoader.IrLeachResidue.get(OrePrefixes.dust, 2),
-                            GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 1),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.NaquadahEnriched, 1),
                             GTOreDictUnificator.get(OrePrefixes.dust, Materials.Draconium, 1))
                     .outputChances(10000, 1250, 750, 250).duration(20 * SECONDS).eut(TierEU.RECIPE_IV / 2)
                     .addTo(maceratorRecipes);
@@ -805,7 +804,7 @@ public class MaceratorRecipes implements Runnable {
                     .itemOutputs(
                             NHItemList.CentauriAStoneDust.get(),
                             WerkstoffLoader.IrOsLeachResidue.get(OrePrefixes.dust, 2),
-                            GGMaterial.enrichedNaquadahEarth.get(OrePrefixes.dust, 1),
+                            GTOreDictUnificator.get(OrePrefixes.dust, Materials.NaquadahEnriched, 1),
                             GTOreDictUnificator.get(OrePrefixes.dust, Materials.Neutronium, 1))
                     .outputChances(10000, 1250, 750, 125).duration(20 * SECONDS).eut(TierEU.RECIPE_IV / 2)
                     .addTo(maceratorRecipes);


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
This change makes static the changes done by the NaquadahReworkRecipeLoader recipe scan loop of GT5U in memory.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
