### PR TITLE
Adjust open to lan warnings behavior

### DIFF
--- a/src/main/java/com/dreammaster/client/util/GTNHPauseScreen.java
+++ b/src/main/java/com/dreammaster/client/util/GTNHPauseScreen.java
@@ -31,6 +31,7 @@ public class GTNHPauseScreen {
     private static final int BUG_BUTTON_ID = -161518;
     private static final int WIKI_BUTTON_ID = -8998561;
 
+    private GuiButton shareToLANButton;
     private HoverChecker shareToLANButtonHoverChecker;
 
     @SuppressWarnings("unchecked")
@@ -57,9 +58,12 @@ public class GTNHPauseScreen {
         // TODO add credits page
 
         // find the Share To LAN button and attach a tooltip to it
+        shareToLANButton = null;
+        shareToLANButtonHoverChecker = null;
         for (Object element : event.buttonList) {
             if (element instanceof GuiButton button) {
                 if (button.id == 7) {
+                    shareToLANButton = button;
                     shareToLANButtonHoverChecker = new HoverChecker(button, 200);
                 }
             }
@@ -113,7 +117,7 @@ public class GTNHPauseScreen {
     }
 
     private void drawShareToLANButtonTooltip(GuiScreen gui, int x, int y) {
-        if (shareToLANButtonHoverChecker != null && shareToLANButtonHoverChecker.checkHover(x, y)) {
+        if (shareToLANButton != null && shareToLANButtonHoverChecker.checkHover(x, y, shareToLANButton.enabled)) {
             gui.func_146283_a(
                     Arrays.asList(
                             StatCollector.translateToLocal("dreamcraft.pausemenu.sharetolan.tooltip").split("\\\\n")),

--- a/src/main/java/com/dreammaster/mixin/mixins/early/MixinGuiShareToLan.java
+++ b/src/main/java/com/dreammaster/mixin/mixins/early/MixinGuiShareToLan.java
@@ -1,24 +1,26 @@
 package com.dreammaster.mixin.mixins.early;
 
+import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiShareToLan;
 import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.IChatComponent;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GuiShareToLan.class)
 public abstract class MixinGuiShareToLan extends GuiScreen {
 
-    @ModifyArg(
+    @Inject(
             method = "actionPerformed",
             at = @At(
                     value = "INVOKE",
-                    target = "Lnet/minecraft/client/gui/GuiNewChat;printChatMessage(Lnet/minecraft/util/IChatComponent;)V"))
-    public IChatComponent dreamcraft$changeShareToLANChatMessage(IChatComponent p_146227_1_) {
-
-        return new ChatComponentTranslation("dreamcraft.gui.sharetolan.message");
+                    target = "Lnet/minecraft/client/gui/GuiNewChat;printChatMessage(Lnet/minecraft/util/IChatComponent;)V",
+                    shift = At.Shift.AFTER))
+    private void dreamcraft$appendShareToLANChatMessage(GuiButton button, CallbackInfo ci) {
+        this.mc.ingameGUI.getChatGUI()
+                .printChatMessage(new ChatComponentTranslation("dreamcraft.gui.sharetolan.message"));
     }
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Before this PR, the warning was overwritting the vanilla message. Now it appends the warning to the vanilla message.
Another thing that was annoying me is that the warning message in the pause menu was displayed even when the Open to LAN button was hovered but greyed out (already opened lan, dedicated server). This PR also fixes this.
<img width="938" height="93" alt="image" src="https://github.com/user-attachments/assets/6028223e-83d4-48fb-8b6c-63476c42c83a" />

Tested in daily 672. closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26066

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
