### PR TITLE
Add Black Plutonium Cables

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Wires.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Wires.java
@@ -37,7 +37,7 @@ public class GT_Loader_Wires {
         makeWires(Materials.Draconium, 11330, 32L, 64L, 8L, GTValues.V[10], true, false);
         makeWires(Materials.NetherStar, 11350, 16L, 32L, 4L, GTValues.V[11], true, false);
         makeWires(Materials.Quantium, 11370, 32L, 128L, 4L, GTValues.V[12], true, false);
-        makeWires(Materials.BlackPlutonium, 11390, 8L, 8L, 8L, GTValues.V[13], false, false);
+        makeWires(Materials.BlackPlutonium, 11390, 8L, 8L, 8L, GTValues.V[13], true, false);
         makeWires(Materials.DraconiumAwakened, 11410, 64L, 64L, 8L, GTValues.V[14], false, false);
         makeWires(Materials.Infinity, 11430, 0L, 0L, 8192L, GTValues.V[14], false, true);
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2295,7 +2295,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.cableGt16, Materials.Quantium, 2),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.BlackPlutonium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt08, Materials.BlackPlutonium, 1),
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.Infinity, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.SpaceTime, 1),
                         ItemList.Transformer_HA_UXV_UMV.get(1),

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -2295,7 +2295,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.cableGt16, Materials.Quantium, 2),
-                        GTOreDictUnificator.get(OrePrefixes.cableGt08, Materials.BlackPlutonium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.BlackPlutonium, 1),
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.Infinity, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.SpaceTime, 1),
                         ItemList.Transformer_HA_UXV_UMV.get(1),


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
This PR is crashing daily because black plutonium cables don't exist: https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1916

Well... at least they didn't ;). I was going to switch it back to wires but it would break the theme and I figure what's the harm in more cable options.

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
