### PR TITLE
Use circuit 1 for the remote orderer logistics pipe

### DIFF
--- a/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
+++ b/src/main/java/com/dreammaster/scripts/ScriptLogisticPipes.java
@@ -954,7 +954,7 @@ public class ScriptLogisticPipes implements IScriptLoader {
                 .itemInputs(
                         getModItem(LogisticsPipes.ID, "item.remoteOrdererItem", 0, wildcard),
                         getModItem(LogisticsPipes.ID, "item.PipeItemsRequestLogistics", 1, 0))
-                .circuit(18).itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsRemoteOrdererLogistics", 1, 0))
+                .circuit(1).itemOutputs(getModItem(LogisticsPipes.ID, "item.PipeItemsRemoteOrdererLogistics", 1, 0))
                 .duration(30 * SECONDS).eut(TierEU.RECIPE_LV).addTo(assemblerRecipes);
 
         // Bee Analyzer Logistics Pipe


### PR DESCRIPTION
Avoid recipe conflicts with the Request Logistics Pipe Mk2 when a Remote Orderer is present in the assembler.
<img width="337" height="195" alt="image" src="https://github.com/user-attachments/assets/340183d4-1306-4613-a9c7-6518b301ad63" />

<img width="343" height="204" alt="image" src="https://github.com/user-attachments/assets/35e6f49c-c560-4694-a145-1711c8241b5b" />
