### PR TITLE
changes around uxv cable

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -137,14 +137,14 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
         GTOreDictUnificator.addItemDataFromInputs(
                 ItemList.Hull_UMV.get(1L),
                 ItemList.Casing_UMV.get(1L),
-                OrePrefixes.wireGt12.get(Materials.Quantium),
-                OrePrefixes.wireGt12.get(Materials.Quantium));
+                OrePrefixes.cableGt12.get(Materials.Quantium),
+                OrePrefixes.cableGt12.get(Materials.Quantium));
 
         GTOreDictUnificator.addItemDataFromInputs(
                 ItemList.Hull_UXV.get(1L),
                 ItemList.Casing_UXV.get(1L),
-                OrePrefixes.wireGt16.get(Materials.BlackPlutonium),
-                OrePrefixes.wireGt16.get(Materials.BlackPlutonium));
+                OrePrefixes.cableGt16.get(Materials.BlackPlutonium),
+                OrePrefixes.cableGt16.get(Materials.BlackPlutonium));
 
         // Mine and Blade Battlegear remove recipes NBT?
         Object[] o = new Object[0];
@@ -1027,28 +1027,28 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
                         BITSD,
                         new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GTOreDictUnificator
-                                        .get(i < 13 ? OrePrefixes.cableGt12 : OrePrefixes.wireGt12, cable, 1L),
+                                        .get(i < 14 ? OrePrefixes.cableGt12 : OrePrefixes.wireGt12, cable, 1L),
                                 'P', hull, 'C', machinehull });
                 GTModHandler.addCraftingRecipe(
                         ItemRegistry.diode8A[i],
                         BITSD,
                         new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GTOreDictUnificator
-                                        .get(i < 13 ? OrePrefixes.cableGt08 : OrePrefixes.wireGt08, cable, 1L),
+                                        .get(i < 14 ? OrePrefixes.cableGt08 : OrePrefixes.wireGt08, cable, 1L),
                                 'P', hull, 'C', machinehull });
                 GTModHandler.addCraftingRecipe(
                         ItemRegistry.diode4A[i],
                         BITSD,
                         new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GTOreDictUnificator
-                                        .get(i < 13 ? OrePrefixes.cableGt04 : OrePrefixes.wireGt04, cable, 1L),
+                                        .get(i < 14 ? OrePrefixes.cableGt04 : OrePrefixes.wireGt04, cable, 1L),
                                 'P', hull, 'C', machinehull });
                 GTModHandler.addCraftingRecipe(
                         ItemRegistry.diode2A[i],
                         BITSD,
                         new Object[] { "WDW", "DCD", "PDP", 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GTOreDictUnificator
-                                        .get(i < 13 ? OrePrefixes.cableGt02 : OrePrefixes.wireGt02, cable, 1L),
+                                        .get(i < 14 ? OrePrefixes.cableGt02 : OrePrefixes.wireGt02, cable, 1L),
                                 'P', hull, 'C', machinehull });
                 GTModHandler.addCraftingRecipe(
                         ItemRegistry.diode16A[i],
@@ -1056,7 +1056,7 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
                         new Object[] { "WHW", "DCD", "PDP", 'H', OrePrefixes.componentCircuit.get(Materials.Inductor),
                                 'D', OrePrefixes.componentCircuit.get(Materials.Diode), 'W',
                                 GTOreDictUnificator
-                                        .get(i < 13 ? OrePrefixes.cableGt16 : OrePrefixes.wireGt16, cable, 1L),
+                                        .get(i < 14 ? OrePrefixes.cableGt16 : OrePrefixes.wireGt16, cable, 1L),
                                 'P', hull, 'C', machinehull });
 
             } catch (ArrayIndexOutOfBoundsException e) {

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Machines.java
@@ -74,9 +74,8 @@ public class GT_Loader_Machines {
                 GTModHandler.RecipeBits.BUFFERED | GTModHandler.RecipeBits.NOT_REMOVABLE
                         | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "PHP", "WMW", 'M', ItemList.Casing_UEV, 'W',
-                        OrePrefixes.cableGt08.get(Materials.Draconium), 'H',
-                        OrePrefixes.plate.get(Materials.Bedrockium), 'P',
-                        OrePrefixes.plateDouble.get(Materials.Polybenzimidazole) });
+                        OrePrefixes.cableGt08.get(Materials.Draconium), 'H', OrePrefixes.plate.get(Materials.Infinity),
+                        'P', OrePrefixes.plateDouble.get(Materials.Polybenzimidazole) });
 
         GTModHandler.addCraftingRecipe(
                 ItemList.Hull_UIV.get(1L),
@@ -84,7 +83,7 @@ public class GT_Loader_Machines {
                         | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "PHP", "WMW", 'M', ItemList.Casing_UIV, 'W',
                         OrePrefixes.cableGt08.get(Materials.NetherStar), 'H',
-                        OrePrefixes.plate.get(Materials.BlackPlutonium), 'P',
+                        OrePrefixes.plate.get(Materials.TranscendentMetal), 'P',
                         OrePrefixes.plateDouble.get(Materials.Polybenzimidazole) });
 
         GTModHandler.addCraftingRecipe(
@@ -100,7 +99,7 @@ public class GT_Loader_Machines {
                 GTModHandler.RecipeBits.BUFFERED | GTModHandler.RecipeBits.NOT_REMOVABLE
                         | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "PHP", "WMW", 'M', ItemList.Casing_UXV, 'W',
-                        OrePrefixes.wireGt16.get(Materials.BlackPlutonium), 'H',
+                        OrePrefixes.cableGt16.get(Materials.BlackPlutonium), 'H',
                         OrePrefixes.plate.get(Materials.MHDCSM), 'P', OrePrefixes.plateDense.get(Materials.Kevlar) });
 
         GTModHandler.addCraftingRecipe(
@@ -684,7 +683,7 @@ public class GT_Loader_Machines {
                 ItemList.Transformer_UXV_UMV.get(1L),
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_UMV, 'C',
-                        OrePrefixes.wireGt01.get(Materials.BlackPlutonium), 'B',
+                        OrePrefixes.cableGt01.get(Materials.BlackPlutonium), 'B',
                         OrePrefixes.cableGt04.get(Materials.Quantium), 'K', ItemList.Circuit_Chip_APIC });
 
         GTModHandler.addCraftingRecipe(
@@ -692,7 +691,7 @@ public class GT_Loader_Machines {
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,
                 new Object[] { "KBB", "CM ", "KBB", 'M', ItemList.Hull_UXV, 'C',
                         OrePrefixes.wireGt01.get(Materials.Infinity), 'B',
-                        OrePrefixes.wireGt04.get(Materials.BlackPlutonium), 'K', ItemList.Circuit_Chip_ZPIC });
+                        OrePrefixes.cableGt04.get(Materials.BlackPlutonium), 'K', ItemList.Circuit_Chip_ZPIC });
         GTModHandler.addCraftingRecipe(
                 ItemList.Battery_Buffer_4by4_UEV.get(1L),
                 GTModHandler.RecipeBits.BITSD | GTModHandler.RecipeBits.DO_NOT_CHECK_FOR_COLLISIONS,

--- a/src/main/java/com/dreammaster/gthandler/GT_Loader_Wires.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_Loader_Wires.java
@@ -37,7 +37,7 @@ public class GT_Loader_Wires {
         makeWires(Materials.Draconium, 11330, 32L, 64L, 8L, GTValues.V[10], true, false);
         makeWires(Materials.NetherStar, 11350, 16L, 32L, 4L, GTValues.V[11], true, false);
         makeWires(Materials.Quantium, 11370, 32L, 128L, 4L, GTValues.V[12], true, false);
-        makeWires(Materials.BlackPlutonium, 11390, 8L, 8L, 8L, GTValues.V[13], true, false);
+        makeWires(Materials.BlackPlutonium, 11390, 8L, 32L, 8L, GTValues.V[13], true, false);
         makeWires(Materials.DraconiumAwakened, 11410, 64L, 64L, 8L, GTValues.V[14], false, false);
         makeWires(Materials.Infinity, 11430, 0L, 0L, 8192L, GTValues.V[14], false, true);
 

--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -844,7 +844,7 @@ public class AssemblerRecipes implements Runnable {
 
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.BlackPlutonium, 2L),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt16, Materials.BlackPlutonium, 2L),
                         ItemList.Casing_UXV.get(1L))
                 .itemOutputs(ItemList.Hull_UXV.get(1L)).fluidInputs(Materials.Kevlar.getMolten(576L))
                 .duration(2 * SECONDS + 10 * TICKS).eut(TierEU.RECIPE_LV / 2).addTo(assemblerRecipes);
