### PR TITLE
[NAC] Rework NAC power consumption

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -522,8 +522,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // Elite Board
         GTValues.RA.stdBuilder().hidden().metadata(BoardProcessingModuleFluidKey.INSTANCE, 1)
                 .itemInputs(CircuitComponent.BoardMultifiberglassElite.getFakeStack(1))
-                .itemOutputs(CircuitComponent.ProcessedBoardMultifiberglassElite.getFakeStack(1)).duration(25 * SECONDS)
-                .eut(TierEU.RECIPE_UHV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
+                .itemOutputs(CircuitComponent.ProcessedBoardMultifiberglassElite.getFakeStack(1)).duration(10 * SECONDS)
+                .eut(TierEU.RECIPE_UV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
 
         // Elite Board fake recipe
         GTValues.RA.stdBuilder().fake().itemInputs(CircuitComponent.BoardMultifiberglassElite.getFakeStack(1))
@@ -843,7 +843,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // Crystal
         GTValues.RA.stdBuilder().itemInputs(CircuitComponent.ProcessedFrameboxAluminium.getFakeStack(2))
                 .itemOutputs(CircuitComponent.ProcessedBasicMainframeCasing.getFakeStack(1))
-                .duration(22 * SECONDS + 10 * TICKS).eut(TierEU.RECIPE_UIV).addTo(RecipeMaps.nanochipEncasementWrapper);
+                .duration(20 * SECONDS).eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipEncasementWrapper);
 
         // Wetware, Bioware, Optical
         GTValues.RA.stdBuilder()
@@ -957,8 +957,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.ChipCrystalSoC,
                 CircuitComponent.ProcessedChipCrystalSoC,
-                TierEU.RECIPE_UEV,
-                22 * SECONDS + 10 * TICKS,
+                TierEU.RECIPE_UV,
+                40 * SECONDS,
                 RecipeMaps.nanochipEtchingArray);
     }
 
@@ -1059,8 +1059,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.SuperconductorLuV,
                 CircuitComponent.ProcessedSuperconductorLuV,
-                TierEU.RECIPE_UHV,
-                22 * SECONDS + 10 * TICKS,
+                TierEU.RECIPE_UV,
+                10 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // ZPM
@@ -1192,22 +1192,22 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // Crystal // todo 3810s UHV of power per mainframe
         // ======= // todo already removed 3170s UHV
 
-        // todo 75% non-matrix, 25% matrix
+        // todo 80% non-matrix, 20% matrix
         // todo 2857.5 UHV non-matrix, 952.5 UHV matrix
         // todo 9.375% per non-matrix module, 18.75% etching
         // todo applied a 33% discount to the time
 
         // todo matrix should be 628 UHV
-        // todo 14 board @ 377 UHV    -> 25s UHV ea.
-        // todo 1 encasement          -> 22.5s UIV ea.
-        // todo 16 supercon @ 377 UHV -> 22.5s UHV ea.
-        // todo 8 SoC @ 1142.8 UHV    -> 90s UHV ea.
+        // todo 14 board @ 377 UHV    -> 10s UV ea.
+        // todo 1 encasement          -> 10s UEV ea.
+        // todo 16 supercon @ 377 UHV -> 10s UV ea.
+        // todo 8 SoC @ 1142.8 UHV    -> 40s UV ea.
 
         // todo 40 15 ways
-        // todo IV  = 20s UHV  -> 5s UEV
-        // todo LuV = 40s UHV  -> 10s UEV
-        // todo ZPM = 80s UHV  -> 20s UEV
-        // todo UV  = 160s UHV -> 40s UEV
+        // todo IV  = 20s UHV  -> 2.5s UHV
+        // todo LuV = 40s UHV  -> 5s UHV
+        // todo ZPM = 80s UHV  -> 10s UHV
+        // todo UV  = 160s UHV -> 20s UHV
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1217,8 +1217,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedBoltYttriumBariumCuprate, 4)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(4)),
                 CircuitComponent.CrystalProcessor,
-                5 * SECONDS,
-                TierEU.RECIPE_UEV,
+                2 * SECONDS + 10 * TICKS,
+                TierEU.RECIPE_UHV,
                 VoltageIndex.UV);
 
         addAssemblyMatrixRecipe(
@@ -1231,8 +1231,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedWireNiobiumTitanium, 16)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(9)),
                 CircuitComponent.CrystalAssembly,
-                10 * SECONDS,
-                TierEU.RECIPE_UEV,
+                5 * SECONDS,
+                TierEU.RECIPE_UHV,
                 VoltageIndex.UV);
 
         addAssemblyMatrixRecipe(
@@ -1245,8 +1245,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedWireNiobiumTitanium, 32)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(9)),
                 CircuitComponent.CrystalComputer,
-                20 * SECONDS,
-                TierEU.RECIPE_UEV,
+                10 * SECONDS,
+                TierEU.RECIPE_UHV,
                 VoltageIndex.UV);
 
         addAssemblyMatrixRecipe(
@@ -1259,8 +1259,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedSuperconductorLuV, 16)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(18)),
                 CircuitComponent.CrystalMainframe,
-                40 * SECONDS,
-                TierEU.RECIPE_UEV,
+                20 * SECONDS,
+                TierEU.RECIPE_UHV,
                 VoltageIndex.UV);
 
         // ======= //

