### PR TITLE
Fix hollow hill mob spawns being lost after relog

### DIFF
--- a/src/main/java/com/dreammaster/TwilightForest/TwilightForestMajorFeatureOverride.java
+++ b/src/main/java/com/dreammaster/TwilightForest/TwilightForestMajorFeatureOverride.java
@@ -35,7 +35,10 @@ public class TwilightForestMajorFeatureOverride {
         return null;
     }
 
-    private static class ComponentGregtechHollowHill extends ComponentTFHollowHill {
+    public static class ComponentGregtechHollowHill extends ComponentTFHollowHill {
+
+        @SuppressWarnings("unused")
+        public ComponentGregtechHollowHill() {}
 
         public ComponentGregtechHollowHill(World world, Random rand, int i, int size, int x, int y, int z) {
             super(world, rand, i, size, x, y, z);


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
Resolves GTNewHorizons/GT-New-Horizons-Modpack#25770

Previously the structure piece failed to load, meaning mobs specific to hills couldn't spawn. This was due to a missing constructor and wrong visibility. This fixes that.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
