### PR TITLE
Add a sponge recipe

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/recipes/ChemicalBathRecipes.java
+++ b/src/main/java/com/dreammaster/gthandler/recipes/ChemicalBathRecipes.java
@@ -9,6 +9,7 @@ import static gregtech.api.enums.Mods.HardcoreEnderExpansion;
 import static gregtech.api.enums.Mods.IndustrialCraft2;
 import static gregtech.api.enums.Mods.LogisticsPipes;
 import static gregtech.api.enums.Mods.Minecraft;
+import static gregtech.api.enums.Mods.OpenBlocks;
 import static gregtech.api.enums.Mods.OpenModularTurrets;
 import static gregtech.api.enums.Mods.PamsHarvestCraft;
 import static gregtech.api.enums.Mods.StevesCarts2;
@@ -416,6 +417,11 @@ public class ChemicalBathRecipes implements Runnable {
                     .itemOutputs(getModItem(StevesCarts2.ID, "ModuleComponents", 1, 65))
                     .fluidInputs(FluidRegistry.getFluidStack("dye.watermixed.dyegreen", 864)).duration(10 * SECONDS)
                     .eut(2).addTo(chemicalBathRecipes);
+        }
+        if (OpenBlocks.isModLoaded()) {
+            GTValues.RA.stdBuilder().itemInputs(getModItem(OpenBlocks.ID, "sponge", 1))
+                    .fluidInputs(FluidRegistry.getFluidStack("dye.chemical.dyeyellow", 576))
+                    .itemOutputs(new ItemStack(Blocks.sponge, 1)).duration(100).eut(16).addTo(chemicalBathRecipes);
         }
     }
 }


### PR DESCRIPTION
## Summary
uses openblock's sponge (which has a chemical reactor recipe) and yellow dye
The recipe is taken from GT Not Leisure addon
<img width="689" height="792" alt="image" src="https://github.com/user-attachments/assets/f0ecf80c-e276-4bc9-918d-0acea7caadad" />



## Checklist
- [X] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