@@ -1991,7 +1991,7 @@ public class AssemblerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.cableGt04, Materials.Quantium, 4),
-                        GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.BlackPlutonium, 1),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt01, Materials.BlackPlutonium, 1),
                         ItemList.Hull_UMV.get(1),
                         ItemList.Circuit_Chip_APIC.get(2))
                 .itemOutputs(ItemList.Transformer_UXV_UMV.get(1)).duration(5 * SECONDS).eut(TierEU.RECIPE_LV)
@@ -2000,7 +2000,7 @@ public class AssemblerRecipes implements Runnable {
         // UXV Transformer
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.BlackPlutonium, 4),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt04, Materials.BlackPlutonium, 4),
                         GTOreDictUnificator.get(OrePrefixes.wireGt01, Materials.Infinity, 1),
                         ItemList.Hull_UXV.get(1),
                         ItemList.Circuit_Chip_ZPIC.get(2))
@@ -2307,7 +2307,7 @@ public class AssemblerRecipes implements Runnable {
         // 64A UXV transformer
         GTValues.RA.stdBuilder()
                 .itemInputs(
-                        GTOreDictUnificator.get(OrePrefixes.wireGt16, Materials.BlackPlutonium, 2),
+                        GTOreDictUnificator.get(OrePrefixes.cableGt16, Materials.BlackPlutonium, 2),
                         GTOreDictUnificator.get(OrePrefixes.wireGt08, Materials.Infinity, 1),
                         GTOreDictUnificator.get(OrePrefixes.spring, Materials.SpaceTime, 1),
                         GTOreDictUnificator.get(OrePrefixes.springSmall, Materials.Universium, 1),


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
while prev breaking daily was from adding black plutonium cable to uxv 64a transformer, and with another pr https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1918 added black plutonium cable, now nerf the black plutonium wire on its cable loss, 8 -> 32 EU/m, cable remained 8EU/m loss
then made uxv hulls, uxv energy distributors and uxv diodes to need black plutonium cables

also cleaned up the miss with last pr https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/1916, made the uev and uiv hull workbench recipes to need an extra infinity/transcendent metal plate to make

<details>

UEV machine hull
<img width="341" height="227" alt="Screenshot 2026-08-23 at 14 52 56" src="https://github.com/user-attachments/assets/6da6a666-647d-4563-bb22-3e3383c58e52" />

UIV machine hull
<img width="341" height="214" alt="Screenshot 2026-08-23 at 14 53 03" src="https://github.com/user-attachments/assets/d6a1822f-0cf1-47d4-b4fb-84a2a2a1ef98" />

UXV machine hull
<img width="492" height="259" alt="Screenshot 2026-08-23 at 14 52 42" src="https://github.com/user-attachments/assets/5c2c7f91-6d82-4b24-913f-c1332e767f8a" />

UXV_UMV transformer
<img width="350" height="232" alt="Screenshot 2026-08-23 at 14 54 08" src="https://github.com/user-attachments/assets/ba041057-aa7a-4e19-b105-2d834ad9b0e9" />
<img width="349" height="317" alt="Screenshot 2026-08-23 at 14 54 17" src="https://github.com/user-attachments/assets/4e5e8156-ba10-4ade-85af-74f49cdd34b3" />

MAX_UXV transformer
<img width="415" height="296" alt="Screenshot 2026-08-23 at 14 54 27" src="https://github.com/user-attachments/assets/51b59785-8433-4b4c-882c-7235eb081a57" />
<img width="317" height="307" alt="Screenshot 2026-08-23 at 14 54 32" src="https://github.com/user-attachments/assets/4a4b7e19-c4c9-426c-8d8a-8cca88bdd937" />

UXV diode
<img width="412" height="266" alt="Screenshot 2026-08-23 at 14 55 43" src="https://github.com/user-attachments/assets/284acd87-9790-4ae9-9d52-d0c1c276eefb" />

</details>

## Checklist
- [ ] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