--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -1189,25 +1189,28 @@ public class ScriptNanochipRecipes implements IScriptLoader {
     // spotless:off
     private static void registerAssemblyMatrixRecipes() {
         // ======= //
-        // Crystal // todo 3810s UHV of power per mainframe
-        // ======= // todo already removed 3170s UHV
+        // Crystal //
+        // ======= //
 
-        // todo 80% non-matrix, 20% matrix
-        // todo 2857.5 UHV non-matrix, 952.5 UHV matrix
-        // todo 9.375% per non-matrix module, 18.75% etching
-        // todo applied a 33% discount to the time
+        // Ideal ratio: 20% matrix, 80% non-matrix
+        // 7 non-matrix needed, ideal needs 8 for 2 etching arrays
+        // Ideal distribution: 9.375% per non-matrix module, 18.75% for etching array
 
-        // todo matrix should be 628 UHV
-        // todo 14 board @ 377 UHV    -> 10s UV ea.
-        // todo 1 encasement          -> 10s UEV ea.
-        // todo 16 supercon @ 377 UHV -> 10s UV ea.
-        // todo 8 SoC @ 1142.8 UHV    -> 40s UV ea.
+        // Non-matrix:
+        // ~40s UHV each (2x for SoC)
+        // - Elite board:      14     -> 10s UV ea.
+        // - Crystal SoC:      8      -> 40s UV ea.
+        // - Basic encasement: 1      -> 10s UEV ea.
+        // - Superconductor:   16 luv -> 10s UV ea.
 
-        // todo 80s UHV total per mainframe
-        // todo IV  = 20s UHV  -> 2.5s UHV
-        // todo LuV = 40s UHV  -> 5s UHV
-        // todo ZPM = 80s UHV  -> 10s UHV
-        // todo UV  = 160s UHV -> 20s UHV
+        // Matrix:
+        // 80s UHV, split 15 ways for 15 crafts
+        // - IV  -> 2.5s UHV
+        // - LuV -> 5s UHV
+        // - ZPM -> 10s UHV
+        // - UV  -> 20s UHV
+
+        // Note on old NAC balance: old total time 3810s UHV
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1267,9 +1270,6 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // Wetware //
         // ======= //
 
-        // todo old total time 7220s UHV
-        // todo old minus new zero time 3280s UHV
-
         // Ideal ratio: 40% matrix, 60% non-matrix
         // 7 non-matrix needed, ideal needs 8 for 2 bio coordinators
         // Ideal distribution: 7.5% per non-matrix module, 15% for bio coordinator
@@ -1287,6 +1287,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // - ZPM -> 22.5s UEV
         // - UV  -> 45s UEV
         // - UHV -> 90s UEV
+
+        // Note on old NAC balance: old total time 7220s UHV
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1359,39 +1361,39 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // Bioware //
         // ======= //
 
-        // todo old normal: 11,410s UHV
-        // todo old soc: 15,930s UHV
+        // Ideal ratio: 50% matrix, 50% non-matrix
 
-        // todo 50% matrix, 50% non-matrix
-        // todo 8 non-matrix modules.
-        // todo Bio SoC needs 3 bio modules
-        // todo Bio normal needs 2 etching, 2 bio module
+        // Normal Recipe
+        // 8 non-matrix needed, ideal needs 10 for 2 bio coordinators and 2 superconductor splitters
+        // Ideal distribution: 5% per non-matrix module, 10% for bio coordinator and superconductor splitter
 
-        // todo bio normal: 10 non-matrix modules. 2x superconductor, 2x bio
-        // todo bio normal: 5% per non-matrix module. 10% for both etching and bio
+        // SoC Recipe
+        // 7 non-matrix needed, ideal needs 10 for 2 bio coordinators, 2 superconductor splitters, and 2 board modules
+        // Ideal distribution: 5% per non-matrix module, 10% for bio, superconductor, and board
 
-        // todo 570.5s UHV per (2x for bio and superconductor)
-        // todo Bio board:      8      -> 16s UEV
-        // todo Bio unit:       8      -> 32s UEV
-        // todo Crystal chip    8      -> 16s UEV
-        // todo adv encasement: 4      -> 32s UEV
-        // todo superconductor: 64 uhv -> 4s UEV
+        // Non-matrix (Normal):
+        // ~570.5s UHV per (2x for bio and superconductor)
+        // - Bio board:      8      -> 16s UEV
+        // - Bio unit:       8      -> 32s UEV
+        // - Crystal chip    8      -> 16s UEV
+        // - Adv encasement: 4      -> 32s UEV
+        // - Superconductor: 64 uhv -> 4s UEV
 
-        // todo 5760s UHV
-        // todo ZPM -> 11.25s UIV
-        // todo UV  -> 22.5s UIV
-        // todo UHV -> 45s UIV
-        // todo UEV -> 90s UIV
+        // Non-matrix (SoC):
+        // ~570.5s UHV per (2x for bio, superconductor, and board)
+        // - Bio board:      16     -> 16s UEV
+        // - Bio soc:        8      -> 32s UEV
+        // - Adv encasement: 4      -> 32s UEV
+        // - Superconductor: 64 uhv -> 4s UEV
 
+        // Matrix:
+        // ~5760s UHV, split 15 ways for 16 crafts
+        // - ZPM -> 11.25s UIV
+        // - UV  -> 22.5s UIV
+        // - UHV -> 45s UIV
+        // - UEV -> 90s UIV
 
-        // todo bio soc: 10 non-matrix modules. 2x board, 2x supercon, 2x bio
-        // todo bio soc: 5.55% per non-matrix. 16.66% for bio
-
-        // todo: 3776s
-        // todo Bio board:      16     -> 16s UEV
-        // todo Bio soc:        8      -> 32s UEV
-        // todo adv encasement: 4      -> 32s UEV
-        // todo superconductor: 64 uhv -> 4s UEV
+        // Notes on old NAC balance: old total time 11,410s (normal), 15,930s (SoC)
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1487,25 +1489,27 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // Optical //
         // ======= //
 
-        // todo old recipe: 22,120s UHV
+        // Ideal ratio: 60% matrix, 40% non-matrix
+        // 7 non-matrix needed, ideal needs 9 for 2 organizers and 2 superconductor
+        // Ideal distribution: 4.44% per non-matrix module, 8.88% for organizer and superconductor
 
-        // todo ratio: 60% matrix, 40% non-matrix
-        // todo 7 non-matrix modules needed, but 2x organizers and 2x optical
-        // todo 4.44% per non-matrix module, 8.88% for organizer
+        // Non-matrix:
+        // ~970s UHV each (2x for organizer and supercon)
+        // - Opt board:      8      -> 30s UEV ea.
+        // - Opt cpu:        8      -> 30s UEV ea.
+        // - Opt ram:        16     -> 15s UEV ea.
+        // - Opt cable:      32     -> 5s UEV ea.
+        // - Adv encasement: 8      -> 30s UEV ea.
+        // - Superconductor: 64 uev -> 8s UEV ea.
 
-        // todo 970s UHV per (2x for organizer and supercon)
-        // todo opt board:      8      -> 30s UEV ea.
-        // todo opt cpu:        8      -> 30s UEV ea.
-        // todo opt ram:        16     -> 15s UEV ea.
-        // todo opt cable:      32     -> 5s UEV ea.
-        // todo adv encasement: 8      -> 30s UEV ea.
-        // todo superconductor: 64 uev -> 8s UEV ea.
+        // Matrix:
+        // ~13,480s UHV, split 15 ways for 15 crafts
+        // - UV  -> 25s UIV
+        // - UHV -> 50s UIV
+        // - UEV -> 100s UIV
+        // - UIV -> 200s UIV
 
-        // todo 13,480s UHV
-        // todo UV  -> 25s UIV
-        // todo UHV -> 50s UIV
-        // todo UEV -> 100s UIV
-        // todo UIV -> 200s UIV
+        // Note on old NAC balance: old total time 22,120s UHV
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(

--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -560,14 +560,14 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // Optical Board
         GTValues.RA.stdBuilder().hidden().metadata(BoardProcessingModuleFluidKey.INSTANCE, 4)
                 .itemInputs(CircuitComponent.BoardOptical.getFakeStack(1))
-                .itemOutputs(CircuitComponent.ProcessedBoardOptical.getFakeStack(1)).duration(20 * SECONDS)
-                .eut(ModuleRecipeInfo.ExtremeTier.recipeEUt).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
+                .itemOutputs(CircuitComponent.ProcessedBoardOptical.getFakeStack(1)).duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
 
         // Optical Board fake recipe
         GTValues.RA.stdBuilder().fake().itemInputs(CircuitComponent.BoardOptical.getFakeStack(1))
                 .fluidInputs(Materials.PrismaticAcid.getFluid(0)).fluidOutputs(Materials.PrismaticGas.getFluid(0))
-                .itemOutputs(CircuitComponent.ProcessedBoardOptical.getFakeStack(1)).duration(20 * SECONDS)
-                .eut(ModuleRecipeInfo.ExtremeTier.recipeEUt).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
+                .itemOutputs(CircuitComponent.ProcessedBoardOptical.getFakeStack(1)).duration(30 * SECONDS)
+                .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
     }
 
     private static void registerCuttingChamberRecipes() {
@@ -851,7 +851,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         CircuitComponent.ProcessedFoilSiliconeRubber.getFakeStack(16),
                         CircuitComponent.ProcessedFrameboxTritanium.getFakeStack(1),
                         CircuitComponent.ProcessedFoilPolybenzimidazole.getFakeStack(16))
-                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(32 * SECONDS)
+                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(30 * SECONDS)
                 .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipEncasementWrapper);
 
         GTValues.RA.stdBuilder()
@@ -859,7 +859,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         CircuitComponent.ProcessedFoilStyreneRubber.getFakeStack(16),
                         CircuitComponent.ProcessedFrameboxTritanium.getFakeStack(1),
                         CircuitComponent.ProcessedFoilPolybenzimidazole.getFakeStack(16))
