### PR TITLE
update casing material and use cable other than wire

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -105,11 +105,11 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
         GTModHandler.addCraftingRecipe(
                 ItemList.Casing_UEV.get(1L),
                 GTModHandler.RecipeBits.BITS | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
-                new Object[] { "PPP", "PwP", "PPP", 'P', OrePrefixes.plate.get(Materials.Bedrockium) });
+                new Object[] { "PPP", "PwP", "PPP", 'P', OrePrefixes.plate.get(Materials.Infinity) });
         GTModHandler.addCraftingRecipe(
                 ItemList.Casing_UIV.get(1L),
                 GTModHandler.RecipeBits.BITS | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
-                new Object[] { "PPP", "PwP", "PPP", 'P', OrePrefixes.plate.get(Materials.BlackPlutonium) });
+                new Object[] { "PPP", "PwP", "PPP", 'P', OrePrefixes.plate.get(Materials.TranscendentMetal) });
         GTModHandler.addCraftingRecipe(
                 ItemList.Casing_UMV.get(1L),
                 GTModHandler.RecipeBits.BITS | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
@@ -1075,32 +1075,6 @@ public class GT_Loader_Machines {
                         OrePrefixes.cableGt08.get(Materials.NetherStar), 'O', ItemList.Reactor_Coolant_He_3, 'P',
                         ItemList.Electric_Pump_HV, 'T', ItemList.Transformer_HA_UIV_UEV });
 
-        GTModHandler.addCraftingRecipe(
-                ItemList.WetTransformer_UMV_UIV.get(1L),
-                GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
-                new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.BlackPlutonium), 'C',
-                        OrePrefixes.cableGt16.get(Materials.NetherStar), 'S',
-                        OrePrefixes.spring.get(Materials.Quantium), 'X', OrePrefixes.cableGt08.get(Materials.Quantium),
-                        'O', ItemList.Reactor_Coolant_He_6, 'P', ItemList.Electric_Pump_IV, 'T',
-                        ItemList.Transformer_HA_UMV_UIV });
-
-        GTModHandler.addCraftingRecipe(
-                ItemList.WetTransformer_UXV_UMV.get(1L),
-                GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
-                new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.SpaceTime), 'C',
-                        OrePrefixes.cableGt16.get(Materials.Quantium), 'S', OrePrefixes.spring.get(Materials.Infinity),
-                        'X', OrePrefixes.wireGt08.get(Materials.BlackPlutonium), 'O', ItemList.Reactor_Coolant_Sp_1,
-                        'P', ItemList.Electric_Pump_LuV, 'T', ItemList.Transformer_HA_UXV_UMV });
-
-        GTModHandler.addCraftingRecipe(
-                ItemList.WetTransformer_MAX_UXV.get(1L),
-                GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
-                new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Universium), 'C',
-                        OrePrefixes.wireGt16.get(Materials.BlackPlutonium), 'S',
-                        OrePrefixes.spring.get(Materials.SpaceTime), 'X', OrePrefixes.wireGt08.get(Materials.Infinity),
-                        'O', ItemList.Reactor_Coolant_Sp_2, 'P', ItemList.Electric_Pump_ZPM, 'T',
-                        ItemList.Transformer_HA_MAX_UXV });
-
         ItemStack[] inHatches = { ItemList.Hatch_Input_UEV.get(1), ItemList.Hatch_Input_UIV.get(1),
                 ItemList.Hatch_Input_UMV.get(1), ItemList.Hatch_Input_UXV.get(1), ItemList.Hatch_Input_MAX.get(1) };
         ItemStack[] outHatches = { ItemList.Hatch_Output_UEV.get(1), ItemList.Hatch_Output_UIV.get(1),

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
@@ -663,29 +663,29 @@ public class GT_Loader_Machines {
                 ItemList.Transformer_UEV_UHV.get(1L),
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_MAX, 'C',
-                        OrePrefixes.wireGt01.get(Materials.Draconium), 'B',
+                        OrePrefixes.cableGt01.get(Materials.Draconium), 'B',
                         OrePrefixes.wireGt04.get(Materials.SuperconductorUHV), 'K', ItemList.Circuit_Chip_PPIC });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_UIV_UEV.get(1L),
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_UEV, 'C',
-                        OrePrefixes.wireGt01.get(Materials.NetherStar), 'B',
-                        OrePrefixes.wireGt04.get(Materials.Draconium), 'K', ItemList.Circuit_Chip_QPIC });
+                        OrePrefixes.cableGt01.get(Materials.NetherStar), 'B',
+                        OrePrefixes.cableGt04.get(Materials.Draconium), 'K', ItemList.Circuit_Chip_QPIC });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_UMV_UIV.get(1L),
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_UIV, 'C',
-                        OrePrefixes.wireGt01.get(Materials.Quantium), 'B',
-                        OrePrefixes.wireGt04.get(Materials.NetherStar), 'K', ItemList.Circuit_Chip_FPIC });
+                        OrePrefixes.cableGt01.get(Materials.Quantium), 'B',
+                        OrePrefixes.cableGt04.get(Materials.NetherStar), 'K', ItemList.Circuit_Chip_FPIC });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_UXV_UMV.get(1L),
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_UMV, 'C',
                         OrePrefixes.wireGt01.get(Materials.BlackPlutonium), 'B',
