### PR TITLE
Fix/futurum stripped logs to planks

### DIFF
--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -7,6 +7,7 @@ import static gregtech.api.enums.Materials.Bronze;
 import static gregtech.api.enums.Mods.AE2FluidCraft;
 import static gregtech.api.enums.Mods.AdventureBackpack;
 import static gregtech.api.enums.Mods.AppliedEnergistics2;
+import static gregtech.api.enums.Mods.BiomesOPlenty;
 import static gregtech.api.enums.Mods.BuildCraftFactory;
 import static gregtech.api.enums.Mods.Chisel;
 import static gregtech.api.enums.Mods.Computronics;
@@ -24,6 +25,7 @@ import static gregtech.api.enums.Mods.OpenPrinters;
 import static gregtech.api.enums.Mods.ProjectRedIllumination;
 import static gregtech.api.enums.Mods.Railcraft;
 import static gregtech.api.enums.Mods.TinkerConstruct;
+import static gregtech.api.enums.Mods.Witchery;
 import static gregtech.api.enums.Mods.ZTones;
 import static gregtech.api.enums.OrePrefixes.pipeMedium;
 import static gregtech.api.enums.OrePrefixes.screw;
@@ -2443,6 +2445,96 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
             GameRegistry.addShapelessRecipe(
                     getModItem(EtFuturumRequiem.ID, "wood_planks", 4, 3),
                     getModItem(EtFuturumRequiem.ID, "cherry_log", 1, 2));
+
+            // Stripped Sacred Oak
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 0),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 0));
+
+            // Stripped Cherry
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 1),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 1));
+
+            // Stripped Dark
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 2),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 2));
+
+            // Stripped Fir
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 3),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 3));
+
+            // Stripped Ethereal
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 4),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 0));
+
+            // Stripped Magic
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 5),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 1));
+
+            // Stripped Magic
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 5),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 1));
+
+            // Stripped Mangrove
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 6),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 2));
+
+            // Stripped Palm
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 7),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 3));
+
+            // Stripped Redwood
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 8),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped3", 1, 0));
+
+            // Stripped Willow
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 9),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped3", 1, 1));
+
+            // Stripped Pine
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 11),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 0));
+
+            // Stripped Hellbark
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 12),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 1));
+
+            // Stripped Jacaranda
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 13),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 2));
+
+            // Stripped Mahogany
+            GameRegistry.addShapelessRecipe(
+                    getModItem(BiomesOPlenty.ID, "planks", 4, 14),
+                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 3));
+
+            // Stripped Rowan
+            GameRegistry.addShapelessRecipe(
+                    getModItem(Witchery.ID, "witchwood", 4, 0),
+                    getModItem(EtFuturumRequiem.ID, "witchery_log_stripped", 1, 0));
+
+            // Stripped Alder
+            GameRegistry.addShapelessRecipe(
+                    getModItem(Witchery.ID, "witchwood", 4, 1),
+                    getModItem(EtFuturumRequiem.ID, "witchery_log_stripped", 1, 1));
+
+            // Stripped Hawthorn
+            GameRegistry.addShapelessRecipe(
+                    getModItem(Witchery.ID, "witchwood", 4, 2),
+                    getModItem(EtFuturumRequiem.ID, "witchery_log_stripped", 1, 2));
         }
 
         GameRegistry.addRecipe(

--- a/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
+++ b/src/main/java/com/dreammaster/gthandler/GT_CraftingRecipeLoader.java
@@ -2446,95 +2446,99 @@ public class GT_CraftingRecipeLoader extends gregtech.loaders.postload.CraftingR
                     getModItem(EtFuturumRequiem.ID, "wood_planks", 4, 3),
                     getModItem(EtFuturumRequiem.ID, "cherry_log", 1, 2));
 
-            // Stripped Sacred Oak
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 0),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 0));
+            if (BiomesOPlenty.isModLoaded()) {
+                // Stripped Sacred Oak
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 0),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 0));
 
-            // Stripped Cherry
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 1),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 1));
+                // Stripped Cherry
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 1),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 1));
 
-            // Stripped Dark
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 2),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 2));
+                // Stripped Dark
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 2),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 2));
 