-                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(32 * SECONDS)
+                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(30 * SECONDS)
                 .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipEncasementWrapper);
 
         // Pico
@@ -967,16 +967,16 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.ChipOpticalCPU,
                 CircuitComponent.ProcessedChipOpticalCPU,
-                ModuleRecipeInfo.ExtremeTier,
-                10 * SECONDS,
+                TierEU.RECIPE_UEV,
+                30 * SECONDS,
                 RecipeMaps.nanochipOpticalOrganizer);
 
         // Optical Memory
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalRAM,
                 CircuitComponent.ProcessedOpticalRAM,
-                ModuleRecipeInfo.ExtremeTier,
-                5 * SECONDS,
+                TierEU.RECIPE_UEV,
+                15 * SECONDS,
                 RecipeMaps.nanochipOpticalOrganizer);
     }
 
@@ -1165,8 +1165,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.CableOpticalFiber,
                 CircuitComponent.ProcessedCableOpticalFiber,
-                TierEU.RECIPE_ZPM,
-                1 * SECONDS,
+                TierEU.RECIPE_UEV,
+                5 * SECONDS,
                 RecipeMaps.nanochipWireTracer);
 
         // Hypogen
@@ -1487,6 +1487,26 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // Optical //
         // ======= //
 
+        // todo old recipe: 22,120s UHV
+
+        // todo ratio: 60% matrix, 40% non-matrix
+        // todo 7 non-matrix modules needed, but 2x organizers and 2x optical
+        // todo 4.44% per non-matrix module, 8.88% for organizer
+
+        // todo 970s UHV per (2x for organizer and supercon)
+        // todo opt board:      8      -> 30s UEV ea.
+        // todo opt cpu:        8      -> 30s UEV ea.
+        // todo opt ram:        16     -> 15s UEV ea.
+        // todo opt cable:      32     -> 5s UEV ea.
+        // todo adv encasement: 8      -> 30s UEV ea.
+        // todo superconductor: 64 uev -> 8s UEV ea.
+
+        // todo 13,480s UHV
+        // todo UV  -> 25s UIV
+        // todo UHV -> 50s UIV
+        // todo UEV -> 100s UIV
+        // todo UIV -> 200s UIV
+
         addAssemblyMatrixRecipe(
                 Arrays.asList(
                         new CircuitComponentStack(CircuitComponent.ProcessedChipOpticalCPU, 1),
@@ -1497,8 +1517,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedBoltEnrichedHolmium, 4)),
                 Arrays.asList(MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(18)),
                 CircuitComponent.OpticalProcessor,
-                15 * SECONDS,
-                614_400, // UHV
+                25 * SECONDS,
+                TierEU.RECIPE_UIV,
                 VoltageIndex.UHV);
 
         addAssemblyMatrixRecipe(
@@ -1521,7 +1541,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         Materials.SuperCoolant.getFluid(10000),
                         WerkstoffLoader.Oganesson.getFluidOrGas(500)),
                 CircuitComponent.OpticalAssembly,
-                20 * SECONDS,
+                50 * SECONDS,
                 TierEU.RECIPE_UIV,
                 VoltageIndex.UHV);
 
@@ -1547,7 +1567,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         Materials.SuperCoolant.getFluid(20000),
                         WerkstoffLoader.Oganesson.getFluidOrGas(1000)),
                 CircuitComponent.OpticalComputer,
-                200 * SECONDS,
+                100 * SECONDS,
                 TierEU.RECIPE_UIV,
                 VoltageIndex.UHV);
 
@@ -1572,8 +1592,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         Materials.SuperCoolant.getFluid(40000),
                         WerkstoffLoader.Oganesson.getFluidOrGas(2000)),
                 CircuitComponent.OpticalMainframe,
-                300 * SECONDS,
-                TierEU.RECIPE_UMV,
+                200 * SECONDS,
+                TierEU.RECIPE_UIV,
                 VoltageIndex.UHV);
 
         // ======= //

--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -842,7 +842,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
     private static void registerEncasementWrapperRecipes() {
         // Crystal
         GTValues.RA.stdBuilder().itemInputs(CircuitComponent.ProcessedFrameboxAluminium.getFakeStack(2))
-                .itemOutputs(CircuitComponent.ProcessedBasicMainframeCasing.getFakeStack(1)).duration(20 * SECONDS)
+                .itemOutputs(CircuitComponent.ProcessedBasicMainframeCasing.getFakeStack(1)).duration(10 * SECONDS)
                 .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipEncasementWrapper);
 
         // Wetware, Bioware, Optical
@@ -851,7 +851,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         CircuitComponent.ProcessedFoilSiliconeRubber.getFakeStack(16),
                         CircuitComponent.ProcessedFrameboxTritanium.getFakeStack(1),
                         CircuitComponent.ProcessedFoilPolybenzimidazole.getFakeStack(16))
-                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(30 * SECONDS)
+                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(15 * SECONDS)
                 .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipEncasementWrapper);
 
         GTValues.RA.stdBuilder()
@@ -859,7 +859,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         CircuitComponent.ProcessedFoilStyreneRubber.getFakeStack(16),
                         CircuitComponent.ProcessedFrameboxTritanium.getFakeStack(1),
                         CircuitComponent.ProcessedFoilPolybenzimidazole.getFakeStack(16))
-                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(30 * SECONDS)
+                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(15 * SECONDS)
                 .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipEncasementWrapper);
 
         // Pico
@@ -1060,7 +1060,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.SuperconductorLuV,
                 CircuitComponent.ProcessedSuperconductorLuV,
                 TierEU.RECIPE_UV,
-                10 * SECONDS,
+                5 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // ZPM
@@ -1068,7 +1068,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.SuperconductorZPM,
                 CircuitComponent.ProcessedSuperconductorZPM,
                 TierEU.RECIPE_UHV,
-                4 * SECONDS,
+                2 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // UV
@@ -1076,7 +1076,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.SuperconductorUV,
                 CircuitComponent.ProcessedSuperconductorUV,
                 TierEU.RECIPE_UHV,
-                8 * SECONDS,
+                4 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // UHV
@@ -1084,7 +1084,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.SuperconductorUHV,
                 CircuitComponent.ProcessedSuperconductorUHV,
                 TierEU.RECIPE_UEV,
-                4 * SECONDS,
+                2 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // UEV
@@ -1092,7 +1092,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.SuperconductorUEV,
                 CircuitComponent.ProcessedSuperconductorUEV,
                 TierEU.RECIPE_UEV,
-                8 * SECONDS,
+                4 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // UIV
@@ -1100,7 +1100,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.SuperconductorUIV,
                 CircuitComponent.ProcessedSuperconductorUIV,
                 TierEU.RECIPE_UIV,
-                4 * SECONDS,
+                2 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // UMV
@@ -1108,7 +1108,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.SuperconductorUMV,
                 CircuitComponent.ProcessedSuperconductorUMV,
                 TierEU.RECIPE_UIV,
-                8 * SECONDS,
+                4 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
     }
 

--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -495,8 +495,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.ChipLivingCrystal,
                 Materials.BioMediumSterilized.getFluid(5),
                 CircuitComponent.ProcessedChipLivingCrystal,
-                ModuleRecipeInfo.ExtremeTier,
-                20 * SECONDS,
+                TierEU.RECIPE_UHV,
+                16 * SECONDS,
                 RecipeMaps.nanochipBiologicalCoordinator);
 
         // Bio Processing Unit
@@ -504,8 +504,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.BioProcessingUnit,
                 Materials.BioMediumSterilized.getFluid(50),
                 CircuitComponent.ProcessedBioProcessingUnit,