-                        OrePrefixes.wireGt04.get(Materials.Quantium), 'K', ItemList.Circuit_Chip_APIC });
+                        OrePrefixes.cableGt04.get(Materials.Quantium), 'K', ItemList.Circuit_Chip_APIC });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Transformer_MAX_UXV.get(1L),
@@ -1054,7 +1054,7 @@ public class GT_Loader_Machines {
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.NaquadahAlloy), 'C',
                         OrePrefixes.cableGt16.get(Materials.NaquadahAlloy), 'S',
                         OrePrefixes.spring.get(Materials.Neutronium), 'X',
-                        OrePrefixes.wireGt08.get(Materials.Bedrockium), 'O', OrePrefixes.cell.get(Materials.Lubricant),
+                        OrePrefixes.cableGt08.get(Materials.Bedrockium), 'O', OrePrefixes.cell.get(Materials.Lubricant),
                         'P', ItemList.Electric_Pump_LV, 'T', GregtechItemList.Transformer_HA_MAX_UV.get(1) });
 
         GTModHandler.addCraftingRecipe(
@@ -1062,7 +1062,7 @@ public class GT_Loader_Machines {
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Neutronium), 'C',
                         OrePrefixes.wireGt16.get(Materials.SuperconductorUHV), 'S',
-                        OrePrefixes.spring.get(Materials.Draconium), 'X', OrePrefixes.wireGt08.get(Materials.Draconium),
+                        OrePrefixes.spring.get(Materials.Draconium), 'X', OrePrefixes.cableGt08.get(Materials.Draconium),
                         'O', ItemList.Reactor_Coolant_He_1, 'P', ItemList.Electric_Pump_MV, 'T',
                         ItemList.Transformer_HA_UEV_UHV });
 
@@ -1070,24 +1070,24 @@ public class GT_Loader_Machines {
                 ItemList.WetTransformer_UIV_UEV.get(1L),
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Draconium), 'C',
-                        OrePrefixes.wireGt16.get(Materials.Draconium), 'S',
+                        OrePrefixes.cableGt16.get(Materials.Draconium), 'S',
                         OrePrefixes.spring.get(Materials.BlackPlutonium), 'X',
-                        OrePrefixes.wireGt08.get(Materials.NetherStar), 'O', ItemList.Reactor_Coolant_He_3, 'P',
+                        OrePrefixes.cableGt08.get(Materials.NetherStar), 'O', ItemList.Reactor_Coolant_He_3, 'P',
                         ItemList.Electric_Pump_HV, 'T', ItemList.Transformer_HA_UIV_UEV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_UMV_UIV.get(1L),
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.BlackPlutonium), 'C',
-                        OrePrefixes.wireGt16.get(Materials.NetherStar), 'S', OrePrefixes.spring.get(Materials.Quantium),
-                        'X', OrePrefixes.wireGt08.get(Materials.Quantium), 'O', ItemList.Reactor_Coolant_He_6, 'P',
+                        OrePrefixes.cableGt16.get(Materials.NetherStar), 'S', OrePrefixes.spring.get(Materials.Quantium),
+                        'X', OrePrefixes.cableGt08.get(Materials.Quantium), 'O', ItemList.Reactor_Coolant_He_6, 'P',
                         ItemList.Electric_Pump_IV, 'T', ItemList.Transformer_HA_UMV_UIV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_UXV_UMV.get(1L),
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.SpaceTime), 'C',
-                        OrePrefixes.wireGt16.get(Materials.Quantium), 'S', OrePrefixes.spring.get(Materials.Infinity),
+                        OrePrefixes.cableGt16.get(Materials.Quantium), 'S', OrePrefixes.spring.get(Materials.Infinity),
                         'X', OrePrefixes.wireGt08.get(Materials.BlackPlutonium), 'O', ItemList.Reactor_Coolant_Sp_1,
                         'P', ItemList.Electric_Pump_LuV, 'T', ItemList.Transformer_HA_UXV_UMV });
 

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
@@ -1062,9 +1062,9 @@ public class GT_Loader_Machines {
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.Neutronium), 'C',
                         OrePrefixes.wireGt16.get(Materials.SuperconductorUHV), 'S',
