### PR TITLE
Armor: Fix recipe balancing/gating 

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptTCCoreMod.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptTCCoreMod.java
@@ -1235,7 +1235,7 @@ public class ScriptTCCoreMod implements IScriptLoader {
                         .add(Aspect.MAGIC, 32).add(Aspect.TRAVEL, 32).add(Aspect.ARMOR, 24),
 
                 ItemList.Armor_Chip_T1.get(1),
-                NHItemList.QuantumCrystal.get(1),
+                NHItemList.NanoCrystal.get(1),
                 GTOreDictUnificator.get(OrePrefixes.plateDense, Materials.StainlessSteel, 1),
                 GTOreDictUnificator.get(OrePrefixes.wireGt04, Materials.Electrum, 1),
                 ItemList.Field_Generator_LV.get(1),


### PR DESCRIPTION
Apprentice Striders Augment recipe should be HV, it's currently EV though due to the quantum crystal. (The arcane recipe is also HV)

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