-                ModuleRecipeInfo.HighTier,
-                30 * SECONDS,
+                TierEU.RECIPE_UEV,
+                32 * SECONDS,
                 RecipeMaps.nanochipBiologicalCoordinator);
 
         // Living Bio Chip
@@ -513,8 +513,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.LivingBioChip,
                 Materials.BioMediumSterilized.getFluid(50),
                 CircuitComponent.ProcessedLivingBioChip,
-                ModuleRecipeInfo.ExtremeTier,
-                30 * SECONDS,
+                TierEU.RECIPE_UEV,
+                32 * SECONDS,
                 RecipeMaps.nanochipBiologicalCoordinator);
     }
 
@@ -529,33 +529,33 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         GTValues.RA.stdBuilder().fake().itemInputs(CircuitComponent.BoardMultifiberglassElite.getFakeStack(1))
                 .fluidInputs(Materials.IronIIIChloride.getFluid(0))
                 .fluidOutputs(GGMaterial.ferrousChloride.getFluidOrGas(0))
-                .itemOutputs(CircuitComponent.ProcessedBoardMultifiberglassElite.getFakeStack(1)).duration(25 * SECONDS)
-                .eut(TierEU.RECIPE_UHV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
+                .itemOutputs(CircuitComponent.ProcessedBoardMultifiberglassElite.getFakeStack(1)).duration(10 * SECONDS)
+                .eut(TierEU.RECIPE_UV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
 
         // Wetware Board
         GTValues.RA.stdBuilder().hidden().metadata(BoardProcessingModuleFluidKey.INSTANCE, 2)
                 .itemInputs(CircuitComponent.BoardWetwareLifesupport.getFakeStack(1))
-                .itemOutputs(CircuitComponent.ProcessedBoardWetwareLifesupport.getFakeStack(1)).duration(10 * SECONDS)
-                .eut(ModuleRecipeInfo.HighTier.recipeEUt).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
+                .itemOutputs(CircuitComponent.ProcessedBoardWetwareLifesupport.getFakeStack(1)).duration(16 * SECONDS)
+                .eut(TierEU.RECIPE_UHV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
 
         // Wetware Board fake recipe
         GTValues.RA.stdBuilder().fake().itemInputs(CircuitComponent.BoardWetwareLifesupport.getFakeStack(1))
                 .fluidInputs(Materials.GrowthMediumSterilized.getFluid(0))
                 .fluidOutputs(Materials.GrowthMediumRaw.getFluid(0))
-                .itemOutputs(CircuitComponent.ProcessedBoardWetwareLifesupport.getFakeStack(1)).duration(10 * SECONDS)
-                .eut(ModuleRecipeInfo.HighTier.recipeEUt).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
+                .itemOutputs(CircuitComponent.ProcessedBoardWetwareLifesupport.getFakeStack(1)).duration(16 * SECONDS)
+                .eut(TierEU.RECIPE_UHV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
 
         // Bio Board
         GTValues.RA.stdBuilder().hidden().metadata(BoardProcessingModuleFluidKey.INSTANCE, 3)
                 .itemInputs(CircuitComponent.BoardBioMutated.getFakeStack(1))
-                .itemOutputs(CircuitComponent.ProcessedBoardBioMutated.getFakeStack(1)).duration(10 * SECONDS)
-                .eut(ModuleRecipeInfo.ExtremeTier.recipeEUt).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
+                .itemOutputs(CircuitComponent.ProcessedBoardBioMutated.getFakeStack(1)).duration(16 * SECONDS)
+                .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
 
         // Bio Board fake recipe
         GTValues.RA.stdBuilder().fake().itemInputs(CircuitComponent.BoardBioMutated.getFakeStack(1))
                 .fluidInputs(Materials.BioMediumSterilized.getFluid(0)).fluidOutputs(Materials.BioMediumRaw.getFluid(0))
-                .itemOutputs(CircuitComponent.ProcessedBoardBioMutated.getFakeStack(1)).duration(10 * SECONDS)
-                .eut(ModuleRecipeInfo.ExtremeTier.recipeEUt).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
+                .itemOutputs(CircuitComponent.ProcessedBoardBioMutated.getFakeStack(1)).duration(16 * SECONDS)
+                .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
 
         // Optical Board
         GTValues.RA.stdBuilder().hidden().metadata(BoardProcessingModuleFluidKey.INSTANCE, 4)
@@ -842,8 +842,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
     private static void registerEncasementWrapperRecipes() {
         // Crystal
         GTValues.RA.stdBuilder().itemInputs(CircuitComponent.ProcessedFrameboxAluminium.getFakeStack(2))
-                .itemOutputs(CircuitComponent.ProcessedBasicMainframeCasing.getFakeStack(1))
-                .duration(20 * SECONDS).eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipEncasementWrapper);
+                .itemOutputs(CircuitComponent.ProcessedBasicMainframeCasing.getFakeStack(1)).duration(20 * SECONDS)
+                .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipEncasementWrapper);
 
         // Wetware, Bioware, Optical
         GTValues.RA.stdBuilder()
@@ -851,16 +851,16 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         CircuitComponent.ProcessedFoilSiliconeRubber.getFakeStack(16),
                         CircuitComponent.ProcessedFrameboxTritanium.getFakeStack(1),
                         CircuitComponent.ProcessedFoilPolybenzimidazole.getFakeStack(16))
-                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(10 * SECONDS)
-                .eut(ModuleRecipeInfo.HighTier.recipeEUt).addTo(RecipeMaps.nanochipEncasementWrapper);
+                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(32 * SECONDS)
+                .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipEncasementWrapper);
 
         GTValues.RA.stdBuilder()
                 .itemInputs(
                         CircuitComponent.ProcessedFoilStyreneRubber.getFakeStack(16),
                         CircuitComponent.ProcessedFrameboxTritanium.getFakeStack(1),
                         CircuitComponent.ProcessedFoilPolybenzimidazole.getFakeStack(16))
-                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(10 * SECONDS)
-                .eut(ModuleRecipeInfo.HighTier.recipeEUt).addTo(RecipeMaps.nanochipEncasementWrapper);
+                .itemOutputs(CircuitComponent.ProcessedAdvancedMainframeCasing.getFakeStack(1)).duration(32 * SECONDS)
+                .eut(TierEU.RECIPE_UEV).addTo(RecipeMaps.nanochipEncasementWrapper);
 
         // Pico
         GTValues.RA.stdBuilder()
@@ -949,8 +949,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.ChipRawAdvancedCrystal,
                 CircuitComponent.ProcessedChipRawAdvancedCrystal,
-                ModuleRecipeInfo.HighTier,
-                10 * SECONDS,
+                TierEU.RECIPE_UEV,
+                16 * SECONDS,
                 RecipeMaps.nanochipEtchingArray);
 
         // Crystal SoC
@@ -1021,35 +1021,35 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalSMDResistor,
                 CircuitComponent.ProcessedOpticalSMDResistor,
-                TierEU.RECIPE_LuV,
+                TierEU.RECIPE_ZPM,
                 1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalSMDTransistor,
                 CircuitComponent.ProcessedOpticalSMDTransistor,
-                TierEU.RECIPE_LuV,
+                TierEU.RECIPE_ZPM,
                 1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalSMDInductor,
                 CircuitComponent.ProcessedOpticalSMDInductor,
-                TierEU.RECIPE_LuV,
+                TierEU.RECIPE_ZPM,
                 1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalSMDCapacitor,
                 CircuitComponent.ProcessedOpticalSMDCapacitor,
-                TierEU.RECIPE_LuV,
+                TierEU.RECIPE_ZPM,
                 1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalSMDDiode,
                 CircuitComponent.ProcessedOpticalSMDDiode,