-                        OrePrefixes.spring.get(Materials.Draconium), 'X', OrePrefixes.cableGt08.get(Materials.Draconium),
-                        'O', ItemList.Reactor_Coolant_He_1, 'P', ItemList.Electric_Pump_MV, 'T',
-                        ItemList.Transformer_HA_UEV_UHV });
+                        OrePrefixes.spring.get(Materials.Draconium), 'X',
+                        OrePrefixes.cableGt08.get(Materials.Draconium), 'O', ItemList.Reactor_Coolant_He_1, 'P',
+                        ItemList.Electric_Pump_MV, 'T', ItemList.Transformer_HA_UEV_UHV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_UIV_UEV.get(1L),
@@ -1079,9 +1079,10 @@ public class GT_Loader_Machines {
                 ItemList.WetTransformer_UMV_UIV.get(1L),
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "XOC", "STA", "POC", 'A', OrePrefixes.springSmall.get(Materials.BlackPlutonium), 'C',
-                        OrePrefixes.cableGt16.get(Materials.NetherStar), 'S', OrePrefixes.spring.get(Materials.Quantium),
-                        'X', OrePrefixes.cableGt08.get(Materials.Quantium), 'O', ItemList.Reactor_Coolant_He_6, 'P',
-                        ItemList.Electric_Pump_IV, 'T', ItemList.Transformer_HA_UMV_UIV });
+                        OrePrefixes.cableGt16.get(Materials.NetherStar), 'S',
+                        OrePrefixes.spring.get(Materials.Quantium), 'X', OrePrefixes.cableGt08.get(Materials.Quantium),
+                        'O', ItemList.Reactor_Coolant_He_6, 'P', ItemList.Electric_Pump_IV, 'T',
+                        ItemList.Transformer_HA_UMV_UIV });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.WetTransformer_UXV_UMV.get(1L),

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -1951,7 +1951,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.NaquadahAlloy, 4),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Bedrockium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Bedrockium, 1),
                         ItemList.Hull_UV.get(1),
                         ItemList.Circuit_Chip_NPIC.get(2))
                 .itemOutputs(ItemList.Transformer_MAX_UV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
@@ -1961,7 +1961,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.SuperconductorUHV, 4),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Draconium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Draconium, 1),
                         ItemList.Hull_MAX.get(1),
                         ItemList.Circuit_Chip_PPIC.get(2))
                 .itemOutputs(ItemList.Transformer_UEV_UHV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
@@ -1970,8 +1970,8 @@ public class AssemblerRecipes implements Runnable {
         // UEV Transformer
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Draconium, 4),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.NetherStar, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt04, Materials.Draconium, 4),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.NetherStar, 1),
                         ItemList.Hull_UEV.get(1),
                         ItemList.Circuit_Chip_QPIC.get(2))
                 .itemOutputs(ItemList.Transformer_UIV_UEV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
@@ -1980,8 +1980,8 @@ public class AssemblerRecipes implements Runnable {
         // UIV Transformer
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.NetherStar, 4),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Quantium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt04, Materials.NetherStar, 4),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.Quantium, 1),
                         ItemList.Hull_UIV.get(1),
                         ItemList.Circuit_Chip_FPIC.get(2))
                 .itemOutputs(ItemList.Transformer_UMV_UIV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
@@ -1990,7 +1990,7 @@ public class AssemblerRecipes implements Runnable {
         // UMV Transformer
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Quantium, 4),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt04, Materials.Quantium, 4),
                         GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.BlackPlutonium, 1),
                         ItemList.Hull_UMV.get(1),
                         ItemList.Circuit_Chip_APIC.get(2))
@@ -2244,7 +2244,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.cableGt16, Materials.NaquadahAlloy, 2),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Bedrockium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt08, Materials.Bedrockium, 1),
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.Neutronium, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.NaquadahAlloy, 1),
                         GregtechItemList.Transformer_HA_MAX_UV.get(1),
@@ -2256,7 +2256,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.SuperconductorUHV, 2),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Draconium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt08, Materials.Draconium, 1),
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.Draconium, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.Neutronium, 1),
                         ItemList.Transformer_HA_UEV_UHV.get(1),
