### PR TITLE
Fixed switchboard recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/AssemblerRecipes.java
@@ -9718,7 +9718,7 @@ public class AssemblerRecipes implements Runnable {
                     .itemInputs(
                             ItemList.Circuit_Board_Epoxy_Advanced.get(1L),
                             getModItem(OpenComputers.ID, "item", 2, 24),
-                            new ItemStack(Blocks.stone_button, 64, 30720),
+                            new ItemStack(Blocks.stone_button, 64),
                             GTOreDictUnificator.get(OrePrefixes.plate, Materials.Glass, 2L),
                             ItemList.Dye_SquidInk.get(4L))
                     .circuit(1).itemOutputs(getModItem(Computronics.ID, "computronics.ocParts", 1, 13))


### PR DESCRIPTION
## Summary
Idk why the buttons in the recipe had this weird meta value.

Closes [Issue 26544](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26544)

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