-                TierEU.RECIPE_LuV,
+                TierEU.RECIPE_ZPM,
                 1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
     }
@@ -1067,48 +1067,48 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.SuperconductorZPM,
                 CircuitComponent.ProcessedSuperconductorZPM,
-                ModuleRecipeInfo.MediumTier,
-                10 * SECONDS,
+                TierEU.RECIPE_UHV,
+                4 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // UV
         addSimpleProcessingRecipe(
                 CircuitComponent.SuperconductorUV,
                 CircuitComponent.ProcessedSuperconductorUV,
-                ModuleRecipeInfo.HighTier,
-                5 * SECONDS,
+                TierEU.RECIPE_UHV,
+                8 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // UHV
         addSimpleProcessingRecipe(
                 CircuitComponent.SuperconductorUHV,
                 CircuitComponent.ProcessedSuperconductorUHV,
-                ModuleRecipeInfo.HighTier,
-                10 * SECONDS,
+                TierEU.RECIPE_UEV,
+                4 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // UEV
         addSimpleProcessingRecipe(
                 CircuitComponent.SuperconductorUEV,
                 CircuitComponent.ProcessedSuperconductorUEV,
-                ModuleRecipeInfo.HighTier,
-                20 * SECONDS,
+                TierEU.RECIPE_UEV,
+                8 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // UIV
         addSimpleProcessingRecipe(
                 CircuitComponent.SuperconductorUIV,
                 CircuitComponent.ProcessedSuperconductorUIV,
-                ModuleRecipeInfo.ExtremeTier,
-                5 * SECONDS,
+                TierEU.RECIPE_UIV,
+                4 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // UMV
         addSimpleProcessingRecipe(
                 CircuitComponent.SuperconductorUMV,
                 CircuitComponent.ProcessedSuperconductorUMV,
-                ModuleRecipeInfo.ExtremeTier,
-                10 * SECONDS,
+                TierEU.RECIPE_UIV,
+                8 * SECONDS,
                 RecipeMaps.nanochipSuperconductorSplitter);
     }
 
@@ -1203,7 +1203,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // todo 16 supercon @ 377 UHV -> 10s UV ea.
         // todo 8 SoC @ 1142.8 UHV    -> 40s UV ea.
 
-        // todo 40 15 ways
+        // todo 80s UHV total per mainframe
         // todo IV  = 20s UHV  -> 2.5s UHV
         // todo LuV = 40s UHV  -> 5s UHV
         // todo ZPM = 80s UHV  -> 10s UHV
@@ -1267,6 +1267,27 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // Wetware //
         // ======= //
 
+        // todo old total time 7220s UHV
+        // todo old minus new zero time 3280s UHV
+
+        // Ideal ratio: 40% matrix, 60% non-matrix
+        // 7 non-matrix needed, ideal needs 8 for 2 bio coordinators
+        // Ideal distribution: 7.5% per non-matrix module, 15% for bio coordinator
+
+        // Non-matrix:
+        // ~270.75s UHV each (2x for SoC)
+        // - Wetware board    16     -> 16s UHV ea.
+        // - Wetware soc      8      -> 16s UHV ea.
+        // - Adv encasement   2      -> 32s UEV ea.
+        // - Superconductor   64 zpm -> 4s UHV ea.
+
+        // Matrix:
+        // 1440s UHV, split 15 ways for 15 crafts
+        // - LuV -> 11.25s UEV
+        // - ZPM -> 22.5s UEV
+        // - UV  -> 45s UEV
+        // - UHV -> 90s UEV
+
         addAssemblyMatrixRecipe(
                 Arrays.asList(
                         new CircuitComponentStack(CircuitComponent.ProcessedBoardWetwareLifesupport, 1),
@@ -1275,9 +1296,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedBoltCosmicNeutronium, 4)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(4)),
                 CircuitComponent.WetwareProcessor,
-                2 * SECONDS,
-                614_400, // UHV
-                VoltageIndex.ZPM);
+                11 * SECONDS + 4 * TICKS,
+                TierEU.RECIPE_UEV,
+                VoltageIndex.UV);
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1289,9 +1310,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedWireYttriumBariumCuprate, 16)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(9)),
                 CircuitComponent.WetwareAssembly,
-                1 * SECONDS + 10 * TICKS,
-                153_600, // UV
-                VoltageIndex.ZPM);
+                22 * SECONDS + 10 * TICKS,
+                TierEU.RECIPE_UEV,
+                VoltageIndex.UV);
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1303,9 +1324,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedWireYttriumBariumCuprate, 24)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(9)),
                 CircuitComponent.WetwareComputer,
-                3 * SECONDS,
-                153_600, // UV
-                VoltageIndex.ZPM);
+                45 * SECONDS,
+                TierEU.RECIPE_UEV,
+                VoltageIndex.UV);
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1330,13 +1351,47 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         FluidRegistry.getFluidStack("ic2coolant", 10000),
                         Materials.Radon.getGas(2500)),
                 CircuitComponent.WetwareMainframe,
-                100 * SECONDS,
-                4_800_000, // UEV
-                VoltageIndex.ZPM);
+                90 * SECONDS,
+                TierEU.RECIPE_UEV,
+                VoltageIndex.UV);
 
         // ======= //
         // Bioware //
         // ======= //
+
+        // todo old normal: 11,410s UHV
+        // todo old soc: 15,930s UHV
+
+        // todo 50% matrix, 50% non-matrix
+        // todo 8 non-matrix modules.
+        // todo Bio SoC needs 3 bio modules
+        // todo Bio normal needs 2 etching, 2 bio module
+
+        // todo bio normal: 10 non-matrix modules. 2x superconductor, 2x bio
+        // todo bio normal: 5% per non-matrix module. 10% for both etching and bio
+
+        // todo 570.5s UHV per (2x for bio and superconductor)
+        // todo Bio board:      8      -> 16s UEV
+        // todo Bio unit:       8      -> 32s UEV
+        // todo Crystal chip    8      -> 16s UEV
+        // todo adv encasement: 4      -> 32s UEV
+        // todo superconductor: 64 uhv -> 4s UEV
+
+        // todo 5760s UHV
+        // todo ZPM -> 11.25s UIV
+        // todo UV  -> 22.5s UIV
+        // todo UHV -> 45s UIV
+        // todo UEV -> 90s UIV
+
+
+        // todo bio soc: 10 non-matrix modules. 2x board, 2x supercon, 2x bio
+        // todo bio soc: 5.55% per non-matrix. 16.66% for bio
+
+        // todo: 3776s
+        // todo Bio board:      16     -> 16s UEV
+        // todo Bio soc:        8      -> 32s UEV
+        // todo adv encasement: 4      -> 32s UEV
+        // todo superconductor: 64 uhv -> 4s UEV
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1348,9 +1403,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedWireNiobiumTitanium, 16)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(4)),
                 CircuitComponent.BiowareProcessor,
-                2 * SECONDS + 10 * TICKS,
-                614_400, // UHV
-                VoltageIndex.UV);
+                11 * SECONDS + 5 * TICKS,
+                TierEU.RECIPE_UIV,
+                VoltageIndex.UHV);
 
         // SoC
         addAssemblyMatrixRecipe(
@@ -1361,9 +1416,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedBoltChromaticGlass, 4)),
                 Arrays.asList(MaterialMisc.MUTATED_LIVING_SOLDER.getFluidStack(9)),
                 CircuitComponent.BiowareProcessor,
