### PR TITLE
Replace epoxy circuit board with plastic circuit board

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptProjectRed.java
@@ -1497,7 +1497,7 @@ public class ScriptProjectRed implements IScriptLoader {
                 .eut(TierEU.RECIPE_LV).requireMods(ProjectRedFabrication).addTo(assemblerRecipes);
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        ItemList.Circuit_Board_Epoxy.get(1L),
+                        ItemList.Circuit_Board_Plastic.get(1L),
                         GTOreDictUnificator.get(OrePrefixes.plate, Materials.Lapis, 4L))
                 .itemOutputs(getModItem(ProjectRedFabrication.ID, "projectred.fabrication.icblueprint", 1, 0))
                 .fluidInputs(FluidRegistry.getFluidStack("molten.redstone", 144)).duration(30 * SECONDS)


### PR DESCRIPTION
## Summary
The "IC Workbench" and "IC Printer" are made at the LV tier, but they can't be used for anything without the "IC Blueprint". I propose lowering the recipe from the epoxy board to the plastic one, so people can start making circuits with them earlier.

## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