-            // Stripped Fir
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 3),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 3));
+                // Stripped Fir
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 3),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped", 1, 3));
 
-            // Stripped Ethereal
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 4),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 0));
+                // Stripped Ethereal
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 4),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 0));
 
-            // Stripped Magic
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 5),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 1));
+                // Stripped Magic
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 5),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 1));
 
-            // Stripped Magic
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 5),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 1));
+                // Stripped Magic
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 5),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 1));
 
-            // Stripped Mangrove
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 6),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 2));
+                // Stripped Mangrove
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 6),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 2));
 
-            // Stripped Palm
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 7),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 3));
+                // Stripped Palm
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 7),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped2", 1, 3));
 
-            // Stripped Redwood
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 8),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped3", 1, 0));
+                // Stripped Redwood
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 8),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped3", 1, 0));
 
-            // Stripped Willow
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 9),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped3", 1, 1));
+                // Stripped Willow
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 9),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped3", 1, 1));
 
-            // Stripped Pine
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 11),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 0));
+                // Stripped Pine
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 11),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 0));
 
-            // Stripped Hellbark
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 12),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 1));
+                // Stripped Hellbark
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 12),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 1));
 
-            // Stripped Jacaranda
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 13),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 2));
+                // Stripped Jacaranda
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 13),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 2));
 
-            // Stripped Mahogany
-            GameRegistry.addShapelessRecipe(
-                    getModItem(BiomesOPlenty.ID, "planks", 4, 14),
-                    getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 3));
+                // Stripped Mahogany
+                GameRegistry.addShapelessRecipe(
+                        getModItem(BiomesOPlenty.ID, "planks", 4, 14),
+                        getModItem(EtFuturumRequiem.ID, "bop_log_stripped4", 1, 3));
+            }
 
-            // Stripped Rowan
-            GameRegistry.addShapelessRecipe(
-                    getModItem(Witchery.ID, "witchwood", 4, 0),
-                    getModItem(EtFuturumRequiem.ID, "witchery_log_stripped", 1, 0));
+            if (Witchery.isModLoaded()) {
+                // Stripped Rowan
+                GameRegistry.addShapelessRecipe(
+                        getModItem(Witchery.ID, "witchwood", 4, 0),
+                        getModItem(EtFuturumRequiem.ID, "witchery_log_stripped", 1, 0));
 
-            // Stripped Alder
-            GameRegistry.addShapelessRecipe(
-                    getModItem(Witchery.ID, "witchwood", 4, 1),
-                    getModItem(EtFuturumRequiem.ID, "witchery_log_stripped", 1, 1));
+                // Stripped Alder
+                GameRegistry.addShapelessRecipe(
+                        getModItem(Witchery.ID, "witchwood", 4, 1),
+                        getModItem(EtFuturumRequiem.ID, "witchery_log_stripped", 1, 1));
 
-            // Stripped Hawthorn
-            GameRegistry.addShapelessRecipe(
-                    getModItem(Witchery.ID, "witchwood", 4, 2),
-                    getModItem(EtFuturumRequiem.ID, "witchery_log_stripped", 1, 2));
+                // Stripped Hawthorn
+                GameRegistry.addShapelessRecipe(
+                        getModItem(Witchery.ID, "witchwood", 4, 2),
+                        getModItem(EtFuturumRequiem.ID, "witchery_log_stripped", 1, 2));
+            }
         }
 
         GameRegistry.addRecipe(


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
I was playing on latest beta, and noticed that some stripped logs can't be converted to planks, this PR adds those recipes.
Issue related to this PR https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25795

<img width="519" height="280" alt="image" src="https://github.com/user-attachments/assets/cf9b8976-995d-4112-8e04-039ff011691a" />
<img width="520" height="280" alt="image" src="https://github.com/user-attachments/assets/b7692054-0fbc-41be-b532-000252ee63d4" />
<img width="511" height="946" alt="image" src="https://github.com/user-attachments/assets/6421249c-c630-40ea-9c2c-62c647ac2eca" />

I omitted the recipe screenshots for all other woods, however all of stripped logs added by et-futurum-requiem for BiomesOPlenty (except Dead Log and Giant Flower Stem which do not have respective planks) and Witchery have received the same treatment.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