-                3 * SECONDS,
-                2_457_600, // UEV
-                VoltageIndex.UV);
+                11 * SECONDS + 5 * TICKS,
+                TierEU.RECIPE_UIV,
+                VoltageIndex.UHV);
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1375,9 +1430,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedWireYttriumBariumCuprate, 24)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(9)),
                 CircuitComponent.BiowareAssembly,
-                2 * SECONDS,
-                614_400, // UHV
-                VoltageIndex.UV);
+                22 * SECONDS + 10 * TICKS,
+                TierEU.RECIPE_UIV,
+                VoltageIndex.UHV);
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1399,9 +1454,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         Materials.BioMediumSterilized.getFluid(5 * INGOTS),
                         Materials.SuperCoolant.getFluid(10000)),
                 CircuitComponent.BiowareComputer,
-                200 * SECONDS,
-                TierEU.RECIPE_UEV,
-                VoltageIndex.UV);
+                45 * SECONDS,
+                TierEU.RECIPE_UIV,
+                VoltageIndex.UHV);
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1424,9 +1479,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         Materials.BioMediumSterilized.getFluid(10 * INGOTS),
                         Materials.SuperCoolant.getFluid(20000)),
                 CircuitComponent.BiowareMainframe,
-                300 * SECONDS,
+                90 * SECONDS,
                 TierEU.RECIPE_UIV,
-                VoltageIndex.UV);
+                VoltageIndex.UHV);
 
         // ======= //
         // Optical //

--- a/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptNanochipRecipes.java
@@ -418,6 +418,21 @@ public class ScriptNanochipRecipes implements IScriptLoader {
     }
 
     // Adds a simple processing recipe for circuit components in a module
+    private static void addSimpleProcessingRecipe(CircuitComponent input, CircuitComponent output, long eut,
+            int duration, RecipeMap<?> recipeMap) {
+        GTValues.RA.stdBuilder().itemInputs(input.getFakeStack(1)).itemOutputs(output.getFakeStack(1))
+                .duration(duration).eut(eut).addTo(recipeMap);
+    }
+
+    // Adds a simple processing recipe with a fluid for circuit components in a module
+    private static void addSimpleProcessingRecipe(CircuitComponent input, FluidStack inputStack,
+            CircuitComponent output, long eut, long duration, RecipeMap<?> recipeMap) {
+        GTValues.RA.stdBuilder().itemInputs(input.getFakeStack(1)).fluidInputs(inputStack)
+                .itemOutputs(output.getFakeStack(1)).duration(duration).eut(eut).addTo(recipeMap);
+    }
+
+    // Adds a simple processing recipe for circuit components in a module
+    @Deprecated
     private static void addSimpleProcessingRecipe(CircuitComponent input, CircuitComponent output,
             ModuleRecipeInfo info, int duration, RecipeMap<?> recipeMap) {
         GTValues.RA.stdBuilder().itemInputs(input.getFakeStack(1)).itemOutputs(output.getFakeStack(1))
@@ -425,6 +440,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
     }
 
     // Adds a simple processing recipe with a fluid for circuit components in a module