@@ -2268,8 +2268,8 @@ public class AssemblerRecipes implements Runnable {
         // 64A UEV transformer
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.Draconium, 2),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.NetherStar, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt16, Materials.Draconium, 2),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt08, Materials.NetherStar, 1),
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.BlackPlutonium, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.Draconium, 1),
                         ItemList.Transformer_HA_UIV_UEV.get(1),
@@ -2281,8 +2281,8 @@ public class AssemblerRecipes implements Runnable {
         // 64A UIV transformer
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.NetherStar, 2),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Quantium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt16, Materials.NetherStar, 2),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt08, Materials.Quantium, 1),
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.Quantium, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.BlackPlutonium, 1),
                         ItemList.Transformer_HA_UMV_UIV.get(1),
@@ -2294,8 +2294,8 @@ public class AssemblerRecipes implements Runnable {
         // 64A UMV transformer
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.Quantium, 2),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.BlackPlutonium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt16, Materials.Quantium, 2),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt08, Materials.BlackPlutonium, 1),
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.Infinity, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.SpaceTime, 1),
                         ItemList.Transformer_HA_UXV_UMV.get(1),

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2286,9 +2286,9 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.Quantium, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.BlackPlutonium, 1),
                         ItemList.Transformer_HA_UMV_UIV.get(1),
-                        ItemList.Electric_Pump_IV.get(1),
-                        ItemList.Reactor_Coolant_He_6.get(2))
-                .itemOutputs(ItemList.WetTransformer_UMV_UIV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
+                        ItemList.Electric_Pump_IV.get(1))
+                .fluidInputs(Materials.DimensionallyShiftedSuperfluid.getFluid(2000L))
+                .itemOutputs(ItemList.WetTransformer_UMV_UIV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_UEV)
                 .addTo(assemblerRecipes);
 
         // 64A UMV transformer
@@ -2299,9 +2299,9 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.Infinity, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.SpaceTime, 1),
                         ItemList.Transformer_HA_UXV_UMV.get(1),
-                        ItemList.Electric_Pump_LuV.get(1),
-                        ItemList.Reactor_Coolant_Sp_1.get(2))
-                .itemOutputs(ItemList.WetTransformer_UXV_UMV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
+                        ItemList.Electric_Pump_LuV.get(1))
+                .fluidInputs(Materials.DimensionallyShiftedSuperfluid.getFluid(8000L))
+                .itemOutputs(ItemList.WetTransformer_UXV_UMV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_UIV)
                 .addTo(assemblerRecipes);
 
         // 64A UXV transformer
@@ -2312,9 +2312,9 @@ public class AssemblerRecipes implements Runnable {
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.SpaceTime, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.Universium, 1),
                         ItemList.Transformer_HA_MAX_UXV.get(1),
-                        ItemList.Electric_Pump_ZPM.get(1),
-                        ItemList.Reactor_Coolant_Sp_2.get(2))
-                .itemOutputs(ItemList.WetTransformer_MAX_UXV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
+                        ItemList.Electric_Pump_ZPM.get(1))
+                .fluidInputs(Materials.DimensionallyShiftedSuperfluid.getFluid(32_000L))
+                .itemOutputs(ItemList.WetTransformer_MAX_UXV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_UMV)
                 .addTo(assemblerRecipes);
 
         // Tesla Coil

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -802,11 +802,11 @@ public class AssemblerRecipes implements Runnable {
 
         // UEV-UXV casings+hulls
 
-        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Bedrockium, 8))
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.Infinity, 8))
                 .circuit(8).itemOutputs(ItemList.Casing_UEV.get(1L)).duration(2 * SECONDS + 10 * TICKS)
                 .eut(TierEU.RECIPE_LV / 2).addTo(assemblerRecipes);
 
-        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.BlackPlutonium, 8L))
+        GTValues.RA.stdBuilder().itemInputs(GTOreDictUnificator.get(OrePrefixes.plate, Materials.TranscendentMetal, 8L))
                 .circuit(8).itemOutputs(ItemList.Casing_UIV.get(1L)).duration(2 * SECONDS + 10 * TICKS)
                 .eut(TierEU.RECIPE_LV / 2).addTo(assemblerRecipes);
 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
discussion is here:
https://discord.com/channels/181078474394566657/401118216228831252/1539747211632451665

as hi-amp transformers and multiamp hatches are already in line with each other so I did not change
did not see the issue with diodes

also as cloud pointed out that uev and uiv casings are outdated, so updated as well

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
