### PR TITLE
Fix enderium base dust mixer dust ratio

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/MixerRecipes.java
@@ -428,9 +428,9 @@ public class MixerRecipes implements Runnable {
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         GTOreDictUnificator.get(OrePrefixes.dust, Materials.Tin, 2L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Silver, 1L),
-                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Platinum, 1L))
-                .circuit(2).itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.EnderiumBase, 4L))
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Silver, 2L),
+                        GTOreDictUnificator.get(OrePrefixes.dust, Materials.Platinum, 2L))
+                .circuit(2).itemOutputs(GTOreDictUnificator.get(OrePrefixes.dust, Materials.EnderiumBase, 6L))
                 .duration(20 * SECONDS).eut(TierEU.RECIPE_ULV).addTo(mixerRecipes);
 
         GTValues.RA.stdBuilder()


### PR DESCRIPTION
## Summary
Mixer ratio for enderium base dust was wrong, allowing you to dupe platinum.
<img width="975" height="550" alt="image" src="https://github.com/user-attachments/assets/741f4c2c-390f-4c7c-83fb-92365f05673f" />
<img width="775" height="471" alt="image" src="https://github.com/user-attachments/assets/c580c6c0-6743-44e5-b662-2b568647b025" />

Adjusted the mixer ratio to match the chemical formula (2/2/2 -> 6)

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