+    @Deprecated
     private static void addSimpleProcessingRecipe(CircuitComponent input, FluidStack inputStack,
             CircuitComponent output, ModuleRecipeInfo info, long duration, RecipeMap<?> recipeMap) {
         GTValues.RA.stdBuilder().itemInputs(input.getFakeStack(1)).fluidInputs(inputStack)
@@ -474,15 +490,6 @@ public class ScriptNanochipRecipes implements IScriptLoader {
     }
 
     private static void registerBiologicalCoordinatorRecipes() {
-        // Neuro Processing Unit
-        addSimpleProcessingRecipe(
-                CircuitComponent.NeuroProcessingUnit,
-                Materials.GrowthMediumSterilized.getFluid(50),
-                CircuitComponent.ProcessedNeuroProcessingUnit,
-                ModuleRecipeInfo.HighTier,
-                20 * SECONDS,
-                RecipeMaps.nanochipBiologicalCoordinator);
-
         // Living Crystal Chip
         addSimpleProcessingRecipe(
                 CircuitComponent.ChipLivingCrystal,
@@ -515,14 +522,15 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         // Elite Board
         GTValues.RA.stdBuilder().hidden().metadata(BoardProcessingModuleFluidKey.INSTANCE, 1)
                 .itemInputs(CircuitComponent.BoardMultifiberglassElite.getFakeStack(1))
-                .itemOutputs(CircuitComponent.ProcessedBoardMultifiberglassElite.getFakeStack(1)).duration(5 * SECONDS)
-                .eut(ModuleRecipeInfo.HighTier.recipeEUt).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
+                .itemOutputs(CircuitComponent.ProcessedBoardMultifiberglassElite.getFakeStack(1)).duration(25 * SECONDS)
+                .eut(TierEU.RECIPE_UHV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
 
         // Elite Board fake recipe
         GTValues.RA.stdBuilder().fake().itemInputs(CircuitComponent.BoardMultifiberglassElite.getFakeStack(1))
-                .fluidInputs(Materials.IronIIIChloride.getFluid(0)).fluidOutputs(Materials.IronIIIChloride.getFluid(0))
-                .itemOutputs(CircuitComponent.ProcessedBoardMultifiberglassElite.getFakeStack(1)).duration(5 * SECONDS)
-                .eut(ModuleRecipeInfo.HighTier.recipeEUt).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
+                .fluidInputs(Materials.IronIIIChloride.getFluid(0))
+                .fluidOutputs(GGMaterial.ferrousChloride.getFluidOrGas(0))
+                .itemOutputs(CircuitComponent.ProcessedBoardMultifiberglassElite.getFakeStack(1)).duration(25 * SECONDS)
+                .eut(TierEU.RECIPE_UHV).addTo(RecipeMaps.nanochipBoardProcessorRecipes);
 
         // Wetware Board
         GTValues.RA.stdBuilder().hidden().metadata(BoardProcessingModuleFluidKey.INSTANCE, 2)
@@ -569,8 +577,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.ChipNanoCPU,
                 Materials.Lubricant.getFluid(50),
                 CircuitComponent.ProcessedChipNanoCPU,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
         // RAM
@@ -578,8 +586,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.ChipRAM,
                 Materials.Lubricant.getFluid(50),
                 CircuitComponent.ProcessedChipRAM,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
         // NOR
@@ -587,8 +595,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.ChipNOR,
                 Materials.Lubricant.getFluid(50),
                 CircuitComponent.ProcessedChipNOR,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
         // NAND
@@ -596,8 +604,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.ChipNAND,
                 Materials.Lubricant.getFluid(50),
                 CircuitComponent.ProcessedChipNAND,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
         // ASoC
@@ -605,8 +613,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.ChipASOC,
                 Materials.Lubricant.getFluid(50),
                 CircuitComponent.ProcessedChipASOC,
-                ModuleRecipeInfo.HighTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
         // PPIC
@@ -660,8 +668,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.BoltEnrichedHolmium,
                 Materials.Lubricant.getFluid(20),
                 CircuitComponent.ProcessedBoltEnrichedHolmium,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_ZPM,
+                1 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
         // Transcendent Metal
@@ -678,8 +686,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.BoltYttriumBariumCuprate,
                 Materials.Lubricant.getFluid(20),
                 CircuitComponent.ProcessedBoltYttriumBariumCuprate,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
         // Cosmic Neutronium
@@ -687,8 +695,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.BoltCosmicNeutronium,
                 Materials.Lubricant.getFluid(20),
                 CircuitComponent.ProcessedBoltCosmicNeutronium,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_ZPM,
+                1 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
         // Chromatic Glass
@@ -696,8 +704,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.BoltChromaticGlass,
                 Materials.Lubricant.getFluid(20),
                 CircuitComponent.ProcessedBoltChromaticGlass,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_ZPM,
+                1 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
         // SC Base UMV
@@ -725,7 +733,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.FrameboxAluminium,
                 Materials.Grade1PurifiedWater.getFluid(500),
                 CircuitComponent.ProcessedFrameboxAluminium,
-                ModuleRecipeInfo.HighTier,
+                TierEU.RECIPE_UV,
                 10 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
@@ -733,7 +741,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.FrameboxAluminium,
                 Materials.Grade2PurifiedWater.getFluid(250),
                 CircuitComponent.ProcessedFrameboxAluminium,
-                ModuleRecipeInfo.HighTier,
+                TierEU.RECIPE_UV,
                 5 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
@@ -742,7 +750,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.FrameboxTritanium,
                 Materials.Grade3PurifiedWater.getFluid(500),
                 CircuitComponent.ProcessedFrameboxTritanium,
-                ModuleRecipeInfo.HighTier,
+                TierEU.RECIPE_UHV,
                 20 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
@@ -750,7 +758,7 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                 CircuitComponent.FrameboxTritanium,
                 Materials.Grade4PurifiedWater.getFluid(250),
                 CircuitComponent.ProcessedFrameboxTritanium,
-                ModuleRecipeInfo.HighTier,
+                TierEU.RECIPE_UHV,
                 10 * SECONDS,
                 RecipeMaps.nanochipCuttingChamber);
 
@@ -834,8 +842,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
     private static void registerEncasementWrapperRecipes() {
         // Crystal
         GTValues.RA.stdBuilder().itemInputs(CircuitComponent.ProcessedFrameboxAluminium.getFakeStack(2))
-                .itemOutputs(CircuitComponent.ProcessedBasicMainframeCasing.getFakeStack(1)).duration(10 * SECONDS)
-                .eut(ModuleRecipeInfo.MediumTier.recipeEUt).addTo(RecipeMaps.nanochipEncasementWrapper);
+                .itemOutputs(CircuitComponent.ProcessedBasicMainframeCasing.getFakeStack(1))
+                .duration(22 * SECONDS + 10 * TICKS).eut(TierEU.RECIPE_UIV).addTo(RecipeMaps.nanochipEncasementWrapper);
 
         // Wetware, Bioware, Optical
         GTValues.RA.stdBuilder()
@@ -896,22 +904,22 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.FoilPolybenzimidazole,
                 CircuitComponent.ProcessedFoilPolybenzimidazole,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipEncasementWrapper);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.FoilSiliconeRubber,
                 CircuitComponent.ProcessedFoilSiliconeRubber,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipEncasementWrapper);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.FoilStyreneRubber,
                 CircuitComponent.ProcessedFoilStyreneRubber,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipEncasementWrapper);
 
         addSimpleProcessingRecipe(
@@ -937,14 +945,6 @@ public class ScriptNanochipRecipes implements IScriptLoader {
     }
 
     private static void registerEtchingArrayRecipes() {
-        // Crystal CPU
-        addSimpleProcessingRecipe(
-                CircuitComponent.ChipCrystalCPU,
-                CircuitComponent.ProcessedChipCrystalCPU,
-                ModuleRecipeInfo.MediumTier,
-                10 * SECONDS,
-                RecipeMaps.nanochipEtchingArray);
-
         // Raw Advanced Crystal Chip
         addSimpleProcessingRecipe(
                 CircuitComponent.ChipRawAdvancedCrystal,
@@ -957,8 +957,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.ChipCrystalSoC,
                 CircuitComponent.ProcessedChipCrystalSoC,
-                ModuleRecipeInfo.HighTier,
-                20 * SECONDS,
+                TierEU.RECIPE_UEV,
+                22 * SECONDS + 10 * TICKS,
                 RecipeMaps.nanochipEtchingArray);
     }
 
@@ -985,72 +985,72 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.AdvSMDResistor,
                 CircuitComponent.ProcessedAdvSMDResistor,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.AdvSMDTransistor,
                 CircuitComponent.ProcessedAdvSMDTransistor,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.AdvSMDInductor,
                 CircuitComponent.ProcessedAdvSMDInductor,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.AdvSMDCapacitor,
                 CircuitComponent.ProcessedAdvSMDCapacitor,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.AdvSMDDiode,
                 CircuitComponent.ProcessedAdvSMDDiode,
-                ModuleRecipeInfo.LowTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         // Optical SMDs
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalSMDResistor,
                 CircuitComponent.ProcessedOpticalSMDResistor,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalSMDTransistor,
                 CircuitComponent.ProcessedOpticalSMDTransistor,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalSMDInductor,
                 CircuitComponent.ProcessedOpticalSMDInductor,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalSMDCapacitor,
                 CircuitComponent.ProcessedOpticalSMDCapacitor,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
 
         addSimpleProcessingRecipe(
                 CircuitComponent.OpticalSMDDiode,
                 CircuitComponent.ProcessedOpticalSMDDiode,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipSMDProcessorRecipes);
     }
 
@@ -1059,8 +1059,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.SuperconductorLuV,
                 CircuitComponent.ProcessedSuperconductorLuV,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_UHV,
+                22 * SECONDS + 10 * TICKS,
                 RecipeMaps.nanochipSuperconductorSplitter);
 
         // ZPM
@@ -1117,24 +1117,24 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.WireNiobiumTitanium,
                 CircuitComponent.ProcessedWireNiobiumTitanium,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipWireTracer);
 
         // YBCO
         addSimpleProcessingRecipe(
                 CircuitComponent.WireYttriumBariumCuprate,
                 CircuitComponent.ProcessedWireYttriumBariumCuprate,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipWireTracer);
 
         // Lumiium
         addSimpleProcessingRecipe(
                 CircuitComponent.WireLumiium,
                 CircuitComponent.ProcessedWireLumiium,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_LuV,
+                1 * SECONDS,
                 RecipeMaps.nanochipWireTracer);
 
         // Proto Halkonite
@@ -1165,8 +1165,8 @@ public class ScriptNanochipRecipes implements IScriptLoader {
         addSimpleProcessingRecipe(
                 CircuitComponent.CableOpticalFiber,
                 CircuitComponent.ProcessedCableOpticalFiber,
-                ModuleRecipeInfo.MediumTier,
-                5 * SECONDS,
+                TierEU.RECIPE_ZPM,
+                1 * SECONDS,
                 RecipeMaps.nanochipWireTracer);
 
         // Hypogen
@@ -1189,23 +1189,26 @@ public class ScriptNanochipRecipes implements IScriptLoader {
     // spotless:off
     private static void registerAssemblyMatrixRecipes() {
         // ======= //
-        // Crystal //
-        // ======= //
-        addAssemblyMatrixRecipe(
-                Arrays.asList(
-                        new CircuitComponentStack(CircuitComponent.ProcessedBoardMultifiberglassElite, 1),
-                        new CircuitComponentStack(CircuitComponent.ProcessedChipCrystalCPU, 1),
-                        new CircuitComponentStack(CircuitComponent.ProcessedChipNanoCPU, 2),
-                        new CircuitComponentStack(CircuitComponent.ProcessedAdvSMDCapacitor, 6),
-                        new CircuitComponentStack(CircuitComponent.ProcessedAdvSMDTransistor, 6),
-                        new CircuitComponentStack(CircuitComponent.ProcessedWireNiobiumTitanium, 8)),
-                Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(4)),
-                CircuitComponent.CrystalProcessor,
-                4 * SECONDS,
-                9_600, // LuV
-                VoltageIndex.LuV);
+        // Crystal // todo 3810s UHV of power per mainframe
+        // ======= // todo already removed 3170s UHV
 
-        // SoC
+        // todo 75% non-matrix, 25% matrix
+        // todo 2857.5 UHV non-matrix, 952.5 UHV matrix
+        // todo 9.375% per non-matrix module, 18.75% etching
+        // todo applied a 33% discount to the time
+
+        // todo matrix should be 628 UHV
+        // todo 14 board @ 377 UHV    -> 25s UHV ea.
+        // todo 1 encasement          -> 22.5s UIV ea.
+        // todo 16 supercon @ 377 UHV -> 22.5s UHV ea.
+        // todo 8 SoC @ 1142.8 UHV    -> 90s UHV ea.
+
+        // todo 40 15 ways
+        // todo IV  = 20s UHV  -> 5s UEV
+        // todo LuV = 40s UHV  -> 10s UEV
+        // todo ZPM = 80s UHV  -> 20s UEV
+        // todo UV  = 160s UHV -> 40s UEV
+
         addAssemblyMatrixRecipe(
                 Arrays.asList(
                         new CircuitComponentStack(CircuitComponent.ProcessedBoardMultifiberglassElite, 1),
@@ -1214,9 +1217,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedBoltYttriumBariumCuprate, 4)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(4)),
                 CircuitComponent.CrystalProcessor,
-                2 * SECONDS,
-                153_600, // UV
-                VoltageIndex.LuV);
+                5 * SECONDS,
+                TierEU.RECIPE_UEV,
+                VoltageIndex.UV);
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1228,9 +1231,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedWireNiobiumTitanium, 16)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(9)),
                 CircuitComponent.CrystalAssembly,
