### PR TITLE
Don't add nasa bench recipe sometimes (VaraibleHorizons compat)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,6 +40,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:ForbiddenMagic:0.9.17-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:MagicBees:2.10.12-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:GTNH-TC-Wands:1.4.14:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Variable-Horizons:0.1.00:dev") { transitive = false }
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:WailaHarvestability:1.3.6-GTNH:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Galacticraft:3.4.33-GTNH:dev")

--- a/src/main/java/com/dreammaster/scripts/ScriptGalaxySpace.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalaxySpace.java
@@ -11,6 +11,7 @@ import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.OpenComputers;
 import static gregtech.api.enums.Mods.OpenModularTurrets;
 import static gregtech.api.enums.Mods.TinkerConstruct;
+import static gregtech.api.enums.Mods.VariableHorizons;
 import static gregtech.api.recipe.RecipeMaps.arcFurnaceRecipes;
 import static gregtech.api.recipe.RecipeMaps.assemblerRecipes;
 import static gregtech.api.recipe.RecipeMaps.autoclaveRecipes;
@@ -32,6 +33,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidRegistry;
 
+import com.LazyFlesh.variablehorizons.variants.VariantNames;
 import com.dreammaster.block.BlockList;
 import com.dreammaster.item.NHItemList;
 
@@ -794,7 +796,9 @@ public class ScriptGalaxySpace implements IScriptLoader {
                 'C',
                 OrePrefixes.circuit.get(Materials.EV));
 
-        if (OpenModularTurrets.isModLoaded()) {
+        if (OpenModularTurrets.isModLoaded()
+                && !(VariableHorizons.isModLoaded() && VariantNames.activeContains(VariantNames.NO_ROCKET.id))) {
+            // don't add nasa bench recipe if NoRocket is active 
             addShapedRecipe(
                     new ItemStack(GCBlocks.nasaWorkbench),
                     "RRR",

--- a/src/main/java/com/dreammaster/scripts/ScriptGalaxySpace.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptGalaxySpace.java
@@ -798,7 +798,7 @@ public class ScriptGalaxySpace implements IScriptLoader {
 
         if (OpenModularTurrets.isModLoaded()
                 && !(VariableHorizons.isModLoaded() && VariantNames.activeContains(VariantNames.NO_ROCKET.id))) {
-            // don't add nasa bench recipe if NoRocket is active 
+            // don't add nasa bench recipe if NoRocket is active
             addShapedRecipe(
                     new ItemStack(GCBlocks.nasaWorkbench),
                     "RRR",


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

Don't add Nasa bench recipe when VariableHorizons is loaded and NoRocket is active.
This is alternative to doing a recipe removal when pack is done loading. 

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