-                8 * SECONDS,
-                9_600, // LuV
-                VoltageIndex.LuV);
+                10 * SECONDS,
+                TierEU.RECIPE_UEV,
+                VoltageIndex.UV);
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1242,9 +1245,9 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedWireNiobiumTitanium, 32)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(9)),
                 CircuitComponent.CrystalComputer,
-                16 * SECONDS,
-                9_600, // LuV
-                VoltageIndex.LuV);
+                20 * SECONDS,
+                TierEU.RECIPE_UEV,
+                VoltageIndex.UV);
 
         addAssemblyMatrixRecipe(
                 Arrays.asList(
@@ -1256,29 +1259,14 @@ public class ScriptNanochipRecipes implements IScriptLoader {
                         new CircuitComponentStack(CircuitComponent.ProcessedSuperconductorLuV, 16)),
                 Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(18)),
                 CircuitComponent.CrystalMainframe,
-                32 * SECONDS,
-                TierEU.RECIPE_LuV,
-                VoltageIndex.LuV);
+                40 * SECONDS,
+                TierEU.RECIPE_UEV,
+                VoltageIndex.UV);
 
         // ======= //
         // Wetware //
         // ======= //
 
-        addAssemblyMatrixRecipe(
-                Arrays.asList(
-                        new CircuitComponentStack(CircuitComponent.ProcessedNeuroProcessingUnit, 1),
-                        new CircuitComponentStack(CircuitComponent.ProcessedChipCrystalCPU, 1),
-                        new CircuitComponentStack(CircuitComponent.ProcessedChipNanoCPU, 1),
-                        new CircuitComponentStack(CircuitComponent.ProcessedOpticalSMDCapacitor, 2),
-                        new CircuitComponentStack(CircuitComponent.ProcessedOpticalSMDTransistor, 2),
-                        new CircuitComponentStack(CircuitComponent.ProcessedWireYttriumBariumCuprate, 8)),
-                Arrays.asList(MaterialsAlloy.INDALLOY_140.getFluidStack(4)),
-                CircuitComponent.WetwareProcessor,
-                1 * SECONDS,
-                153_600, // UV
-                VoltageIndex.ZPM);
-
-        // SoC
         addAssemblyMatrixRecipe(
                 Arrays.asList(
                         new CircuitComponentStack(CircuitComponent.ProcessedBoardWetwareLifesupport, 1),


### PR DESCRIPTION
## Summary
Coremod portion for https://github.com/GTNewHorizons/GT5-Unofficial/pull/8005. Needed for balance, not for compiling the mod.

## Basics

This PR includes a full power consumption rework for every NAC recipe from Crystal through Optical. Pico+ NAC recipes will be modified as well in a future PR, since they are getting a more complete recipe overhaul compared to these being duration/eut changes.

In order to determine the starting point for NAC recipes, we ran some metrics on existing NAC recipes as well as CAL/AAL recipes. We broke every recipe into how many "seconds of UHV power" it would take to craft a mainframe, balancing around this.

With the new power distribution logic, we now have very well-known numbers for what proportions of power each module can and should have. Every recipe in the NAC, for Crystal through Optical, was balanced by breaking the circuits down into their complete list of components (all four steps of the circuit line), determining an "ideal ratio" for the matrix vs. non-matrix modules, and distributing power effectively across all modules in each group to remove bottlenecks from appropriately built NACs. Some NAC setups will require multiple modules of certain kinds to be full efficiency, though this is not a hard requirement by any means.

## General Changes
In order to reduce balance complexity due to many items being shared between many circuit lines, and many items being used in very strange amounts, some items were reduced to be considered "trivial time/power cost" for the NAC to process. These include:
- Silicon chips (cutting module)
- ASMDs/OSMDs (part preparer)
- Foils (encasement wrapper)
- Fine Wires (wire tracer)
- Frameboxes (part preparer)

Some of these still have scaled power usages, such as OSMDs taking a bit more power than ASMDs. However we intend for these to never be a significant power draw on the NAC, where most of this is shifted to more critical modules.

Every circuit line was designed in the NAC around a specific "optimal ratio," though in a real setup this will depend on several other factors, like:
- Calibration bonuses
- CoAL casing on the matrix
- Laser hatch on the etching array
- Water options chosen for the optical organizer

among others. Due to this we want to have the ratio be fully configurable, since different setups may need different ratios.

## Crystal Changes

**Optimal Ratio**: 20% matrix, 80% non-matrix
**Optimal Modules:** 2 etching arrays, one of each other module needed

This circuit line used to be somewhere in the realm of 3000x slower in NAC compared to CAL. We ended up buffing crystal circuits in the NAC by a factor of about 48x. In addition, the crystal non-SoC recipe was removed, and the minimum CoAL casing requirement on matrix was changed from LuV to UV.

## Wetware Changes

**Optimal Ratio**: 40% matrix, 60% non-matrix
**Optimal Modules:** 2 bio coordinators, one of each other module needed

The Wetware NAC was buffed by about 4x overall, as well as receiving ratio adjustments. The Wetware non-SoC recipe was removed, like crystal, and the minimum CoAL casing tier for matrix was changed from ZPM to UV.

## Bioware Changes

**Optimal Ratio**: 50% matrix, 50% non-matrix
**Optimal Modules (Normal):** 2 bio coordinators, 2 superconductor splitters, one of each other module needed
**Optimal Modules (SoC):** 2 bio coordinators, 2 superconductor splitters, 2 board immersion, one of each other module needed

The Bioware NAC is relatively unchanged in terms of total power usage to make a mainframe, being only ~2x faster than previously. The ratios are rebalanced to allow for better throughput. When using the SoC recipe, the etching array module will be replaced by a second board immersion module in an optimal setup. The minimum CoAL casing tier for matrix was changed from UV to UHV.

## Optical Changes

**Optimal Ratio**: 60% matrix, 40% non-matrix
**Optimal Modules:** 2 optical organizers, 2 superconductor splitters, one of each other module needed

Optical is relatively unchanged in terms of "optimal performance," receiving primarily ratio adjustments.

## Pico+ Changes
None yet, these are getting a more complete overhaul and as such will be in a separate PR.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
